### PR TITLE
Validating properties of the claim object

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.claim.management/org.wso2.carbon.identity.api.server.claim.management.common/src/main/java/org/wso2/carbon/identity/api/server/claim/management/common/Constant.java
+++ b/components/org.wso2.carbon.identity.api.server.claim.management/org.wso2.carbon.identity.api.server.claim.management.common/src/main/java/org/wso2/carbon/identity/api/server/claim/management/common/Constant.java
@@ -164,7 +164,7 @@ public class Constant {
                 "Claim description is not specified in the request"),
         ERROR_CODE_USERSTORE_NOT_SPECIFIED_IN_MAPPINGS("CMT-60005", "Userstore not specified",
                 "Mapped userstore cannot be empty"),
-        ERROR_CODE_EMPTY_ATTRIBUTE_MAPPINGS("CMT-60005", "Attribute mapping not specified",
+        ERROR_CODE_EMPTY_ATTRIBUTE_MAPPINGS("CMT-60006", "Attribute mapping not specified",
                 "Attribute mapping cannot be empty");
 
         private final String code;

--- a/components/org.wso2.carbon.identity.api.server.claim.management/org.wso2.carbon.identity.api.server.claim.management.common/src/main/java/org/wso2/carbon/identity/api/server/claim/management/common/Constant.java
+++ b/components/org.wso2.carbon.identity.api.server.claim.management/org.wso2.carbon.identity.api.server.claim.management.common/src/main/java/org/wso2/carbon/identity/api/server/claim/management/common/Constant.java
@@ -161,7 +161,11 @@ public class Constant {
         ERROR_CODE_CLAIM_DISPLAY_NAME_NOT_SPECIFIED("CMT-60003", "Empty display name",
                 "Claim display name is not specified in the request"),
         ERROR_CODE_CLAIM_DESCRIPTION_NOT_SPECIFIED("CMT-60004", "Empty description",
-                "Claim description is not specified in the request");
+                "Claim description is not specified in the request"),
+        ERROR_CODE_USERSTORE_NOT_SPECIFIED_IN_MAPPINGS("CMT-60005", "Userstore not specified",
+                "Mapped userstore cannot be empty"),
+        ERROR_CODE_EMPTY_ATTRIBUTE_MAPPINGS("CMT-60005", "Attribute mapping not specified",
+                "Attribute mapping cannot be empty");
 
         private final String code;
         private final String message;

--- a/components/org.wso2.carbon.identity.api.server.claim.management/org.wso2.carbon.identity.rest.api.server.claim.management.v1/src/main/java/org/wso2/carbon/identity/rest/api/server/claim/management/v1/core/ServerClaimManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.claim.management/org.wso2.carbon.identity.rest.api.server.claim.management.v1/src/main/java/org/wso2/carbon/identity/rest/api/server/claim/management/v1/core/ServerClaimManagementService.java
@@ -955,6 +955,7 @@ public class ServerClaimManagementService {
                 throw handleClaimManagementClientError(ERROR_CODE_USERSTORE_NOT_SPECIFIED_IN_MAPPINGS,
                         BAD_REQUEST, attributeMappingDTO.getUserstore());
             }
+            // Validating mapped attribute only the userstore is equal to the primary userstore domain name.
             if (StringUtils.isBlank(attributeMappingDTO.getMappedAttribute()) &&
                     primaryUserstoreDomainName.equals(attributeMappingDTO.getUserstore())) {
                 throw handleClaimManagementClientError(ERROR_CODE_EMPTY_MAPPED_ATTRIBUTES_IN_LOCAL_CLAIM,

--- a/components/org.wso2.carbon.identity.api.server.claim.management/org.wso2.carbon.identity.rest.api.server.claim.management.v1/src/main/java/org/wso2/carbon/identity/rest/api/server/claim/management/v1/core/ServerClaimManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.claim.management/org.wso2.carbon.identity.rest.api.server.claim.management.v1/src/main/java/org/wso2/carbon/identity/rest/api/server/claim/management/v1/core/ServerClaimManagementService.java
@@ -949,12 +949,14 @@ public class ServerClaimManagementService {
         if (attributeMappingDTOList == null) {
             throw handleClaimManagementClientError(ERROR_CODE_EMPTY_ATTRIBUTE_MAPPINGS, BAD_REQUEST);
         }
+        String primaryUserstoreDomainName = IdentityUtil.getPrimaryDomainName();
         for (AttributeMappingDTO attributeMappingDTO : attributeMappingDTOList) {
             if (StringUtils.isBlank(attributeMappingDTO.getUserstore())) {
                 throw handleClaimManagementClientError(ERROR_CODE_USERSTORE_NOT_SPECIFIED_IN_MAPPINGS,
                         BAD_REQUEST, attributeMappingDTO.getUserstore());
             }
-            if (StringUtils.isBlank(attributeMappingDTO.getMappedAttribute())) {
+            if (StringUtils.isBlank(attributeMappingDTO.getMappedAttribute()) &&
+                    primaryUserstoreDomainName.equals(attributeMappingDTO.getUserstore())) {
                 throw handleClaimManagementClientError(ERROR_CODE_EMPTY_MAPPED_ATTRIBUTES_IN_LOCAL_CLAIM,
                         BAD_REQUEST, attributeMappingDTO.getUserstore());
             }

--- a/components/org.wso2.carbon.identity.api.server.claim.management/org.wso2.carbon.identity.rest.api.server.claim.management.v1/src/main/java/org/wso2/carbon/identity/rest/api/server/claim/management/v1/core/ServerClaimManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.claim.management/org.wso2.carbon.identity.rest.api.server.claim.management.v1/src/main/java/org/wso2/carbon/identity/rest/api/server/claim/management/v1/core/ServerClaimManagementService.java
@@ -61,6 +61,8 @@ import static org.wso2.carbon.identity.api.server.claim.management.common.Consta
 import static org.wso2.carbon.identity.api.server.claim.management.common.Constant.ErrorMessage.ERROR_CODE_ATTRIBUTE_FILTERING_NOT_IMPLEMENTED;
 import static org.wso2.carbon.identity.api.server.claim.management.common.Constant.ErrorMessage.ERROR_CODE_CLAIMS_NOT_FOUND_FOR_DIALECT;
 import static org.wso2.carbon.identity.api.server.claim.management.common.Constant.ErrorMessage.ERROR_CODE_DIALECT_NOT_FOUND;
+import static org.wso2.carbon.identity.api.server.claim.management.common.Constant.ErrorMessage.ERROR_CODE_EMPTY_ATTRIBUTE_MAPPINGS;
+import static org.wso2.carbon.identity.api.server.claim.management.common.Constant.ErrorMessage.ERROR_CODE_EMPTY_MAPPED_ATTRIBUTES_IN_LOCAL_CLAIM;
 import static org.wso2.carbon.identity.api.server.claim.management.common.Constant.ErrorMessage.ERROR_CODE_ERROR_ADDING_DIALECT;
 import static org.wso2.carbon.identity.api.server.claim.management.common.Constant.ErrorMessage.ERROR_CODE_ERROR_ADDING_EXTERNAL_CLAIM;
 import static org.wso2.carbon.identity.api.server.claim.management.common.Constant.ErrorMessage.ERROR_CODE_ERROR_ADDING_LOCAL_CLAIM;
@@ -85,6 +87,7 @@ import static org.wso2.carbon.identity.api.server.claim.management.common.Consta
 import static org.wso2.carbon.identity.api.server.claim.management.common.Constant.ErrorMessage.ERROR_CODE_LOCAL_CLAIM_NOT_FOUND;
 import static org.wso2.carbon.identity.api.server.claim.management.common.Constant.ErrorMessage.ERROR_CODE_PAGINATION_NOT_IMPLEMENTED;
 import static org.wso2.carbon.identity.api.server.claim.management.common.Constant.ErrorMessage.ERROR_CODE_SORTING_NOT_IMPLEMENTED;
+import static org.wso2.carbon.identity.api.server.claim.management.common.Constant.ErrorMessage.ERROR_CODE_USERSTORE_NOT_SPECIFIED_IN_MAPPINGS;
 import static org.wso2.carbon.identity.api.server.claim.management.common.Constant.LOCAL_DIALECT;
 import static org.wso2.carbon.identity.api.server.claim.management.common.Constant.LOCAL_DIALECT_PATH;
 import static org.wso2.carbon.identity.api.server.claim.management.common.Constant.PROP_DESCRIPTION;
@@ -266,16 +269,8 @@ public class ServerClaimManagementService {
         }
 
         try {
-            for (AttributeMappingDTO attributeMappingDTO :
-                    localClaimReqDTO.getAttributeMapping()) {
-                if (!isUserStoreExists(attributeMappingDTO.getUserstore())) {
-                    throw handleClaimManagementClientError(ERROR_CODE_INVALID_USERSTORE, BAD_REQUEST,
-                            attributeMappingDTO.getUserstore());
-                }
-            }
-
-            getClaimMetadataManagementService().addLocalClaim(
-                    createLocalClaim(localClaimReqDTO),
+            validateAttributeMappings(localClaimReqDTO.getAttributeMapping());
+            getClaimMetadataManagementService().addLocalClaim(createLocalClaim(localClaimReqDTO),
                     ContextLoader.getTenantDomainFromContext());
         } catch (ClaimMetadataException e) {
             throw handleClaimManagementException(e, ERROR_CODE_ERROR_ADDING_LOCAL_CLAIM,
@@ -385,16 +380,8 @@ public class ServerClaimManagementService {
                 throw handleClaimManagementClientError(Constant.ErrorMessage.ERROR_CODE_CLAIM_DESCRIPTION_NOT_SPECIFIED,
                         BAD_REQUEST);
             }
-            for (AttributeMappingDTO attributeMappingDTO :
-                    localClaimReqDTO.getAttributeMapping()) {
-                if (!isUserStoreExists(attributeMappingDTO.getUserstore())) {
-                    throw handleClaimManagementClientError(ERROR_CODE_INVALID_USERSTORE, BAD_REQUEST,
-                            attributeMappingDTO.getUserstore());
-                }
-            }
-
-            getClaimMetadataManagementService().updateLocalClaim(
-                    createLocalClaim(localClaimReqDTO),
+            validateAttributeMappings(localClaimReqDTO.getAttributeMapping());
+            getClaimMetadataManagementService().updateLocalClaim(createLocalClaim(localClaimReqDTO),
                     ContextLoader.getTenantDomainFromContext());
         } catch (ClaimMetadataException e) {
             throw handleClaimManagementException(e, ERROR_CODE_ERROR_UPDATING_LOCAL_CLAIM, claimId);
@@ -954,5 +941,27 @@ public class ServerClaimManagementService {
             });
         }
         return propList;
+    }
+
+    private void validateAttributeMappings(List<AttributeMappingDTO> attributeMappingDTOList)
+            throws UserStoreException {
+
+        if (attributeMappingDTOList == null) {
+            throw handleClaimManagementClientError(ERROR_CODE_EMPTY_ATTRIBUTE_MAPPINGS, BAD_REQUEST);
+        }
+        for (AttributeMappingDTO attributeMappingDTO : attributeMappingDTOList) {
+            if (StringUtils.isBlank(attributeMappingDTO.getUserstore())) {
+                throw handleClaimManagementClientError(ERROR_CODE_USERSTORE_NOT_SPECIFIED_IN_MAPPINGS,
+                        BAD_REQUEST, attributeMappingDTO.getUserstore());
+            }
+            if (StringUtils.isBlank(attributeMappingDTO.getMappedAttribute())) {
+                throw handleClaimManagementClientError(ERROR_CODE_EMPTY_MAPPED_ATTRIBUTES_IN_LOCAL_CLAIM,
+                        BAD_REQUEST, attributeMappingDTO.getUserstore());
+            }
+            if (!isUserStoreExists(attributeMappingDTO.getUserstore())) {
+                throw handleClaimManagementClientError(ERROR_CODE_INVALID_USERSTORE, BAD_REQUEST,
+                        attributeMappingDTO.getUserstore());
+            }
+        }
     }
 }

--- a/components/org.wso2.carbon.identity.api.server.claim.management/org.wso2.carbon.identity.rest.api.server.claim.management.v1/src/main/java/org/wso2/carbon/identity/rest/api/server/claim/management/v1/core/ServerClaimManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.claim.management/org.wso2.carbon.identity.rest.api.server.claim.management.v1/src/main/java/org/wso2/carbon/identity/rest/api/server/claim/management/v1/core/ServerClaimManagementService.java
@@ -957,7 +957,7 @@ public class ServerClaimManagementService {
             }
             // Validating mapped attribute only the userstore is equal to the primary userstore domain name.
             if (StringUtils.isBlank(attributeMappingDTO.getMappedAttribute()) &&
-                    primaryUserstoreDomainName.equals(attributeMappingDTO.getUserstore())) {
+                    primaryUserstoreDomainName.equalsIgnoreCase(attributeMappingDTO.getUserstore())) {
                 throw handleClaimManagementClientError(ERROR_CODE_EMPTY_MAPPED_ATTRIBUTES_IN_LOCAL_CLAIM,
                         BAD_REQUEST, attributeMappingDTO.getUserstore());
             }

--- a/findbugs-exclude-filter.xml
+++ b/findbugs-exclude-filter.xml
@@ -73,6 +73,14 @@
             <Bug pattern="IMPROPER_UNICODE" />
         </Match>
     </FindBugsFilter>
+
+    <FindBugsFilter>
+        <Match>
+            <Class name="org.wso2.carbon.identity.rest.api.server.claim.management.v1.core.ServerClaimManagementService" />
+            <Method name="validateAttributeMappings" />
+            <Bug pattern="IMPROPER_UNICODE" />
+        </Match>
+    </FindBugsFilter>
     <FindBugsFilter>
         <Match>
             <Class name="org.wso2.carbon.identity.api.server.application.management.v1.core.functions.Utils" />


### PR DESCRIPTION
Resolves https://github.com/wso2/product-is/issues/10397

### Purpose
Validating properties in the LocalClaimReqDTO.

**Validated against the following scenarios**
```
<class name="org.wso2.identity.integration.test.rest.api.server.claim.management.v1.ClaimManagementSuccessTest"/>
<class name="org.wso2.identity.integration.test.rest.api.server.claim.management.v1.ClaimManagementNegativeTest"/>
```
