### PR TITLE
Add IDP template management REST API

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.common/pom.xml
+++ b/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.common/pom.xml
@@ -61,6 +61,7 @@
         <dependency>
             <groupId>org.wso2.carbon.identity.framework</groupId>
             <artifactId>org.wso2.carbon.identity.template.mgt</artifactId>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
     

--- a/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.common/pom.xml
+++ b/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.common/pom.xml
@@ -58,6 +58,10 @@
             <artifactId>spring-web</artifactId>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.template.mgt</artifactId>
+        </dependency>
     </dependencies>
     
 </project>

--- a/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.common/src/main/java/org/wso2/carbon/identity/api/server/idp/common/Constants.java
+++ b/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.common/src/main/java/org/wso2/carbon/identity/api/server/idp/common/Constants.java
@@ -23,11 +23,13 @@ public class Constants {
 
     public static final String IDP_MANAGEMENT_PREFIX = "IDP-";
     public static final String IDP_PATH_COMPONENT = "/identity-providers";
+    public static final String IDP_TEMPLATE_PATH_COMPONENT = "/templates";
     public static final String PATH_SEPERATOR = "/";
     public static final String JWKS_URI = "jwksUri";
     public static final String META_DATA_SAML = "meta_data_saml";
     public static final String SELECT_MODE = "SelectMode";
     public static final String SELECT_MODE_METADATA = "Metadata File Configuration";
+    public static final String TEMPLATE_MGT_ERROR_CODE_DELIMITER = "_";
 
     // IdP property keys.
     public static final String PROP_DISPLAY_NAME = "DisplayName";
@@ -60,6 +62,11 @@ public class Constants {
     public static final String ROLES = "roles";
     public static final String FEDERATED_AUTHENTICATORS = "federatedAuthenticators";
     public static final String PROVISIONING = "provisioning";
+
+    // IdP template property keys
+    public static final String PROP_CATEGORY = "category";
+    public static final String PROP_DISPLAY_ORDER = "displayOrder";
+
 
     /**
      * Enum for error messages.
@@ -165,7 +172,17 @@ public class Constants {
         ERROR_CODE_INVALID_INPUT("60025", "Invalid input.", "One of the given inputs is invalid."),
         ERROR_CODE_INVALID_SAML_METADATA("60026", "Invalid SAML metadata.", "SAML metadata is invalid/empty."),
         ERROR_CODE_BUILDING_LINKS("65042", "Error building page links", "Error occurred during building page links. " +
-                "%s");
+                "%s"),
+        ERROR_CODE_ERROR_LISTING_IDP_TEMPLATES("65050", "Unable to list existing identity provider " +
+                "templates.", "Error occured while listing identity provider templates."),
+        ERROR_CODE_ERROR_ADDING_IDP_TEMPLATE("65051", "Unable to add IDP template.",
+                "Error occurred while trying to add the IDP template."),
+        ERROR_CODE_ERROR_DELETING_IDP_TEMPLATE("65052", "Unable to delete IDP template.",
+                "Error occurred while trying to delete the IDP template with identifier %s."),
+        ERROR_CODE_ERROR_UPDATING_IDP_TEMPLATE("65053", "Unable to update IDP template.",
+                "Error occurred while updating the IDP template with identifier %s."),
+        ERROR_CODE_ERROR_RETRIEVING_IDP_TEMPLATE("65054", "Unable to retrieve IDP template.",
+                "Error occurred while retrieving the IDP template with identifier %s");
 
         private final String code;
         private final String message;

--- a/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.common/src/main/java/org/wso2/carbon/identity/api/server/idp/common/IdentityProviderServiceHolder.java
+++ b/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.common/src/main/java/org/wso2/carbon/identity/api/server/idp/common/IdentityProviderServiceHolder.java
@@ -81,7 +81,7 @@ public class IdentityProviderServiceHolder {
     }
 
     /**
-     * Get TemplateManager osgi service
+     * Get TemplateManager osgi service.
      *
      * @return TemplateManager
      */

--- a/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.common/src/main/java/org/wso2/carbon/identity/api/server/idp/common/IdentityProviderServiceHolder.java
+++ b/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.common/src/main/java/org/wso2/carbon/identity/api/server/idp/common/IdentityProviderServiceHolder.java
@@ -17,6 +17,7 @@
 package org.wso2.carbon.identity.api.server.idp.common;
 
 import org.wso2.carbon.identity.claim.metadata.mgt.ClaimMetadataManagementService;
+import org.wso2.carbon.identity.template.mgt.TemplateManager;
 import org.wso2.carbon.idp.mgt.IdentityProviderManager;
 
 /**
@@ -26,6 +27,7 @@ public class IdentityProviderServiceHolder {
 
     private static IdentityProviderManager identityProviderManager;
     private static ClaimMetadataManagementService claimMetadataManagementService;
+    private static TemplateManager templateManager;
 
     /**
      * Get IdentityProviderManager osgi service.
@@ -66,5 +68,25 @@ public class IdentityProviderServiceHolder {
             ClaimMetadataManagementService claimMetadataManagementService) {
 
         IdentityProviderServiceHolder.claimMetadataManagementService = claimMetadataManagementService;
+    }
+
+    /**
+     * Set TemplateManager osgi service.
+     *
+     * @param templateManager TemplateManager service
+     */
+    public static void setTemplateManager(TemplateManager templateManager) {
+
+        IdentityProviderServiceHolder.templateManager = templateManager;
+    }
+
+    /**
+     * Get TemplateManager osgi service
+     *
+     * @return TemplateManager
+     */
+    public static TemplateManager getTemplateManager() {
+
+        return templateManager;
     }
 }

--- a/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.common/src/main/java/org/wso2/carbon/identity/api/server/idp/common/factory/TemplateMgtOSGIServiceFactory.java
+++ b/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.common/src/main/java/org/wso2/carbon/identity/api/server/idp/common/factory/TemplateMgtOSGIServiceFactory.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.wso2.carbon.identity.api.server.idp.common.factory;
 
 import org.springframework.beans.factory.config.AbstractFactoryBean;

--- a/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.common/src/main/java/org/wso2/carbon/identity/api/server/idp/common/factory/TemplateMgtOSGIServiceFactory.java
+++ b/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.common/src/main/java/org/wso2/carbon/identity/api/server/idp/common/factory/TemplateMgtOSGIServiceFactory.java
@@ -1,0 +1,35 @@
+package org.wso2.carbon.identity.api.server.idp.common.factory;
+
+import org.springframework.beans.factory.config.AbstractFactoryBean;
+import org.wso2.carbon.context.PrivilegedCarbonContext;
+import org.wso2.carbon.identity.template.mgt.TemplateManager;
+
+/**
+ * Factory Beans serves as a factory for creating other beans within the IOC container. This factory bean is used to
+ * instantiate the TemplateManager type of object inside the container.
+ */
+public class TemplateMgtOSGIServiceFactory extends AbstractFactoryBean<TemplateManager> {
+
+    private TemplateManager templateManager;
+
+    @Override
+    public Class<?> getObjectType() {
+
+        return Object.class;
+    }
+
+    @Override
+    protected TemplateManager createInstance() throws Exception {
+
+        if (this.templateManager == null) {
+            TemplateManager taskOperationService = (TemplateManager) PrivilegedCarbonContext.
+                    getThreadLocalCarbonContext().getOSGiService(TemplateManager.class, null);
+            if (taskOperationService != null) {
+                this.templateManager = taskOperationService;
+            } else {
+                throw new Exception("Unable to retrieve TemplateManager service.");
+            }
+        }
+        return this.templateManager;
+    }
+}

--- a/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/pom.xml
+++ b/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/pom.xml
@@ -180,6 +180,11 @@
             <groupId>commons-beanutils</groupId>
             <artifactId>commons-beanutils</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.template.mgt</artifactId>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
     
 </project>

--- a/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/gen/java/org/wso2/carbon/identity/api/server/idp/v1/IdentityProvidersApi.java
+++ b/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/gen/java/org/wso2/carbon/identity/api/server/idp/v1/IdentityProvidersApi.java
@@ -30,6 +30,8 @@ import org.wso2.carbon.identity.api.server.idp.v1.model.FederatedAuthenticatorPU
 import org.wso2.carbon.identity.api.server.idp.v1.model.IdentityProviderListResponse;
 import org.wso2.carbon.identity.api.server.idp.v1.model.IdentityProviderPOSTRequest;
 import org.wso2.carbon.identity.api.server.idp.v1.model.IdentityProviderResponse;
+import org.wso2.carbon.identity.api.server.idp.v1.model.IdentityProviderTemplate;
+import org.wso2.carbon.identity.api.server.idp.v1.model.IdentityProviderTemplateListResponse;
 import org.wso2.carbon.identity.api.server.idp.v1.model.JustInTimeProvisioning;
 import java.util.List;
 import org.wso2.carbon.identity.api.server.idp.v1.model.MetaFederatedAuthenticator;
@@ -84,6 +86,30 @@ public class IdentityProvidersApi  {
     }
 
     @Valid
+    @POST
+    @Path("/templates")
+    @Consumes({ "application/json", "application/xml" })
+    @Produces({ "application/json", "application/xml" })
+    @ApiOperation(value = "Create a new IDP template ", notes = "This API provides the capability to create a new IDP template. ", response = Void.class, authorizations = {
+        @Authorization(value = "BasicAuth"),
+        @Authorization(value = "OAuth2", scopes = {
+            
+        })
+    }, tags={ "Template management", })
+    @ApiResponses(value = { 
+        @ApiResponse(code = 201, message = "Successful response", response = Void.class),
+        @ApiResponse(code = 400, message = "Bad Request", response = Error.class),
+        @ApiResponse(code = 401, message = "Unauthorized", response = Void.class),
+        @ApiResponse(code = 403, message = "Forbidden", response = Void.class),
+        @ApiResponse(code = 409, message = "Conflict", response = Error.class),
+        @ApiResponse(code = 500, message = "Server Error", response = Error.class)
+    })
+    public Response addIDPTemplate(@ApiParam(value = "This represents the identity provider template to be created" ,required=true) @Valid IdentityProviderTemplate identityProviderTemplate) {
+
+        return delegate.addIDPTemplate(identityProviderTemplate );
+    }
+
+    @Valid
     @DELETE
     @Path("/{identity-provider-id}")
     
@@ -99,11 +125,36 @@ public class IdentityProvidersApi  {
         @ApiResponse(code = 400, message = "Bad Request", response = Error.class),
         @ApiResponse(code = 401, message = "Unauthorized", response = Void.class),
         @ApiResponse(code = 403, message = "Forbidden", response = Void.class),
+        @ApiResponse(code = 404, message = "Not Found", response = Error.class),
         @ApiResponse(code = 500, message = "Server Error", response = Error.class)
     })
     public Response deleteIDP(@ApiParam(value = "Id of the identity provider",required=true) @PathParam("identity-provider-id") String identityProviderId,     @Valid@ApiParam(value = "Enforce the forceful deletetion of either an identity provider, federated authenticator or an outbound provisioning connector eventhough it is being reffered by a service provider ", defaultValue="false") @DefaultValue("false")  @QueryParam("force") Boolean force) {
 
         return delegate.deleteIDP(identityProviderId,  force );
+    }
+
+    @Valid
+    @DELETE
+    @Path("/templates/{template-id}")
+    
+    @Produces({ "application/json" })
+    @ApiOperation(value = "Delete a IDP template using the template Id. ", notes = "This API provides the capability to delete a IDP template using the template Id. ", response = Void.class, authorizations = {
+        @Authorization(value = "BasicAuth"),
+        @Authorization(value = "OAuth2", scopes = {
+            
+        })
+    }, tags={ "Template management", })
+    @ApiResponses(value = { 
+        @ApiResponse(code = 204, message = "Successfully Deleted", response = Void.class),
+        @ApiResponse(code = 400, message = "Bad Request", response = Error.class),
+        @ApiResponse(code = 401, message = "Unauthorized", response = Void.class),
+        @ApiResponse(code = 403, message = "Forbidden", response = Void.class),
+        @ApiResponse(code = 404, message = "Not Found", response = Error.class),
+        @ApiResponse(code = 500, message = "Server Error", response = Error.class)
+    })
+    public Response deleteIDPTemplate(@ApiParam(value = "Id of the IDP template",required=true) @PathParam("template-id") String templateId) {
+
+        return delegate.deleteIDPTemplate(templateId );
     }
 
     @Valid
