### PR TITLE
Add access token binding type configuration to application OIDC configuration using REST API

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/application/management/v1/OpenIDConnectConfiguration.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/application/management/v1/OpenIDConnectConfiguration.java
@@ -88,6 +88,7 @@ public enum StateEnum {
     private Boolean validateRequestObjectSignature = false;
     private List<String> scopeValidators = null;
 
+    private String accessTokenBindingType;
 
     /**
     **/
@@ -375,7 +376,26 @@ public enum StateEnum {
         return this;
     }
 
+        /**
+    * Access token binding type.
+    **/
+    public OpenIDConnectConfiguration accessTokenBindingType(String accessTokenBindingType) {
+
+        this.accessTokenBindingType = accessTokenBindingType;
+        return this;
+    }
     
+    @ApiModelProperty(example = "[\"sso-session\",\"cookie\"]", value = "Access token binding type.")
+    @JsonProperty("accessTokenBindingType")
+    @Valid
+    public String getAccessTokenBindingType() {
+        return accessTokenBindingType;
+    }
+    public void setAccessTokenBindingType(String accessTokenBindingType) {
+        this.accessTokenBindingType = accessTokenBindingType;
+    }
+
+
 
     @Override
     public boolean equals(java.lang.Object o) {
@@ -400,12 +420,13 @@ public enum StateEnum {
             Objects.equals(this.idToken, openIDConnectConfiguration.idToken) &&
             Objects.equals(this.logout, openIDConnectConfiguration.logout) &&
             Objects.equals(this.validateRequestObjectSignature, openIDConnectConfiguration.validateRequestObjectSignature) &&
-            Objects.equals(this.scopeValidators, openIDConnectConfiguration.scopeValidators);
+            Objects.equals(this.scopeValidators, openIDConnectConfiguration.scopeValidators) &&
+            Objects.equals(this.accessTokenBindingType, openIDConnectConfiguration.accessTokenBindingType);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(clientId, clientSecret, state, grantTypes, callbackURLs, allowedOrigins, publicClient, pkce, accessToken, refreshToken, idToken, logout, validateRequestObjectSignature, scopeValidators);
+        return Objects.hash(clientId, clientSecret, state, grantTypes, callbackURLs, allowedOrigins, publicClient, pkce, accessToken, refreshToken, idToken, logout, validateRequestObjectSignature, scopeValidators, accessTokenBindingType);
     }
 
     @Override
@@ -428,6 +449,7 @@ public enum StateEnum {
         sb.append("    logout: ").append(toIndentedString(logout)).append("\n");
         sb.append("    validateRequestObjectSignature: ").append(toIndentedString(validateRequestObjectSignature)).append("\n");
         sb.append("    scopeValidators: ").append(toIndentedString(scopeValidators)).append("\n");
+        sb.append("    accessTokenBindingType: ").append(toIndentedString(accessTokenBindingType)).append("\n");
         sb.append("}");
         return sb.toString();
     }

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/functions/application/inbound/oauth2/ApiModelToOAuthConsumerApp.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/functions/application/inbound/oauth2/ApiModelToOAuthConsumerApp.java
@@ -57,6 +57,7 @@ public class ApiModelToOAuthConsumerApp implements Function<OpenIDConnectConfigu
 
         consumerAppDTO.setBypassClientCredentials(oidcModel.getPublicClient());
         consumerAppDTO.setRequestObjectSignatureValidationEnabled(oidcModel.getValidateRequestObjectSignature());
+        consumerAppDTO.setTokenBindingType(oidcModel.getAccessTokenBindingType());
 
         updateAllowedOrigins(consumerAppDTO, oidcModel.getAllowedOrigins());
         updatePkceConfigurations(consumerAppDTO, oidcModel.getPkce());

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/functions/application/inbound/oauth2/OAuthConsumerAppToApiModel.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/functions/application/inbound/oauth2/OAuthConsumerAppToApiModel.java
@@ -53,7 +53,8 @@ public class OAuthConsumerAppToApiModel implements Function<OAuthConsumerAppDTO,
                 .idToken(buildIdTokenConfiguration(oauthAppDTO))
                 .logout(buildLogoutConfiguration(oauthAppDTO))
                 .scopeValidators(getScopeValidators(oauthAppDTO))
-                .validateRequestObjectSignature(oauthAppDTO.isRequestObjectSignatureValidationEnabled());
+                .validateRequestObjectSignature(oauthAppDTO.isRequestObjectSignatureValidationEnabled())
+                .accessTokenBindingType(oauthAppDTO.getTokenBindingType());
     }
 
     private List<String> getScopeValidators(OAuthConsumerAppDTO oauthAppDTO) {

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/resources/applications.yaml
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/resources/applications.yaml
@@ -2590,6 +2590,12 @@ components:
             - RoleBasedScopeValidator
           items:
             type: string
+        accessTokenBindingType:
+          type: string
+          description: Access token binding type.
+          example:
+            - sso-session
+            - cookie
     OAuth2PKCEConfiguration:
       type: object
       properties:


### PR DESCRIPTION
Issue : https://github.com/wso2/product-is/issues/7747

## Purpose
> Added access token binding type configuration to _/api/server/v1/applications/{app-id}/inbound-protocols/oidc_ REST API endpoint.