### PR TITLE
Improvements to Application Management REST APIs

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/application/management/v1/ApplicationModel.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/application/management/v1/ApplicationModel.java
@@ -76,7 +76,7 @@ public class ApplicationModel  {
     @JsonProperty("name")
     @Valid
     @NotNull(message = "Property name cannot be null.")
- @Pattern(regexp="^[a-zA-Z0-9._-]+(?: [a-zA-Z0-9._-]+)*$")
+
     public String getName() {
         return name;
     }

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/application/management/v1/ApplicationPatchModel.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/application/management/v1/ApplicationPatchModel.java
@@ -53,7 +53,7 @@ public class ApplicationPatchModel  {
     
     @ApiModelProperty(example = "pickup", value = "")
     @JsonProperty("name")
-    @Valid @Pattern(regexp="^[a-zA-Z0-9._-]+(?: [a-zA-Z0-9._-]+)*$")
+    @Valid
     public String getName() {
         return name;
     }

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/application/management/v1/ApplicationResponseModel.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/application/management/v1/ApplicationResponseModel.java
@@ -79,7 +79,7 @@ public class ApplicationResponseModel  {
     @JsonProperty("name")
     @Valid
     @NotNull(message = "Property name cannot be null.")
- @Pattern(regexp="^[a-zA-Z0-9._-]+(?: [a-zA-Z0-9._-]+)*$")
+
     public String getName() {
         return name;
     }

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/application/management/v1/ApplicationsApi.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/application/management/v1/ApplicationsApi.java
@@ -670,6 +670,7 @@ public class ApplicationsApi  {
         @ApiResponse(code = 400, message = "Bad Request", response = Error.class),
         @ApiResponse(code = 401, message = "Unauthorized", response = Error.class),
         @ApiResponse(code = 403, message = "Forbidden", response = Error.class),
+        @ApiResponse(code = 409, message = "Conflict", response = Error.class),
         @ApiResponse(code = 500, message = "Server Error", response = Error.class)
     })
     public Response patchApplication(@ApiParam(value = "Id of the application.",required=true) @PathParam("applicationId") String applicationId, @ApiParam(value = "This represents the application details to be updated." ,required=true) @Valid ApplicationPatchModel applicationPatchModel) {

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/ServerApplicationManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/ServerApplicationManagementService.java
@@ -79,6 +79,7 @@ import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import static org.wso2.carbon.identity.api.server.application.management.common.ApplicationManagementConstants.ErrorMessage.APPLICATION_CREATION_WITH_TEMPLATES_NOT_IMPLEMENTED;
 import static org.wso2.carbon.identity.api.server.application.management.common.ApplicationManagementConstants.ErrorMessage.INBOUND_NOT_CONFIGURED;
 import static org.wso2.carbon.identity.api.server.application.management.v1.core.functions.Utils.buildBadRequestError;
 import static org.wso2.carbon.identity.api.server.application.management.v1.core.functions.Utils.buildNotImplementedError;
@@ -268,7 +269,8 @@ public class ServerApplicationManagementService {
     public String createApplication(ApplicationModel applicationModel, String template) {
 
         if (StringUtils.isNotBlank(template)) {
-            throw buildNotImplementedError("Application creation with templates not supported.");
+            String errorCode = APPLICATION_CREATION_WITH_TEMPLATES_NOT_IMPLEMENTED.getCode();
+            throw buildNotImplementedError(errorCode, "Application creation with templates not supported.");
         }
 
         String username = ContextLoader.getUsernameFromContext();

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/functions/Utils.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/functions/Utils.java
@@ -115,6 +115,19 @@ public class Utils {
         return new APIError(status, errorResponse);
     }
 
+    public static APIError buildNotImplementedError(String errorCode, String message) {
+
+        ErrorResponse.Builder builder = new ErrorResponse.Builder();
+        ErrorResponse errorResponse = builder
+                .withMessage("Server error while trying the attempted operation.")
+                .withCode(errorCode)
+                .withDescription(message)
+                .build(log, message);
+
+        Response.Status status = Response.Status.NOT_IMPLEMENTED;
+        return new APIError(status, errorResponse);
+    }
+
     public static APIError buildServerError(String errorCode, String message, String description) {
 
         throw buildServerError(errorCode, message, description, null);

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/resources/applications.yaml
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/resources/applications.yaml
@@ -370,6 +370,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
+        '409':
+          description: Conflict
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
         '500':
           description: Server Error
           content:

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/resources/applications.yaml
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/resources/applications.yaml
@@ -2073,7 +2073,6 @@ components:
         name:
           type: string
           example: pickup
-          pattern: '^[a-zA-Z0-9._-]+(?: [a-zA-Z0-9._-]+)*$'
         description:
           type: string
           example: This is the configuration for Pickup application.
@@ -2106,7 +2105,6 @@ components:
         name:
           type: string
           example: pickup
-          pattern: '^[a-zA-Z0-9._-]+(?: [a-zA-Z0-9._-]+)*$'
         description:
           type: string
           example: This is the configuration for Pickup application.
@@ -2133,7 +2131,6 @@ components:
         name:
           type: string
           example: pickup
-          pattern: '^[a-zA-Z0-9._-]+(?: [a-zA-Z0-9._-]+)*$'
         description:
           type: string
           example: This is the configuration for Pickup application.


### PR DESCRIPTION
This PR includes few improvements to the application management REST API

1. Improve SAML SP PUT rollback logic
This PR provides a temporary solution SAML SP update rollback.
We need to provide first-class support at the OSGi level for the update to fix this cleanly. Created https://github.com/wso2/product-is/issues/7050 to track the required improvement. 

2. Send correct error code for unsupported operation - creating an application with a template.

3. Remove application name validation at the swagger level.