### PR TITLE
Mark domain as optional

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.userstore/org.wso2.carbon.identity.api.server.userstore.v1/src/gen/java/org/wso2/carbon/identity/api/server/userstore/v1/model/RDBMSConnectionReq.java
+++ b/components/org.wso2.carbon.identity.api.server.userstore/org.wso2.carbon.identity.api.server.userstore.v1/src/gen/java/org/wso2/carbon/identity/api/server/userstore/v1/model/RDBMSConnectionReq.java
@@ -48,11 +48,9 @@ public class RDBMSConnectionReq  {
         return this;
     }
     
-    @ApiModelProperty(example = "PRIMARY", required = true, value = "User store domain name.")
+    @ApiModelProperty(example = "PRIMARY", value = "User store domain name.")
     @JsonProperty("domain")
     @Valid
-    @NotNull(message = "Property domain cannot be null.")
-
     public String getDomain() {
         return domain;
     }

--- a/components/org.wso2.carbon.identity.api.server.userstore/org.wso2.carbon.identity.api.server.userstore.v1/src/main/resources/userstore.yaml
+++ b/components/org.wso2.carbon.identity.api.server.userstore/org.wso2.carbon.identity.api.server.userstore.v1/src/main/resources/userstore.yaml
@@ -522,7 +522,6 @@ components:
           example: 'true'
     RDBMSConnectionReq:
       required:
-        - domain
         - driverName
         - connectionURL
         - username


### PR DESCRIPTION
## Purpose
Fixes https://github.com/wso2/product-is/issues/10670.

## Goals
Domain parameter is only required when testing RDBMS connections with the masked password. Therefore it needs to be an optional parameter.