### PR TITLE
Introduce a new endpoint to get homeRealmIdentifiers from server configuration

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/gen/java/org/wso2/carbon/identity/api/server/configs/v1/ConfigsApi.java
+++ b/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/gen/java/org/wso2/carbon/identity/api/server/configs/v1/ConfigsApi.java
@@ -122,6 +122,30 @@ public class ConfigsApi  {
 
     @Valid
     @GET
+    @Path("/homeRealmIdentifiers")
+    
+    @Produces({ "application/json" })
+    @ApiOperation(value = "Retrieve the Home Realm Identifiers.", notes = "Retrieve the Home Realm Identifiers.", response = String.class, responseContainer = "List", authorizations = {
+        @Authorization(value = "BasicAuth"),
+        @Authorization(value = "OAuth2", scopes = {
+            
+        })
+    }, tags={ "Home Realm Identifiers", })
+    @ApiResponses(value = { 
+        @ApiResponse(code = 200, message = "Successful Response", response = String.class, responseContainer = "List"),
+        @ApiResponse(code = 400, message = "Bad Request", response = Error.class),
+        @ApiResponse(code = 401, message = "Unauthorized", response = Void.class),
+        @ApiResponse(code = 403, message = "Forbidden", response = Void.class),
+        @ApiResponse(code = 404, message = "Not Found", response = Error.class),
+        @ApiResponse(code = 500, message = "Server Error", response = Error.class)
+    })
+    public Response getHomeRealmIdentifiers() {
+
+        return delegate.getHomeRealmIdentifiers();
+    }
+
+    @Valid
+    @GET
     @Path("/provisioning/inbound/scim")
     
     @Produces({ "application/json" })

--- a/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/gen/java/org/wso2/carbon/identity/api/server/configs/v1/ConfigsApi.java
+++ b/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/gen/java/org/wso2/carbon/identity/api/server/configs/v1/ConfigsApi.java
@@ -122,7 +122,7 @@ public class ConfigsApi  {
 
     @Valid
     @GET
-    @Path("/homeRealmIdentifiers")
+    @Path("/home-realm-identifiers")
     
     @Produces({ "application/json" })
     @ApiOperation(value = "Retrieve the Home Realm Identifiers.", notes = "Retrieve the Home Realm Identifiers.", response = String.class, responseContainer = "List", authorizations = {

--- a/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/gen/java/org/wso2/carbon/identity/api/server/configs/v1/ConfigsApiService.java
+++ b/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/gen/java/org/wso2/carbon/identity/api/server/configs/v1/ConfigsApiService.java
@@ -42,6 +42,8 @@ public interface ConfigsApiService {
 
       public Response getConfigs();
 
+      public Response getHomeRealmIdentifiers();
+
       public Response getInboundScimConfigs();
 
       public Response listAuthenticators(String type);

--- a/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/main/java/org/wso2/carbon/identity/api/server/configs/v1/core/ServerConfigManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/main/java/org/wso2/carbon/identity/api/server/configs/v1/core/ServerConfigManagementService.java
@@ -187,7 +187,8 @@ public class ServerConfigManagementService {
         String homeRealmIdStr = residentIdP.getHomeRealmId();
         List<String> homeRealmIdentifiers = null;
         if (StringUtils.isNotBlank(homeRealmIdStr)) {
-            homeRealmIdentifiers = Arrays.stream(homeRealmIdStr.split(",")).collect(Collectors.toList());
+            homeRealmIdentifiers =
+                    Arrays.stream(homeRealmIdStr.trim().split("\\s*,\\s*")).collect(Collectors.toList());
         }
         ServerConfig serverConfig = new ServerConfig();
         serverConfig.setRealmConfig(realmConfig);
@@ -392,7 +393,8 @@ public class ServerConfigManagementService {
         String homeRealmIdStr = residentIdP.getHomeRealmId();
         List<String> homeRealmIdentifiers = new ArrayList<>();
         if (StringUtils.isNotBlank(homeRealmIdStr)) {
-            homeRealmIdentifiers = Arrays.stream(homeRealmIdStr.split(",")).collect(Collectors.toList());
+            homeRealmIdentifiers =
+                    Arrays.stream(homeRealmIdStr.trim().split("\\s*,\\s*")).collect(Collectors.toList());
         }
         return homeRealmIdentifiers;
     }

--- a/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/main/java/org/wso2/carbon/identity/api/server/configs/v1/core/ServerConfigManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/main/java/org/wso2/carbon/identity/api/server/configs/v1/core/ServerConfigManagementService.java
@@ -381,6 +381,22 @@ public class ServerConfigManagementService {
         }
     }
 
+    /**
+     * Get Home Realm Identifiers.
+     *
+     * @return List of home realm identifiers.
+     */
+    public List<String> getHomeRealmIdentifiers() {
+
+        IdentityProvider residentIdP = getResidentIdP();
+        String homeRealmIdStr = residentIdP.getHomeRealmId();
+        List<String> homeRealmIdentifiers = new ArrayList<>();
+        if (StringUtils.isNotBlank(homeRealmIdStr)) {
+            homeRealmIdentifiers = Arrays.stream(homeRealmIdStr.split(",")).collect(Collectors.toList());
+        }
+        return homeRealmIdentifiers;
+    }
+
     private List<AuthenticatorListItem> buildAuthenticatorListResponse(
             LocalAuthenticatorConfig[] localConfigs, RequestPathAuthenticatorConfig[] requestPathConfigs) {
 

--- a/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/main/java/org/wso2/carbon/identity/api/server/configs/v1/impl/ConfigsApiServiceImpl.java
+++ b/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/main/java/org/wso2/carbon/identity/api/server/configs/v1/impl/ConfigsApiServiceImpl.java
@@ -54,6 +54,11 @@ public class ConfigsApiServiceImpl implements ConfigsApiService {
     }
 
     @Override
+    public Response getHomeRealmIdentifiers() {
+        return Response.ok().entity(configManagementService.getHomeRealmIdentifiers()).build();
+    }
+
+    @Override
     public Response getInboundScimConfigs() {
 
         return Response.ok().entity(configManagementService.getInboundScimConfig()).build();

--- a/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/main/resources/configs.yaml
+++ b/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/main/resources/configs.yaml
@@ -326,6 +326,42 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
+  /configs/homeRealmIdentifiers:
+    get:
+      tags:
+        - Home Realm Identifiers
+      summary: Retrieve the Home Realm Identifiers.
+      operationId: getHomeRealmIdentifiers
+      description: Retrieve the Home Realm Identifiers.
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HomeRealmIdentifiers'
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '500':
+          description: Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
 servers:
   - url: 'https://localhost:9443/t/{tenant-domain}/api/server/v1'
     variables:
@@ -603,3 +639,9 @@ components:
           type: string
           description: The value to be used within the operations.
           example: '30'
+    HomeRealmIdentifiers:
+      type: array
+      description: The list of home realm identifiers.
+      items:
+        type: string
+        example: localhost

--- a/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/main/resources/configs.yaml
+++ b/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/main/resources/configs.yaml
@@ -326,7 +326,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-  /configs/homeRealmIdentifiers:
+  /configs/home-realm-identifiers:
     get:
       tags:
         - Home Realm Identifiers


### PR DESCRIPTION
## Purpose
> This PR introduces a new endpoint to configs API to retrieve home realm identifiers.

Related to : https://github.com/wso2/identity-apps/pull/1414
Resolves : https://github.com/wso2-enterprise/asgardeo-product/issues/1189