### PR TITLE
[FIX] Updating http binding using the patch request

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.common/src/main/java/org/wso2/carbon/identity/api/server/application/management/common/ApplicationManagementConstants.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.common/src/main/java/org/wso2/carbon/identity/api/server/application/management/common/ApplicationManagementConstants.java
@@ -66,6 +66,9 @@ public class ApplicationManagementConstants {
         APPLICATION_NOT_FOUND("60006",
                 "Application not found.",
                 "Application cannot be found for the provided id: %s in the tenantDomain: %s."),
+        DISABLE_REDIRECT_OR_POST_BINDINGS("APP-60007",
+                "Disabling HTTP_POST or HTTP_REDIRECT is not allowed",
+                "HTTP_POST or HTTP_REDIRECT cannot be disabled"),
 
         // Client errors defined at API level.
         INVALID_INBOUND_PROTOCOL("60501",
@@ -118,6 +121,9 @@ public class ApplicationManagementConstants {
 
         public String getCode() {
 
+            if (code.contains(APPLICATION_MANAGEMENT_PREFIX)) {
+                return code;
+            }
             return APPLICATION_MANAGEMENT_PREFIX + code;
         }
 


### PR DESCRIPTION
Part of the fix https://github.com/wso2/product-is/issues/10027

### Approach
Using the PUT operation [1], we can update the `HTTP_POST` or `HTTP_REDIRECT`. But we don't have the backend support. Therefore, these are enabled by default. Therefore, these binding options should not be allowed to disable.


[1] - `/applications/{applicationId}/inbound-protocols/saml`