### PR TITLE
Update error codes for invalid application search filters

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/ServerApplicationManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/ServerApplicationManagementService.java
@@ -867,8 +867,7 @@ public class ServerApplicationManagementService {
                     throw buildClientError(ErrorMessage.INVALID_FILTER_FORMAT);
                 }
             } catch (IOException | IdentityException e) {
-                throw buildClientError(ApplicationManagementConstants.ErrorMessage
-                        .ERROR_CODE_ERROR_INVALID_SEARCH_FILTER, null);
+                throw buildClientError(ApplicationManagementConstants.ErrorMessage.INVALID_FILTER_FORMAT, null);
             }
         } else {
             return null;


### PR DESCRIPTION
Fix the test failures due to https://github.com/wso2/identity-api-server/pull/170 as the error codes were changed.