### PR TITLE
Fix responses of tenant management API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ ass
 *.ipr
 .idea
 .DS_Store
+.factorypath
 
 # Mobile Tools for Java (J2ME)
 .mtj.tmp/

--- a/components/org.wso2.carbon.identity.api.server.tenant.management/org.wso2.carbon.identity.api.server.tenant.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/tenant/management/v1/TenantsApi.java
+++ b/components/org.wso2.carbon.identity.api.server.tenant.management/org.wso2.carbon.identity.api.server.tenant.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/tenant/management/v1/TenantsApi.java
@@ -20,6 +20,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.apache.cxf.jaxrs.ext.multipart.Attachment;
 import org.apache.cxf.jaxrs.ext.multipart.Multipart;
 import java.io.InputStream;
+import java.util.List;
 
 import org.wso2.carbon.identity.api.server.tenant.management.v1.model.Error;
 import org.wso2.carbon.identity.api.server.tenant.management.v1.model.OwnerResponse;

--- a/components/org.wso2.carbon.identity.api.server.tenant.management/org.wso2.carbon.identity.api.server.tenant.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/tenant/management/v1/TenantsApiService.java
+++ b/components/org.wso2.carbon.identity.api.server.tenant.management/org.wso2.carbon.identity.api.server.tenant.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/tenant/management/v1/TenantsApiService.java
@@ -21,6 +21,7 @@ import org.wso2.carbon.identity.api.server.tenant.management.v1.model.*;
 import org.apache.cxf.jaxrs.ext.multipart.Attachment;
 import org.apache.cxf.jaxrs.ext.multipart.Multipart;
 import java.io.InputStream;
+import java.util.List;
 import org.wso2.carbon.identity.api.server.tenant.management.v1.model.Error;
 import org.wso2.carbon.identity.api.server.tenant.management.v1.model.OwnerResponse;
 import org.wso2.carbon.identity.api.server.tenant.management.v1.model.TenantModel;

--- a/components/org.wso2.carbon.identity.api.server.tenant.management/org.wso2.carbon.identity.api.server.tenant.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/tenant/management/v1/model/TenantListItem.java
+++ b/components/org.wso2.carbon.identity.api.server.tenant.management/org.wso2.carbon.identity.api.server.tenant.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/tenant/management/v1/model/TenantListItem.java
@@ -134,7 +134,7 @@ public class TenantListItem  {
     }
     
     @ApiModelProperty(value = "")
