### PR TITLE
SAML Inbound Swagger Structure changes

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/application/management/v1/ApplicationsApi.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/application/management/v1/ApplicationsApi.java
@@ -40,6 +40,7 @@ import org.wso2.carbon.identity.api.server.application.management.v1.ResidentApp
 import org.wso2.carbon.identity.api.server.application.management.v1.SAML2Configuration;
 import org.wso2.carbon.identity.api.server.application.management.v1.SAML2ServiceProvider;
 import org.wso2.carbon.identity.api.server.application.management.v1.SAMLMetaData;
+import org.wso2.carbon.identity.api.server.application.management.v1.SAMLRequestValidation;
 import org.wso2.carbon.identity.api.server.application.management.v1.WSTrustConfiguration;
 import org.wso2.carbon.identity.api.server.application.management.v1.WSTrustMetaData;
 import org.wso2.carbon.identity.api.server.application.management.v1.ApplicationsApiService;
@@ -446,14 +447,14 @@ public class ApplicationsApi  {
     @Path("/{applicationId}/inbound-protocols/saml")
     
     @Produces({ "application/json" })
-    @ApiOperation(value = "Retrieve SAML2 authentication protocol parameters of an application. ", notes = "This API provides the capability to retrieve SAML2 authentication protocol parameters of an application. ", response = SAML2ServiceProvider.class, authorizations = {
+    @ApiOperation(value = "Retrieve SAML2 authentication protocol parameters of an application. ", notes = "This API provides the capability to retrieve SAML2 authentication protocol parameters of an application. ", response = SAMLRequestValidation.class, authorizations = {
         @Authorization(value = "BasicAuth"),
         @Authorization(value = "OAuth2", scopes = {
             
         })
     }, tags={ "Inbound Protocols - SAML", })
     @ApiResponses(value = { 
-        @ApiResponse(code = 200, message = "OK", response = SAML2ServiceProvider.class),
+        @ApiResponse(code = 200, message = "OK", response = SAMLRequestValidation.class),
         @ApiResponse(code = 400, message = "Bad Request", response = Error.class),
         @ApiResponse(code = 401, message = "Unauthorized", response = Error.class),
         @ApiResponse(code = 404, message = "Not Found", response = Error.class),

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/application/management/v1/ApplicationsApiService.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/application/management/v1/ApplicationsApiService.java
@@ -40,6 +40,7 @@ import org.wso2.carbon.identity.api.server.application.management.v1.ResidentApp
 import org.wso2.carbon.identity.api.server.application.management.v1.SAML2Configuration;
 import org.wso2.carbon.identity.api.server.application.management.v1.SAML2ServiceProvider;
 import org.wso2.carbon.identity.api.server.application.management.v1.SAMLMetaData;
+import org.wso2.carbon.identity.api.server.application.management.v1.SAMLRequestValidation;
 import org.wso2.carbon.identity.api.server.application.management.v1.WSTrustConfiguration;
 import org.wso2.carbon.identity.api.server.application.management.v1.WSTrustMetaData;
 import javax.ws.rs.core.Response;

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/application/management/v1/AssertionEncryptionConfiguration.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/application/management/v1/AssertionEncryptionConfiguration.java
@@ -1,0 +1,138 @@
+/*
+* Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package org.wso2.carbon.identity.api.server.application.management.v1;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import javax.validation.constraints.*;
+
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+import javax.validation.Valid;
+import javax.xml.bind.annotation.*;
+
+public class AssertionEncryptionConfiguration  {
+  
+    private Boolean enabled = false;
+    private String assertionEncryptionAlgorithm = "http://www.w3.org/2001/04/xmlenc#aes256-cbc";
+    private String keyEncryptionAlgorithm = "http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p";
+
+    /**
+    **/
+    public AssertionEncryptionConfiguration enabled(Boolean enabled) {
+
+        this.enabled = enabled;
+        return this;
+    }
+    
+    @ApiModelProperty(value = "")
+    @JsonProperty("enabled")
+    @Valid
+    public Boolean getEnabled() {
+        return enabled;
+    }
+    public void setEnabled(Boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    /**
+    **/
+    public AssertionEncryptionConfiguration assertionEncryptionAlgorithm(String assertionEncryptionAlgorithm) {
+
+        this.assertionEncryptionAlgorithm = assertionEncryptionAlgorithm;
+        return this;
+    }
+    
+    @ApiModelProperty(value = "")
+    @JsonProperty("assertionEncryptionAlgorithm")
+    @Valid
+    public String getAssertionEncryptionAlgorithm() {
+        return assertionEncryptionAlgorithm;
+    }
+    public void setAssertionEncryptionAlgorithm(String assertionEncryptionAlgorithm) {
+        this.assertionEncryptionAlgorithm = assertionEncryptionAlgorithm;
+    }
+
+    /**
+    **/
+    public AssertionEncryptionConfiguration keyEncryptionAlgorithm(String keyEncryptionAlgorithm) {
+
+        this.keyEncryptionAlgorithm = keyEncryptionAlgorithm;
+        return this;
+    }
+    
+    @ApiModelProperty(value = "")
+    @JsonProperty("keyEncryptionAlgorithm")
+    @Valid
+    public String getKeyEncryptionAlgorithm() {
+        return keyEncryptionAlgorithm;
+    }
+    public void setKeyEncryptionAlgorithm(String keyEncryptionAlgorithm) {
+        this.keyEncryptionAlgorithm = keyEncryptionAlgorithm;
+    }
+
+
+
+    @Override
+    public boolean equals(java.lang.Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        AssertionEncryptionConfiguration assertionEncryptionConfiguration = (AssertionEncryptionConfiguration) o;
+        return Objects.equals(this.enabled, assertionEncryptionConfiguration.enabled) &&
+            Objects.equals(this.assertionEncryptionAlgorithm, assertionEncryptionConfiguration.assertionEncryptionAlgorithm) &&
+            Objects.equals(this.keyEncryptionAlgorithm, assertionEncryptionConfiguration.keyEncryptionAlgorithm);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(enabled, assertionEncryptionAlgorithm, keyEncryptionAlgorithm);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class AssertionEncryptionConfiguration {\n");
+        
+        sb.append("    enabled: ").append(toIndentedString(enabled)).append("\n");
+        sb.append("    assertionEncryptionAlgorithm: ").append(toIndentedString(assertionEncryptionAlgorithm)).append("\n");
+        sb.append("    keyEncryptionAlgorithm: ").append(toIndentedString(keyEncryptionAlgorithm)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+    * Convert the given object to string with each line indented by 4 spaces
+    * (except the first line).
+    */
+    private String toIndentedString(java.lang.Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}
+

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/application/management/v1/IdpInitiatedSingleLogout.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/application/management/v1/IdpInitiatedSingleLogout.java
@@ -1,0 +1,128 @@
+/*
+* Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package org.wso2.carbon.identity.api.server.application.management.v1;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import java.util.ArrayList;
+import java.util.List;
+import javax.validation.constraints.*;
+
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+import javax.validation.Valid;
+import javax.xml.bind.annotation.*;
+
+public class IdpInitiatedSingleLogout  {
+  
+    private Boolean enabled = false;
+    private List<String> returnToUrls = null;
+
+
+    /**
+    **/
+    public IdpInitiatedSingleLogout enabled(Boolean enabled) {
+
+        this.enabled = enabled;
+        return this;
+    }
+    
+    @ApiModelProperty(value = "")
+    @JsonProperty("enabled")
+    @Valid
+    public Boolean getEnabled() {
+        return enabled;
+    }
+    public void setEnabled(Boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    /**
+    **/
+    public IdpInitiatedSingleLogout returnToUrls(List<String> returnToUrls) {
+
+        this.returnToUrls = returnToUrls;
+        return this;
+    }
+    
+    @ApiModelProperty(value = "")
+    @JsonProperty("returnToUrls")
+    @Valid
+    public List<String> getReturnToUrls() {
+        return returnToUrls;
+    }
+    public void setReturnToUrls(List<String> returnToUrls) {
+        this.returnToUrls = returnToUrls;
+    }
+
+    public IdpInitiatedSingleLogout addReturnToUrlsItem(String returnToUrlsItem) {
+        if (this.returnToUrls == null) {
+            this.returnToUrls = new ArrayList<>();
+        }
+        this.returnToUrls.add(returnToUrlsItem);
+        return this;
+    }
+
+    
+
+    @Override
+    public boolean equals(java.lang.Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        IdpInitiatedSingleLogout idpInitiatedSingleLogout = (IdpInitiatedSingleLogout) o;
+        return Objects.equals(this.enabled, idpInitiatedSingleLogout.enabled) &&
+            Objects.equals(this.returnToUrls, idpInitiatedSingleLogout.returnToUrls);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(enabled, returnToUrls);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class IdpInitiatedSingleLogout {\n");
+        
+        sb.append("    enabled: ").append(toIndentedString(enabled)).append("\n");
+        sb.append("    returnToUrls: ").append(toIndentedString(returnToUrls)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+    * Convert the given object to string with each line indented by 4 spaces
+    * (except the first line).
+    */
+    private String toIndentedString(java.lang.Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}
+

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/application/management/v1/SAML2ServiceProvider.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/application/management/v1/SAML2ServiceProvider.java
@@ -22,6 +22,11 @@ import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import java.util.ArrayList;
 import java.util.List;
+import org.wso2.carbon.identity.api.server.application.management.v1.SAMLAttributeProfile;
+import org.wso2.carbon.identity.api.server.application.management.v1.SAMLRequestValidation;
+import org.wso2.carbon.identity.api.server.application.management.v1.SAMLResponseSigning;
+import org.wso2.carbon.identity.api.server.application.management.v1.SingleLogoutProfile;
+import org.wso2.carbon.identity.api.server.application.management.v1.SingleSignOnProfile;
 import javax.validation.constraints.*;
 
 
@@ -37,67 +42,13 @@ public class SAML2ServiceProvider  {
     private List<String> assertionConsumerUrls = new ArrayList<>();
 
     private String defaultAssertionConsumerUrl;
-    private String attributeConsumingServiceIndex;
-    private Boolean enableRequestSignatureValidation = true;
-    private Boolean enableAssertionEncryption = false;
-    private String assertionEncryptionAlgroithm;
-    private String keyEncryptionAlgorithm;
-    private String nameIdFormat = "urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress";
-    private Boolean enableIdpInitiatedSingleSignOn = false;
-    private Boolean enableResponseSigning = true;
-    private String requestValidationCertificateAlias;
-    private String responseSigningAlgorithm;
-    private String responseDigestAlgorithm;
-    private Boolean enableSingleLogout = true;
-    private String singleLogoutResponseUrl;
-    private String singleLogoutRequestUrl;
-
-@XmlType(name="SingleLogoutMethodEnum")
-@XmlEnum(String.class)
-public enum SingleLogoutMethodEnum {
-
-    @XmlEnumValue("BACKCHANNEL") BACKCHANNEL(String.valueOf("BACKCHANNEL")), @XmlEnumValue("FRONTCHANNEL_HTTP_REDIRECT") FRONTCHANNEL_HTTP_REDIRECT(String.valueOf("FRONTCHANNEL_HTTP_REDIRECT")), @XmlEnumValue("FRONTCHANNEL_HTTP_POST") FRONTCHANNEL_HTTP_POST(String.valueOf("FRONTCHANNEL_HTTP_POST"));
-
-
-    private String value;
-
-    SingleLogoutMethodEnum(String v) {
-        value = v;
-    }
-
-    public String value() {
-        return value;
-    }
-
-    @Override
-    public String toString() {
-        return String.valueOf(value);
-    }
-
-    public static SingleLogoutMethodEnum fromValue(String value) {
-        for (SingleLogoutMethodEnum b : SingleLogoutMethodEnum.values()) {
-            if (b.value.equals(value)) {
-                return b;
-            }
-        }
-        throw new IllegalArgumentException("Unexpected value '" + value + "'");
-    }
-}
-
-    private SingleLogoutMethodEnum singleLogoutMethod;
-    private Boolean enableIdpInitiatedSingleLogOut = false;
-    private List<String> idpInitiatedLogoutReturnUrls = null;
-
-    private Boolean enableAttributeProfile = false;
-    private Boolean includedAttributeInResponseAlways = false;
-    private List<String> audiences = null;
-
-    private List<String> recipients = null;
-
+    private String idpEntityIdAlias;
+    private SingleSignOnProfile singleSignOnProfile;
+    private SAMLAttributeProfile attributeProfile;
+    private SingleLogoutProfile singleLogoutProfile;
+    private SAMLRequestValidation requestValidation;
+    private SAMLResponseSigning responseSigning;
     private Boolean enableAssertionQueryProfile = false;
-    private Boolean enableSAML2ArtifactBinding = false;
-    private Boolean enableSignatureValidationInArtifactBinding = false;
-    private String idPEntityidAlias;
 
     /**
     **/
@@ -163,6 +114,7 @@ public enum SingleLogoutMethodEnum {
     }
 
         /**
+    * If not provided, the first assertion consumer URL on the assertionConsumerUrls will be picked as the default assertion consumer URL.
     **/
     public SAML2ServiceProvider defaultAssertionConsumerUrl(String defaultAssertionConsumerUrl) {
 
@@ -170,7 +122,7 @@ public enum SingleLogoutMethodEnum {
         return this;
     }
     
-    @ApiModelProperty(value = "")
+    @ApiModelProperty(value = "If not provided, the first assertion consumer URL on the assertionConsumerUrls will be picked as the default assertion consumer URL.")
     @JsonProperty("defaultAssertionConsumerUrl")
     @Valid
     public String getDefaultAssertionConsumerUrl() {
@@ -181,412 +133,115 @@ public enum SingleLogoutMethodEnum {
     }
 
     /**
+    * Default value is the IdP Entity ID value specified in Resident IdP
     **/
-    public SAML2ServiceProvider attributeConsumingServiceIndex(String attributeConsumingServiceIndex) {
+    public SAML2ServiceProvider idpEntityIdAlias(String idpEntityIdAlias) {
 
-        this.attributeConsumingServiceIndex = attributeConsumingServiceIndex;
+        this.idpEntityIdAlias = idpEntityIdAlias;
+        return this;
+    }
+    
+    @ApiModelProperty(value = "Default value is the IdP Entity ID value specified in Resident IdP")
+    @JsonProperty("idpEntityIdAlias")
+    @Valid
+    public String getIdpEntityIdAlias() {
+        return idpEntityIdAlias;
+    }
+    public void setIdpEntityIdAlias(String idpEntityIdAlias) {
+        this.idpEntityIdAlias = idpEntityIdAlias;
+    }
+
+    /**
+    **/
+    public SAML2ServiceProvider singleSignOnProfile(SingleSignOnProfile singleSignOnProfile) {
+
+        this.singleSignOnProfile = singleSignOnProfile;
         return this;
     }
     
     @ApiModelProperty(value = "")
-    @JsonProperty("attributeConsumingServiceIndex")
+    @JsonProperty("singleSignOnProfile")
     @Valid
-    public String getAttributeConsumingServiceIndex() {
-        return attributeConsumingServiceIndex;
+    public SingleSignOnProfile getSingleSignOnProfile() {
+        return singleSignOnProfile;
     }
-    public void setAttributeConsumingServiceIndex(String attributeConsumingServiceIndex) {
-        this.attributeConsumingServiceIndex = attributeConsumingServiceIndex;
+    public void setSingleSignOnProfile(SingleSignOnProfile singleSignOnProfile) {
+        this.singleSignOnProfile = singleSignOnProfile;
     }
 
     /**
     **/
-    public SAML2ServiceProvider enableRequestSignatureValidation(Boolean enableRequestSignatureValidation) {
+    public SAML2ServiceProvider attributeProfile(SAMLAttributeProfile attributeProfile) {
 
-        this.enableRequestSignatureValidation = enableRequestSignatureValidation;
+        this.attributeProfile = attributeProfile;
         return this;
     }
     
     @ApiModelProperty(value = "")
-    @JsonProperty("enableRequestSignatureValidation")
+    @JsonProperty("attributeProfile")
     @Valid
-    public Boolean getEnableRequestSignatureValidation() {
-        return enableRequestSignatureValidation;
+    public SAMLAttributeProfile getAttributeProfile() {
+        return attributeProfile;
     }
-    public void setEnableRequestSignatureValidation(Boolean enableRequestSignatureValidation) {
-        this.enableRequestSignatureValidation = enableRequestSignatureValidation;
+    public void setAttributeProfile(SAMLAttributeProfile attributeProfile) {
+        this.attributeProfile = attributeProfile;
     }
 
     /**
     **/
-    public SAML2ServiceProvider enableAssertionEncryption(Boolean enableAssertionEncryption) {
+    public SAML2ServiceProvider singleLogoutProfile(SingleLogoutProfile singleLogoutProfile) {
 
-        this.enableAssertionEncryption = enableAssertionEncryption;
+        this.singleLogoutProfile = singleLogoutProfile;
         return this;
     }
     
     @ApiModelProperty(value = "")
-    @JsonProperty("enableAssertionEncryption")
+    @JsonProperty("singleLogoutProfile")
     @Valid
-    public Boolean getEnableAssertionEncryption() {
-        return enableAssertionEncryption;
+    public SingleLogoutProfile getSingleLogoutProfile() {
+        return singleLogoutProfile;
     }
-    public void setEnableAssertionEncryption(Boolean enableAssertionEncryption) {
-        this.enableAssertionEncryption = enableAssertionEncryption;
+    public void setSingleLogoutProfile(SingleLogoutProfile singleLogoutProfile) {
+        this.singleLogoutProfile = singleLogoutProfile;
     }
 
     /**
     **/
-    public SAML2ServiceProvider assertionEncryptionAlgroithm(String assertionEncryptionAlgroithm) {
+    public SAML2ServiceProvider requestValidation(SAMLRequestValidation requestValidation) {
 
-        this.assertionEncryptionAlgroithm = assertionEncryptionAlgroithm;
+        this.requestValidation = requestValidation;
         return this;
     }
     
     @ApiModelProperty(value = "")
-    @JsonProperty("assertionEncryptionAlgroithm")
+    @JsonProperty("requestValidation")
     @Valid
-    public String getAssertionEncryptionAlgroithm() {
-        return assertionEncryptionAlgroithm;
+    public SAMLRequestValidation getRequestValidation() {
+        return requestValidation;
     }
-    public void setAssertionEncryptionAlgroithm(String assertionEncryptionAlgroithm) {
-        this.assertionEncryptionAlgroithm = assertionEncryptionAlgroithm;
+    public void setRequestValidation(SAMLRequestValidation requestValidation) {
+        this.requestValidation = requestValidation;
     }
 
     /**
     **/
-    public SAML2ServiceProvider keyEncryptionAlgorithm(String keyEncryptionAlgorithm) {
+    public SAML2ServiceProvider responseSigning(SAMLResponseSigning responseSigning) {
 
-        this.keyEncryptionAlgorithm = keyEncryptionAlgorithm;
+        this.responseSigning = responseSigning;
         return this;
     }
     
     @ApiModelProperty(value = "")
-    @JsonProperty("keyEncryptionAlgorithm")
+    @JsonProperty("responseSigning")
     @Valid
-    public String getKeyEncryptionAlgorithm() {
-        return keyEncryptionAlgorithm;
+    public SAMLResponseSigning getResponseSigning() {
+        return responseSigning;
     }
-    public void setKeyEncryptionAlgorithm(String keyEncryptionAlgorithm) {
-        this.keyEncryptionAlgorithm = keyEncryptionAlgorithm;
+    public void setResponseSigning(SAMLResponseSigning responseSigning) {
+        this.responseSigning = responseSigning;
     }
 
     /**
-    **/
-    public SAML2ServiceProvider nameIdFormat(String nameIdFormat) {
-
-        this.nameIdFormat = nameIdFormat;
-        return this;
-    }
-    
-    @ApiModelProperty(example = "urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress", value = "")
-    @JsonProperty("nameIdFormat")
-    @Valid
-    public String getNameIdFormat() {
-        return nameIdFormat;
-    }
-    public void setNameIdFormat(String nameIdFormat) {
-        this.nameIdFormat = nameIdFormat;
-    }
-
-    /**
-    **/
-    public SAML2ServiceProvider enableIdpInitiatedSingleSignOn(Boolean enableIdpInitiatedSingleSignOn) {
-
-        this.enableIdpInitiatedSingleSignOn = enableIdpInitiatedSingleSignOn;
-        return this;
-    }
-    
-    @ApiModelProperty(value = "")
-    @JsonProperty("enableIdpInitiatedSingleSignOn")
-    @Valid
-    public Boolean getEnableIdpInitiatedSingleSignOn() {
-        return enableIdpInitiatedSingleSignOn;
-    }
-    public void setEnableIdpInitiatedSingleSignOn(Boolean enableIdpInitiatedSingleSignOn) {
-        this.enableIdpInitiatedSingleSignOn = enableIdpInitiatedSingleSignOn;
-    }
-
-    /**
-    **/
-    public SAML2ServiceProvider enableResponseSigning(Boolean enableResponseSigning) {
-
-        this.enableResponseSigning = enableResponseSigning;
-        return this;
-    }
-    
-    @ApiModelProperty(value = "")
-    @JsonProperty("enableResponseSigning")
-    @Valid
-    public Boolean getEnableResponseSigning() {
-        return enableResponseSigning;
-    }
-    public void setEnableResponseSigning(Boolean enableResponseSigning) {
-        this.enableResponseSigning = enableResponseSigning;
-    }
-
-    /**
-    **/
-    public SAML2ServiceProvider requestValidationCertificateAlias(String requestValidationCertificateAlias) {
-
-        this.requestValidationCertificateAlias = requestValidationCertificateAlias;
-        return this;
-    }
-    
-    @ApiModelProperty(value = "")
-    @JsonProperty("requestValidationCertificateAlias")
-    @Valid
-    public String getRequestValidationCertificateAlias() {
-        return requestValidationCertificateAlias;
-    }
-    public void setRequestValidationCertificateAlias(String requestValidationCertificateAlias) {
-        this.requestValidationCertificateAlias = requestValidationCertificateAlias;
-    }
-
-    /**
-    **/
-    public SAML2ServiceProvider responseSigningAlgorithm(String responseSigningAlgorithm) {
-
-        this.responseSigningAlgorithm = responseSigningAlgorithm;
-        return this;
-    }
-    
-    @ApiModelProperty(value = "")
-    @JsonProperty("responseSigningAlgorithm")
-    @Valid
-    public String getResponseSigningAlgorithm() {
-        return responseSigningAlgorithm;
-    }
-    public void setResponseSigningAlgorithm(String responseSigningAlgorithm) {
-        this.responseSigningAlgorithm = responseSigningAlgorithm;
-    }
-
-    /**
-    **/
-    public SAML2ServiceProvider responseDigestAlgorithm(String responseDigestAlgorithm) {
-
-        this.responseDigestAlgorithm = responseDigestAlgorithm;
-        return this;
-    }
-    
-    @ApiModelProperty(value = "")
-    @JsonProperty("responseDigestAlgorithm")
-    @Valid
-    public String getResponseDigestAlgorithm() {
-        return responseDigestAlgorithm;
-    }
-    public void setResponseDigestAlgorithm(String responseDigestAlgorithm) {
-        this.responseDigestAlgorithm = responseDigestAlgorithm;
-    }
-
-    /**
-    **/
-    public SAML2ServiceProvider enableSingleLogout(Boolean enableSingleLogout) {
-
-        this.enableSingleLogout = enableSingleLogout;
-        return this;
-    }
-    
-    @ApiModelProperty(value = "")
-    @JsonProperty("enableSingleLogout")
-    @Valid
-    public Boolean getEnableSingleLogout() {
-        return enableSingleLogout;
-    }
-    public void setEnableSingleLogout(Boolean enableSingleLogout) {
-        this.enableSingleLogout = enableSingleLogout;
-    }
-
-    /**
-    * Single logout response accepting endpoint
-    **/
-    public SAML2ServiceProvider singleLogoutResponseUrl(String singleLogoutResponseUrl) {
-
-        this.singleLogoutResponseUrl = singleLogoutResponseUrl;
-        return this;
-    }
-    
-    @ApiModelProperty(value = "Single logout response accepting endpoint")
-    @JsonProperty("singleLogoutResponseUrl")
-    @Valid
-    public String getSingleLogoutResponseUrl() {
-        return singleLogoutResponseUrl;
-    }
-    public void setSingleLogoutResponseUrl(String singleLogoutResponseUrl) {
-        this.singleLogoutResponseUrl = singleLogoutResponseUrl;
-    }
-
-    /**
-    * Single logout request accepting endpoint
-    **/
-    public SAML2ServiceProvider singleLogoutRequestUrl(String singleLogoutRequestUrl) {
-
-        this.singleLogoutRequestUrl = singleLogoutRequestUrl;
-        return this;
-    }
-    
-    @ApiModelProperty(value = "Single logout request accepting endpoint")
-    @JsonProperty("singleLogoutRequestUrl")
-    @Valid
-    public String getSingleLogoutRequestUrl() {
-        return singleLogoutRequestUrl;
-    }
-    public void setSingleLogoutRequestUrl(String singleLogoutRequestUrl) {
-        this.singleLogoutRequestUrl = singleLogoutRequestUrl;
-    }
-
-    /**
-    **/
-    public SAML2ServiceProvider singleLogoutMethod(SingleLogoutMethodEnum singleLogoutMethod) {
-
-        this.singleLogoutMethod = singleLogoutMethod;
-        return this;
-    }
-    
-    @ApiModelProperty(value = "")
-    @JsonProperty("singleLogoutMethod")
-    @Valid
-    public SingleLogoutMethodEnum getSingleLogoutMethod() {
-        return singleLogoutMethod;
-    }
-    public void setSingleLogoutMethod(SingleLogoutMethodEnum singleLogoutMethod) {
-        this.singleLogoutMethod = singleLogoutMethod;
-    }
-
-    /**
-    **/
-    public SAML2ServiceProvider enableIdpInitiatedSingleLogOut(Boolean enableIdpInitiatedSingleLogOut) {
-
-        this.enableIdpInitiatedSingleLogOut = enableIdpInitiatedSingleLogOut;
-        return this;
-    }
-    
-    @ApiModelProperty(value = "")
-    @JsonProperty("enableIdpInitiatedSingleLogOut")
-    @Valid
-    public Boolean getEnableIdpInitiatedSingleLogOut() {
-        return enableIdpInitiatedSingleLogOut;
-    }
-    public void setEnableIdpInitiatedSingleLogOut(Boolean enableIdpInitiatedSingleLogOut) {
-        this.enableIdpInitiatedSingleLogOut = enableIdpInitiatedSingleLogOut;
-    }
-
-    /**
-    **/
-    public SAML2ServiceProvider idpInitiatedLogoutReturnUrls(List<String> idpInitiatedLogoutReturnUrls) {
-
-        this.idpInitiatedLogoutReturnUrls = idpInitiatedLogoutReturnUrls;
-        return this;
-    }
-    
-    @ApiModelProperty(value = "")
-    @JsonProperty("idpInitiatedLogoutReturnUrls")
-    @Valid
-    public List<String> getIdpInitiatedLogoutReturnUrls() {
-        return idpInitiatedLogoutReturnUrls;
-    }
-    public void setIdpInitiatedLogoutReturnUrls(List<String> idpInitiatedLogoutReturnUrls) {
-        this.idpInitiatedLogoutReturnUrls = idpInitiatedLogoutReturnUrls;
-    }
-
-    public SAML2ServiceProvider addIdpInitiatedLogoutReturnUrlsItem(String idpInitiatedLogoutReturnUrlsItem) {
-        if (this.idpInitiatedLogoutReturnUrls == null) {
-            this.idpInitiatedLogoutReturnUrls = new ArrayList<>();
-        }
-        this.idpInitiatedLogoutReturnUrls.add(idpInitiatedLogoutReturnUrlsItem);
-        return this;
-    }
-
-        /**
-    **/
-    public SAML2ServiceProvider enableAttributeProfile(Boolean enableAttributeProfile) {
-
-        this.enableAttributeProfile = enableAttributeProfile;
-        return this;
-    }
-    
-    @ApiModelProperty(value = "")
-    @JsonProperty("enableAttributeProfile")
-    @Valid
-    public Boolean getEnableAttributeProfile() {
-        return enableAttributeProfile;
-    }
-    public void setEnableAttributeProfile(Boolean enableAttributeProfile) {
-        this.enableAttributeProfile = enableAttributeProfile;
-    }
-
-    /**
-    **/
-    public SAML2ServiceProvider includedAttributeInResponseAlways(Boolean includedAttributeInResponseAlways) {
-
-        this.includedAttributeInResponseAlways = includedAttributeInResponseAlways;
-        return this;
-    }
-    
-    @ApiModelProperty(value = "")
-    @JsonProperty("includedAttributeInResponseAlways")
-    @Valid
-    public Boolean getIncludedAttributeInResponseAlways() {
-        return includedAttributeInResponseAlways;
-    }
-    public void setIncludedAttributeInResponseAlways(Boolean includedAttributeInResponseAlways) {
-        this.includedAttributeInResponseAlways = includedAttributeInResponseAlways;
-    }
-
-    /**
-    * Additional audience values to be added to the SAML Assertions
-    **/
-    public SAML2ServiceProvider audiences(List<String> audiences) {
-
-        this.audiences = audiences;
-        return this;
-    }
-    
-    @ApiModelProperty(example = "[\"https://app.example.com/saml\"]", value = "Additional audience values to be added to the SAML Assertions")
-    @JsonProperty("audiences")
-    @Valid
-    public List<String> getAudiences() {
-        return audiences;
-    }
-    public void setAudiences(List<String> audiences) {
-        this.audiences = audiences;
-    }
-
-    public SAML2ServiceProvider addAudiencesItem(String audiencesItem) {
-        if (this.audiences == null) {
-            this.audiences = new ArrayList<>();
-        }
-        this.audiences.add(audiencesItem);
-        return this;
-    }
-
-        /**
-    * Additional recipient values to be added to the SAML Assertions
-    **/
-    public SAML2ServiceProvider recipients(List<String> recipients) {
-
-        this.recipients = recipients;
-        return this;
-    }
-    
-    @ApiModelProperty(example = "[\"https://app.example.com/saml\"]", value = "Additional recipient values to be added to the SAML Assertions")
-    @JsonProperty("recipients")
-    @Valid
-    public List<String> getRecipients() {
-        return recipients;
-    }
-    public void setRecipients(List<String> recipients) {
-        this.recipients = recipients;
-    }
-
-    public SAML2ServiceProvider addRecipientsItem(String recipientsItem) {
-        if (this.recipients == null) {
-            this.recipients = new ArrayList<>();
-        }
-        this.recipients.add(recipientsItem);
-        return this;
-    }
-
-        /**
     **/
     public SAML2ServiceProvider enableAssertionQueryProfile(Boolean enableAssertionQueryProfile) {
 
@@ -602,61 +257,6 @@ public enum SingleLogoutMethodEnum {
     }
     public void setEnableAssertionQueryProfile(Boolean enableAssertionQueryProfile) {
         this.enableAssertionQueryProfile = enableAssertionQueryProfile;
-    }
-
-    /**
-    **/
-    public SAML2ServiceProvider enableSAML2ArtifactBinding(Boolean enableSAML2ArtifactBinding) {
-
-        this.enableSAML2ArtifactBinding = enableSAML2ArtifactBinding;
-        return this;
-    }
-    
-    @ApiModelProperty(value = "")
-    @JsonProperty("enableSAML2ArtifactBinding")
-    @Valid
-    public Boolean getEnableSAML2ArtifactBinding() {
-        return enableSAML2ArtifactBinding;
-    }
-    public void setEnableSAML2ArtifactBinding(Boolean enableSAML2ArtifactBinding) {
-        this.enableSAML2ArtifactBinding = enableSAML2ArtifactBinding;
-    }
-
-    /**
-    **/
-    public SAML2ServiceProvider enableSignatureValidationInArtifactBinding(Boolean enableSignatureValidationInArtifactBinding) {
-
-        this.enableSignatureValidationInArtifactBinding = enableSignatureValidationInArtifactBinding;
-        return this;
-    }
-    
-    @ApiModelProperty(value = "")
-    @JsonProperty("enableSignatureValidationInArtifactBinding")
-    @Valid
-    public Boolean getEnableSignatureValidationInArtifactBinding() {
-        return enableSignatureValidationInArtifactBinding;
-    }
-    public void setEnableSignatureValidationInArtifactBinding(Boolean enableSignatureValidationInArtifactBinding) {
-        this.enableSignatureValidationInArtifactBinding = enableSignatureValidationInArtifactBinding;
-    }
-
-    /**
-    * Default value is the IdP Entity ID value specified in Resident IdP
-    **/
-    public SAML2ServiceProvider idPEntityidAlias(String idPEntityidAlias) {
-
-        this.idPEntityidAlias = idPEntityidAlias;
-        return this;
-    }
-    
-    @ApiModelProperty(value = "Default value is the IdP Entity ID value specified in Resident IdP")
-    @JsonProperty("idPEntityidAlias")
-    @Valid
-    public String getIdPEntityidAlias() {
-        return idPEntityidAlias;
-    }
-    public void setIdPEntityidAlias(String idPEntityidAlias) {
-        this.idPEntityidAlias = idPEntityidAlias;
     }
 
 
@@ -675,36 +275,18 @@ public enum SingleLogoutMethodEnum {
             Objects.equals(this.serviceProviderQualifier, saML2ServiceProvider.serviceProviderQualifier) &&
             Objects.equals(this.assertionConsumerUrls, saML2ServiceProvider.assertionConsumerUrls) &&
             Objects.equals(this.defaultAssertionConsumerUrl, saML2ServiceProvider.defaultAssertionConsumerUrl) &&
-            Objects.equals(this.attributeConsumingServiceIndex, saML2ServiceProvider.attributeConsumingServiceIndex) &&
-            Objects.equals(this.enableRequestSignatureValidation, saML2ServiceProvider.enableRequestSignatureValidation) &&
-            Objects.equals(this.enableAssertionEncryption, saML2ServiceProvider.enableAssertionEncryption) &&
-            Objects.equals(this.assertionEncryptionAlgroithm, saML2ServiceProvider.assertionEncryptionAlgroithm) &&
-            Objects.equals(this.keyEncryptionAlgorithm, saML2ServiceProvider.keyEncryptionAlgorithm) &&
-            Objects.equals(this.nameIdFormat, saML2ServiceProvider.nameIdFormat) &&
-            Objects.equals(this.enableIdpInitiatedSingleSignOn, saML2ServiceProvider.enableIdpInitiatedSingleSignOn) &&
-            Objects.equals(this.enableResponseSigning, saML2ServiceProvider.enableResponseSigning) &&
-            Objects.equals(this.requestValidationCertificateAlias, saML2ServiceProvider.requestValidationCertificateAlias) &&
-            Objects.equals(this.responseSigningAlgorithm, saML2ServiceProvider.responseSigningAlgorithm) &&
-            Objects.equals(this.responseDigestAlgorithm, saML2ServiceProvider.responseDigestAlgorithm) &&
-            Objects.equals(this.enableSingleLogout, saML2ServiceProvider.enableSingleLogout) &&
-            Objects.equals(this.singleLogoutResponseUrl, saML2ServiceProvider.singleLogoutResponseUrl) &&
-            Objects.equals(this.singleLogoutRequestUrl, saML2ServiceProvider.singleLogoutRequestUrl) &&
-            Objects.equals(this.singleLogoutMethod, saML2ServiceProvider.singleLogoutMethod) &&
-            Objects.equals(this.enableIdpInitiatedSingleLogOut, saML2ServiceProvider.enableIdpInitiatedSingleLogOut) &&
-            Objects.equals(this.idpInitiatedLogoutReturnUrls, saML2ServiceProvider.idpInitiatedLogoutReturnUrls) &&
-            Objects.equals(this.enableAttributeProfile, saML2ServiceProvider.enableAttributeProfile) &&
-            Objects.equals(this.includedAttributeInResponseAlways, saML2ServiceProvider.includedAttributeInResponseAlways) &&
-            Objects.equals(this.audiences, saML2ServiceProvider.audiences) &&
-            Objects.equals(this.recipients, saML2ServiceProvider.recipients) &&
-            Objects.equals(this.enableAssertionQueryProfile, saML2ServiceProvider.enableAssertionQueryProfile) &&
-            Objects.equals(this.enableSAML2ArtifactBinding, saML2ServiceProvider.enableSAML2ArtifactBinding) &&
-            Objects.equals(this.enableSignatureValidationInArtifactBinding, saML2ServiceProvider.enableSignatureValidationInArtifactBinding) &&
-            Objects.equals(this.idPEntityidAlias, saML2ServiceProvider.idPEntityidAlias);
+            Objects.equals(this.idpEntityIdAlias, saML2ServiceProvider.idpEntityIdAlias) &&
+            Objects.equals(this.singleSignOnProfile, saML2ServiceProvider.singleSignOnProfile) &&
+            Objects.equals(this.attributeProfile, saML2ServiceProvider.attributeProfile) &&
+            Objects.equals(this.singleLogoutProfile, saML2ServiceProvider.singleLogoutProfile) &&
+            Objects.equals(this.requestValidation, saML2ServiceProvider.requestValidation) &&
+            Objects.equals(this.responseSigning, saML2ServiceProvider.responseSigning) &&
+            Objects.equals(this.enableAssertionQueryProfile, saML2ServiceProvider.enableAssertionQueryProfile);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(issuer, serviceProviderQualifier, assertionConsumerUrls, defaultAssertionConsumerUrl, attributeConsumingServiceIndex, enableRequestSignatureValidation, enableAssertionEncryption, assertionEncryptionAlgroithm, keyEncryptionAlgorithm, nameIdFormat, enableIdpInitiatedSingleSignOn, enableResponseSigning, requestValidationCertificateAlias, responseSigningAlgorithm, responseDigestAlgorithm, enableSingleLogout, singleLogoutResponseUrl, singleLogoutRequestUrl, singleLogoutMethod, enableIdpInitiatedSingleLogOut, idpInitiatedLogoutReturnUrls, enableAttributeProfile, includedAttributeInResponseAlways, audiences, recipients, enableAssertionQueryProfile, enableSAML2ArtifactBinding, enableSignatureValidationInArtifactBinding, idPEntityidAlias);
+        return Objects.hash(issuer, serviceProviderQualifier, assertionConsumerUrls, defaultAssertionConsumerUrl, idpEntityIdAlias, singleSignOnProfile, attributeProfile, singleLogoutProfile, requestValidation, responseSigning, enableAssertionQueryProfile);
     }
 
     @Override
@@ -717,31 +299,13 @@ public enum SingleLogoutMethodEnum {
         sb.append("    serviceProviderQualifier: ").append(toIndentedString(serviceProviderQualifier)).append("\n");
         sb.append("    assertionConsumerUrls: ").append(toIndentedString(assertionConsumerUrls)).append("\n");
         sb.append("    defaultAssertionConsumerUrl: ").append(toIndentedString(defaultAssertionConsumerUrl)).append("\n");
-        sb.append("    attributeConsumingServiceIndex: ").append(toIndentedString(attributeConsumingServiceIndex)).append("\n");
-        sb.append("    enableRequestSignatureValidation: ").append(toIndentedString(enableRequestSignatureValidation)).append("\n");
-        sb.append("    enableAssertionEncryption: ").append(toIndentedString(enableAssertionEncryption)).append("\n");
-        sb.append("    assertionEncryptionAlgroithm: ").append(toIndentedString(assertionEncryptionAlgroithm)).append("\n");
-        sb.append("    keyEncryptionAlgorithm: ").append(toIndentedString(keyEncryptionAlgorithm)).append("\n");
-        sb.append("    nameIdFormat: ").append(toIndentedString(nameIdFormat)).append("\n");
-        sb.append("    enableIdpInitiatedSingleSignOn: ").append(toIndentedString(enableIdpInitiatedSingleSignOn)).append("\n");
-        sb.append("    enableResponseSigning: ").append(toIndentedString(enableResponseSigning)).append("\n");
-        sb.append("    requestValidationCertificateAlias: ").append(toIndentedString(requestValidationCertificateAlias)).append("\n");
-        sb.append("    responseSigningAlgorithm: ").append(toIndentedString(responseSigningAlgorithm)).append("\n");
-        sb.append("    responseDigestAlgorithm: ").append(toIndentedString(responseDigestAlgorithm)).append("\n");
-        sb.append("    enableSingleLogout: ").append(toIndentedString(enableSingleLogout)).append("\n");
-        sb.append("    singleLogoutResponseUrl: ").append(toIndentedString(singleLogoutResponseUrl)).append("\n");
-        sb.append("    singleLogoutRequestUrl: ").append(toIndentedString(singleLogoutRequestUrl)).append("\n");
-        sb.append("    singleLogoutMethod: ").append(toIndentedString(singleLogoutMethod)).append("\n");
-        sb.append("    enableIdpInitiatedSingleLogOut: ").append(toIndentedString(enableIdpInitiatedSingleLogOut)).append("\n");
-        sb.append("    idpInitiatedLogoutReturnUrls: ").append(toIndentedString(idpInitiatedLogoutReturnUrls)).append("\n");
-        sb.append("    enableAttributeProfile: ").append(toIndentedString(enableAttributeProfile)).append("\n");
-        sb.append("    includedAttributeInResponseAlways: ").append(toIndentedString(includedAttributeInResponseAlways)).append("\n");
-        sb.append("    audiences: ").append(toIndentedString(audiences)).append("\n");
-        sb.append("    recipients: ").append(toIndentedString(recipients)).append("\n");
+        sb.append("    idpEntityIdAlias: ").append(toIndentedString(idpEntityIdAlias)).append("\n");
+        sb.append("    singleSignOnProfile: ").append(toIndentedString(singleSignOnProfile)).append("\n");
+        sb.append("    attributeProfile: ").append(toIndentedString(attributeProfile)).append("\n");
+        sb.append("    singleLogoutProfile: ").append(toIndentedString(singleLogoutProfile)).append("\n");
+        sb.append("    requestValidation: ").append(toIndentedString(requestValidation)).append("\n");
+        sb.append("    responseSigning: ").append(toIndentedString(responseSigning)).append("\n");
         sb.append("    enableAssertionQueryProfile: ").append(toIndentedString(enableAssertionQueryProfile)).append("\n");
-        sb.append("    enableSAML2ArtifactBinding: ").append(toIndentedString(enableSAML2ArtifactBinding)).append("\n");
-        sb.append("    enableSignatureValidationInArtifactBinding: ").append(toIndentedString(enableSignatureValidationInArtifactBinding)).append("\n");
-        sb.append("    idPEntityidAlias: ").append(toIndentedString(idPEntityidAlias)).append("\n");
         sb.append("}");
         return sb.toString();
     }

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/application/management/v1/SAMLAssertionConfiguration.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/application/management/v1/SAMLAssertionConfiguration.java
@@ -1,0 +1,203 @@
+/*
+* Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package org.wso2.carbon.identity.api.server.application.management.v1;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import java.util.ArrayList;
+import java.util.List;
+import org.wso2.carbon.identity.api.server.application.management.v1.AssertionEncryptionConfiguration;
+import javax.validation.constraints.*;
+
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+import javax.validation.Valid;
+import javax.xml.bind.annotation.*;
+
+public class SAMLAssertionConfiguration  {
+  
+    private String nameIdFormat = "urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress";
+    private List<String> audiences = null;
+
+    private List<String> recipients = null;
+
+    private String digestAlgorithm = "http://www.w3.org/2000/09/xmldsig#sha1";
+    private AssertionEncryptionConfiguration encryption;
+
+    /**
+    **/
+    public SAMLAssertionConfiguration nameIdFormat(String nameIdFormat) {
+
+        this.nameIdFormat = nameIdFormat;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress", value = "")
+    @JsonProperty("nameIdFormat")
+    @Valid
+    public String getNameIdFormat() {
+        return nameIdFormat;
+    }
+    public void setNameIdFormat(String nameIdFormat) {
+        this.nameIdFormat = nameIdFormat;
+    }
+
+    /**
+    * Additional audience values to be added to the SAML Assertions
+    **/
+    public SAMLAssertionConfiguration audiences(List<String> audiences) {
+
+        this.audiences = audiences;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "[\"https://app.example.com/saml\"]", value = "Additional audience values to be added to the SAML Assertions")
+    @JsonProperty("audiences")
+    @Valid
+    public List<String> getAudiences() {
+        return audiences;
+    }
+    public void setAudiences(List<String> audiences) {
+        this.audiences = audiences;
+    }
+
+    public SAMLAssertionConfiguration addAudiencesItem(String audiencesItem) {
+        if (this.audiences == null) {
+            this.audiences = new ArrayList<>();
+        }
+        this.audiences.add(audiencesItem);
+        return this;
+    }
+
+        /**
+    * Additional recipient values to be added to the SAML Assertions
+    **/
+    public SAMLAssertionConfiguration recipients(List<String> recipients) {
+
+        this.recipients = recipients;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "[\"https://app.example.com/saml\"]", value = "Additional recipient values to be added to the SAML Assertions")
+    @JsonProperty("recipients")
+    @Valid
+    public List<String> getRecipients() {
+        return recipients;
+    }
+    public void setRecipients(List<String> recipients) {
+        this.recipients = recipients;
+    }
+
+    public SAMLAssertionConfiguration addRecipientsItem(String recipientsItem) {
+        if (this.recipients == null) {
+            this.recipients = new ArrayList<>();
+        }
+        this.recipients.add(recipientsItem);
+        return this;
+    }
+
+        /**
+    **/
+    public SAMLAssertionConfiguration digestAlgorithm(String digestAlgorithm) {
+
+        this.digestAlgorithm = digestAlgorithm;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "http://www.w3.org/2000/09/xmldsig#sha1", value = "")
+    @JsonProperty("digestAlgorithm")
+    @Valid
+    public String getDigestAlgorithm() {
+        return digestAlgorithm;
+    }
+    public void setDigestAlgorithm(String digestAlgorithm) {
+        this.digestAlgorithm = digestAlgorithm;
+    }
+
+    /**
+    **/
+    public SAMLAssertionConfiguration encryption(AssertionEncryptionConfiguration encryption) {
+
+        this.encryption = encryption;
+        return this;
+    }
+    
+    @ApiModelProperty(value = "")
+    @JsonProperty("encryption")
+    @Valid
+    public AssertionEncryptionConfiguration getEncryption() {
+        return encryption;
+    }
+    public void setEncryption(AssertionEncryptionConfiguration encryption) {
+        this.encryption = encryption;
+    }
+
+
+
+    @Override
+    public boolean equals(java.lang.Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        SAMLAssertionConfiguration saMLAssertionConfiguration = (SAMLAssertionConfiguration) o;
+        return Objects.equals(this.nameIdFormat, saMLAssertionConfiguration.nameIdFormat) &&
+            Objects.equals(this.audiences, saMLAssertionConfiguration.audiences) &&
+            Objects.equals(this.recipients, saMLAssertionConfiguration.recipients) &&
+            Objects.equals(this.digestAlgorithm, saMLAssertionConfiguration.digestAlgorithm) &&
+            Objects.equals(this.encryption, saMLAssertionConfiguration.encryption);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(nameIdFormat, audiences, recipients, digestAlgorithm, encryption);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class SAMLAssertionConfiguration {\n");
+        
+        sb.append("    nameIdFormat: ").append(toIndentedString(nameIdFormat)).append("\n");
+        sb.append("    audiences: ").append(toIndentedString(audiences)).append("\n");
+        sb.append("    recipients: ").append(toIndentedString(recipients)).append("\n");
+        sb.append("    digestAlgorithm: ").append(toIndentedString(digestAlgorithm)).append("\n");
+        sb.append("    encryption: ").append(toIndentedString(encryption)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+    * Convert the given object to string with each line indented by 4 spaces
+    * (except the first line).
+    */
+    private String toIndentedString(java.lang.Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}
+

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/application/management/v1/SAMLAttributeProfile.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/application/management/v1/SAMLAttributeProfile.java
@@ -1,0 +1,117 @@
+/*
+* Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package org.wso2.carbon.identity.api.server.application.management.v1;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import javax.validation.constraints.*;
+
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+import javax.validation.Valid;
+import javax.xml.bind.annotation.*;
+
+public class SAMLAttributeProfile  {
+  
+    private Boolean enabled = false;
+    private Boolean alwaysIncludeAttributesInResponse = false;
+
+    /**
+    **/
+    public SAMLAttributeProfile enabled(Boolean enabled) {
+
+        this.enabled = enabled;
+        return this;
+    }
+    
+    @ApiModelProperty(value = "")
+    @JsonProperty("enabled")
+    @Valid
+    public Boolean getEnabled() {
+        return enabled;
+    }
+    public void setEnabled(Boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    /**
+    **/
+    public SAMLAttributeProfile alwaysIncludeAttributesInResponse(Boolean alwaysIncludeAttributesInResponse) {
+
+        this.alwaysIncludeAttributesInResponse = alwaysIncludeAttributesInResponse;
+        return this;
+    }
+    
+    @ApiModelProperty(value = "")
+    @JsonProperty("alwaysIncludeAttributesInResponse")
+    @Valid
+    public Boolean getAlwaysIncludeAttributesInResponse() {
+        return alwaysIncludeAttributesInResponse;
+    }
+    public void setAlwaysIncludeAttributesInResponse(Boolean alwaysIncludeAttributesInResponse) {
+        this.alwaysIncludeAttributesInResponse = alwaysIncludeAttributesInResponse;
+    }
+
+
+
+    @Override
+    public boolean equals(java.lang.Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        SAMLAttributeProfile saMLAttributeProfile = (SAMLAttributeProfile) o;
+        return Objects.equals(this.enabled, saMLAttributeProfile.enabled) &&
+            Objects.equals(this.alwaysIncludeAttributesInResponse, saMLAttributeProfile.alwaysIncludeAttributesInResponse);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(enabled, alwaysIncludeAttributesInResponse);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class SAMLAttributeProfile {\n");
+        
+        sb.append("    enabled: ").append(toIndentedString(enabled)).append("\n");
+        sb.append("    alwaysIncludeAttributesInResponse: ").append(toIndentedString(alwaysIncludeAttributesInResponse)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+    * Convert the given object to string with each line indented by 4 spaces
+    * (except the first line).
+    */
+    private String toIndentedString(java.lang.Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}
+

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/application/management/v1/SAMLRequestValidation.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/application/management/v1/SAMLRequestValidation.java
@@ -1,0 +1,117 @@
+/*
+* Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package org.wso2.carbon.identity.api.server.application.management.v1;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import javax.validation.constraints.*;
+
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+import javax.validation.Valid;
+import javax.xml.bind.annotation.*;
+
+public class SAMLRequestValidation  {
+  
+    private Boolean enableSignatureValidation = true;
+    private String signatureValidationCertAlias;
+
+    /**
+    **/
+    public SAMLRequestValidation enableSignatureValidation(Boolean enableSignatureValidation) {
+
+        this.enableSignatureValidation = enableSignatureValidation;
+        return this;
+    }
+    
+    @ApiModelProperty(value = "")
+    @JsonProperty("enableSignatureValidation")
+    @Valid
+    public Boolean getEnableSignatureValidation() {
+        return enableSignatureValidation;
+    }
+    public void setEnableSignatureValidation(Boolean enableSignatureValidation) {
+        this.enableSignatureValidation = enableSignatureValidation;
+    }
+
+    /**
+    **/
+    public SAMLRequestValidation signatureValidationCertAlias(String signatureValidationCertAlias) {
+
+        this.signatureValidationCertAlias = signatureValidationCertAlias;
+        return this;
+    }
+    
+    @ApiModelProperty(value = "")
+    @JsonProperty("signatureValidationCertAlias")
+    @Valid
+    public String getSignatureValidationCertAlias() {
+        return signatureValidationCertAlias;
+    }
+    public void setSignatureValidationCertAlias(String signatureValidationCertAlias) {
+        this.signatureValidationCertAlias = signatureValidationCertAlias;
+    }
+
+
+
+    @Override
+    public boolean equals(java.lang.Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        SAMLRequestValidation saMLRequestValidation = (SAMLRequestValidation) o;
+        return Objects.equals(this.enableSignatureValidation, saMLRequestValidation.enableSignatureValidation) &&
+            Objects.equals(this.signatureValidationCertAlias, saMLRequestValidation.signatureValidationCertAlias);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(enableSignatureValidation, signatureValidationCertAlias);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class SAMLRequestValidation {\n");
+        
+        sb.append("    enableSignatureValidation: ").append(toIndentedString(enableSignatureValidation)).append("\n");
+        sb.append("    signatureValidationCertAlias: ").append(toIndentedString(signatureValidationCertAlias)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+    * Convert the given object to string with each line indented by 4 spaces
+    * (except the first line).
+    */
+    private String toIndentedString(java.lang.Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}
+

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/application/management/v1/SAMLResponseSigning.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/application/management/v1/SAMLResponseSigning.java
@@ -1,0 +1,117 @@
+/*
+* Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package org.wso2.carbon.identity.api.server.application.management.v1;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import javax.validation.constraints.*;
+
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+import javax.validation.Valid;
+import javax.xml.bind.annotation.*;
+
+public class SAMLResponseSigning  {
+  
+    private Boolean enabled = true;
+    private String signingAlgorithm;
+
+    /**
+    **/
+    public SAMLResponseSigning enabled(Boolean enabled) {
+
+        this.enabled = enabled;
+        return this;
+    }
+    
+    @ApiModelProperty(value = "")
+    @JsonProperty("enabled")
+    @Valid
+    public Boolean getEnabled() {
+        return enabled;
+    }
+    public void setEnabled(Boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    /**
+    **/
+    public SAMLResponseSigning signingAlgorithm(String signingAlgorithm) {
+
+        this.signingAlgorithm = signingAlgorithm;
+        return this;
+    }
+    
+    @ApiModelProperty(value = "")
+    @JsonProperty("signingAlgorithm")
+    @Valid
+    public String getSigningAlgorithm() {
+        return signingAlgorithm;
+    }
+    public void setSigningAlgorithm(String signingAlgorithm) {
+        this.signingAlgorithm = signingAlgorithm;
+    }
+
+
+
+    @Override
+    public boolean equals(java.lang.Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        SAMLResponseSigning saMLResponseSigning = (SAMLResponseSigning) o;
+        return Objects.equals(this.enabled, saMLResponseSigning.enabled) &&
+            Objects.equals(this.signingAlgorithm, saMLResponseSigning.signingAlgorithm);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(enabled, signingAlgorithm);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class SAMLResponseSigning {\n");
+        
+        sb.append("    enabled: ").append(toIndentedString(enabled)).append("\n");
+        sb.append("    signingAlgorithm: ").append(toIndentedString(signingAlgorithm)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+    * Convert the given object to string with each line indented by 4 spaces
+    * (except the first line).
+    */
+    private String toIndentedString(java.lang.Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}
+

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/application/management/v1/SingleLogoutProfile.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/application/management/v1/SingleLogoutProfile.java
@@ -1,0 +1,216 @@
+/*
+* Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package org.wso2.carbon.identity.api.server.application.management.v1;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import org.wso2.carbon.identity.api.server.application.management.v1.IdpInitiatedSingleLogout;
+import javax.validation.constraints.*;
+
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+import javax.validation.Valid;
+import javax.xml.bind.annotation.*;
+
+public class SingleLogoutProfile  {
+  
+    private Boolean enabled = true;
+    private String logoutRequestUrl;
+    private String logoutResponseUrl;
+
+@XmlType(name="LogoutMethodEnum")
+@XmlEnum(String.class)
+public enum LogoutMethodEnum {
+
+    @XmlEnumValue("BACKCHANNEL") BACKCHANNEL(String.valueOf("BACKCHANNEL")), @XmlEnumValue("FRONTCHANNEL_HTTP_REDIRECT") FRONTCHANNEL_HTTP_REDIRECT(String.valueOf("FRONTCHANNEL_HTTP_REDIRECT")), @XmlEnumValue("FRONTCHANNEL_HTTP_POST") FRONTCHANNEL_HTTP_POST(String.valueOf("FRONTCHANNEL_HTTP_POST"));
+
+
+    private String value;
+
+    LogoutMethodEnum(String v) {
+        value = v;
+    }
+
+    public String value() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    public static LogoutMethodEnum fromValue(String value) {
+        for (LogoutMethodEnum b : LogoutMethodEnum.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
+}
+
+    private LogoutMethodEnum logoutMethod;
+    private IdpInitiatedSingleLogout idpInitiatedSingleLogout;
+
+    /**
+    **/
+    public SingleLogoutProfile enabled(Boolean enabled) {
+
+        this.enabled = enabled;
+        return this;
+    }
+    
+    @ApiModelProperty(value = "")
+    @JsonProperty("enabled")
+    @Valid
+    public Boolean getEnabled() {
+        return enabled;
+    }
+    public void setEnabled(Boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    /**
+    * Single logout request accepting endpoint
+    **/
+    public SingleLogoutProfile logoutRequestUrl(String logoutRequestUrl) {
+
+        this.logoutRequestUrl = logoutRequestUrl;
+        return this;
+    }
+    
+    @ApiModelProperty(value = "Single logout request accepting endpoint")
+    @JsonProperty("logoutRequestUrl")
+    @Valid
+    public String getLogoutRequestUrl() {
+        return logoutRequestUrl;
+    }
+    public void setLogoutRequestUrl(String logoutRequestUrl) {
+        this.logoutRequestUrl = logoutRequestUrl;
+    }
+
+    /**
+    * Single logout response accepting endpoint
+    **/
+    public SingleLogoutProfile logoutResponseUrl(String logoutResponseUrl) {
+
+        this.logoutResponseUrl = logoutResponseUrl;
+        return this;
+    }
+    
+    @ApiModelProperty(value = "Single logout response accepting endpoint")
+    @JsonProperty("logoutResponseUrl")
+    @Valid
+    public String getLogoutResponseUrl() {
+        return logoutResponseUrl;
+    }
+    public void setLogoutResponseUrl(String logoutResponseUrl) {
+        this.logoutResponseUrl = logoutResponseUrl;
+    }
+
+    /**
+    **/
+    public SingleLogoutProfile logoutMethod(LogoutMethodEnum logoutMethod) {
+
+        this.logoutMethod = logoutMethod;
+        return this;
+    }
+    
+    @ApiModelProperty(value = "")
+    @JsonProperty("logoutMethod")
+    @Valid
+    public LogoutMethodEnum getLogoutMethod() {
+        return logoutMethod;
+    }
+    public void setLogoutMethod(LogoutMethodEnum logoutMethod) {
+        this.logoutMethod = logoutMethod;
+    }
+
+    /**
+    **/
+    public SingleLogoutProfile idpInitiatedSingleLogout(IdpInitiatedSingleLogout idpInitiatedSingleLogout) {
+
+        this.idpInitiatedSingleLogout = idpInitiatedSingleLogout;
+        return this;
+    }
+    
+    @ApiModelProperty(value = "")
+    @JsonProperty("idpInitiatedSingleLogout")
+    @Valid
+    public IdpInitiatedSingleLogout getIdpInitiatedSingleLogout() {
+        return idpInitiatedSingleLogout;
+    }
+    public void setIdpInitiatedSingleLogout(IdpInitiatedSingleLogout idpInitiatedSingleLogout) {
+        this.idpInitiatedSingleLogout = idpInitiatedSingleLogout;
+    }
+
+
+
+    @Override
+    public boolean equals(java.lang.Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        SingleLogoutProfile singleLogoutProfile = (SingleLogoutProfile) o;
+        return Objects.equals(this.enabled, singleLogoutProfile.enabled) &&
+            Objects.equals(this.logoutRequestUrl, singleLogoutProfile.logoutRequestUrl) &&
+            Objects.equals(this.logoutResponseUrl, singleLogoutProfile.logoutResponseUrl) &&
+            Objects.equals(this.logoutMethod, singleLogoutProfile.logoutMethod) &&
+            Objects.equals(this.idpInitiatedSingleLogout, singleLogoutProfile.idpInitiatedSingleLogout);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(enabled, logoutRequestUrl, logoutResponseUrl, logoutMethod, idpInitiatedSingleLogout);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class SingleLogoutProfile {\n");
+        
+        sb.append("    enabled: ").append(toIndentedString(enabled)).append("\n");
+        sb.append("    logoutRequestUrl: ").append(toIndentedString(logoutRequestUrl)).append("\n");
+        sb.append("    logoutResponseUrl: ").append(toIndentedString(logoutResponseUrl)).append("\n");
+        sb.append("    logoutMethod: ").append(toIndentedString(logoutMethod)).append("\n");
+        sb.append("    idpInitiatedSingleLogout: ").append(toIndentedString(idpInitiatedSingleLogout)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+    * Convert the given object to string with each line indented by 4 spaces
+    * (except the first line).
+    */
+    private String toIndentedString(java.lang.Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}
+

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/application/management/v1/SingleSignOnProfile.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/application/management/v1/SingleSignOnProfile.java
@@ -1,0 +1,226 @@
+/*
+* Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package org.wso2.carbon.identity.api.server.application.management.v1;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import java.util.ArrayList;
+import java.util.List;
+import org.wso2.carbon.identity.api.server.application.management.v1.SAMLAssertionConfiguration;
+import javax.validation.constraints.*;
+
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+import javax.validation.Valid;
+import javax.xml.bind.annotation.*;
+
+public class SingleSignOnProfile  {
+  
+
+@XmlType(name="BindingsEnum")
+@XmlEnum(String.class)
+public enum BindingsEnum {
+
+    @XmlEnumValue("HTTP_POST") HTTP_POST(String.valueOf("HTTP_POST")), @XmlEnumValue("HTTP_REDIRECT") HTTP_REDIRECT(String.valueOf("HTTP_REDIRECT")), @XmlEnumValue("ARTIFACT") ARTIFACT(String.valueOf("ARTIFACT"));
+
+
+    private String value;
+
+    BindingsEnum(String v) {
+        value = v;
+    }
+
+    public String value() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    public static BindingsEnum fromValue(String value) {
+        for (BindingsEnum b : BindingsEnum.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
+}
+
+    private List<BindingsEnum> bindings = null;
+
+    private Boolean enableSignatureValidationForArtifactBinding = false;
+    private String attributeConsumingServiceIndex;
+    private Boolean enableIdpInitiatedSingleSignOn = false;
+    private SAMLAssertionConfiguration assertion;
+
+    /**
+    **/
+    public SingleSignOnProfile bindings(List<BindingsEnum> bindings) {
+
+        this.bindings = bindings;
+        return this;
+    }
+    
+    @ApiModelProperty(value = "")
+    @JsonProperty("bindings")
+    @Valid
+    public List<BindingsEnum> getBindings() {
+        return bindings;
+    }
+    public void setBindings(List<BindingsEnum> bindings) {
+        this.bindings = bindings;
+    }
+
+    public SingleSignOnProfile addBindingsItem(BindingsEnum bindingsItem) {
+        if (this.bindings == null) {
+            this.bindings = new ArrayList<>();
+        }
+        this.bindings.add(bindingsItem);
+        return this;
+    }
+
+        /**
+    * Enables Signature validation for SAML Artifact Binding. Applicable only if SAML Artifact binding is enabled through the bindings option.
+    **/
+    public SingleSignOnProfile enableSignatureValidationForArtifactBinding(Boolean enableSignatureValidationForArtifactBinding) {
+
+        this.enableSignatureValidationForArtifactBinding = enableSignatureValidationForArtifactBinding;
+        return this;
+    }
+    
+    @ApiModelProperty(value = "Enables Signature validation for SAML Artifact Binding. Applicable only if SAML Artifact binding is enabled through the bindings option.")
+    @JsonProperty("enableSignatureValidationForArtifactBinding")
+    @Valid
+    public Boolean getEnableSignatureValidationForArtifactBinding() {
+        return enableSignatureValidationForArtifactBinding;
+    }
+    public void setEnableSignatureValidationForArtifactBinding(Boolean enableSignatureValidationForArtifactBinding) {
+        this.enableSignatureValidationForArtifactBinding = enableSignatureValidationForArtifactBinding;
+    }
+
+    /**
+    **/
+    public SingleSignOnProfile attributeConsumingServiceIndex(String attributeConsumingServiceIndex) {
+
+        this.attributeConsumingServiceIndex = attributeConsumingServiceIndex;
+        return this;
+    }
+    
+    @ApiModelProperty(value = "")
+    @JsonProperty("attributeConsumingServiceIndex")
+    @Valid
+    public String getAttributeConsumingServiceIndex() {
+        return attributeConsumingServiceIndex;
+    }
+    public void setAttributeConsumingServiceIndex(String attributeConsumingServiceIndex) {
+        this.attributeConsumingServiceIndex = attributeConsumingServiceIndex;
+    }
+
+    /**
+    **/
+    public SingleSignOnProfile enableIdpInitiatedSingleSignOn(Boolean enableIdpInitiatedSingleSignOn) {
+
+        this.enableIdpInitiatedSingleSignOn = enableIdpInitiatedSingleSignOn;
+        return this;
+    }
+    
+    @ApiModelProperty(value = "")
+    @JsonProperty("enableIdpInitiatedSingleSignOn")
+    @Valid
+    public Boolean getEnableIdpInitiatedSingleSignOn() {
+        return enableIdpInitiatedSingleSignOn;
+    }
+    public void setEnableIdpInitiatedSingleSignOn(Boolean enableIdpInitiatedSingleSignOn) {
+        this.enableIdpInitiatedSingleSignOn = enableIdpInitiatedSingleSignOn;
+    }
+
+    /**
+    **/
+    public SingleSignOnProfile assertion(SAMLAssertionConfiguration assertion) {
+
+        this.assertion = assertion;
+        return this;
+    }
+    
+    @ApiModelProperty(value = "")
+    @JsonProperty("assertion")
+    @Valid
+    public SAMLAssertionConfiguration getAssertion() {
+        return assertion;
+    }
+    public void setAssertion(SAMLAssertionConfiguration assertion) {
+        this.assertion = assertion;
+    }
+
+
+
+    @Override
+    public boolean equals(java.lang.Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        SingleSignOnProfile singleSignOnProfile = (SingleSignOnProfile) o;
+        return Objects.equals(this.bindings, singleSignOnProfile.bindings) &&
+            Objects.equals(this.enableSignatureValidationForArtifactBinding, singleSignOnProfile.enableSignatureValidationForArtifactBinding) &&
+            Objects.equals(this.attributeConsumingServiceIndex, singleSignOnProfile.attributeConsumingServiceIndex) &&
+            Objects.equals(this.enableIdpInitiatedSingleSignOn, singleSignOnProfile.enableIdpInitiatedSingleSignOn) &&
+            Objects.equals(this.assertion, singleSignOnProfile.assertion);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(bindings, enableSignatureValidationForArtifactBinding, attributeConsumingServiceIndex, enableIdpInitiatedSingleSignOn, assertion);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class SingleSignOnProfile {\n");
+        
+        sb.append("    bindings: ").append(toIndentedString(bindings)).append("\n");
+        sb.append("    enableSignatureValidationForArtifactBinding: ").append(toIndentedString(enableSignatureValidationForArtifactBinding)).append("\n");
+        sb.append("    attributeConsumingServiceIndex: ").append(toIndentedString(attributeConsumingServiceIndex)).append("\n");
+        sb.append("    enableIdpInitiatedSingleSignOn: ").append(toIndentedString(enableIdpInitiatedSingleSignOn)).append("\n");
+        sb.append("    assertion: ").append(toIndentedString(assertion)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+    * Convert the given object to string with each line indented by 4 spaces
+    * (except the first line).
+    */
+    private String toIndentedString(java.lang.Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}
+

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/functions/application/inbound/PassiveSTSInboundFunctions.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/functions/application/inbound/PassiveSTSInboundFunctions.java
@@ -24,6 +24,7 @@ import org.wso2.carbon.identity.application.common.model.ServiceProvider;
 import org.wso2.carbon.identity.application.common.util.IdentityApplicationConstants;
 
 import static org.wso2.carbon.identity.api.server.application.management.v1.core.functions.Utils.arrayToStream;
+import static org.wso2.carbon.identity.api.server.application.management.v1.core.functions.Utils.buildBadRequestError;
 import static org.wso2.carbon.identity.application.common.util.IdentityApplicationConstants.PassiveSTS.PASSIVE_STS_REPLY_URL;
 
 /**
@@ -38,7 +39,18 @@ public class PassiveSTSInboundFunctions {
     public static InboundAuthenticationRequestConfig putPassiveSTSInbound(ServiceProvider application,
                                                                           PassiveStsConfiguration passiveSTSConfig) {
 
+        String currentRealm = InboundFunctions.getInboundAuthKey(application, StandardInboundProtocols.PASSIVE_STS);
+        if (currentRealm != null && isRealmValueChanged(passiveSTSConfig, currentRealm)) {
+            // We do not allow the inbound unique key to be changed during an update.
+            throw buildBadRequestError("Invalid realm value provided for update.");
+        }
+
         return createPassiveSTSInboundConfig(passiveSTSConfig);
+    }
+
+    private static boolean isRealmValueChanged(PassiveStsConfiguration passiveSTSConfig, String currentRealm) {
+
+        return !StringUtils.equals(currentRealm, passiveSTSConfig.getRealm());
     }
 
     public static InboundAuthenticationRequestConfig createPassiveSTSInboundConfig(PassiveStsConfiguration config) {

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/functions/application/inbound/saml/ApiModelToSAMLSSOServiceProvider.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/functions/application/inbound/saml/ApiModelToSAMLSSOServiceProvider.java
@@ -15,10 +15,25 @@
  */
 package org.wso2.carbon.identity.api.server.application.management.v1.core.functions.application.inbound.saml;
 
+import org.apache.commons.collections.CollectionUtils;
+import org.wso2.carbon.identity.api.server.application.management.v1.AssertionEncryptionConfiguration;
+import org.wso2.carbon.identity.api.server.application.management.v1.IdpInitiatedSingleLogout;
 import org.wso2.carbon.identity.api.server.application.management.v1.SAML2ServiceProvider;
+import org.wso2.carbon.identity.api.server.application.management.v1.SAMLAssertionConfiguration;
+import org.wso2.carbon.identity.api.server.application.management.v1.SAMLAttributeProfile;
+import org.wso2.carbon.identity.api.server.application.management.v1.SAMLRequestValidation;
+import org.wso2.carbon.identity.api.server.application.management.v1.SAMLResponseSigning;
+import org.wso2.carbon.identity.api.server.application.management.v1.SingleLogoutProfile;
+import org.wso2.carbon.identity.api.server.application.management.v1.SingleSignOnProfile;
+import org.wso2.carbon.identity.sso.saml.common.SAMLSSOProviderConstants;
 import org.wso2.carbon.identity.sso.saml.dto.SAMLSSOServiceProviderDTO;
 
+import java.util.List;
 import java.util.function.Function;
+
+import static org.apache.commons.collections.CollectionUtils.isEmpty;
+import static org.wso2.carbon.identity.api.server.application.management.v1.core.functions.Utils.buildBadRequestError;
+import static org.wso2.carbon.identity.api.server.application.management.v1.core.functions.Utils.setIfNotNull;
 
 /**
  * Converts api model
@@ -26,48 +41,129 @@ import java.util.function.Function;
 public class ApiModelToSAMLSSOServiceProvider implements Function<SAML2ServiceProvider, SAMLSSOServiceProviderDTO> {
 
     @Override
-    public SAMLSSOServiceProviderDTO apply(SAML2ServiceProvider sp) {
+    public SAMLSSOServiceProviderDTO apply(SAML2ServiceProvider samlModel) {
 
-        SAMLSSOServiceProviderDTO serviceProviderDTO = new SAMLSSOServiceProviderDTO();
-        serviceProviderDTO.setIssuer(sp.getIssuer());
-        serviceProviderDTO.setIssuerQualifier(sp.getServiceProviderQualifier());
-        serviceProviderDTO.setAssertionConsumerUrls(getAssertionConsumerUrls(sp));
-        serviceProviderDTO.setDefaultAssertionConsumerUrl(getDefaultAssertionConsumerUrl(sp));
+        SAMLSSOServiceProviderDTO dto = new SAMLSSOServiceProviderDTO();
+        dto.setIssuer(samlModel.getIssuer());
+        dto.setIssuerQualifier(samlModel.getServiceProviderQualifier());
+        dto.setAssertionConsumerUrls(getAssertionConsumerUrls(samlModel));
+        dto.setDefaultAssertionConsumerUrl(getDefaultAssertionConsumerUrl(samlModel));
+        dto.setIdpEntityIDAlias(samlModel.getIdpEntityIdAlias());
 
-        serviceProviderDTO.setDoValidateSignatureInRequests(sp.getEnableRequestSignatureValidation());
-        serviceProviderDTO.setDoEnableEncryptedAssertion(sp.getEnableAssertionEncryption());
-        serviceProviderDTO.setAssertionEncryptionAlgorithmURI(sp.getAssertionEncryptionAlgroithm());
-        serviceProviderDTO.setKeyEncryptionAlgorithmURI(sp.getKeyEncryptionAlgorithm());
+        updateSingleSignOnProfile(dto, samlModel.getSingleSignOnProfile());
+        updateAttributeProfile(dto, samlModel.getAttributeProfile());
+        updateSingleLogoutProfile(dto, samlModel.getSingleLogoutProfile());
+        updateRequestSignatureValidationConfig(dto, samlModel.getRequestValidation());
+        updateResponseSigningConfig(dto, samlModel.getResponseSigning());
 
-        serviceProviderDTO.setNameIDFormat(sp.getNameIdFormat());
-        serviceProviderDTO.setIdPInitSSOEnabled(sp.getEnableIdpInitiatedSingleSignOn());
+        setIfNotNull(samlModel.getEnableAssertionQueryProfile(), dto::setAssertionQueryRequestProfileEnabled);
+        dto.setAssertionQueryRequestProfileEnabled(samlModel.getEnableAssertionQueryProfile());
 
-        serviceProviderDTO.setDoSignResponse(sp.getEnableResponseSigning());
-        serviceProviderDTO.setCertAlias(sp.getRequestValidationCertificateAlias());
+        return dto;
+    }
 
-        serviceProviderDTO.setSigningAlgorithmURI(sp.getResponseSigningAlgorithm());
-        serviceProviderDTO.setDigestAlgorithmURI(sp.getResponseDigestAlgorithm());
+    private void updateResponseSigningConfig(SAMLSSOServiceProviderDTO dto,
+                                             SAMLResponseSigning responseSigning) {
 
-        serviceProviderDTO.setDoSingleLogout(sp.getEnableSingleLogout());
-        serviceProviderDTO.setSloResponseURL(sp.getSingleLogoutRequestUrl());
-        serviceProviderDTO.setSloRequestURL(sp.getSingleLogoutRequestUrl());
+        if (responseSigning != null) {
+            setIfNotNull(responseSigning.getEnabled(), dto::setDoSignResponse);
+            dto.setSigningAlgorithmURI(dto.getSigningAlgorithmURI());
+        }
+    }
 
-        serviceProviderDTO.setDoFrontChannelLogout(isFrontChannelLogoutEnabled(sp));
+    private void updateRequestSignatureValidationConfig(SAMLSSOServiceProviderDTO dto,
+                                                        SAMLRequestValidation requestValidation) {
 
-        // TODO fill the rest.
+        if (requestValidation != null) {
+            setIfNotNull(requestValidation.getEnableSignatureValidation(), dto::setDoValidateSignatureInRequests);
+            dto.setCertAlias(requestValidation.getSignatureValidationCertAlias());
+        }
+    }
 
-        return serviceProviderDTO;
+    private void updateSingleLogoutProfile(SAMLSSOServiceProviderDTO dto, SingleLogoutProfile sloProfile) {
+
+        if (sloProfile != null) {
+            setIfNotNull(sloProfile.getEnabled(), dto::setDoSingleLogout);
+            dto.setSloRequestURL(sloProfile.getLogoutRequestUrl());
+            dto.setSloResponseURL(sloProfile.getLogoutResponseUrl());
+
+            updateLogoutMechanism(dto, sloProfile);
+
+            IdpInitiatedSingleLogout idpInitiatedSingleLogout = sloProfile.getIdpInitiatedSingleLogout();
+            if (idpInitiatedSingleLogout != null) {
+                setIfNotNull(idpInitiatedSingleLogout.getEnabled(), dto::setIdPInitSLOEnabled);
+                dto.setIdpInitSLOReturnToURLs(toArray(idpInitiatedSingleLogout.getReturnToUrls()));
+            }
+        }
+    }
+
+    private void updateLogoutMechanism(SAMLSSOServiceProviderDTO dto, SingleLogoutProfile sloProfile) {
+
+        SingleLogoutProfile.LogoutMethodEnum logoutMethod = sloProfile.getLogoutMethod();
+
+        if (isFrontChannelLogoutEnabled(logoutMethod)) {
+            dto.setDoFrontChannelLogout(true);
+
+            if (logoutMethod == SingleLogoutProfile.LogoutMethodEnum.FRONTCHANNEL_HTTP_POST) {
+                dto.setFrontChannelLogoutBinding(SAMLSSOProviderConstants.HTTP_POST_BINDING);
+            }
+
+            if (logoutMethod == SingleLogoutProfile.LogoutMethodEnum.FRONTCHANNEL_HTTP_REDIRECT) {
+                dto.setFrontChannelLogoutBinding(SAMLSSOProviderConstants.HTTP_REDIRECT_BINDING);
+            }
+        }
+    }
+
+    private void updateAttributeProfile(SAMLSSOServiceProviderDTO dto, SAMLAttributeProfile attributeProfile) {
+
+        if (attributeProfile != null) {
+            setIfNotNull(attributeProfile.getEnabled(), dto::setEnableAttributeProfile);
+            setIfNotNull(attributeProfile.getAlwaysIncludeAttributesInResponse(), dto::setEnableAttributesByDefault);
+        }
+    }
+
+    private void updateSingleSignOnProfile(SAMLSSOServiceProviderDTO dto, SingleSignOnProfile ssoConfig) {
+
+        if (ssoConfig != null) {
+
+            List<SingleSignOnProfile.BindingsEnum> bindings = ssoConfig.getBindings();
+            // HTTP_POST and HTTP_REDIRECT bindings are not considered at the backend. They are always available by
+            // default, therefore we only need to process the artifact binding.
+            if (CollectionUtils.isNotEmpty(bindings) && bindings.contains(SingleSignOnProfile.BindingsEnum.ARTIFACT)) {
+                dto.setEnableSAML2ArtifactBinding(true);
+            }
+
+            dto.setDoValidateSignatureInArtifactResolve(ssoConfig.getEnableSignatureValidationForArtifactBinding());
+            dto.setIdPInitSSOEnabled(ssoConfig.getEnableIdpInitiatedSingleSignOn());
+
+            SAMLAssertionConfiguration assertionConfig = ssoConfig.getAssertion();
+            if (assertionConfig != null) {
+                dto.setNameIDFormat(assertionConfig.getNameIdFormat());
+                dto.setRequestedAudiences(toArray(assertionConfig.getAudiences()));
+                dto.setRequestedRecipients(toArray(assertionConfig.getRecipients()));
+                dto.setDigestAlgorithmURI(assertionConfig.getDigestAlgorithm());
+
+                AssertionEncryptionConfiguration encryption = assertionConfig.getEncryption();
+                if (encryption != null) {
+                    setIfNotNull(encryption.getEnabled(), dto::setDoEnableEncryptedAssertion);
+                    dto.setAssertionEncryptionAlgorithmURI(encryption.getAssertionEncryptionAlgorithm());
+                    dto.setKeyEncryptionAlgorithmURI(encryption.getKeyEncryptionAlgorithm());
+                }
+            }
+        }
     }
 
     private String[] getAssertionConsumerUrls(SAML2ServiceProvider sp) {
 
-        return sp.getAssertionConsumerUrls().toArray(new String[0]);
+        if (isEmpty(sp.getAssertionConsumerUrls())) {
+            throw buildBadRequestError("At least one assertion consumer URL is required for a SAML Application.");
+        }
+        return toArray(sp.getAssertionConsumerUrls());
     }
 
-    private boolean isFrontChannelLogoutEnabled(SAML2ServiceProvider sp) {
+    private boolean isFrontChannelLogoutEnabled(SingleLogoutProfile.LogoutMethodEnum logoutMethod) {
 
-        return sp.getSingleLogoutMethod() != null &&
-                sp.getSingleLogoutMethod() != SAML2ServiceProvider.SingleLogoutMethodEnum.BACKCHANNEL;
+        return logoutMethod != null && logoutMethod != SingleLogoutProfile.LogoutMethodEnum.BACKCHANNEL;
     }
 
     private String getDefaultAssertionConsumerUrl(SAML2ServiceProvider spModel) {
@@ -76,6 +172,15 @@ public class ApiModelToSAMLSSOServiceProvider implements Function<SAML2ServicePr
             return spModel.getDefaultAssertionConsumerUrl();
         } else {
             return spModel.getAssertionConsumerUrls().get(0);
+        }
+    }
+
+    private String[] toArray(List<String> list) {
+
+        if (isEmpty(list)) {
+            return new String[0];
+        } else {
+            return list.toArray(new String[0]);
         }
     }
 }

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/resources/applications.yaml
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/resources/applications.yaml
@@ -672,7 +672,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/SAML2ServiceProvider'
+                $ref: '#/components/schemas/SAMLRequestValidation'
         '400':
           description: Bad Request
           content:
@@ -2440,95 +2440,90 @@ components:
         metadataFile:
           type: string
           example: 'Base64 encoded metadata file content'
-          writeOnly: true
         metadataURL:
           type: string
           example: 'https://example.com/samlsso/meta'
-          writeOnly: true
         manualConfiguration:
           $ref: '#/components/schemas/SAML2ServiceProvider'
 
-    SAML2ServiceProvider:
+    SingleSignOnProfile:
       type: object
-      required:
-        - issuer
-        - assertionConsumerUrls
       properties:
-        issuer:
-          type: string
-        serviceProviderQualifier:
-          type: string
-        assertionConsumerUrls:
+        bindings:
           type: array
           items:
             type: string
-          minItems: 1
-        defaultAssertionConsumerUrl:
-          type: string
+            enum:
+              - HTTP_POST
+              - HTTP_REDIRECT
+              - ARTIFACT
+          default: [ "HTTP_POST", "HTTP_REDIRECT"]
+
+        enableSignatureValidationForArtifactBinding:
+          type: boolean
+          description: Enables Signature validation for SAML Artifact Binding. Applicable only if SAML Artifact binding is enabled through the bindings option.
+          default: false
+
         attributeConsumingServiceIndex:
           type: string
           readOnly: true
 
-        enableRequestSignatureValidation:
-          type: boolean
-          default: true
-
-        enableAssertionEncryption:
-          type: boolean
-          default: false
-        assertionEncryptionAlgroithm:
-          type: string
-        keyEncryptionAlgorithm:
-          type: string
-        nameIdFormat:
-          type: string
-          default: 'urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress'
-          example: 'urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress'
         enableIdpInitiatedSingleSignOn:
           type: boolean
           default: false
 
-        enableResponseSigning:
+        assertion:
+          $ref: '#/components/schemas/SAMLAssertionConfiguration'
+
+    SAMLAttributeProfile:
+      type: object
+      properties:
+        enabled:
+          type: boolean
+          default: false
+        alwaysIncludeAttributesInResponse:
+          type: boolean
+          default: false
+
+    SingleLogoutProfile:
+      type: object
+      properties:
+        enabled:
           type: boolean
           default: true
-
-        requestValidationCertificateAlias:
-          type: string
-        responseSigningAlgorithm:
-          type: string
-        responseDigestAlgorithm:
-          type: string
-
-
-        enableSingleLogout:
-          type: boolean
-          default: true
-        singleLogoutResponseUrl:
-          type: string
-          description: Single logout response accepting endpoint
-        singleLogoutRequestUrl:
+        logoutRequestUrl:
           type: string
           description: Single logout request accepting endpoint
-        singleLogoutMethod:
+        logoutResponseUrl:
+          type: string
+          description: Single logout response accepting endpoint
+        logoutMethod:
           type: string
           enum:
             - BACKCHANNEL
             - FRONTCHANNEL_HTTP_REDIRECT
             - FRONTCHANNEL_HTTP_POST
-        enableIdpInitiatedSingleLogOut:
+        idpInitiatedSingleLogout:
+          $ref: '#/components/schemas/IdpInitiatedSingleLogout'
+
+    IdpInitiatedSingleLogout:
+      type: object
+      properties:
+        enabled:
           type: boolean
           default: false
-        idpInitiatedLogoutReturnUrls:
+        returnToUrls:
           type: array
           items:
             type: string
 
-        enableAttributeProfile:
-          type: boolean
-          default: false
-        includedAttributeInResponseAlways:
-          type: boolean
-          default: false
+    SAMLAssertionConfiguration:
+      type: object
+      properties:
+        nameIdFormat:
+          type: string
+          default: 'urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress'
+          example: 'urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress'
 
         audiences:
           type: array
@@ -2546,20 +2541,85 @@ components:
           items:
             type: string
 
+        digestAlgorithm:
+          type: string
+          default: "http://www.w3.org/2000/09/xmldsig#sha1"
+          example: "http://www.w3.org/2000/09/xmldsig#sha1"
+        encryption:
+          $ref: '#/components/schemas/AssertionEncryptionConfiguration'
+
+    AssertionEncryptionConfiguration:
+      type: object
+      properties:
+        enabled:
+          type: boolean
+          default: false
+        assertionEncryptionAlgorithm:
+          type: string
+          default: "http://www.w3.org/2001/04/xmlenc#aes256-cbc"
+        keyEncryptionAlgorithm:
+          type: string
+          default: "http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p"
+
+    SAMLRequestValidation:
+      type: object
+      properties:
+        enableSignatureValidation:
+          type: boolean
+          default: true
+        signatureValidationCertAlias:
+          type: string
+
+    SAMLResponseSigning:
+      type: object
+      properties:
+        enabled:
+          type: boolean
+          default: true
+        signingAlgorithm:
+          type: string
+
+    SAML2ServiceProvider:
+      type: object
+      required:
+        - issuer
+        - assertionConsumerUrls
+
+      properties:
+        issuer:
+          type: string
+        serviceProviderQualifier:
+          type: string
+        assertionConsumerUrls:
+          type: array
+          items:
+            type: string
+          minItems: 1
+        defaultAssertionConsumerUrl:
+          type: string
+          description: "If not provided, the first assertion consumer URL on the assertionConsumerUrls will be picked as the default assertion consumer URL."
+        idpEntityIdAlias  :
+          type: string
+          description: "Default value is the IdP Entity ID value specified in Resident IdP"
+
+        singleSignOnProfile:
+          $ref: '#/components/schemas/SingleSignOnProfile'
+
+        attributeProfile:
+          $ref: '#/components/schemas/SAMLAttributeProfile'
+
+        singleLogoutProfile:
+          $ref: '#/components/schemas/SingleLogoutProfile'
+
+        requestValidation:
+          $ref: '#/components/schemas/SAMLRequestValidation'
+
+        responseSigning:
+          $ref: '#/components/schemas/SAMLResponseSigning'
+
         enableAssertionQueryProfile:
           type: boolean
           default: false
-
-        enableSAML2ArtifactBinding:
-          type: boolean
-          default: false
-        enableSignatureValidationInArtifactBinding:
-          type: boolean
-          default: false
-
-        idPEntityidAlias  :
-          type: string
-          description: "Default value is the IdP Entity ID value specified in Resident IdP"
 
     OpenIDConnectConfiguration:
       type: object

--- a/pom.xml
+++ b/pom.xml
@@ -440,7 +440,7 @@
         <maven.buildnumber.plugin.version>1.4</maven.buildnumber.plugin.version>
         <org.apache.felix.annotations.version>1.2.4</org.apache.felix.annotations.version>
         <identity.governance.version>1.3.15</identity.governance.version>
-        <carbon.identity.framework.version>5.15.35</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.15.36</carbon.identity.framework.version>
         <maven.findbugsplugin.version>3.0.4</maven.findbugsplugin.version>
         <identity.workflow.impl.bps.version>5.2.0</identity.workflow.impl.bps.version>
         <maven.checkstyleplugin.excludes>**/gen/**/*</maven.checkstyleplugin.excludes>


### PR DESCRIPTION
With this PR the swagger object structure of SAML Configs would be like the below sample,

```
{
    "issuer": "https://saml.wso2.com",
    "assertionConsumerUrls": [
        "https://saml.wso2.com/acs"
    ],
    "defaultAssertionConsumerUrl": "https://saml.wso2.com/acs",
    "idpEntityIdAlias": "https://localhost/myidp",
    "singleSignOnProfile": {
        "bindings": [
            "HTTP_POST",
            "HTTP_REDIRECT",
            "ARTIFACT"
        ],
        "enableSignatureValidationForArtifactBinding": true,
        "attributeConsumingServiceIndex": "480766126",
        "enableIdpInitiatedSingleSignOn": true,
        "assertion": {
            "nameIdFormat": "urn/oasis/names/tc/SAML/1.1/nameid-format/unspecified",
            "audiences": [],
            "recipients": [],
            "digestAlgorithm": "http://www.w3.org/2000/09/xmldsig#sha1",
            "encryption": {
                "enabled": false,
                "assertionEncryptionAlgorithm": "http://www.w3.org/2001/04/xmlenc#aes256-cbc",
                "keyEncryptionAlgorithm": "http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p"
            }
        }
    },
    "attributeProfile": {
        "enabled": true,
        "alwaysIncludeAttributesInResponse": true
    },
    "singleLogoutProfile": {
        "enabled": true,
        "logoutRequestUrl": "https://saml.wso2.com/slo",
        "logoutMethod": "BACKCHANNEL",
        "idpInitiatedSingleLogout": {
            "enabled": false,
            "returnToUrls": []
        }
    },
    "requestValidation": {
        "enableSignatureValidation": true,
        "signatureValidationCertAlias": "wso2carbon"
    },
    "responseSigning": {
        "enabled": false,
        "signingAlgorithm": "http://www.w3.org/2000/09/xmldsig#rsa-sha1"
    },
    "enableAssertionQueryProfile": true
}
```