### PR TITLE
[FIX] Error when adding role mapping for service providers via REST APIs

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/pom.xml
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/pom.xml
@@ -119,6 +119,11 @@
             <artifactId>org.wso2.carbon.identity.template.mgt</artifactId>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.core</artifactId>
+            <scope>provided</scope>
+        </dependency>
 
         <dependency>
             <groupId>org.wso2.carbon.identity.server.api</groupId>

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/functions/application/UpdateClaimConfiguration.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/functions/application/UpdateClaimConfiguration.java
@@ -15,6 +15,7 @@
  */
 package org.wso2.carbon.identity.api.server.application.management.v1.core.functions.application;
 
+import org.wso2.carbon.CarbonConstants;
 import org.wso2.carbon.identity.api.server.application.management.v1.ClaimConfiguration;
 import org.wso2.carbon.identity.api.server.application.management.v1.ClaimMappings;
 import org.wso2.carbon.identity.api.server.application.management.v1.RequestedClaimConfiguration;
@@ -28,6 +29,7 @@ import org.wso2.carbon.identity.application.common.model.LocalRole;
 import org.wso2.carbon.identity.application.common.model.PermissionsAndRoleConfig;
 import org.wso2.carbon.identity.application.common.model.RoleMapping;
 import org.wso2.carbon.identity.application.common.model.ServiceProvider;
+import org.wso2.carbon.identity.core.util.IdentityUtil;
 
 import java.util.Map;
 import java.util.Optional;
@@ -182,7 +184,17 @@ public class UpdateClaimConfiguration implements UpdateFunction<ServiceProvider,
     private RoleMapping buildRoleMapping(
             org.wso2.carbon.identity.api.server.application.management.v1.RoleMapping roleMapping) {
 
-        return new RoleMapping(new LocalRole(roleMapping.getLocalRole()), roleMapping.getApplicationRole());
+        String localRoleName = roleMapping.getLocalRole();
+        /*
+        For the local roles with userstore domain prepended to the role name, the domain name should not be
+        removed from the role name since userstore domain of a role is identified via the given role name. If the
+        domain name is not available in the role, the role's domain will be considered as PRIMARY.
+        */
+        if (localRoleName.contains(CarbonConstants.DOMAIN_SEPARATOR)) {
+            String userStoreId = IdentityUtil.extractDomainFromName(localRoleName);
+            return new RoleMapping(new LocalRole(userStoreId, localRoleName), roleMapping.getApplicationRole());
+        }
+        return new RoleMapping(new LocalRole(localRoleName), roleMapping.getApplicationRole());
     }
 
     private PermissionsAndRoleConfig getPermissionAndRoleConfig(ServiceProvider application) {

--- a/pom.xml
+++ b/pom.xml
@@ -400,11 +400,6 @@
                 <scope>provided</scope>
             </dependency>
             <dependency>
-                <groupId>org.wso2.carbon.identity.framework</groupId>
-                <artifactId>org.wso2.carbon.identity.template.mgt</artifactId>
-                <version>${carbon.identity.framework.version}</version>
-            </dependency>
-            <dependency>
                 <groupId>org.apache.cxf</groupId>
                 <artifactId>cxf-rt-rs-extension-search</artifactId>
                 <version>${cxf.extensions.search.version}</version>


### PR DESCRIPTION
## Purpose
Resolves: https://github.com/wso2/product-is/issues/8355

## Approach

- According to the role names in IS, the domain name should be in front of the roleName. Eg: `TEST/testRole`.

- In the existing implementation of the Application Management API, the userstore domain is removed from the role name and stored as  `userStoreId` of the `LocalRole` object.
**userStoreId:** TEST
**localRoleName:** testRole

#### FIX:
- The userstore name was not removed from the role name. Therefore the `LocalRole` object will look as follows.
**userStoreId:** TEST
**localRoleName:** TEST/testRole
