### PR TITLE
Add method to get url without hostname and port

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.common/pom.xml
+++ b/components/org.wso2.carbon.identity.api.server.common/pom.xml
@@ -42,6 +42,10 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.core</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-frontend-jaxrs</artifactId>
             <scope>provided</scope>

--- a/components/org.wso2.carbon.identity.api.server.common/src/main/java/org/wso2/carbon/identity/api/server/common/ContextLoader.java
+++ b/components/org.wso2.carbon.identity.api.server.common/src/main/java/org/wso2/carbon/identity/api/server/common/ContextLoader.java
@@ -69,4 +69,19 @@ public class ContextLoader {
         String url = IdentityUtil.getServerURL(tenantQualifiedRelativePath + endpoint, true, true);
         return URI.create(url);
     }
+
+    /**
+     * Build URI prepending the user API context with to the endpoint.
+     * /t/<tenant-domain>/api/users/<endpoint>
+     *
+     * @param endpoint relative endpoint path.
+     * @return Fully qualified URI.
+     */
+    public static URI buildURIForBody(String endpoint) {
+
+        String tenantQualifiedRelativePath =
+                String.format(TENANT_CONTEXT_PATH_COMPONENT, getTenantDomainFromContext()) + SERVER_API_PATH_COMPONENT;
+        String url = IdentityUtil.getEndpointURIPath(tenantQualifiedRelativePath + endpoint, true, true);
+        return URI.create(url);
+    }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -120,6 +120,11 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
+                <groupId>org.wso2.carbon.identity.framework</groupId>
+                <artifactId>org.wso2.carbon.identity.core</artifactId>
+                <version>${carbon.identity.framework.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.apache.cxf</groupId>
                 <artifactId>cxf-rt-frontend-jaxrs</artifactId>
                 <version>${cxf-bundle.version}</version>
@@ -300,7 +305,7 @@
         <maven.buildnumber.plugin.version>1.4</maven.buildnumber.plugin.version>
         <org.apache.felix.annotations.version>1.2.4</org.apache.felix.annotations.version>
         <identity.governance.version>1.2.7</identity.governance.version>
-        <carbon.identity.framework.version>5.13.45</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.14.94</carbon.identity.framework.version>
         <maven.findbugsplugin.version>3.0.4</maven.findbugsplugin.version>
         <identity.workflow.impl.bps.version>5.2.0</identity.workflow.impl.bps.version>
         <!--<maven.checkstyleplugin.excludes>**/gen/**/*</maven.checkstyleplugin.excludes>-->


### PR DESCRIPTION
## Purpose
> Added a method get the URI of a given resource without the hostname and port. Can be used to add location parameters in the response body of APIs.