### PR TITLE
Add fix to validate invalid dialect ID

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.claim.management/org.wso2.carbon.identity.rest.api.server.claim.management.v1/src/main/java/org/wso2/carbon/identity/rest/api/server/claim/management/v1/core/ServerClaimManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.claim.management/org.wso2.carbon.identity.rest.api.server.claim.management.v1/src/main/java/org/wso2/carbon/identity/rest/api/server/claim/management/v1/core/ServerClaimManagementService.java
@@ -477,6 +477,15 @@ public class ServerClaimManagementService {
         handleNotImplementedCapabilities(limit, offset, filter, sort);
 
         try {
+            List<ClaimDialect> claimDialectList = getClaimMetadataManagementService().getClaimDialects(
+                    ContextLoader.getTenantDomainFromContext());
+            String decodedDialectId = base64DecodeId(dialectId);
+            ClaimDialect claimDialect = extractDialectFromDialectList(decodedDialectId, claimDialectList);
+
+            if (claimDialect == null) {
+                throw handleClaimManagementClientError(ERROR_CODE_DIALECT_NOT_FOUND, NOT_FOUND, dialectId);
+            }
+
             List<ExternalClaim> externalClaimList = getClaimMetadataManagementService().getExternalClaims(
                     base64DecodeId(dialectId),
                     ContextLoader.getTenantDomainFromContext());


### PR DESCRIPTION
Previously claim dialect was assumed to be invalid, if its claim list is empty. Added proper validation.