-    @JsonProperty("lifecycle-status")
+    @JsonProperty("lifecycleStatus")
     @Valid
     public LifeCycleStatus getLifecycleStatus() {
         return lifecycleStatus;

--- a/components/org.wso2.carbon.identity.api.server.tenant.management/org.wso2.carbon.identity.api.server.tenant.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/tenant/management/v1/model/TenantResponseModel.java
+++ b/components/org.wso2.carbon.identity.api.server.tenant.management/org.wso2.carbon.identity.api.server.tenant.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/tenant/management/v1/model/TenantResponseModel.java
@@ -107,7 +107,7 @@ public class TenantResponseModel  {
     }
 
         /**
-    * Tenant created time.
+    * Tenant created time in ISO-8601 format.
     **/
     public TenantResponseModel createdDate(String createdDate) {
 
@@ -115,7 +115,7 @@ public class TenantResponseModel  {
         return this;
     }
     
-    @ApiModelProperty(example = "2020-03-03T17:04:06.570+05:30", value = "Tenant created time.")
+    @ApiModelProperty(example = "2020-06-19T17:36:46.271Z", value = "Tenant created time in ISO-8601 format.")
     @JsonProperty("createdDate")
     @Valid
     public String getCreatedDate() {
@@ -134,7 +134,7 @@ public class TenantResponseModel  {
     }
     
     @ApiModelProperty(value = "")
-    @JsonProperty("lifecycle-status")
+    @JsonProperty("lifecycleStatus")
     @Valid
     public LifeCycleStatus getLifecycleStatus() {
         return lifecycleStatus;

--- a/components/org.wso2.carbon.identity.api.server.tenant.management/org.wso2.carbon.identity.api.server.tenant.management.v1/src/main/java/org/wso2/carbon/identity/api/server/tenant/management/v1/core/ServerTenantManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.tenant.management/org.wso2.carbon.identity.api.server.tenant.management.v1/src/main/java/org/wso2/carbon/identity/api/server/tenant/management/v1/core/ServerTenantManagementService.java
@@ -45,7 +45,10 @@ import org.wso2.carbon.user.core.tenant.TenantSearchResult;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -53,7 +56,10 @@ import java.util.Map;
 import javax.ws.rs.core.Response;
 
 import static org.wso2.carbon.identity.api.server.common.Constants.V1_API_PATH_COMPONENT;
-import static org.wso2.carbon.identity.api.server.tenant.management.common.TenantManagementConstants.TENANT_MANAGEMENT_PATH_COMPONENT;
+import static org.wso2.carbon.identity.api.server.tenant.management.common.TenantManagementConstants
+        .TENANT_MANAGEMENT_PATH_COMPONENT;
+
+import static java.time.format.DateTimeFormatter.ISO_OFFSET_DATE_TIME;
 
 /**
  * Call internal osgi services to perform server tenant management related operations.
@@ -179,7 +185,7 @@ public class ServerTenantManagementService {
     private TenantResponseModel createTenantResponse(Tenant tenant) {
 
         TenantResponseModel tenantResponseModel = new TenantResponseModel();
-        tenantResponseModel.setCreatedDate(tenant.getCreatedDate().toString());
+        tenantResponseModel.setCreatedDate(getISOFormatDate(tenant.getCreatedDate()));
         tenantResponseModel.setDomain(tenant.getDomain());
         tenantResponseModel.setId(tenant.getTenantUniqueID());
         tenantResponseModel.setLifecycleStatus(getLifeCycleStatus(tenant.isActive()));
@@ -255,7 +261,7 @@ public class ServerTenantManagementService {
         for (Tenant tenant : tenants) {
             TenantListItem listItem = new TenantListItem();
             listItem.setLifecycleStatus(getLifeCycleStatus(tenant.isActive()));
-            listItem.setCreatedDate(tenant.getCreatedDate().toString());
+            listItem.setCreatedDate(getISOFormatDate(tenant.getCreatedDate()));
             listItem.setDomain(tenant.getDomain());
             listItem.setId(tenant.getTenantUniqueID());
             listItem.setOwners(getOwnerResponses(tenant));
@@ -434,4 +440,16 @@ public class ServerTenantManagementService {
         }
     }
 
+    /**
+     * Convert {@link Date} instance to ISO-8601 format string.
+     *
+     * @param date Date instance to be converted.
+     * @return ISO-8601 representation of the date.
+     */
+    private String getISOFormatDate(Date date) {
+
+        ZonedDateTime zonedDateTime = ZonedDateTime.ofInstant(date.toInstant(), ZoneId.systemDefault())
+                                                   .withZoneSameInstant(ZoneId.of("UTC"));
+        return ISO_OFFSET_DATE_TIME.format(zonedDateTime);
+    }
 }

--- a/components/org.wso2.carbon.identity.api.server.tenant.management/org.wso2.carbon.identity.api.server.tenant.management.v1/src/main/resources/tenant-management.yaml
+++ b/components/org.wso2.carbon.identity.api.server.tenant.management/org.wso2.carbon.identity.api.server.tenant.management.v1/src/main/resources/tenant-management.yaml
@@ -350,7 +350,7 @@ components:
           example: "2020-03-03T17:04:06.570+05:30"
           readOnly: true
           description: Tenant created time.
-        lifecycle-status:
+        lifecycleStatus:
           $ref: '#/components/schemas/LifeCycleStatus'
         region:
           type: string
@@ -406,10 +406,10 @@ components:
             $ref: '#/components/schemas/OwnerResponse'
         createdDate:
           type: string
-          example: "2020-03-03T17:04:06.570+05:30"
+          example: "2020-06-19T17:36:46.271Z"
           readOnly: true
-          description: Tenant created time.
-        lifecycle-status:
+          description: Tenant created time in ISO-8601 format.
+        lifecycleStatus:
           $ref: '#/components/schemas/LifeCycleStatus'
         region:
           type: string
@@ -420,7 +420,7 @@ components:
     TenantPutModel:
       type: object
       required:
-        - lifecycle-status
+        - lifecycleStatus
       properties:
         activated:
           type: boolean


### PR DESCRIPTION
The fix includes the following
- lifecycle-status attribute name is changed to lifecycleStatus
- createdDate attribute is changed to ISO-8601 format