### PR TITLE
Fix test RDBMS user store via the REST API functionality 

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.userstore/org.wso2.carbon.identity.api.server.userstore.v1/src/gen/java/org/wso2/carbon/identity/api/server/userstore/v1/UserstoresApi.java
+++ b/components/org.wso2.carbon.identity.api.server.userstore/org.wso2.carbon.identity.api.server.userstore.v1/src/gen/java/org/wso2/carbon/identity/api/server/userstore/v1/UserstoresApi.java
@@ -1,5 +1,5 @@
 /*
-* Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+* Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.apache.cxf.jaxrs.ext.multipart.Attachment;
 import org.apache.cxf.jaxrs.ext.multipart.Multipart;
 import java.io.InputStream;
+import java.util.List;
 
 import org.wso2.carbon.identity.api.server.userstore.v1.model.AvailableUserStoreClassesRes;
 import org.wso2.carbon.identity.api.server.userstore.v1.model.ConnectionEstablishedResponse;
@@ -54,7 +55,7 @@ public class UserstoresApi  {
     
     @Consumes({ "application/json" })
     @Produces({ "application/json" })
-    @ApiOperation(value = "Add a secondary user store.", notes = "This API provides the capability to add a secondary user store.   <b>Permission required:</b>   *_/permission/admin ", response = UserStoreResponse.class, authorizations = {
+    @ApiOperation(value = "Add a secondary user store.", notes = "This API provides the capability to add a secondary user store.  **NOTE:**    To retrieve the available user store classes/types, use the **api/server/v1/userstores/meta/types** API.   <b>Permission required:</b>   - /permission/admin ", response = UserStoreResponse.class, authorizations = {
         @Authorization(value = "BasicAuth"),
         @Authorization(value = "OAuth2", scopes = {
             
@@ -143,7 +144,7 @@ public class UserstoresApi  {
     
     
     @Produces({ "application/json" })
-    @ApiOperation(value = "Retrieve or List the configured secondary user stores.", notes = "This API provides the capability to list the configured secondary userstores. <b>Permission required:</b> *_/permission/admin ", response = UserStoreListResponse.class, responseContainer = "List", authorizations = {
+    @ApiOperation(value = "Retrieve or list the configured secondary user stores.", notes = "This API provides the capability to list the configured secondary userstores. <b>Permission required:</b> *_/permission/admin ", response = UserStoreListResponse.class, responseContainer = "List", authorizations = {
         @Authorization(value = "BasicAuth"),
         @Authorization(value = "OAuth2", scopes = {
             
@@ -156,7 +157,7 @@ public class UserstoresApi  {
         @ApiResponse(code = 500, message = "Internal Server Error.", response = Error.class),
         @ApiResponse(code = 501, message = "Not Implemented.", response = Error.class)
     })
-    public Response getSecondaryUserStores(    @Valid@ApiParam(value = "maximum number of records to return")  @QueryParam("limit") Integer limit,     @Valid@ApiParam(value = "number of records to skip for pagination")  @QueryParam("offset") Integer offset,     @Valid@ApiParam(value = "Condition to filter the retrival of records.")  @QueryParam("filter") String filter,     @Valid@ApiParam(value = "Define the order how the retrieved records should be sorted.")  @QueryParam("sort") String sort,     @Valid@ApiParam(value = "Define set of user store attributes (as comma separated) to be returned.")  @QueryParam("requiredAttributes") String requiredAttributes) {
+    public Response getSecondaryUserStores(    @Valid@ApiParam(value = "maximum number of records to return")  @QueryParam("limit") Integer limit,     @Valid@ApiParam(value = "number of records to skip for pagination")  @QueryParam("offset") Integer offset,     @Valid@ApiParam(value = "Condition to filter the retrieval of records.")  @QueryParam("filter") String filter,     @Valid@ApiParam(value = "Define the order of how the retrieved records should be sorted.")  @QueryParam("sort") String sort,     @Valid@ApiParam(value = "Define set of user store attributes (as comma separated) to be returned.")  @QueryParam("requiredAttributes") String requiredAttributes) {
 
         return delegate.getSecondaryUserStores(limit,  offset,  filter,  sort,  requiredAttributes );
     }
@@ -212,7 +213,7 @@ public class UserstoresApi  {
     @Path("/{userstore-domain-id}")
     @Consumes({ "application/json" })
     @Produces({ "application/json" })
-    @ApiOperation(value = "Patch the secondary user store by it's domain id.", notes = "This API provides the capability to update the secondary user store's property using patch request by using it's domain id.   <b>Permission required:</b>  *_/permission/admin ", response = UserStoreResponse.class, authorizations = {
+    @ApiOperation(value = "Patch the secondary user store by it's domain id.", notes = "This API provides the capability to update the secondary user store's property using patch request by using its domain id.   <b>Permission required:</b>  *_/permission/admin ", response = UserStoreResponse.class, authorizations = {
         @Authorization(value = "BasicAuth"),
         @Authorization(value = "OAuth2", scopes = {
             
@@ -272,7 +273,7 @@ public class UserstoresApi  {
         @ApiResponse(code = 404, message = "The specified resource is not found.", response = Error.class),
         @ApiResponse(code = 500, message = "Internal Server Error.", response = Error.class)
     })
-    public Response updateUserStore(@ApiParam(value = "Current domain id of the user store",required=true) @PathParam("userstore-domain-id") String userstoreDomainId, @ApiParam(value = "The secondary user store values which are need to be edited of the given domain id." ) @Valid UserStoreReq userStoreReq) {
+    public Response updateUserStore(@ApiParam(value = "Current domain id of the user store",required=true) @PathParam("userstore-domain-id") String userstoreDomainId, @ApiParam(value = "The secondary user store values which are needed to be edited for a given domain id." ) @Valid UserStoreReq userStoreReq) {
 
         return delegate.updateUserStore(userstoreDomainId,  userStoreReq );
     }

--- a/components/org.wso2.carbon.identity.api.server.userstore/org.wso2.carbon.identity.api.server.userstore.v1/src/gen/java/org/wso2/carbon/identity/api/server/userstore/v1/UserstoresApiService.java
+++ b/components/org.wso2.carbon.identity.api.server.userstore/org.wso2.carbon.identity.api.server.userstore.v1/src/gen/java/org/wso2/carbon/identity/api/server/userstore/v1/UserstoresApiService.java
@@ -1,5 +1,5 @@
 /*
-* Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+* Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ import org.wso2.carbon.identity.api.server.userstore.v1.model.*;
 import org.apache.cxf.jaxrs.ext.multipart.Attachment;
 import org.apache.cxf.jaxrs.ext.multipart.Multipart;
 import java.io.InputStream;
+import java.util.List;
 import org.wso2.carbon.identity.api.server.userstore.v1.model.AvailableUserStoreClassesRes;
 import org.wso2.carbon.identity.api.server.userstore.v1.model.ConnectionEstablishedResponse;
 import org.wso2.carbon.identity.api.server.userstore.v1.model.Error;

--- a/components/org.wso2.carbon.identity.api.server.userstore/org.wso2.carbon.identity.api.server.userstore.v1/src/gen/java/org/wso2/carbon/identity/api/server/userstore/v1/factories/UserstoresApiServiceFactory.java
+++ b/components/org.wso2.carbon.identity.api.server.userstore/org.wso2.carbon.identity.api.server.userstore.v1/src/gen/java/org/wso2/carbon/identity/api/server/userstore/v1/factories/UserstoresApiServiceFactory.java
@@ -1,5 +1,5 @@
 /*
-* Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+* Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/components/org.wso2.carbon.identity.api.server.userstore/org.wso2.carbon.identity.api.server.userstore.v1/src/gen/java/org/wso2/carbon/identity/api/server/userstore/v1/model/AddUserStorePropertiesRes.java
+++ b/components/org.wso2.carbon.identity.api.server.userstore/org.wso2.carbon.identity.api.server.userstore.v1/src/gen/java/org/wso2/carbon/identity/api/server/userstore/v1/model/AddUserStorePropertiesRes.java
@@ -1,5 +1,5 @@
 /*
-* Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+* Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/components/org.wso2.carbon.identity.api.server.userstore/org.wso2.carbon.identity.api.server.userstore.v1/src/gen/java/org/wso2/carbon/identity/api/server/userstore/v1/model/AvailableUserStoreClassesRes.java
+++ b/components/org.wso2.carbon.identity.api.server.userstore/org.wso2.carbon.identity.api.server.userstore.v1/src/gen/java/org/wso2/carbon/identity/api/server/userstore/v1/model/AvailableUserStoreClassesRes.java
@@ -1,5 +1,5 @@
 /*
-* Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+* Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/components/org.wso2.carbon.identity.api.server.userstore/org.wso2.carbon.identity.api.server.userstore.v1/src/gen/java/org/wso2/carbon/identity/api/server/userstore/v1/model/ConnectionEstablishedResponse.java
+++ b/components/org.wso2.carbon.identity.api.server.userstore/org.wso2.carbon.identity.api.server.userstore.v1/src/gen/java/org/wso2/carbon/identity/api/server/userstore/v1/model/ConnectionEstablishedResponse.java
@@ -1,5 +1,5 @@
 /*
-* Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+* Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/components/org.wso2.carbon.identity.api.server.userstore/org.wso2.carbon.identity.api.server.userstore.v1/src/gen/java/org/wso2/carbon/identity/api/server/userstore/v1/model/Error.java
+++ b/components/org.wso2.carbon.identity.api.server.userstore/org.wso2.carbon.identity.api.server.userstore.v1/src/gen/java/org/wso2/carbon/identity/api/server/userstore/v1/model/Error.java
@@ -1,5 +1,5 @@
 /*
-* Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+* Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/components/org.wso2.carbon.identity.api.server.userstore/org.wso2.carbon.identity.api.server.userstore.v1/src/gen/java/org/wso2/carbon/identity/api/server/userstore/v1/model/MetaUserStoreType.java
+++ b/components/org.wso2.carbon.identity.api.server.userstore/org.wso2.carbon.identity.api.server.userstore.v1/src/gen/java/org/wso2/carbon/identity/api/server/userstore/v1/model/MetaUserStoreType.java
@@ -1,5 +1,5 @@
 /*
-* Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+* Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/components/org.wso2.carbon.identity.api.server.userstore/org.wso2.carbon.identity.api.server.userstore.v1/src/gen/java/org/wso2/carbon/identity/api/server/userstore/v1/model/PatchDocument.java
+++ b/components/org.wso2.carbon.identity.api.server.userstore/org.wso2.carbon.identity.api.server.userstore.v1/src/gen/java/org/wso2/carbon/identity/api/server/userstore/v1/model/PatchDocument.java
@@ -1,5 +1,5 @@
 /*
-* Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+* Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/components/org.wso2.carbon.identity.api.server.userstore/org.wso2.carbon.identity.api.server.userstore.v1/src/gen/java/org/wso2/carbon/identity/api/server/userstore/v1/model/PropertiesRes.java
+++ b/components/org.wso2.carbon.identity.api.server.userstore/org.wso2.carbon.identity.api.server.userstore.v1/src/gen/java/org/wso2/carbon/identity/api/server/userstore/v1/model/PropertiesRes.java
@@ -1,5 +1,5 @@
 /*
-* Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+* Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/components/org.wso2.carbon.identity.api.server.userstore/org.wso2.carbon.identity.api.server.userstore.v1/src/gen/java/org/wso2/carbon/identity/api/server/userstore/v1/model/Property.java
+++ b/components/org.wso2.carbon.identity.api.server.userstore/org.wso2.carbon.identity.api.server.userstore.v1/src/gen/java/org/wso2/carbon/identity/api/server/userstore/v1/model/Property.java
@@ -1,5 +1,5 @@
 /*
-* Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+* Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/components/org.wso2.carbon.identity.api.server.userstore/org.wso2.carbon.identity.api.server.userstore.v1/src/gen/java/org/wso2/carbon/identity/api/server/userstore/v1/model/RDBMSConnectionReq.java
+++ b/components/org.wso2.carbon.identity.api.server.userstore/org.wso2.carbon.identity.api.server.userstore.v1/src/gen/java/org/wso2/carbon/identity/api/server/userstore/v1/model/RDBMSConnectionReq.java
@@ -1,5 +1,5 @@
 /*
-* Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+* Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -33,10 +33,32 @@ import javax.xml.bind.annotation.*;
 @ApiModel(description = "RDBMS Connection Request.")
 public class RDBMSConnectionReq  {
   
+    private String domain;
     private String driverName;
     private String connectionURL;
     private String username;
     private String connectionPassword;
+
+    /**
+    * User store domain name.
+    **/
+    public RDBMSConnectionReq domain(String domain) {
+
+        this.domain = domain;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "PRIMARY", required = true, value = "User store domain name.")
+    @JsonProperty("domain")
+    @Valid
+    @NotNull(message = "Property domain cannot be null.")
+
+    public String getDomain() {
+        return domain;
+    }
+    public void setDomain(String domain) {
+        this.domain = domain;
+    }
 
     /**
     * Driver Name.
@@ -134,7 +156,8 @@ public class RDBMSConnectionReq  {
             return false;
         }
         RDBMSConnectionReq rdBMSConnectionReq = (RDBMSConnectionReq) o;
-        return Objects.equals(this.driverName, rdBMSConnectionReq.driverName) &&
+        return Objects.equals(this.domain, rdBMSConnectionReq.domain) &&
+            Objects.equals(this.driverName, rdBMSConnectionReq.driverName) &&
             Objects.equals(this.connectionURL, rdBMSConnectionReq.connectionURL) &&
             Objects.equals(this.username, rdBMSConnectionReq.username) &&
             Objects.equals(this.connectionPassword, rdBMSConnectionReq.connectionPassword);
@@ -142,7 +165,7 @@ public class RDBMSConnectionReq  {
 
     @Override
     public int hashCode() {
-        return Objects.hash(driverName, connectionURL, username, connectionPassword);
+        return Objects.hash(domain, driverName, connectionURL, username, connectionPassword);
     }
 
     @Override
@@ -151,6 +174,7 @@ public class RDBMSConnectionReq  {
         StringBuilder sb = new StringBuilder();
         sb.append("class RDBMSConnectionReq {\n");
         
+        sb.append("    domain: ").append(toIndentedString(domain)).append("\n");
         sb.append("    driverName: ").append(toIndentedString(driverName)).append("\n");
         sb.append("    connectionURL: ").append(toIndentedString(connectionURL)).append("\n");
         sb.append("    username: ").append(toIndentedString(username)).append("\n");

--- a/components/org.wso2.carbon.identity.api.server.userstore/org.wso2.carbon.identity.api.server.userstore.v1/src/gen/java/org/wso2/carbon/identity/api/server/userstore/v1/model/UserStoreConfigurationsRes.java
+++ b/components/org.wso2.carbon.identity.api.server.userstore/org.wso2.carbon.identity.api.server.userstore.v1/src/gen/java/org/wso2/carbon/identity/api/server/userstore/v1/model/UserStoreConfigurationsRes.java
@@ -1,5 +1,5 @@
 /*
-* Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+* Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/components/org.wso2.carbon.identity.api.server.userstore/org.wso2.carbon.identity.api.server.userstore.v1/src/gen/java/org/wso2/carbon/identity/api/server/userstore/v1/model/UserStoreListResponse.java
+++ b/components/org.wso2.carbon.identity.api.server.userstore/org.wso2.carbon.identity.api.server.userstore.v1/src/gen/java/org/wso2/carbon/identity/api/server/userstore/v1/model/UserStoreListResponse.java
@@ -1,5 +1,5 @@
 /*
-* Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+* Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -61,7 +61,7 @@ public class UserStoreListResponse  {
     }
 
     /**
-    * domain name of the secondary user store
+    * Domain name of the secondary user store.
     **/
     public UserStoreListResponse name(String name) {
 
@@ -69,7 +69,7 @@ public class UserStoreListResponse  {
         return this;
     }
     
-    @ApiModelProperty(example = "JDBC-SECONDARY", value = "domain name of the secondary user store")
+    @ApiModelProperty(example = "JDBC-SECONDARY", value = "Domain name of the secondary user store.")
     @JsonProperty("name")
     @Valid
     public String getName() {

--- a/components/org.wso2.carbon.identity.api.server.userstore/org.wso2.carbon.identity.api.server.userstore.v1/src/gen/java/org/wso2/carbon/identity/api/server/userstore/v1/model/UserStorePropertiesRes.java
+++ b/components/org.wso2.carbon.identity.api.server.userstore/org.wso2.carbon.identity.api.server.userstore.v1/src/gen/java/org/wso2/carbon/identity/api/server/userstore/v1/model/UserStorePropertiesRes.java
@@ -1,5 +1,5 @@
 /*
-* Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+* Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/components/org.wso2.carbon.identity.api.server.userstore/org.wso2.carbon.identity.api.server.userstore.v1/src/gen/java/org/wso2/carbon/identity/api/server/userstore/v1/model/UserStoreReq.java
+++ b/components/org.wso2.carbon.identity.api.server.userstore/org.wso2.carbon.identity.api.server.userstore.v1/src/gen/java/org/wso2/carbon/identity/api/server/userstore/v1/model/UserStoreReq.java
@@ -1,5 +1,5 @@
 /*
-* Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+* Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/components/org.wso2.carbon.identity.api.server.userstore/org.wso2.carbon.identity.api.server.userstore.v1/src/gen/java/org/wso2/carbon/identity/api/server/userstore/v1/model/UserStoreResponse.java
+++ b/components/org.wso2.carbon.identity.api.server.userstore/org.wso2.carbon.identity.api.server.userstore.v1/src/gen/java/org/wso2/carbon/identity/api/server/userstore/v1/model/UserStoreResponse.java
@@ -1,5 +1,5 @@
 /*
-* Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+* Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/components/org.wso2.carbon.identity.api.server.userstore/org.wso2.carbon.identity.api.server.userstore.v1/src/main/java/org/wso2/carbon/identity/api/server/userstore/v1/core/ServerUserStoreService.java
+++ b/components/org.wso2.carbon.identity.api.server.userstore/org.wso2.carbon.identity.api.server.userstore.v1/src/main/java/org/wso2/carbon/identity/api/server/userstore/v1/core/ServerUserStoreService.java
@@ -79,6 +79,8 @@ public class ServerUserStoreService {
 
     private static final Log LOG = LogFactory.getLog(ServerUserStoreService.class);
 
+    private static final String DUMMY_MESSAGE_ID = "DUMMY-MESSAGE-ID";
+
     /**
      * Add a userStore {@link UserStoreReq}.
      *
@@ -341,9 +343,9 @@ public class ServerUserStoreService {
         boolean isConnectionEstablished;
         connectionEstablishedResponse.setConnection(false);
         try {
-            isConnectionEstablished = userStoreConfigService.testRDBMSConnection("",
+            isConnectionEstablished = userStoreConfigService.testRDBMSConnection(rdBMSConnectionReq.getDomain(),
                     rdBMSConnectionReq.getDriverName(), rdBMSConnectionReq.getConnectionURL(),
-                    rdBMSConnectionReq.getUsername(), rdBMSConnectionReq.getConnectionPassword(), "");
+                    rdBMSConnectionReq.getUsername(), rdBMSConnectionReq.getConnectionPassword(), DUMMY_MESSAGE_ID);
             if (isConnectionEstablished) {
                 connectionEstablishedResponse.setConnection(true);
             }

--- a/components/org.wso2.carbon.identity.api.server.userstore/org.wso2.carbon.identity.api.server.userstore.v1/src/main/resources/userstore.yaml
+++ b/components/org.wso2.carbon.identity.api.server.userstore/org.wso2.carbon.identity.api.server.userstore.v1/src/main/resources/userstore.yaml
@@ -522,12 +522,17 @@ components:
           example: 'true'
     RDBMSConnectionReq:
       required:
+        - domain
         - driverName
         - connectionURL
         - username
         - connectionPassword
       description: RDBMS Connection Request.
       properties:
+        domain:
+          type: string
+          description: User store domain name.
+          example: PRIMARY
         driverName:
           type: string
           description: Driver Name.


### PR DESCRIPTION
## Purpose
Fixes https://github.com/wso2/product-is/issues/10670.

## Goals
Testing RDBMS user store connectivity has a bug. Following is the API call to invoke this functionality.

```
curl --location --request POST 'https://localhost:9443/api/server/v1/userstores/test-connection' \
--header 'accept: application/json' \
--header 'Content-Type: application/json' \
--header 'Authorization: Basic ***' \
--data-raw '{
    "driverName": "com.microsoft.sqlserver.jdbc.SQLServerDriver",
    "connectionURL": "jdbc:sqlserver://localhost:1433;databaseName=test",
    "username": "sa",
    "connectionPassword": "ENCRYPTED PROPERTY",
}'
```

Underneath, user store management config service is invoked with the data coming from this request. However, it requires two additional parameters `domain` and `message-id`. The domain is required to interpret the connection password as the password sent with the request should be equal to `ENCRYPTED PROPERTY` string value(this is to make sure that the password is not shared. Internally, code will call the realm service and figure out the password for the provided domain). The message-id can take any value. The current code does not provide these parameters therefore breaking the functionality.

This PR improves the API request body to support domain parameter and use a dummy message-id value to properly invoke underneath service. The improved API body should take the following form.
```
curl --location --request POST 'https://localhost:9443/api/server/v1/userstores/test-connection' \
--header 'accept: application/json' \
--header 'Content-Type: application/json' \
--header 'Authorization: Basic YWRtaW46YWRtaW4=' \
--data-raw '{
    "driverName": "com.microsoft.sqlserver.jdbc.SQLServerDriver",
    "connectionURL": "jdbc:sqlserver://localhost:1433;databaseName=test",
    "username": "sa",
    "connectionPassword": "ENCRYPTED PROPERTY",
    "domain":"SECONDARY"
}'
```