### PR TITLE
Include the new OIDC app configuration

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/application/management/v1/AccessTokenConfiguration.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/application/management/v1/AccessTokenConfiguration.java
@@ -34,6 +34,7 @@ public class AccessTokenConfiguration  {
     private Long userAccessTokenExpiryInSeconds;
     private Long applicationAccessTokenExpiryInSeconds;
     private String bindingType = "None";
+    private Boolean revokeTokensWhenIDPSessionTerminated;
 
     /**
     **/
@@ -108,6 +109,25 @@ public class AccessTokenConfiguration  {
         this.bindingType = bindingType;
     }
 
+    /**
+    * If enabled, when the IDP session is terminated, all the access tokens bound to the session will get revoked.
+    **/
+    public AccessTokenConfiguration revokeTokensWhenIDPSessionTerminated(Boolean revokeTokensWhenIDPSessionTerminated) {
+
+        this.revokeTokensWhenIDPSessionTerminated = revokeTokensWhenIDPSessionTerminated;
+        return this;
+    }
+    
+    @ApiModelProperty(value = "If enabled, when the IDP session is terminated, all the access tokens bound to the session will get revoked.")
+    @JsonProperty("revokeTokensWhenIDPSessionTerminated")
+    @Valid
+    public Boolean getRevokeTokensWhenIDPSessionTerminated() {
+        return revokeTokensWhenIDPSessionTerminated;
+    }
+    public void setRevokeTokensWhenIDPSessionTerminated(Boolean revokeTokensWhenIDPSessionTerminated) {
+        this.revokeTokensWhenIDPSessionTerminated = revokeTokensWhenIDPSessionTerminated;
+    }
+
 
 
     @Override
@@ -123,12 +143,13 @@ public class AccessTokenConfiguration  {
         return Objects.equals(this.type, accessTokenConfiguration.type) &&
             Objects.equals(this.userAccessTokenExpiryInSeconds, accessTokenConfiguration.userAccessTokenExpiryInSeconds) &&
             Objects.equals(this.applicationAccessTokenExpiryInSeconds, accessTokenConfiguration.applicationAccessTokenExpiryInSeconds) &&
-            Objects.equals(this.bindingType, accessTokenConfiguration.bindingType);
+            Objects.equals(this.bindingType, accessTokenConfiguration.bindingType) &&
+            Objects.equals(this.revokeTokensWhenIDPSessionTerminated, accessTokenConfiguration.revokeTokensWhenIDPSessionTerminated);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(type, userAccessTokenExpiryInSeconds, applicationAccessTokenExpiryInSeconds, bindingType);
+        return Objects.hash(type, userAccessTokenExpiryInSeconds, applicationAccessTokenExpiryInSeconds, bindingType, revokeTokensWhenIDPSessionTerminated);
     }
 
     @Override
@@ -141,6 +162,7 @@ public class AccessTokenConfiguration  {
         sb.append("    userAccessTokenExpiryInSeconds: ").append(toIndentedString(userAccessTokenExpiryInSeconds)).append("\n");
         sb.append("    applicationAccessTokenExpiryInSeconds: ").append(toIndentedString(applicationAccessTokenExpiryInSeconds)).append("\n");
         sb.append("    bindingType: ").append(toIndentedString(bindingType)).append("\n");
+        sb.append("    revokeTokensWhenIDPSessionTerminated: ").append(toIndentedString(revokeTokensWhenIDPSessionTerminated)).append("\n");
         sb.append("}");
         return sb.toString();
     }

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/functions/application/inbound/oauth2/ApiModelToOAuthConsumerApp.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/functions/application/inbound/oauth2/ApiModelToOAuthConsumerApp.java
@@ -126,6 +126,8 @@ public class ApiModelToOAuthConsumerApp implements ApiModelToOAuthConsumerAppFun
             consumerAppDTO.setUserAccessTokenExpiryTime(accessToken.getUserAccessTokenExpiryInSeconds());
             consumerAppDTO.setApplicationAccessTokenExpiryTime(accessToken.getApplicationAccessTokenExpiryInSeconds());
             consumerAppDTO.setTokenBindingType(accessToken.getBindingType());
+            consumerAppDTO.setTokenRevocationWithIDPSessionTerminationEnabled(accessToken
+                    .getRevokeTokensWhenIDPSessionTerminated());
         }
     }
 

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/functions/application/inbound/oauth2/OAuthConsumerAppToApiModel.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/functions/application/inbound/oauth2/OAuthConsumerAppToApiModel.java
@@ -82,7 +82,9 @@ public class OAuthConsumerAppToApiModel implements Function<OAuthConsumerAppDTO,
                 .type(oAuthConsumerAppDTO.getTokenType())
                 .userAccessTokenExpiryInSeconds(oAuthConsumerAppDTO.getUserAccessTokenExpiryTime())
                 .applicationAccessTokenExpiryInSeconds(oAuthConsumerAppDTO.getApplicationAccessTokenExpiryTime())
-                .bindingType(oAuthConsumerAppDTO.getTokenBindingType());
+                .bindingType(oAuthConsumerAppDTO.getTokenBindingType())
+                .revokeTokensWhenIDPSessionTerminated(oAuthConsumerAppDTO
+                        .isTokenRevocationWithIDPSessionTerminationEnabled());
     }
 
     private RefreshTokenConfiguration buildRefreshTokenConfiguration(OAuthConsumerAppDTO oAuthConsumerAppDTO) {

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/resources/applications.yaml
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/resources/applications.yaml
@@ -2802,6 +2802,10 @@ components:
           example:
             - sso-session
             - cookie
+        revokeTokensWhenIDPSessionTerminated:
+          type: boolean
+          description: "If enabled, when the IDP session is terminated, all the access tokens bound to the session
+          will get revoked."
     RefreshTokenConfiguration:
       type: object
       properties:

--- a/pom.xml
+++ b/pom.xml
@@ -515,7 +515,7 @@
         <identity.workflow.impl.bps.version>5.2.0</identity.workflow.impl.bps.version>
         <maven.checkstyleplugin.excludes>**/gen/**/*</maven.checkstyleplugin.excludes>
         <identity.event.handler.version>1.3.3</identity.event.handler.version>
-        <identity.inbound.oauth2.version>6.2.120</identity.inbound.oauth2.version>
+        <identity.inbound.oauth2.version>6.4.50</identity.inbound.oauth2.version>
         <identity.inbound.saml2.version>5.7.6</identity.inbound.saml2.version>
         <commons.beanutils.version>1.9.4</commons.beanutils.version>
         <mavan.findbugsplugin.exclude.file>findbugs-exclude-filter.xml</mavan.findbugsplugin.exclude.file>


### PR DESCRIPTION
**Description**
A new OIDC property is introduced to the OAuth2/OIDC inbound authentication configuration with the PR https://github.com/wso2-extensions/identity-inbound-auth-oauth/pull/1413. 
This PR adds this property to the `access-token` attribute returned from the `api/server/v1/applications/{applicationId}/inbound-protocols/oidc` endpoint. And also supports updating the object.
