### PR TITLE
Add API to check tenant availability.

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.tenant.management/org.wso2.carbon.identity.api.server.tenant.management.common/src/main/java/org/wso2/carbon/identity/api/server/tenant/management/common/TenantManagementConstants.java
+++ b/components/org.wso2.carbon.identity.api.server.tenant.management/org.wso2.carbon.identity.api.server.tenant.management.common/src/main/java/org/wso2/carbon/identity/api/server/tenant/management/common/TenantManagementConstants.java
@@ -53,7 +53,10 @@ public class TenantManagementConstants {
         ERROR_CODE_FILTER_NOT_IMPLEMENTED("TM-65006", "Filtering not supported.", "Filtering capability is not " +
                 "supported in this version of the API."),
         ERROR_CODE_ERROR_VALIDATING_TENANT_CODE("TM-65007",
-                                               "Unable to add tenant.", "Error occurred in validating the code.");
+                                               "Unable to add tenant.", "Error occurred in validating the code."),
+        ERROR_CODE_ERROR_CHECKING_TENANT_AVAILABILITY("TM-65008",
+                                                        "Unable to check availability of domain.",
+                "Server encountered an error while checking for tenant domain");
 
         private final String code;
         private final String message;

--- a/components/org.wso2.carbon.identity.api.server.tenant.management/org.wso2.carbon.identity.api.server.tenant.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/tenant/management/v1/TenantsApi.java
+++ b/components/org.wso2.carbon.identity.api.server.tenant.management/org.wso2.carbon.identity.api.server.tenant.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/tenant/management/v1/TenantsApi.java
@@ -24,6 +24,7 @@ import java.util.List;
 
 import org.wso2.carbon.identity.api.server.tenant.management.v1.model.Error;
 import org.wso2.carbon.identity.api.server.tenant.management.v1.model.OwnerResponse;
+import org.wso2.carbon.identity.api.server.tenant.management.v1.model.TenantAvailability;
 import org.wso2.carbon.identity.api.server.tenant.management.v1.model.TenantModel;
 import org.wso2.carbon.identity.api.server.tenant.management.v1.model.TenantPutModel;
 import org.wso2.carbon.identity.api.server.tenant.management.v1.model.TenantResponseModel;
