### PR TITLE
Fix incorrect caching of UserStoreConfigurationsRes object

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.userstore/org.wso2.carbon.identity.api.server.userstore.v1/src/main/java/org/wso2/carbon/identity/api/server/userstore/v1/core/ServerUserStoreService.java
+++ b/components/org.wso2.carbon.identity.api.server.userstore/org.wso2.carbon.identity.api.server.userstore.v1/src/main/java/org/wso2/carbon/identity/api/server/userstore/v1/core/ServerUserStoreService.java
@@ -78,7 +78,6 @@ import static org.wso2.carbon.identity.api.server.common.Constants.V1_API_PATH_C
 public class ServerUserStoreService {
 
     private static final Log LOG = LogFactory.getLog(ServerUserStoreService.class);
-    private static UserStoreConfigurationsRes primaryUserstoreConfigs = null;
 
     /**
      * Add a userStore {@link UserStoreReq}.
@@ -214,32 +213,31 @@ public class ServerUserStoreService {
      */
     public UserStoreConfigurationsRes getPrimaryUserStore() {
 
-        if (primaryUserstoreConfigs == null) {
-            RealmService realmService = UserStoreConfigServiceHolder.getInstance().getRealmService();
-            RealmConfiguration realmConfiguration = realmService.getBootstrapRealmConfiguration();
-            if (realmConfiguration == null) {
-                throw handleException(Response.Status.INTERNAL_SERVER_ERROR, UserStoreConstants.ErrorMessage.
-                        ERROR_CODE_ERROR_RETRIEVING_PRIMARY_USERSTORE);
-            }
-            List<AddUserStorePropertiesRes> propertiesTobeAdd = new ArrayList<>();
-            primaryUserstoreConfigs = new UserStoreConfigurationsRes();
-            primaryUserstoreConfigs.setClassName(realmConfiguration.getUserStoreClass());
-            primaryUserstoreConfigs.setDescription(realmConfiguration.getDescription());
-            primaryUserstoreConfigs.setName(UserCoreConstants.PRIMARY_DEFAULT_DOMAIN_NAME);
-            primaryUserstoreConfigs.setTypeId(base64URLEncodeId(Objects.requireNonNull
-                    (getUserStoreTypeName(realmConfiguration.getUserStoreClass()))));
-            primaryUserstoreConfigs.setTypeName(getUserStoreTypeName(realmConfiguration.getUserStoreClass()));
-            Map<String, String> userstoreProps = realmConfiguration.getUserStoreProperties();
-            if (MapUtils.isNotEmpty(userstoreProps)) {
-                for (String propKey : userstoreProps.keySet()) {
-                    AddUserStorePropertiesRes userStorePropertiesRes = new AddUserStorePropertiesRes();
-                    userStorePropertiesRes.setName(propKey);
-                    userStorePropertiesRes.setValue(userstoreProps.get(propKey));
-                    propertiesTobeAdd.add(userStorePropertiesRes);
-                }
-            }
-            primaryUserstoreConfigs.setProperties(propertiesTobeAdd);
+        RealmService realmService = UserStoreConfigServiceHolder.getInstance().getRealmService();
+        RealmConfiguration realmConfiguration = realmService.getBootstrapRealmConfiguration();
+        if (realmConfiguration == null) {
+            throw handleException(Response.Status.INTERNAL_SERVER_ERROR, UserStoreConstants.ErrorMessage.
+                    ERROR_CODE_ERROR_RETRIEVING_PRIMARY_USERSTORE);
         }
+        List<AddUserStorePropertiesRes> propertiesTobeAdd = new ArrayList<>();
+        UserStoreConfigurationsRes primaryUserstoreConfigs = new UserStoreConfigurationsRes();
+        primaryUserstoreConfigs.setClassName(realmConfiguration.getUserStoreClass());
+        primaryUserstoreConfigs.setDescription(realmConfiguration.getDescription());
+        primaryUserstoreConfigs.setName(UserCoreConstants.PRIMARY_DEFAULT_DOMAIN_NAME);
+        primaryUserstoreConfigs.setTypeId(base64URLEncodeId(Objects.requireNonNull
+                (getUserStoreTypeName(realmConfiguration.getUserStoreClass()))));
+        primaryUserstoreConfigs.setTypeName(getUserStoreTypeName(realmConfiguration.getUserStoreClass()));
+        Map<String, String> userstoreProps = realmConfiguration.getUserStoreProperties();
+        if (MapUtils.isNotEmpty(userstoreProps)) {
+            for (String propKey : userstoreProps.keySet()) {
+                AddUserStorePropertiesRes userStorePropertiesRes = new AddUserStorePropertiesRes();
+                userStorePropertiesRes.setName(propKey);
+                userStorePropertiesRes.setValue(userstoreProps.get(propKey));
+                propertiesTobeAdd.add(userStorePropertiesRes);
+            }
+        }
+        primaryUserstoreConfigs.setProperties(propertiesTobeAdd);
+
         return primaryUserstoreConfigs;
     }
 


### PR DESCRIPTION
If there is a need to cache the primary user store configs, it needs to be done at the realm service level or at a dao level. That can be done after a performance test.