### PR TITLE
Fix custom protocol metadata retrieving issue via application REST API

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/application/management/v1/CustomInboundProtocolMetaData.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/application/management/v1/CustomInboundProtocolMetaData.java
@@ -34,6 +34,7 @@ import javax.xml.bind.annotation.*;
 public class CustomInboundProtocolMetaData  {
   
     private String displayName;
+    private String configName;
     private List<CustomInboundProtocolProperty> properties = null;
 
 
@@ -53,6 +54,24 @@ public class CustomInboundProtocolMetaData  {
     }
     public void setDisplayName(String displayName) {
         this.displayName = displayName;
+    }
+
+    /**
+    **/
+    public CustomInboundProtocolMetaData configName(String configName) {
+
+        this.configName = configName;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "My Custom Protocol", value = "")
+    @JsonProperty("configName")
+    @Valid
+    public String getConfigName() {
+        return configName;
+    }
+    public void setConfigName(String configName) {
+        this.configName = configName;
     }
 
     /**
@@ -94,12 +113,13 @@ public class CustomInboundProtocolMetaData  {
         }
         CustomInboundProtocolMetaData customInboundProtocolMetaData = (CustomInboundProtocolMetaData) o;
         return Objects.equals(this.displayName, customInboundProtocolMetaData.displayName) &&
+            Objects.equals(this.configName, customInboundProtocolMetaData.configName) &&
             Objects.equals(this.properties, customInboundProtocolMetaData.properties);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(displayName, properties);
+        return Objects.hash(displayName, configName, properties);
     }
 
     @Override
@@ -109,6 +129,7 @@ public class CustomInboundProtocolMetaData  {
         sb.append("class CustomInboundProtocolMetaData {\n");
         
         sb.append("    displayName: ").append(toIndentedString(displayName)).append("\n");
+        sb.append("    configName: ").append(toIndentedString(configName)).append("\n");
         sb.append("    properties: ").append(toIndentedString(properties)).append("\n");
         sb.append("}");
         return sb.toString();

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/application/management/v1/CustomInboundProtocolMetaData.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/application/management/v1/CustomInboundProtocolMetaData.java
@@ -64,7 +64,7 @@ public class CustomInboundProtocolMetaData  {
         return this;
     }
     
-    @ApiModelProperty(example = "My Custom Protocol", value = "")
+    @ApiModelProperty(example = "Custom Protocol", value = "")
     @JsonProperty("configName")
     @Valid
     public String getConfigName() {

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/resources/applications.yaml
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/resources/applications.yaml
@@ -3031,6 +3031,9 @@ components:
         displayName:
           type: string
           example: 'My Custom Protocol'
+        configName:
+          type: string
+          example: 'Custom Protocol'
         properties:
           type: array
           items:

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/resources/applications.yaml
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/resources/applications.yaml
@@ -1717,7 +1717,7 @@ paths:
         Retrieve all the metadata related to the custom auth protocol identified by the inboundProtocolId
       description: >
         This API provides the capability to retrieve all the metadata related to the custom auth protocol
-        identified by the inboundProtocolId. <br>
+        identified by the inboundProtocolId. The URL encoded inbound protocol name is used as inboundProtocolId.<br>
           <b>Permission required:</b> <br>
               * /permission/admin/manage/identity/applicationmgt/view <br>
           <b>Scope required:</b> <br>


### PR DESCRIPTION
## Purpose

- Resolves https://github.com/wso2/product-is/issues/8016
- Need to use URL encoded protocol name as 'protocol-id' in  `api/server/v1/applications/meta/inbound-protocols/<protocol-id>`
- Introducing an id to inbound-protocols is useless because saml, oidc, ws-trust are handeled differently due to their different object models
- Add '`configName`' attribute to `CustomInboundProtocolMetaData`  model, which is a missed metadata 
- Remove WS-Federation (Passive) when listing protocols for `api/server/v1/applications/meta/inbound-protocols` request, since it doesn't have metadata
