### PR TITLE
Improve retrieving primary user store configs

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.userstore/org.wso2.carbon.identity.api.server.userstore.common/src/main/java/org/wso2/carbon/identity/api/server/userstore/common/UserStoreConstants.java
+++ b/components/org.wso2.carbon.identity.api.server.userstore/org.wso2.carbon.identity.api.server.userstore.common/src/main/java/org/wso2/carbon/identity/api/server/userstore/common/UserStoreConstants.java
@@ -80,6 +80,10 @@ public class UserStoreConstants {
                 "Unable to get the primary user store.",
                 "Server Encountered an error while retrieving the primary user store.",
                 Response.Status.INTERNAL_SERVER_ERROR),
+        ERROR_CODE_ERROR_RETRIEVING_REALM_CONFIG("65012",
+                "Unable to get the realm configurations",
+                "Server Encountered an error while retrieving realm configuration for tenant: %s",
+                Response.Status.INTERNAL_SERVER_ERROR),
 
         // Client Errors - 600xx
         ERROR_CODE_DOMAIN_ID_NOT_FOUND("60001",

--- a/components/org.wso2.carbon.identity.api.server.userstore/org.wso2.carbon.identity.api.server.userstore.v1/src/main/java/org/wso2/carbon/identity/api/server/userstore/v1/core/ServerUserStoreService.java
+++ b/components/org.wso2.carbon.identity.api.server.userstore/org.wso2.carbon.identity.api.server.userstore.v1/src/main/java/org/wso2/carbon/identity/api/server/userstore/v1/core/ServerUserStoreService.java
@@ -226,7 +226,7 @@ public class ServerUserStoreService {
                 LOG.debug("Error occurred while getting the RealmConfiguration for tenant: " + tenantId, exception);
             }
             throw handleException(Response.Status.INTERNAL_SERVER_ERROR, UserStoreConstants.ErrorMessage.
-                    ERROR_CODE_ERROR_RETRIEVING_PRIMARY_USERSTORE);
+                    ERROR_CODE_ERROR_RETRIEVING_REALM_CONFIG, Integer.toString(tenantId));
         }
         if (realmConfiguration == null) {
             throw handleException(Response.Status.INTERNAL_SERVER_ERROR, UserStoreConstants.ErrorMessage.
@@ -774,6 +774,19 @@ public class ServerUserStoreService {
     private APIError handleException(Response.Status status, UserStoreConstants.ErrorMessage error) {
 
         return new APIError(status, getErrorBuilder(error).build());
+    }
+
+    /**
+     * Handle exceptions generated in API.
+     *
+     * @param status HTTP Status.
+     * @param error  Error Message information.
+     * @param data   Additional data.
+     * @return APIError.
+     */
+    private APIError handleException(Response.Status status, UserStoreConstants.ErrorMessage error, String... data) {
+
+        return new APIError(status, getErrorBuilder(error, data).build());
     }
 
     /**

--- a/pom.xml
+++ b/pom.xml
@@ -495,9 +495,6 @@
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>findbugs-maven-plugin</artifactId>
-                    <configuration>
-                        <skip>true</skip>
-                    </configuration>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -495,6 +495,9 @@
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>findbugs-maven-plugin</artifactId>
+                    <configuration>
+                        <skip>true</skip>
+                    </configuration>
                 </plugin>
             </plugins>
         </pluginManagement>


### PR DESCRIPTION
## Purpose
Unable tenants to get the primary user store configs via `getTenantUserRealm`.

## Approach
In the existing implementation, the primary user store configs were returned from the `BootstrapRealmConfiguration`. In this PR, the realm configs are retrieved via ` realmService.getTenantUserRealm(tenantId).getRealmConfiguration()`. This unables tenants to retrieve their own configs instead of the bootstrap realm.

## Testing
The API was tested manually and tested with the following test scenarios.
```
<class name="org.wso2.identity.integration.test.rest.api.server.user.store.v1.UserStoreSuccessTest"/>
<class name="org.wso2.identity.integration.test.rest.api.server.user.store.v1.UserStoreFailureTest"/>
```