### PR TITLE
Update build status badge icon

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 |  Branch | Build Status | Travis CI Status |
 | :------------ |:------------- |:-------------
-| master      | [![Build Status](https://wso2.org/jenkins/job/platform-builds/job/identity-api-server/badge/icon)](https://wso2.org/jenkins/job/platform-builds/job/identity-api-server/) | [![Travis CI Status](https://travis-ci.org/wso2/identity-api-server.svg?branch=master)](https://travis-ci.org/wso2/identity-api-server?branch=master)|
+| master      | [![Build Status](https://img.shields.io/jenkins/build?jobUrl=https%3A%2F%2Fwso2.org%2Fjenkins%2Fjob%2Fplatform-builds%2Fjob%2Fidentity-api-server%2F)](https://wso2.org/jenkins/job/platform-builds/job/identity-api-server/) | [![Travis CI Status](https://travis-ci.org/wso2/identity-api-server.svg?branch=master)](https://travis-ci.org/wso2/identity-api-server?branch=master)|
 
 This repository contains modules related to the server related REST apis 
 


### PR DESCRIPTION
## Purpose
> Currently in the master branch the build status is not shown as follows:
![Screenshot from 2020-06-23 18-00-34](https://user-images.githubusercontent.com/33062368/85403709-782c5e80-b57b-11ea-90a9-5e1f76178d3c.png)

## Goals
> With this fix the badge will be taken through [shields.io](https://shields.io/) and will be shown as follows:
![Screenshot from 2020-06-23 18-05-38](https://user-images.githubusercontent.com/33062368/85404149-29cb8f80-b57c-11ea-8d62-ef142f18a432.png)

## Release note
> Updated build status badge icon in README.md file

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
> JDK: 1.8.0_161
 OS: Ubuntu
Database: Default H2
Browser: Firefox 77.0.1 (64-bit)