### PR TITLE
Avoid setting the basic authenticator as basic in apps

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/functions/application/UpdateAuthenticationSequence.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/functions/application/UpdateAuthenticationSequence.java
@@ -61,11 +61,13 @@ public class UpdateAuthenticationSequence implements UpdateFunction<ServiceProvi
         if (isRevertToDefaultSequence(authSequenceApiModel, localAndOutboundConfig)) {
             localAndOutboundConfig.setAuthenticationType(ApplicationConstants.AUTH_TYPE_DEFAULT);
             localAndOutboundConfig.setAuthenticationSteps(new AuthenticationStep[0]);
-        } else {
+        } else if (authSequenceApiModel.getType() != AuthenticationSequence.TypeEnum.DEFAULT) {
             AuthenticationStep[] authenticationSteps = getAuthenticationSteps(authSequenceApiModel);
             localAndOutboundConfig.setAuthenticationType(ApplicationConstants.AUTH_TYPE_FLOW);
             localAndOutboundConfig.setAuthenticationSteps(authenticationSteps);
         }
+        // If the authSequenceApiModel.getType() = DEFAULT, we don't have to worry about setting authentication steps
+        // and related configs.
     }
 
     private void updateAdaptiveAuthenticationScript(AuthenticationSequence authSequenceApiModel,


### PR DESCRIPTION
The PR, https://github.com/wso2/identity-api-server/pull/171/files#diff-3504918efa11528eb55fe034c47515d2L67 had removed the validation of authSequenceApiModel.getType() = DEFAULT. Therefore the Basic authenticator is set as a step in the authentication sequence of the newly created applications even though it is set as default.

This PR will maintain the previous behavior.