@@ -115,6 +116,30 @@ public class TenantsApi  {
     public Response getTenant(@ApiParam(value = "tenant id",required=true) @PathParam("tenant-id") String tenantId) {
 
         return delegate.getTenant(tenantId );
+    }
+
+    @Valid
+    @GET
+    @Path("/{tenant-domain}/istaken")
+    
+    @Produces({ "application/json" })
+    @ApiOperation(value = "See if a domain is taken or not.", notes = "Check if the domain is already taken.  <b>Permission required:</b> * /permission/protected/manage/monitor/tenants/list  <b>scope required:</b> * internal_list_tenants ", response = TenantAvailability.class, authorizations = {
+        @Authorization(value = "BasicAuth"),
+        @Authorization(value = "OAuth2", scopes = {
+            
+        })
+    }, tags={ "Tenants", })
+    @ApiResponses(value = { 
+        @ApiResponse(code = 200, message = "OK", response = TenantAvailability.class),
+        @ApiResponse(code = 400, message = "Invalid Input Request", response = Error.class),
+        @ApiResponse(code = 401, message = "Unauthorized", response = Void.class),
+        @ApiResponse(code = 403, message = "Resource Forbidden", response = Void.class),
+        @ApiResponse(code = 404, message = "The specified resource is not found", response = Error.class),
+        @ApiResponse(code = 500, message = "Internal Server Error", response = Error.class)
+    })
+    public Response getTenantAvailability(@ApiParam(value = "tenant domain",required=true) @PathParam("tenant-domain") String tenantDomain) {
+
+        return delegate.getTenantAvailability(tenantDomain );
     }
 
     @Valid

--- a/components/org.wso2.carbon.identity.api.server.tenant.management/org.wso2.carbon.identity.api.server.tenant.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/tenant/management/v1/TenantsApi.java
+++ b/components/org.wso2.carbon.identity.api.server.tenant.management/org.wso2.carbon.identity.api.server.tenant.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/tenant/management/v1/TenantsApi.java
@@ -24,7 +24,6 @@ import java.util.List;
 
 import org.wso2.carbon.identity.api.server.tenant.management.v1.model.Error;
 import org.wso2.carbon.identity.api.server.tenant.management.v1.model.OwnerResponse;
-import org.wso2.carbon.identity.api.server.tenant.management.v1.model.TenantAvailability;
 import org.wso2.carbon.identity.api.server.tenant.management.v1.model.TenantModel;
 import org.wso2.carbon.identity.api.server.tenant.management.v1.model.TenantPutModel;
 import org.wso2.carbon.identity.api.server.tenant.management.v1.model.TenantResponseModel;
@@ -120,26 +119,50 @@ public class TenantsApi  {
 
     @Valid
     @GET
-    @Path("/{tenant-domain}/istaken")
+    @Path("/domain/{tenant-domain}")
     
     @Produces({ "application/json" })
-    @ApiOperation(value = "See if a domain is taken or not.", notes = "Check if the domain is already taken.  <b>Permission required:</b> * /permission/protected/manage/monitor/tenants/list  <b>scope required:</b> * internal_list_tenants ", response = TenantAvailability.class, authorizations = {
+    @ApiOperation(value = "Get tenant by domain.", notes = "Get the tenant using domain.  <b>Permission required:</b> * /permission/protected/manage/monitor/tenants/list  <b>scope required:</b> * internal_list_tenants ", response = TenantResponseModel.class, authorizations = {
         @Authorization(value = "BasicAuth"),
         @Authorization(value = "OAuth2", scopes = {
             
         })
     }, tags={ "Tenants", })
     @ApiResponses(value = { 
-        @ApiResponse(code = 200, message = "OK", response = TenantAvailability.class),
+        @ApiResponse(code = 200, message = "OK", response = TenantResponseModel.class),
         @ApiResponse(code = 400, message = "Invalid Input Request", response = Error.class),
         @ApiResponse(code = 401, message = "Unauthorized", response = Void.class),
         @ApiResponse(code = 403, message = "Resource Forbidden", response = Void.class),
         @ApiResponse(code = 404, message = "The specified resource is not found", response = Error.class),
         @ApiResponse(code = 500, message = "Internal Server Error", response = Error.class)
     })
-    public Response getTenantAvailability(@ApiParam(value = "tenant domain",required=true) @PathParam("tenant-domain") String tenantDomain) {
+    public Response getTenantByDomain(@ApiParam(value = "tenant domain",required=true) @PathParam("tenant-domain") String tenantDomain) {
 
-        return delegate.getTenantAvailability(tenantDomain );
+        return delegate.getTenantByDomain(tenantDomain );
+    }
+
+    @Valid
+    @HEAD
+    @Path("/domain/{tenant-domain}")
+
+    @Produces({ "application/json" })
+    @ApiOperation(value = "Get tenant by domain.", notes = "Just a check if tenant domain is present.  <b>Permission required:</b> * /permission/protected/manage/monitor/tenants/list  <b>scope required:</b> * internal_list_tenants ", response = Void.class, authorizations = {
+        @Authorization(value = "BasicAuth"),
+        @Authorization(value = "OAuth2", scopes = {
+            
+        })
+    }, tags={ "Tenants", })
+    @ApiResponses(value = { 
+        @ApiResponse(code = 200, message = "Requested Resource Exists", response = Void.class),
+        @ApiResponse(code = 400, message = "Invalid Input Request", response = Void.class),
+        @ApiResponse(code = 401, message = "Unauthorized", response = Void.class),
+        @ApiResponse(code = 403, message = "Resource Forbidden", response = Void.class),
+        @ApiResponse(code = 404, message = "The specified resource is not found", response = Void.class),
+        @ApiResponse(code = 500, message = "Internal Server Error", response = Void.class)
+    })
+    public Response isDomainAvailable(@ApiParam(value = "tenant domain",required=true) @PathParam("tenant-domain") String tenantDomain) {
+
+        return delegate.isDomainAvailable(tenantDomain );
     }
 
     @Valid

--- a/components/org.wso2.carbon.identity.api.server.tenant.management/org.wso2.carbon.identity.api.server.tenant.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/tenant/management/v1/TenantsApi.java
+++ b/components/org.wso2.carbon.identity.api.server.tenant.management/org.wso2.carbon.identity.api.server.tenant.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/tenant/management/v1/TenantsApi.java
@@ -146,7 +146,7 @@ public class TenantsApi  {
     @Path("/domain/{tenant-domain}")
 
     @Produces({ "application/json" })
-    @ApiOperation(value = "Get tenant by domain.", notes = "Just a check if tenant domain is present.  <b>Permission required:</b> * /permission/protected/manage/monitor/tenants/list  <b>scope required:</b> * internal_list_tenants ", response = Void.class, authorizations = {
+    @ApiOperation(value = "Check domain availability.", notes = "Just a check if tenant domain is present.  <b>Permission required:</b> * /permission/protected/manage/monitor/tenants/list  <b>scope required:</b> * internal_list_tenants ", response = Void.class, authorizations = {
         @Authorization(value = "BasicAuth"),
         @Authorization(value = "OAuth2", scopes = {
             

--- a/components/org.wso2.carbon.identity.api.server.tenant.management/org.wso2.carbon.identity.api.server.tenant.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/tenant/management/v1/TenantsApi.java
+++ b/components/org.wso2.carbon.identity.api.server.tenant.management/org.wso2.carbon.identity.api.server.tenant.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/tenant/management/v1/TenantsApi.java
@@ -144,9 +144,9 @@ public class TenantsApi  {
     @Valid
     @HEAD
     @Path("/domain/{tenant-domain}")
-
+    
     @Produces({ "application/json" })
-    @ApiOperation(value = "Check domain availability.", notes = "Just a check if tenant domain is present.  <b>Permission required:</b> * /permission/protected/manage/monitor/tenants/list  <b>scope required:</b> * internal_list_tenants ", response = Void.class, authorizations = {
+    @ApiOperation(value = "Check domain Existence.", notes = "Get the tenant using domain.  <b>Permission required:</b> * /permission/protected/manage/monitor/tenants/list  <b>scope required:</b> * internal_list_tenants ", response = Void.class, authorizations = {
         @Authorization(value = "BasicAuth"),
         @Authorization(value = "OAuth2", scopes = {
             
@@ -160,9 +160,9 @@ public class TenantsApi  {
         @ApiResponse(code = 404, message = "The specified resource is not found", response = Void.class),
         @ApiResponse(code = 500, message = "Internal Server Error", response = Void.class)
     })
-    public Response isDomainAvailable(@ApiParam(value = "tenant domain",required=true) @PathParam("tenant-domain") String tenantDomain) {
+    public Response isDomainExist(@ApiParam(value = "tenant domain",required=true) @PathParam("tenant-domain") String tenantDomain) {
 
-        return delegate.isDomainAvailable(tenantDomain );
+        return delegate.isDomainExist(tenantDomain );
     }
 
     @Valid

--- a/components/org.wso2.carbon.identity.api.server.tenant.management/org.wso2.carbon.identity.api.server.tenant.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/tenant/management/v1/TenantsApi.java
+++ b/components/org.wso2.carbon.identity.api.server.tenant.management/org.wso2.carbon.identity.api.server.tenant.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/tenant/management/v1/TenantsApi.java
@@ -146,7 +146,7 @@ public class TenantsApi  {
     @Path("/domain/{tenant-domain}")
     
     @Produces({ "application/json" })
-    @ApiOperation(value = "Check domain Existence.", notes = "Get the tenant using domain.  <b>Permission required:</b> * /permission/protected/manage/monitor/tenants/list  <b>scope required:</b> * internal_list_tenants ", response = Void.class, authorizations = {
+    @ApiOperation(value = "Check domain Existence.", notes = "Check the tenant existence using domain.  <b>Permission required:</b> * /permission/protected/manage/monitor/tenants/list  <b>scope required:</b> * internal_list_tenants ", response = Void.class, authorizations = {
         @Authorization(value = "BasicAuth"),
         @Authorization(value = "OAuth2", scopes = {
             

--- a/components/org.wso2.carbon.identity.api.server.tenant.management/org.wso2.carbon.identity.api.server.tenant.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/tenant/management/v1/TenantsApiService.java
+++ b/components/org.wso2.carbon.identity.api.server.tenant.management/org.wso2.carbon.identity.api.server.tenant.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/tenant/management/v1/TenantsApiService.java
@@ -24,6 +24,7 @@ import java.io.InputStream;
 import java.util.List;
 import org.wso2.carbon.identity.api.server.tenant.management.v1.model.Error;
 import org.wso2.carbon.identity.api.server.tenant.management.v1.model.OwnerResponse;
+import org.wso2.carbon.identity.api.server.tenant.management.v1.model.TenantAvailability;
 import org.wso2.carbon.identity.api.server.tenant.management.v1.model.TenantModel;
 import org.wso2.carbon.identity.api.server.tenant.management.v1.model.TenantPutModel;
 import org.wso2.carbon.identity.api.server.tenant.management.v1.model.TenantResponseModel;
@@ -38,6 +39,8 @@ public interface TenantsApiService {
       public Response getOwners(String tenantId);
 
       public Response getTenant(String tenantId);
+
+      public Response getTenantAvailability(String tenantDomain);
 
       public Response retrieveTenants(Integer limit, Integer offset, String sortOrder, String sortBy, String filter);
 

--- a/components/org.wso2.carbon.identity.api.server.tenant.management/org.wso2.carbon.identity.api.server.tenant.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/tenant/management/v1/TenantsApiService.java
+++ b/components/org.wso2.carbon.identity.api.server.tenant.management/org.wso2.carbon.identity.api.server.tenant.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/tenant/management/v1/TenantsApiService.java
@@ -41,7 +41,7 @@ public interface TenantsApiService {
 
       public Response getTenantByDomain(String tenantDomain);
 
-      public Response isDomainAvailable(String tenantDomain);
+      public Response isDomainExist(String tenantDomain);
 
       public Response retrieveTenants(Integer limit, Integer offset, String sortOrder, String sortBy, String filter);
 

--- a/components/org.wso2.carbon.identity.api.server.tenant.management/org.wso2.carbon.identity.api.server.tenant.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/tenant/management/v1/TenantsApiService.java
+++ b/components/org.wso2.carbon.identity.api.server.tenant.management/org.wso2.carbon.identity.api.server.tenant.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/tenant/management/v1/TenantsApiService.java
@@ -24,7 +24,6 @@ import java.io.InputStream;
 import java.util.List;
 import org.wso2.carbon.identity.api.server.tenant.management.v1.model.Error;
 import org.wso2.carbon.identity.api.server.tenant.management.v1.model.OwnerResponse;
-import org.wso2.carbon.identity.api.server.tenant.management.v1.model.TenantAvailability;
 import org.wso2.carbon.identity.api.server.tenant.management.v1.model.TenantModel;
 import org.wso2.carbon.identity.api.server.tenant.management.v1.model.TenantPutModel;
 import org.wso2.carbon.identity.api.server.tenant.management.v1.model.TenantResponseModel;
@@ -40,7 +39,9 @@ public interface TenantsApiService {
 
       public Response getTenant(String tenantId);
 
-      public Response getTenantAvailability(String tenantDomain);
+      public Response getTenantByDomain(String tenantDomain);
+
+      public Response isDomainAvailable(String tenantDomain);
 
       public Response retrieveTenants(Integer limit, Integer offset, String sortOrder, String sortBy, String filter);
 

--- a/components/org.wso2.carbon.identity.api.server.tenant.management/org.wso2.carbon.identity.api.server.tenant.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/tenant/management/v1/model/TenantAvailability.java
+++ b/components/org.wso2.carbon.identity.api.server.tenant.management/org.wso2.carbon.identity.api.server.tenant.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/tenant/management/v1/model/TenantAvailability.java
@@ -1,0 +1,97 @@
+/*
+* Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package org.wso2.carbon.identity.api.server.tenant.management.v1.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import javax.validation.constraints.*;
+
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+import javax.validation.Valid;
+import javax.xml.bind.annotation.*;
+
+public class TenantAvailability  {
+  
+    private Boolean isTaken;
+
+    /**
+    * Tenant domain is taken or available.
+    **/
+    public TenantAvailability isTaken(Boolean isTaken) {
+
+        this.isTaken = isTaken;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "true", value = "Tenant domain is taken or available.")
+    @JsonProperty("isTaken")
+    @Valid
+    public Boolean getIsTaken() {
+        return isTaken;
+    }
+    public void setIsTaken(Boolean isTaken) {
+        this.isTaken = isTaken;
+    }
+
+
+
+    @Override
+    public boolean equals(java.lang.Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        TenantAvailability tenantAvailability = (TenantAvailability) o;
+        return Objects.equals(this.isTaken, tenantAvailability.isTaken);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(isTaken);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class TenantAvailability {\n");
+        
+        sb.append("    isTaken: ").append(toIndentedString(isTaken)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+    * Convert the given object to string with each line indented by 4 spaces
+    * (except the first line).
+    */
+    private String toIndentedString(java.lang.Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}
+

--- a/components/org.wso2.carbon.identity.api.server.tenant.management/org.wso2.carbon.identity.api.server.tenant.management.v1/src/main/java/org/wso2/carbon/identity/api/server/tenant/management/v1/core/ServerTenantManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.tenant.management/org.wso2.carbon.identity.api.server.tenant.management.v1/src/main/java/org/wso2/carbon/identity/api/server/tenant/management/v1/core/ServerTenantManagementService.java
@@ -29,14 +29,11 @@ import org.wso2.carbon.identity.api.server.tenant.management.v1.model.ChannelVer
 import org.wso2.carbon.identity.api.server.tenant.management.v1.model.LifeCycleStatus;
 import org.wso2.carbon.identity.api.server.tenant.management.v1.model.Link;
 import org.wso2.carbon.identity.api.server.tenant.management.v1.model.OwnerResponse;
-import org.wso2.carbon.identity.api.server.tenant.management.v1.model.TenantAvailability;
 import org.wso2.carbon.identity.api.server.tenant.management.v1.model.TenantListItem;
 import org.wso2.carbon.identity.api.server.tenant.management.v1.model.TenantModel;
 import org.wso2.carbon.identity.api.server.tenant.management.v1.model.TenantPutModel;
 import org.wso2.carbon.identity.api.server.tenant.management.v1.model.TenantResponseModel;
 import org.wso2.carbon.identity.api.server.tenant.management.v1.model.TenantsListResponse;
-import org.wso2.carbon.identity.base.IdentityRuntimeException;
-import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.recovery.IdentityRecoveryException;
 import org.wso2.carbon.identity.recovery.model.UserRecoveryData;
 import org.wso2.carbon.identity.recovery.store.JDBCRecoveryDataStore;
@@ -145,28 +142,36 @@ public class ServerTenantManagementService {
     }
 
     /**
+     * Get a tenant identified by tenant unique id.
+     *
+     * @param domain tenant domain.
+     * @return TenantResponseModel.
+     */
+    public TenantResponseModel getTenantByDomain(String domain) {
+
+        try {
+            Tenant tenant = TenantManagementServiceHolder.getTenantMgtService().getTenantByDomain(domain);
+            return createTenantResponse(tenant);
+        } catch (TenantMgtException e) {
+            throw handleTenantManagementException(e, TenantManagementConstants.ErrorMessage.
+                    ERROR_CODE_ERROR_RETRIEVING_TENANT, domain);
+        }
+    }
+
+    /**
      * Get a tenant identified by tenant domain.
      *
      * @param tenantDomain tenant unique identifier.
      * @return taken or not.
      */
-    public TenantAvailability isDomainTaken(String tenantDomain) {
-        boolean isTaken = true;
-        ErrorResponse errorResponse;
-        Response.Status status;
-        try {
-            IdentityTenantUtil.getTenantId(tenantDomain);
-        } catch (IdentityRuntimeException e) {
-            if (e.getMessage().startsWith("Invalid tenant domain")) {
-                isTaken = false;
-            } else {
-                throw handleException(Response.Status.INTERNAL_SERVER_ERROR,
-                        TenantManagementConstants.ErrorMessage.ERROR_CODE_ERROR_CHECKING_TENANT_AVAILABILITY,
-                        tenantDomain);
-            }
-        }
+    public boolean isDomainAvailable(String tenantDomain) {
 
-        return createTenantAvailability(isTaken);
+        try {
+            return TenantManagementServiceHolder.getTenantMgtService().isDomainAvailable(tenantDomain);
+        } catch (TenantMgtException e) {
+            throw handleTenantManagementException(e, TenantManagementConstants.ErrorMessage.
+                    ERROR_CODE_ERROR_RETRIEVING_TENANT, tenantDomain);
+        }
     }
 
     /**
@@ -228,13 +233,6 @@ public class ServerTenantManagementService {
         tenantResponseModel.setLifecycleStatus(getLifeCycleStatus(tenant.isActive()));
         tenantResponseModel.setOwners(getOwnerResponses(tenant));
         return tenantResponseModel;
-    }
-
-    private TenantAvailability createTenantAvailability(boolean isTaken) {
-
-        TenantAvailability tenantAvailability = new TenantAvailability();
-        tenantAvailability.setIsTaken(isTaken);
-        return tenantAvailability;
     }
 
     private Tenant createTenantInfoBean(TenantModel tenantModel) throws TenantManagementClientException {

--- a/components/org.wso2.carbon.identity.api.server.tenant.management/org.wso2.carbon.identity.api.server.tenant.management.v1/src/main/java/org/wso2/carbon/identity/api/server/tenant/management/v1/impl/TenantsApiServiceImpl.java
+++ b/components/org.wso2.carbon.identity.api.server.tenant.management/org.wso2.carbon.identity.api.server.tenant.management.v1/src/main/java/org/wso2/carbon/identity/api/server/tenant/management/v1/impl/TenantsApiServiceImpl.java
@@ -82,7 +82,7 @@ public class TenantsApiServiceImpl implements TenantsApiService {
     }
 
     @Override
-    public Response isDomainAvailable(String tenantDomain) {
+    public Response isDomainExist(String tenantDomain) {
 
         if (tenantManagementService.isDomainAvailable(tenantDomain)) {
             return Response.status(Response.Status.NOT_FOUND).build();

--- a/components/org.wso2.carbon.identity.api.server.tenant.management/org.wso2.carbon.identity.api.server.tenant.management.v1/src/main/java/org/wso2/carbon/identity/api/server/tenant/management/v1/impl/TenantsApiServiceImpl.java
+++ b/components/org.wso2.carbon.identity.api.server.tenant.management/org.wso2.carbon.identity.api.server.tenant.management.v1/src/main/java/org/wso2/carbon/identity/api/server/tenant/management/v1/impl/TenantsApiServiceImpl.java
@@ -69,15 +69,25 @@ public class TenantsApiServiceImpl implements TenantsApiService {
         return Response.ok().entity(getResourceLocation(resourceId)).build();
     }
 
-    @Override
-    public Response getTenantAvailability(String tenantDomain) {
-
-        return Response.ok().entity(tenantManagementService.isDomainTaken(tenantDomain)).build();
-    }
-
     private URI getResourceLocation(String resourceId) {
 
         return ContextLoader.buildURIForHeader(Constants.V1_API_PATH_COMPONENT +
                 TenantManagementConstants.TENANT_MANAGEMENT_PATH_COMPONENT + "/" + resourceId);
+    }
+
+    @Override
+    public Response getTenantByDomain(String tenantDomain) {
+
+        return Response.ok().entity(tenantManagementService.getTenantByDomain(tenantDomain)).build();
+    }
+
+    @Override
+    public Response isDomainAvailable(String tenantDomain) {
+
+        if (tenantManagementService.isDomainAvailable(tenantDomain)) {
+            return Response.status(Response.Status.NOT_FOUND).build();
+        } else {
+            return Response.status(Response.Status.OK).build();
+        }
     }
 }

--- a/components/org.wso2.carbon.identity.api.server.tenant.management/org.wso2.carbon.identity.api.server.tenant.management.v1/src/main/java/org/wso2/carbon/identity/api/server/tenant/management/v1/impl/TenantsApiServiceImpl.java
+++ b/components/org.wso2.carbon.identity.api.server.tenant.management/org.wso2.carbon.identity.api.server.tenant.management.v1/src/main/java/org/wso2/carbon/identity/api/server/tenant/management/v1/impl/TenantsApiServiceImpl.java
@@ -69,6 +69,12 @@ public class TenantsApiServiceImpl implements TenantsApiService {
         return Response.ok().entity(getResourceLocation(resourceId)).build();
     }
 
+    @Override
+    public Response getTenantAvailability(String tenantDomain) {
+
+        return Response.ok().entity(tenantManagementService.isDomainTaken(tenantDomain)).build();
+    }
+
     private URI getResourceLocation(String resourceId) {
 
         return ContextLoader.buildURIForHeader(Constants.V1_API_PATH_COMPONENT +

--- a/components/org.wso2.carbon.identity.api.server.tenant.management/org.wso2.carbon.identity.api.server.tenant.management.v1/src/main/resources/tenant-management.yaml
+++ b/components/org.wso2.carbon.identity.api.server.tenant.management/org.wso2.carbon.identity.api.server.tenant.management.v1/src/main/resources/tenant-management.yaml
@@ -208,10 +208,10 @@ paths:
     head:
       tags:
         - Tenants
-      summary: Check domain availability.
-      operationId: isDomainAvailable
+      summary: Check domain Existence.
+      operationId: isDomainExist
       description: |
-        Get the tenant using domain.
+        Check the tenant existence using domain.
 
         <b>Permission required:</b>
         * /permission/protected/manage/monitor/tenants/list

--- a/components/org.wso2.carbon.identity.api.server.tenant.management/org.wso2.carbon.identity.api.server.tenant.management.v1/src/main/resources/tenant-management.yaml
+++ b/components/org.wso2.carbon.identity.api.server.tenant.management/org.wso2.carbon.identity.api.server.tenant.management.v1/src/main/resources/tenant-management.yaml
@@ -208,7 +208,7 @@ paths:
     head:
       tags:
         - Tenants
-      summary: Get tenant by domain.
+      summary: Check domain availability.
       operationId: isDomainAvailable
       description: |
         Get the tenant using domain.

--- a/components/org.wso2.carbon.identity.api.server.tenant.management/org.wso2.carbon.identity.api.server.tenant.management.v1/src/main/resources/tenant-management.yaml
+++ b/components/org.wso2.carbon.identity.api.server.tenant.management/org.wso2.carbon.identity.api.server.tenant.management.v1/src/main/resources/tenant-management.yaml
@@ -171,14 +171,14 @@ paths:
           $ref: '#/components/responses/NotFound'
         '500':
           $ref: '#/components/responses/ServerError'
-  '/tenants/{tenant-domain}/istaken':
+  '/tenants/domain/{tenant-domain}':
     get:
       tags:
         - Tenants
-      summary: See if a domain is taken or not.
-      operationId: getTenantAvailability
+      summary: Get tenant by domain.
+      operationId: getTenantByDomain
       description: |
-        Check if the domain is already taken.
+        Get the tenant using domain.
 
         <b>Permission required:</b>
         * /permission/protected/manage/monitor/tenants/list
@@ -193,7 +193,36 @@ paths:
           content:
             'application/json':
               schema:
-                $ref: '#/components/schemas/TenantAvailability'
+                $ref: '#/components/schemas/TenantResponseModel'
+        '400':
+          $ref: '#/components/responses/InvalidInput'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/ServerError'
+
+    head:
+      tags:
+        - Tenants
+      summary: Get tenant by domain.
+      operationId: isDomainAvailable
+      description: |
+        Get the tenant using domain.
+
+        <b>Permission required:</b>
+        * /permission/protected/manage/monitor/tenants/list
+
+        <b>scope required:</b>
+        * internal_list_tenants
+      parameters:
+        - $ref: '#/components/parameters/tenantDomainPathParam'
+      responses:
+        '200':
+          $ref: '#/components/responses/ResourceExist'
         '400':
           $ref: '#/components/responses/InvalidInput'
         '401':
@@ -365,6 +394,8 @@ components:
       description: Unauthorized
     Forbidden:
       description: Resource Forbidden
+    ResourceExist:
+      description: Requested Resource Exists
     ServerError:
       description: Internal Server Error
       content:
@@ -522,14 +553,6 @@ components:
           example: "USA"
           readOnly: true
           description: Region of the tenant.
-
-    TenantAvailability:
-      type: object
-      properties:
-        isTaken:
-          type: boolean
-          example: true
-          description: Tenant domain is taken or available.
 
     TenantPutModel:
       type: object

--- a/components/org.wso2.carbon.identity.api.server.tenant.management/org.wso2.carbon.identity.api.server.tenant.management.v1/src/main/resources/tenant-management.yaml
+++ b/components/org.wso2.carbon.identity.api.server.tenant.management/org.wso2.carbon.identity.api.server.tenant.management.v1/src/main/resources/tenant-management.yaml
@@ -171,6 +171,40 @@ paths:
           $ref: '#/components/responses/NotFound'
         '500':
           $ref: '#/components/responses/ServerError'
+  '/tenants/{tenant-domain}/istaken':
+    get:
+      tags:
+        - Tenants
+      summary: See if a domain is taken or not.
+      operationId: getTenantAvailability
+      description: |
+        Check if the domain is already taken.
+
+        <b>Permission required:</b>
+        * /permission/protected/manage/monitor/tenants/list
+
+        <b>scope required:</b>
+        * internal_list_tenants
+      parameters:
+        - $ref: '#/components/parameters/tenantDomainPathParam'
+      responses:
+        '200':
+          description: OK
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/TenantAvailability'
+        '400':
+          $ref: '#/components/responses/InvalidInput'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/ServerError'
+
   '/tenants/{tenant-id}/lifecycle-status':
     put:
       tags:
@@ -262,6 +296,13 @@ components:
       name: tenant-id
       required: true
       description: tenant id
+      schema:
+        type: string
+    tenantDomainPathParam:
+      in: path
+      name: tenant-domain
+      required: true
+      description: tenant domain
       schema:
         type: string
     offsetQueryParam:
@@ -481,6 +522,14 @@ components:
           example: "USA"
           readOnly: true
           description: Region of the tenant.
+
+    TenantAvailability:
+      type: object
+      properties:
+        isTaken:
+          type: boolean
+          example: true
+          description: Tenant domain is taken or available.
 
     TenantPutModel:
       type: object

--- a/pom.xml
+++ b/pom.xml
@@ -545,7 +545,7 @@
         <commons.beanutils.version>1.9.4</commons.beanutils.version>
         <mavan.findbugsplugin.exclude.file>findbugs-exclude-filter.xml</mavan.findbugsplugin.exclude.file>
         <carbon.kernel.version>4.6.1-m5</carbon.kernel.version>
-        <carbon.multitenancy.version>4.8.6</carbon.multitenancy.version>
+        <carbon.multitenancy.version>4.9.4</carbon.multitenancy.version>
         <org.wso2.carbon.identity.remotefetch.version>0.7.12</org.wso2.carbon.identity.remotefetch.version>
         <!--<maven.checkstyleplugin.excludes>**/gen/**/*</maven.checkstyleplugin.excludes>-->
     </properties>


### PR DESCRIPTION
## Purpose
> Adding API to get tenant by domain and just check the availability.

Eg.
**Check domain availability**
`curl -k -v -X HEAD -H "Authorization: Client ZGFzaGJvYXJkOmRhc2hib2FyZA=="  "https://localhost:9443/t/carbon.super/api/server/v1/tenants/domain/test.com"
`
Response:
`200` --> Domain is taken.
`404` --> Domain is available.

**Get tenant by domain**
`curl -k -v -X GET -H "Authorization: Client ZGFzaGJvYXJkOmRhc2hib2FyZA=="  "https://localhost:9443/t/carbon.super/api/server/v1/tenants/domain/test2.com"
`
`{"domain":"test.com","owners":[{"username":"test"}],"createdDate":"2020-11-03T13:41:43.427Z","lifecycleStatus":{"activated":true}}`

FIxiing https://github.com/wso2/product-is/issues/10044