### PR TITLE
IS_enabled issue in h2 database

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/functions/application/UpdateAuthenticationSequence.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/functions/application/UpdateAuthenticationSequence.java
@@ -78,7 +78,7 @@ public class UpdateAuthenticationSequence implements UpdateFunction<ServiceProvi
         } else if (StringUtils.isNotBlank(authSequenceApiModel.getScript())) {
             AuthenticationScriptConfig adaptiveScript = new AuthenticationScriptConfig();
             adaptiveScript.setContent(authSequenceApiModel.getScript());
-
+            adaptiveScript.setEnabled(true);
             localAndOutboundConfig.setAuthenticationScriptConfig(adaptiveScript);
         }
     }


### PR DESCRIPTION
Resolves https://github.com/wso2/product-is/issues/8602
Resolves https://github.com/wso2/product-is/issues/10000

## Approach
When creating an service provider, Enabled property should be set to true. But here in default it has been set as false. So that while creating an AuthenticationScriptConfig object, the default value is being set here as false. So I have corrected the issue and enabled it as true in order to replicate the changes in h2 database "sp_auth_script" as is_enabled=1

Validated against the following test cases
```
<class name="org.wso2.identity.integration.test.rest.api.server.application.management.v1.ApplicationManagementSuccessTest"/><class name="org.wso2.identity.integration.test.rest.api.server.application.management.v1.ApplicationManagementFailureTest"/>
<class name="org.wso2.identity.integration.test.rest.api.server.application.management.v1.ApplicationImportExportTest"/>
<class name="org.wso2.identity.integration.test.rest.api.server.application.management.v1.ApplicationPatchTest"/>
<class name="org.wso2.identity.integration.test.rest.api.server.application.management.v1.ApplicationManagementSAMLSuccessTest"/>
<class name="org.wso2.identity.integration.test.rest.api.server.application.management.v1.ApplicationManagementOAuthSuccessTest"/>
<class name="org.wso2.identity.integration.test.rest.api.server.application.management.v1.ApplicationManagementPassiveStsSuccessTest"/>
<class name="org.wso2.identity.integration.test.rest.api.server.application.management.v1.ApplicationTemplateManagementFailureTest"/>
```

