### PR TITLE
Validation for Mandatory Description and Displayname which cant be null

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.claim.management/org.wso2.carbon.identity.rest.api.server.claim.management.v1/src/main/java/org/wso2/carbon/identity/rest/api/server/claim/management/v1/core/ServerClaimManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.claim.management/org.wso2.carbon.identity.rest.api.server.claim.management.v1/src/main/java/org/wso2/carbon/identity/rest/api/server/claim/management/v1/core/ServerClaimManagementService.java
@@ -376,6 +376,15 @@ public class ServerClaimManagementService {
                 throw handleClaimManagementClientError(ERROR_CODE_LOCAL_CLAIM_CONFLICT, CONFLICT,
                         base64DecodeId(claimId));
             }
+            if (StringUtils.isBlank(localClaimReqDTO.getDisplayName())) {
+                throw handleClaimManagementClientError(
+                        Constant.ErrorMessage.ERROR_CODE_CLAIM_DISPLAY_NAME_NOT_SPECIFIED,
+                        BAD_REQUEST);
+            }
+            if (StringUtils.isBlank(localClaimReqDTO.getDescription())) {
+                throw handleClaimManagementClientError(Constant.ErrorMessage.ERROR_CODE_CLAIM_DESCRIPTION_NOT_SPECIFIED,
+                        BAD_REQUEST);
+            }
             for (AttributeMappingDTO attributeMappingDTO :
                     localClaimReqDTO.getAttributeMapping()) {
                 if (!isUserStoreExists(attributeMappingDTO.getUserstore())) {


### PR DESCRIPTION
Resolves https://github.com/wso2/product-is/issues/9810


## Approach
While mapped attribute was empty, it is not validating it and allows the request and makes the mapped attribute as empty in the IS. Since mappedAttribute is mandatory, it cannot be empty. So I have validated it and thrown an error

Validated against the following test cases.
```
<class name="org.wso2.identity.integration.test.user.store.ClaimMappingsOnSecondaryUserStoreTestCase"/>
<class name="org.wso2.identity.integration.test.oauth2.OAuth2RoleClaimTestCase"/>
<class name="org.wso2.identity.integration.test.rest.api.server.claim.management.v1.ClaimManagementSuccessTest"/>
<class name="org.wso2.identity.integration.test.rest.api.server.claim.management.v1.ClaimManagementNegativeTest"/>
```

### Related PRs
https://github.com/wso2/carbon-identity-framework/pull/3226