@@ -224,6 +275,54 @@ public class IdentityProvidersApi  {
     public Response getIDP(@ApiParam(value = "Id of the identity provider",required=true) @PathParam("identity-provider-id") String identityProviderId) {
 
         return delegate.getIDP(identityProviderId );
+    }
+
+    @Valid
+    @GET
+    @Path("/templates/{template-id}")
+    
+    @Produces({ "application/json", "application/xml" })
+    @ApiOperation(value = "Retrieve identity provider template by id ", notes = "This API provides the capability to retrieve an indentity provider template using it's id. ", response = IdentityProviderTemplate.class, authorizations = {
+        @Authorization(value = "BasicAuth"),
+        @Authorization(value = "OAuth2", scopes = {
+            
+        })
+    }, tags={ "Template management", })
+    @ApiResponses(value = { 
+        @ApiResponse(code = 200, message = "Successful response", response = IdentityProviderTemplate.class),
+        @ApiResponse(code = 400, message = "Bad Request", response = Error.class),
+        @ApiResponse(code = 401, message = "Unauthorized", response = Void.class),
+        @ApiResponse(code = 403, message = "Forbidden", response = Void.class),
+        @ApiResponse(code = 404, message = "Not Found", response = Error.class),
+        @ApiResponse(code = 500, message = "Server Error", response = Error.class)
+    })
+    public Response getIDPTemplate(@ApiParam(value = "Id of the IDP template",required=true) @PathParam("template-id") String templateId) {
+
+        return delegate.getIDPTemplate(templateId );
+    }
+
+    @Valid
+    @GET
+    @Path("/templates")
+    
+    @Produces({ "application/json" })
+    @ApiOperation(value = "List identity provider templates ", notes = "This API provides the list of available identity provider templates. ", response = IdentityProviderTemplateListResponse.class, authorizations = {
+        @Authorization(value = "BasicAuth"),
+        @Authorization(value = "OAuth2", scopes = {
+            
+        })
+    }, tags={ "Template management", })
+    @ApiResponses(value = { 
+        @ApiResponse(code = 200, message = "Successful response", response = IdentityProviderTemplateListResponse.class),
+        @ApiResponse(code = 400, message = "Bad Request", response = Error.class),
+        @ApiResponse(code = 401, message = "Unauthorized", response = Void.class),
+        @ApiResponse(code = 403, message = "Forbidden", response = Void.class),
+        @ApiResponse(code = 404, message = "Not Found", response = Error.class),
+        @ApiResponse(code = 500, message = "Server Error", response = Error.class)
+    })
+    public Response getIDPTemplates(    @Valid@ApiParam(value = "Maximum number of records to return ")  @QueryParam("limit") Integer limit,     @Valid@ApiParam(value = "Number of records to skip for pagination ")  @QueryParam("offset") Integer offset,     @Valid@ApiParam(value = "Condition to filter the retrival of records. Supports 'sw', 'co', 'ew' and 'eq' operations and also complex queries with 'and' operations. E.g. /identity-providers?filter=name+sw+\"google\"+and+isEnabled+eq+\"true\" ")  @QueryParam("filter") String filter) {
+
+        return delegate.getIDPTemplates(limit,  offset,  filter );
     }
 
     @Valid
@@ -537,6 +636,31 @@ public class IdentityProvidersApi  {
     public Response updateFederatedAuthenticator(@ApiParam(value = "Id of the Identity Provider",required=true) @PathParam("identity-provider-id") String identityProviderId, @ApiParam(value = "Id of the federated authenticator",required=true) @PathParam("federated-authenticator-id") String federatedAuthenticatorId, @ApiParam(value = "This represents the federated authenticator to be updated" ,required=true) @Valid FederatedAuthenticatorPUTRequest federatedAuthenticatorPUTRequest) {
 
         return delegate.updateFederatedAuthenticator(identityProviderId,  federatedAuthenticatorId,  federatedAuthenticatorPUTRequest );
+    }
+
+    @Valid
+    @PUT
+    @Path("/templates/{template-id}")
+    @Consumes({ "application/json", "application/xml" })
+    @Produces({ "application/json", "application/xml",  })
+    @ApiOperation(value = "Update the IDP template of a given template id. ", notes = "This API provides the capability to update the IDP template of a given template id. ", response = Void.class, authorizations = {
+        @Authorization(value = "BasicAuth"),
+        @Authorization(value = "OAuth2", scopes = {
+            
+        })
+    }, tags={ "Template management", })
+    @ApiResponses(value = { 
+        @ApiResponse(code = 200, message = "Successfully updated", response = Void.class),
+        @ApiResponse(code = 400, message = "Bad Request", response = Error.class),
+        @ApiResponse(code = 401, message = "Unauthorized", response = Void.class),
+        @ApiResponse(code = 403, message = "Forbidden", response = Void.class),
+        @ApiResponse(code = 409, message = "Conflict", response = Error.class),
+        @ApiResponse(code = 404, message = "Not Found", response = Error.class),
+        @ApiResponse(code = 500, message = "Server Error", response = Error.class)
+    })
+    public Response updateIDPTemplate(@ApiParam(value = "Id of the IDP template",required=true) @PathParam("template-id") String templateId, @ApiParam(value = "This represents the identity provider template to be created" ,required=true) @Valid IdentityProviderTemplate identityProviderTemplate) {
+
+        return delegate.updateIDPTemplate(templateId,  identityProviderTemplate );
     }
 
     @Valid

--- a/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/gen/java/org/wso2/carbon/identity/api/server/idp/v1/IdentityProvidersApiService.java
+++ b/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/gen/java/org/wso2/carbon/identity/api/server/idp/v1/IdentityProvidersApiService.java
@@ -30,6 +30,8 @@ import org.wso2.carbon.identity.api.server.idp.v1.model.FederatedAuthenticatorPU
 import org.wso2.carbon.identity.api.server.idp.v1.model.IdentityProviderListResponse;
 import org.wso2.carbon.identity.api.server.idp.v1.model.IdentityProviderPOSTRequest;
 import org.wso2.carbon.identity.api.server.idp.v1.model.IdentityProviderResponse;
+import org.wso2.carbon.identity.api.server.idp.v1.model.IdentityProviderTemplate;
+import org.wso2.carbon.identity.api.server.idp.v1.model.IdentityProviderTemplateListResponse;
 import org.wso2.carbon.identity.api.server.idp.v1.model.JustInTimeProvisioning;
 import java.util.List;
 import org.wso2.carbon.identity.api.server.idp.v1.model.MetaFederatedAuthenticator;
@@ -49,7 +51,11 @@ public interface IdentityProvidersApiService {
 
       public Response addIDP(IdentityProviderPOSTRequest identityProviderPOSTRequest);
 
+      public Response addIDPTemplate(IdentityProviderTemplate identityProviderTemplate);
+
       public Response deleteIDP(String identityProviderId, Boolean force);
+
+      public Response deleteIDPTemplate(String templateId);
 
       public Response getClaimConfig(String identityProviderId);
 
@@ -60,6 +66,10 @@ public interface IdentityProvidersApiService {
       public Response getFederatedAuthenticators(String identityProviderId);
 
       public Response getIDP(String identityProviderId);
+
+      public Response getIDPTemplate(String templateId);
+
+      public Response getIDPTemplates(Integer limit, Integer offset, String filter);
 
       public Response getIDPs(Integer limit, Integer offset, String filter, String sortOrder, String sortBy, String requiredAttributes);
 
@@ -86,6 +96,8 @@ public interface IdentityProvidersApiService {
       public Response updateClaimConfig(String identityProviderId, Claims claims);
 
       public Response updateFederatedAuthenticator(String identityProviderId, String federatedAuthenticatorId, FederatedAuthenticatorPUTRequest federatedAuthenticatorPUTRequest);
+
+      public Response updateIDPTemplate(String templateId, IdentityProviderTemplate identityProviderTemplate);
 
       public Response updateJITConfig(String identityProviderId, JustInTimeProvisioning justInTimeProvisioning);
 

--- a/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/gen/java/org/wso2/carbon/identity/api/server/idp/v1/model/IdentityProviderTemplate.java
+++ b/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/gen/java/org/wso2/carbon/identity/api/server/idp/v1/model/IdentityProviderTemplate.java
@@ -1,0 +1,260 @@
+/*
+* Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package org.wso2.carbon.identity.api.server.idp.v1.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import org.wso2.carbon.identity.api.server.idp.v1.model.IdentityProviderPOSTRequest;
+import javax.validation.constraints.*;
+
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+import javax.validation.Valid;
+import javax.xml.bind.annotation.*;
+
+public class IdentityProviderTemplate  {
+  
+    private String id;
+    private String name;
+    private String description;
+    private String image;
+
+@XmlType(name="CategoryEnum")
+@XmlEnum(String.class)
+public enum CategoryEnum {
+
+    @XmlEnumValue("DEFAULT") DEFAULT(String.valueOf("DEFAULT")), @XmlEnumValue("CUSTOM") CUSTOM(String.valueOf("CUSTOM"));
+
+
+    private String value;
+
+    CategoryEnum(String v) {
+        value = v;
+    }
+
+    public String value() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    public static CategoryEnum fromValue(String value) {
+        for (CategoryEnum b : CategoryEnum.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
+}
+
+    private CategoryEnum category;
+    private Integer displayOrder;
+    private IdentityProviderPOSTRequest idp;
+
+    /**
+    **/
+    public IdentityProviderTemplate id(String id) {
+
+        this.id = id;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "123e4567-e89b-12d3-a456-556642440000", value = "")
+    @JsonProperty("id")
+    @Valid
+    public String getId() {
+        return id;
+    }
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    /**
+    **/
+    public IdentityProviderTemplate name(String name) {
+
+        this.name = name;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "google", required = true, value = "")
+    @JsonProperty("name")
+    @Valid
+    @NotNull(message = "Property name cannot be null.")
+
+    public String getName() {
+        return name;
+    }
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    /**
+    **/
+    public IdentityProviderTemplate description(String description) {
+
+        this.description = description;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "Google federated connector", value = "")
+    @JsonProperty("description")
+    @Valid
+    public String getDescription() {
+        return description;
+    }
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    /**
+    **/
+    public IdentityProviderTemplate image(String image) {
+
+        this.image = image;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "google-logo-url", value = "")
+    @JsonProperty("image")
+    @Valid
+    public String getImage() {
+        return image;
+    }
+    public void setImage(String image) {
+        this.image = image;
+    }
+
+    /**
+    **/
+    public IdentityProviderTemplate category(CategoryEnum category) {
+
+        this.category = category;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "DEFAULT", value = "")
+    @JsonProperty("category")
+    @Valid
+    public CategoryEnum getCategory() {
+        return category;
+    }
+    public void setCategory(CategoryEnum category) {
+        this.category = category;
+    }
+
+    /**
+    **/
+    public IdentityProviderTemplate displayOrder(Integer displayOrder) {
+
+        this.displayOrder = displayOrder;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "10", value = "")
+    @JsonProperty("displayOrder")
+    @Valid
+    public Integer getDisplayOrder() {
+        return displayOrder;
+    }
+    public void setDisplayOrder(Integer displayOrder) {
+        this.displayOrder = displayOrder;
+    }
+
+    /**
+    **/
+    public IdentityProviderTemplate idp(IdentityProviderPOSTRequest idp) {
+
+        this.idp = idp;
+        return this;
+    }
+    
+    @ApiModelProperty(required = true, value = "")
+    @JsonProperty("idp")
+    @Valid
+    @NotNull(message = "Property idp cannot be null.")
+
+    public IdentityProviderPOSTRequest getIdp() {
+        return idp;
+    }
+    public void setIdp(IdentityProviderPOSTRequest idp) {
+        this.idp = idp;
+    }
+
+
+
+    @Override
+    public boolean equals(java.lang.Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        IdentityProviderTemplate identityProviderTemplate = (IdentityProviderTemplate) o;
+        return Objects.equals(this.id, identityProviderTemplate.id) &&
+            Objects.equals(this.name, identityProviderTemplate.name) &&
+            Objects.equals(this.description, identityProviderTemplate.description) &&
+            Objects.equals(this.image, identityProviderTemplate.image) &&
+            Objects.equals(this.category, identityProviderTemplate.category) &&
+            Objects.equals(this.displayOrder, identityProviderTemplate.displayOrder) &&
+            Objects.equals(this.idp, identityProviderTemplate.idp);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, name, description, image, category, displayOrder, idp);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class IdentityProviderTemplate {\n");
+        
+        sb.append("    id: ").append(toIndentedString(id)).append("\n");
+        sb.append("    name: ").append(toIndentedString(name)).append("\n");
+        sb.append("    description: ").append(toIndentedString(description)).append("\n");
+        sb.append("    image: ").append(toIndentedString(image)).append("\n");
+        sb.append("    category: ").append(toIndentedString(category)).append("\n");
+        sb.append("    displayOrder: ").append(toIndentedString(displayOrder)).append("\n");
+        sb.append("    idp: ").append(toIndentedString(idp)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+    * Convert the given object to string with each line indented by 4 spaces
+    * (except the first line).
+    */
+    private String toIndentedString(java.lang.Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}
+

--- a/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/gen/java/org/wso2/carbon/identity/api/server/idp/v1/model/IdentityProviderTemplateListItem.java
+++ b/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/gen/java/org/wso2/carbon/identity/api/server/idp/v1/model/IdentityProviderTemplateListItem.java
@@ -1,0 +1,255 @@
+/*
+* Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package org.wso2.carbon.identity.api.server.idp.v1.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import javax.validation.constraints.*;
+
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+import javax.validation.Valid;
+import javax.xml.bind.annotation.*;
+
+public class IdentityProviderTemplateListItem  {
+  
+    private String id;
+    private String name;
+    private String description;
+    private String image;
+
+@XmlType(name="CategoryEnum")
+@XmlEnum(String.class)
+public enum CategoryEnum {
+
+    @XmlEnumValue("DEFAULT") DEFAULT(String.valueOf("DEFAULT")), @XmlEnumValue("CUSTOM") CUSTOM(String.valueOf("CUSTOM"));
+
+
+    private String value;
+
+    CategoryEnum(String v) {
+        value = v;
+    }
+
+    public String value() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    public static CategoryEnum fromValue(String value) {
+        for (CategoryEnum b : CategoryEnum.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
+}
+
+    private CategoryEnum category;
+    private Integer displayOrder;
+    private String self;
+
+    /**
+    **/
+    public IdentityProviderTemplateListItem id(String id) {
+
+        this.id = id;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "123e4567-e89b-12d3-a456-556642440000", value = "")
+    @JsonProperty("id")
+    @Valid
+    public String getId() {
+        return id;
+    }
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    /**
+    **/
+    public IdentityProviderTemplateListItem name(String name) {
+
+        this.name = name;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "google", value = "")
+    @JsonProperty("name")
+    @Valid
+    public String getName() {
+        return name;
+    }
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    /**
+    **/
+    public IdentityProviderTemplateListItem description(String description) {
+
+        this.description = description;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "Identity provider template for google federation", value = "")
+    @JsonProperty("description")
+    @Valid
+    public String getDescription() {
+        return description;
+    }
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    /**
+    **/
+    public IdentityProviderTemplateListItem image(String image) {
+
+        this.image = image;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "google-logo-url", value = "")
+    @JsonProperty("image")
+    @Valid
+    public String getImage() {
+        return image;
+    }
+    public void setImage(String image) {
+        this.image = image;
+    }
+
+    /**
+    **/
+    public IdentityProviderTemplateListItem category(CategoryEnum category) {
+
+        this.category = category;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "DEFAULT", value = "")
+    @JsonProperty("category")
+    @Valid
+    public CategoryEnum getCategory() {
+        return category;
+    }
+    public void setCategory(CategoryEnum category) {
+        this.category = category;
+    }
+
+    /**
+    **/
+    public IdentityProviderTemplateListItem displayOrder(Integer displayOrder) {
+
+        this.displayOrder = displayOrder;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "10", value = "")
+    @JsonProperty("displayOrder")
+    @Valid
+    public Integer getDisplayOrder() {
+        return displayOrder;
+    }
+    public void setDisplayOrder(Integer displayOrder) {
+        this.displayOrder = displayOrder;
+    }
+
+    /**
+    **/
+    public IdentityProviderTemplateListItem self(String self) {
+
+        this.self = self;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "/t/carbon.super/api/server/v1/identity-providers/templates/123e4567-e89b-12d3-a456-556642440000", value = "")
+    @JsonProperty("self")
+    @Valid
+    public String getSelf() {
+        return self;
+    }
+    public void setSelf(String self) {
+        this.self = self;
+    }
+
+
+
+    @Override
+    public boolean equals(java.lang.Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        IdentityProviderTemplateListItem identityProviderTemplateListItem = (IdentityProviderTemplateListItem) o;
+        return Objects.equals(this.id, identityProviderTemplateListItem.id) &&
+            Objects.equals(this.name, identityProviderTemplateListItem.name) &&
+            Objects.equals(this.description, identityProviderTemplateListItem.description) &&
+            Objects.equals(this.image, identityProviderTemplateListItem.image) &&
+            Objects.equals(this.category, identityProviderTemplateListItem.category) &&
+            Objects.equals(this.displayOrder, identityProviderTemplateListItem.displayOrder) &&
+            Objects.equals(this.self, identityProviderTemplateListItem.self);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, name, description, image, category, displayOrder, self);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class IdentityProviderTemplateListItem {\n");
+        
+        sb.append("    id: ").append(toIndentedString(id)).append("\n");
+        sb.append("    name: ").append(toIndentedString(name)).append("\n");
+        sb.append("    description: ").append(toIndentedString(description)).append("\n");
+        sb.append("    image: ").append(toIndentedString(image)).append("\n");
+        sb.append("    category: ").append(toIndentedString(category)).append("\n");
+        sb.append("    displayOrder: ").append(toIndentedString(displayOrder)).append("\n");
+        sb.append("    self: ").append(toIndentedString(self)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+    * Convert the given object to string with each line indented by 4 spaces
+    * (except the first line).
+    */
+    private String toIndentedString(java.lang.Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}
+

--- a/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/gen/java/org/wso2/carbon/identity/api/server/idp/v1/model/IdentityProviderTemplateListResponse.java
+++ b/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/gen/java/org/wso2/carbon/identity/api/server/idp/v1/model/IdentityProviderTemplateListResponse.java
@@ -1,0 +1,202 @@
+/*
+* Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package org.wso2.carbon.identity.api.server.idp.v1.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import java.util.ArrayList;
+import java.util.List;
+import org.wso2.carbon.identity.api.server.idp.v1.model.IdentityProviderTemplateListItem;
+import org.wso2.carbon.identity.api.server.idp.v1.model.Link;
+import javax.validation.constraints.*;
+
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+import javax.validation.Valid;
+import javax.xml.bind.annotation.*;
+
+public class IdentityProviderTemplateListResponse  {
+  
+    private Integer totalResults;
+    private Integer startIndex;
+    private Integer count;
+    private List<Link> links = null;
+
+    private List<IdentityProviderTemplateListItem> templates = null;
+
+
+    /**
+    **/
+    public IdentityProviderTemplateListResponse totalResults(Integer totalResults) {
+
+        this.totalResults = totalResults;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "10", value = "")
+    @JsonProperty("totalResults")
+    @Valid
+    public Integer getTotalResults() {
+        return totalResults;
+    }
+    public void setTotalResults(Integer totalResults) {
+        this.totalResults = totalResults;
+    }
+
+    /**
+    **/
+    public IdentityProviderTemplateListResponse startIndex(Integer startIndex) {
+
+        this.startIndex = startIndex;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "1", value = "")
+    @JsonProperty("startIndex")
+    @Valid
+    public Integer getStartIndex() {
+        return startIndex;
+    }
+    public void setStartIndex(Integer startIndex) {
+        this.startIndex = startIndex;
+    }
+
+    /**
+    **/
+    public IdentityProviderTemplateListResponse count(Integer count) {
+
+        this.count = count;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "10", value = "")
+    @JsonProperty("count")
+    @Valid
+    public Integer getCount() {
+        return count;
+    }
+    public void setCount(Integer count) {
+        this.count = count;
+    }
+
+    /**
+    **/
+    public IdentityProviderTemplateListResponse links(List<Link> links) {
+
+        this.links = links;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "[{\"href\":\"identity-provider/templates?offset=50&limit=10\",\"rel\":\"next\"},{\"href\":\"identity-provider/templates?offset=30&limit=10\",\"rel\":\"previous\"}]", value = "")
+    @JsonProperty("links")
+    @Valid
+    public List<Link> getLinks() {
+        return links;
+    }
+    public void setLinks(List<Link> links) {
+        this.links = links;
+    }
+
+    public IdentityProviderTemplateListResponse addLinksItem(Link linksItem) {
+        if (this.links == null) {
+            this.links = new ArrayList<>();
+        }
+        this.links.add(linksItem);
+        return this;
+    }
+
+        /**
+    **/
+    public IdentityProviderTemplateListResponse templates(List<IdentityProviderTemplateListItem> templates) {
+
+        this.templates = templates;
+        return this;
+    }
+    
+    @ApiModelProperty(value = "")
+    @JsonProperty("templates")
+    @Valid
+    public List<IdentityProviderTemplateListItem> getTemplates() {
+        return templates;
+    }
+    public void setTemplates(List<IdentityProviderTemplateListItem> templates) {
+        this.templates = templates;
+    }
+
+    public IdentityProviderTemplateListResponse addTemplatesItem(IdentityProviderTemplateListItem templatesItem) {
+        if (this.templates == null) {
+            this.templates = new ArrayList<>();
+        }
+        this.templates.add(templatesItem);
+        return this;
+    }
+
+    
+
+    @Override
+    public boolean equals(java.lang.Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        IdentityProviderTemplateListResponse identityProviderTemplateListResponse = (IdentityProviderTemplateListResponse) o;
+        return Objects.equals(this.totalResults, identityProviderTemplateListResponse.totalResults) &&
+            Objects.equals(this.startIndex, identityProviderTemplateListResponse.startIndex) &&
+            Objects.equals(this.count, identityProviderTemplateListResponse.count) &&
+            Objects.equals(this.links, identityProviderTemplateListResponse.links) &&
+            Objects.equals(this.templates, identityProviderTemplateListResponse.templates);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(totalResults, startIndex, count, links, templates);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class IdentityProviderTemplateListResponse {\n");
+        
+        sb.append("    totalResults: ").append(toIndentedString(totalResults)).append("\n");
+        sb.append("    startIndex: ").append(toIndentedString(startIndex)).append("\n");
+        sb.append("    count: ").append(toIndentedString(count)).append("\n");
+        sb.append("    links: ").append(toIndentedString(links)).append("\n");
+        sb.append("    templates: ").append(toIndentedString(templates)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+    * Convert the given object to string with each line indented by 4 spaces
+    * (except the first line).
+    */
+    private String toIndentedString(java.lang.Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}
+

--- a/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/main/java/org/wso2/carbon/identity/api/server/idp/v1/impl/IdentityProvidersApiServiceImpl.java
+++ b/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/main/java/org/wso2/carbon/identity/api/server/idp/v1/impl/IdentityProvidersApiServiceImpl.java
@@ -26,6 +26,7 @@ import org.wso2.carbon.identity.api.server.idp.v1.model.Claims;
 import org.wso2.carbon.identity.api.server.idp.v1.model.FederatedAuthenticatorPUTRequest;
 import org.wso2.carbon.identity.api.server.idp.v1.model.IdentityProviderPOSTRequest;
 import org.wso2.carbon.identity.api.server.idp.v1.model.IdentityProviderResponse;
+import org.wso2.carbon.identity.api.server.idp.v1.model.IdentityProviderTemplate;
 import org.wso2.carbon.identity.api.server.idp.v1.model.JustInTimeProvisioning;
 import org.wso2.carbon.identity.api.server.idp.v1.model.OutboundConnectorPUTRequest;
 import org.wso2.carbon.identity.api.server.idp.v1.model.Patch;
@@ -37,6 +38,7 @@ import javax.ws.rs.core.Response;
 
 import static org.wso2.carbon.identity.api.server.common.Constants.V1_API_PATH_COMPONENT;
 import static org.wso2.carbon.identity.api.server.idp.common.Constants.IDP_PATH_COMPONENT;
+import static org.wso2.carbon.identity.api.server.idp.common.Constants.IDP_TEMPLATE_PATH_COMPONENT;
 
 /**
  * Implementation of the Identity Provider Rest API.
@@ -56,6 +58,16 @@ public class IdentityProvidersApiServiceImpl implements IdentityProvidersApiServ
     }
 
     @Override
+    public Response addIDPTemplate(IdentityProviderTemplate identityProviderTemplatePOSTRequest) {
+
+        String idpTemplateId =
+                idpManagementService.createIDPTemplate(identityProviderTemplatePOSTRequest);
+        URI location = ContextLoader.buildURIForHeader(V1_API_PATH_COMPONENT +
+                IDP_PATH_COMPONENT + IDP_TEMPLATE_PATH_COMPONENT + "/" + idpTemplateId);
+        return Response.created(location).build();
+    }
+
+    @Override
     public Response deleteIDP(String identityProviderId, Boolean force) {
 
         if (force) {
@@ -64,6 +76,13 @@ public class IdentityProvidersApiServiceImpl implements IdentityProvidersApiServ
             idpManagementService.deleteIDP(identityProviderId);
         }
 
+        return Response.noContent().build();
+    }
+
+    @Override
+    public Response deleteIDPTemplate(String templateId) {
+
+        idpManagementService.deleteIDPTemplate(templateId);
         return Response.noContent().build();
     }
 
@@ -96,6 +115,18 @@ public class IdentityProvidersApiServiceImpl implements IdentityProvidersApiServ
     public Response getIDP(String identityProviderId) {
 
         return Response.ok().entity(idpManagementService.getIDP(identityProviderId)).build();
+    }
+
+    @Override
+    public Response getIDPTemplate(String templateId) {
+
+        return Response.ok().entity(idpManagementService.getIDPTemplate(templateId)).build();
+    }
+
+    @Override
+    public Response getIDPTemplates(Integer limit, Integer offset, String filter) {
+
+        return Response.ok().entity(idpManagementService.getIDPTemplates(limit, offset, filter)).build();
     }
 
     @Override
@@ -183,6 +214,14 @@ public class IdentityProvidersApiServiceImpl implements IdentityProvidersApiServ
         return Response.ok().entity(idpManagementService.updateFederatedAuthenticator(identityProviderId,
                 federatedAuthenticatorId, federatedAuthenticatorPUTRequest))
                 .build();
+    }
+
+    @Override
+    public Response updateIDPTemplate(String templateId, IdentityProviderTemplate
+            identityProviderTemplatePOSTRequest) {
+
+        idpManagementService.updateIDPTemplate(templateId, identityProviderTemplatePOSTRequest);
+        return Response.ok().build();
     }
 
     @Override

--- a/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/main/resources/META-INF/cxf/idp-server-v1-cxf.xml
+++ b/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/main/resources/META-INF/cxf/idp-server-v1-cxf.xml
@@ -22,10 +22,13 @@
           class="org.wso2.carbon.identity.api.server.idp.common.factory.IdPMgtOSGIServiceFactory"/>
     <bean id="claimMetadataServiceFactoryBean"
           class="org.wso2.carbon.identity.api.server.idp.common.factory.ClaimMetadataMgtOSGIServiceFactory"/>
+    <bean id="templateManagerServiceFactoryBean"
+          class="org.wso2.carbon.identity.api.server.idp.common.factory.TemplateMgtOSGIServiceFactory"/>
     <bean id="identityProviderServiceHolderBean"
           class="org.wso2.carbon.identity.api.server.idp.common.IdentityProviderServiceHolder">
         <property name="identityProviderManager" ref="identityProviderServiceFactoryBean"/>
         <property name="claimMetadataManagementService" ref="claimMetadataServiceFactoryBean"/>
+        <property name="templateManager" ref="templateManagerServiceFactoryBean"/>
     </bean>
 
 </beans>

--- a/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/main/resources/idp.yaml
+++ b/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/main/resources/idp.yaml
@@ -455,6 +455,12 @@ paths:
           description: Unauthorized
         '403':
           description: Forbidden
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
         '500':
           description: Server Error
           content:
@@ -1195,6 +1201,261 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
+  /identity-providers/templates:
+    get:
+      tags:
+        - Template management
+      summary: |
+        List identity provider templates
+      description: >
+        This API provides the list of available identity provider templates.
+      operationId: getIDPTemplates
+      parameters:
+        - $ref: '#/components/parameters/limitQueryParam'
+        - $ref: '#/components/parameters/offsetQueryParam'
+        - $ref: '#/components/parameters/filterQueryParam'
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IdentityProviderTemplateListResponse'
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '500':
+          description: Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+    post:
+      tags :
+        - Template management
+      summary: |
+        Create a new IDP template
+      description: >
+        This API provides the capability to create a new IDP template.
+      operationId: addIDPTemplate
+      responses:
+        '201':
+          description: Successful response
+          headers:
+            Location:
+              description: Location of the newly created identity provider template
+              schema:
+                type: string
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+            application/xml:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '409':
+          description: Conflict
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+            application/xml:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '500':
+          description: Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+            application/xml:
+              schema:
+                $ref: '#/components/schemas/Error'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/IdentityProviderTemplate'
+          application/xml:
+            schema:
+              $ref: '#/components/schemas/IdentityProviderTemplate'
+        description: This represents the identity provider template to be created
+        required: true
+  '/identity-providers/templates/{template-id}':
+    get:
+      tags:
+        - Template management
+      summary: |
+        Retrieve identity provider template by id
+      description: >
+        This API provides the capability to retrieve an indentity provider template using it's id.
+      operationId: getIDPTemplate
+      parameters:
+        - name: template-id
+          in: path
+          description: Id of the IDP template
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IdentityProviderTemplate'
+            application/xml:
+              schema:
+                $ref: '#/components/schemas/IdentityProviderTemplate'
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+            application/xml:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+            application/xml:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '500':
+          description: Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+            application/xml:
+              schema:
+                $ref: '#/components/schemas/Error'
+    put:
+      tags:
+        - Template management
+      summary: |
+        Update the IDP template of a given template id.
+      description: >
+        This API provides the capability to update the IDP template of a given template id.
+      operationId: updateIDPTemplate
+      parameters:
+        - name: template-id
+          in: path
+          description: Id of the IDP template
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Successfully updated
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '409':
+          description: Conflict
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+            application/xml:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '500':
+          description: Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/IdentityProviderTemplate'
+          application/xml:
+            schema:
+              $ref: '#/components/schemas/IdentityProviderTemplate'
+        description: This represents the identity provider template to be created
+        required: true
+    delete:
+      tags:
+        - Template management
+      summary: |
+        Delete a IDP template using the template Id.
+      description: >
+        This API provides the capability to delete a IDP template using the template Id.
+      operationId: deleteIDPTemplate
+      parameters:
+        - name: template-id
+          in: path
+          description: Id of the IDP template
+          required: true
+          schema:
+            type: string
+      responses:
+        '204':
+          description: Successfully Deleted
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '500':
+          description: Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
 servers:
   - url: 'https://localhost:9443/t/{tenant-domain}/api/server/v1'
     variables:
@@ -1395,15 +1656,15 @@ components:
           example: identity-providers
       readOnly: true
     Certificate:
-          type: object
-          properties:
-            certificates:
-              type: array
-              items:
-                type: string
-            jwksUri:
-              type: string
-              example: "https://localhost:9444/oauth2/jwks"
+      type: object
+      properties:
+        certificates:
+          type: array
+          items:
+            type: string
+        jwksUri:
+          type: string
+          example: "https://localhost:9444/oauth2/jwks"
     IdentityProviderPOSTRequest:
       type: object
       required:
@@ -1947,3 +2208,87 @@ components:
         self:
           type: string
           example: connected-app-url
+    IdentityProviderTemplateListResponse:
+      type: object
+      properties:
+        totalResults:
+          type: integer
+          example: 10
+        startIndex:
+          type: integer
+          example: 1
+        count:
+          type: integer
+          example: 10
+        links:
+          type: array
+          items:
+            $ref: '#/components/schemas/Link'
+          example:
+            [
+            {
+              "href": "identity-provider/templates?offset=50&limit=10",
+              "rel": "next",
+            },  {
+              "href": "identity-provider/templates?offset=30&limit=10",
+              "rel": "previous",
+            }
+            ]
+        templates:
+          type: array
+          items:
+            $ref: '#/components/schemas/IdentityProviderTemplateListItem'
+    IdentityProviderTemplateListItem:
+      type: object
+      properties:
+        id:
+          type: string
+          readOnly: true
+          example: 123e4567-e89b-12d3-a456-556642440000
+        name:
+          type: string
+          example: 'google'
+        description:
+          type: string
+          example: 'Identity provider template for google federation'
+        image:
+          type: string
+          example: 'google-logo-url'
+        category:
+          type: string
+          enum: [DEFAULT, CUSTOM]
+          example: 'DEFAULT'
+        displayOrder:
+          type: integer
+          example: 10
+        self:
+          type: string
+          example: '/t/carbon.super/api/server/v1/identity-providers/templates/123e4567-e89b-12d3-a456-556642440000'
+    IdentityProviderTemplate:
+      type: object
+      properties:
+        id:
+          type: string
+          readOnly: true
+          example: 123e4567-e89b-12d3-a456-556642440000
+        name:
+          type: string
+          example: google
+        description:
+          type: string
+          example: 'Google federated connector'
+        image:
+          type: string
+          example: 'google-logo-url'
+        category:
+          type: string
+          enum: [DEFAULT, CUSTOM]
+          example: 'DEFAULT'
+        displayOrder:
+          type: integer
+          example: 10
+        idp:
+          $ref : '#/components/schemas/IdentityProviderPOSTRequest'
+      required:
+        - name
+        - idp

--- a/pom.xml
+++ b/pom.xml
@@ -399,6 +399,11 @@
                 <version>${project.version}</version>
                 <scope>provided</scope>
             </dependency>
+            <dependency>
+                <groupId>org.wso2.carbon.identity.framework</groupId>
+                <artifactId>org.wso2.carbon.identity.template.mgt</artifactId>
+                <version>${carbon.identity.framework.version}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 


### PR DESCRIPTION
## Purpose
> Add identity provider template management service API. Primary usage of this API is to keep frequently used IdP configurations and re-use them at IdP creation. 

##Dependent on
> https://github.com/wso2/carbon-identity-framework/pull/2827

## Issues
> https://github.com/wso2/product-is/issues/7879