### PR TITLE
[FIX] Wrong response when invalid input is provided for IDP metadata endpoint

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/main/java/org/wso2/carbon/identity/api/server/idp/v1/core/ServerIdpManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/main/java/org/wso2/carbon/identity/api/server/idp/v1/core/ServerIdpManagementService.java
@@ -301,9 +301,9 @@ public class ServerIdpManagementService {
      */
     public MetaFederatedAuthenticator getMetaFederatedAuthenticator(String id) {
 
-        String authenticatorName = base64URLDecode(id);
         MetaFederatedAuthenticator authenticator = null;
         try {
+            String authenticatorName = decodeAuthenticatorID(id);
             FederatedAuthenticatorConfig[] authenticatorConfigs =
                     IdentityProviderServiceHolder.getIdentityProviderManager()
                             .getAllFederatedAuthenticators();
@@ -318,6 +318,26 @@ public class ServerIdpManagementService {
             return authenticator;
         } catch (IdentityProviderManagementException e) {
             throw handleIdPException(e, Constants.ErrorMessage.ERROR_CODE_ERROR_RETRIEVING_META_AUTHENTICATOR, id);
+        }
+    }
+
+    /**
+     * Decode authenticator ID.
+     *
+     * @param id Authenticator ID.
+     * @return Base64 URL decoded authenticator ID.
+     * @throws IdentityProviderManagementClientException IF an error occurred while decoding the authenticator ID.
+     */
+    private String decodeAuthenticatorID(String id) throws IdentityProviderManagementClientException {
+
+        try {
+            return base64URLDecode(id);
+        } catch (IllegalArgumentException e) {
+            if (StringUtils.isBlank(e.getLocalizedMessage())) {
+                throw new IdentityProviderManagementClientException("Invalid Authenticator ID: " + id, e);
+            }
+            throw new IdentityProviderManagementClientException(
+                    String.format("%s : Authenticator ID: %s", e.getMessage(), id), e);
         }
     }
 


### PR DESCRIPTION
Resolves: https://github.com/wso2/product-is/issues/9694

## Approach
Catch the `IllegalArgumentException` thrown when decoding authenticator id and throw an `IdentityProviderManagementClientException` so that a `BAD REQUEST` is returned by the API. 

### Response After the fix
**400: Bad Request
API Response**
```
{
    "code": "IDP-65023",
    "message": "Unable to retrieve meta federated authenticator.",
    "description": "Illegal base64 character 40 : Authenticator ID: @$",
    "traceId": "1626c929-0065-4ec8-a02d-d6ba491cf741"
}
```