### PR TITLE
Fix NPE thrown when invalid typeId is given as input for userstore creation

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.userstore/org.wso2.carbon.identity.api.server.userstore.v1/src/main/java/org/wso2/carbon/identity/api/server/userstore/v1/core/ServerUserStoreService.java
+++ b/components/org.wso2.carbon.identity.api.server.userstore/org.wso2.carbon.identity.api.server.userstore.v1/src/main/java/org/wso2/carbon/identity/api/server/userstore/v1/core/ServerUserStoreService.java
@@ -88,7 +88,7 @@ public class ServerUserStoreService {
     public UserStoreResponse addUserStore(UserStoreReq userStoreReq) {
 
         try {
-            validateMandatoryProperties(getUserStoreType(base64URLDecodeId(userStoreReq.getTypeId())), userStoreReq);
+            validateMandatoryProperties(userStoreReq);
             UserStoreConfigService userStoreConfigService = UserStoreConfigServiceHolder.getInstance()
                     .getUserStoreConfigService();
             userStoreConfigService.addUserStore(createUserStoreDTO(userStoreReq));
@@ -806,14 +806,18 @@ public class ServerUserStoreService {
     /**
      * To check whether API request has all user store mandatory properties or not.
      *
-     * @param className the user store class name
      * @param userStoreReq {@link UserStoreReq}
      */
-    private void validateMandatoryProperties(String className, UserStoreReq userStoreReq) {
+    private void validateMandatoryProperties(UserStoreReq userStoreReq) {
 
+        String userStoreType = getUserStoreType(base64URLDecodeId(userStoreReq.getTypeId()));
+        if (StringUtils.isBlank(userStoreType)) {
+            throw handleException(Response.Status.BAD_REQUEST,
+                    UserStoreConstants.ErrorMessage.ERROR_CODE_INVALID_INPUT);
+        }
         HashMap<String, String> hashMap = new HashMap<String, String>();
         Property[] mandatoryProperties = UserStoreManagerRegistry.
-                getUserStoreProperties(className).getMandatoryProperties();
+                getUserStoreProperties(userStoreType).getMandatoryProperties();
         for (org.wso2.carbon.identity.api.server.userstore.v1.model.Property property : userStoreReq.getProperties()) {
             hashMap.put(property.getName(), property.getValue());
         }


### PR DESCRIPTION
Resolves https://github.com/wso2/product-is/issues/9543

This PR will resolve the above issue and give the following error response when an invalid typeId is given as input for userstore creation REST API.

```
{
   "traceId" : "09ae6fac-a91a-43f2-8717-726276d0a84b",
   "message" : "Invalid Input",
   "description" : "Provided Input is not valid.",
   "code" : "SUS-60004"
}
```