### PR TITLE
Fix possible NPE in OAuth app creation flow

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/functions/Utils.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/functions/Utils.java
@@ -58,6 +58,14 @@ public class Utils {
         }
     }
 
+    public static <T> void setIfNotNull(T value, Consumer<T> consumer) {
+
+        if (value != null) {
+            consumer.accept(value);
+        }
+    }
+
+
     public static <T> Stream<T> arrayToStream(T[] object) {
 
         return object != null ? Stream.of(object) : Stream.empty();

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/functions/application/inbound/oauth2/ApiModelToOAuthConsumerApp.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/functions/application/inbound/oauth2/ApiModelToOAuthConsumerApp.java
@@ -31,6 +31,8 @@ import org.wso2.carbon.identity.oauth.dto.OAuthConsumerAppDTO;
 import java.util.List;
 import java.util.Optional;
 
+import static org.wso2.carbon.identity.api.server.application.management.v1.core.functions.Utils.setIfNotNull;
+
 /**
  * Converts OpenIDConnectConfiguration api model to OAuthConsumerAppDTO.
  */
@@ -87,17 +89,26 @@ public class ApiModelToOAuthConsumerApp implements ApiModelToOAuthConsumerAppFun
     private void updateIdTokenConfiguration(OAuthConsumerAppDTO consumerAppDTO, IdTokenConfiguration idToken) {
 
         if (idToken != null) {
-            consumerAppDTO.setIdTokenExpiryTime(idToken.getExpiryInSeconds());
+            setIfNotNull(idToken.getExpiryInSeconds(), consumerAppDTO::setIdTokenExpiryTime);
             consumerAppDTO.setAudiences(Optional.ofNullable(idToken.getAudience())
                     .map(audiences -> audiences.toArray(new String[0]))
                     .orElse(new String[0])
             );
-            consumerAppDTO.setIdTokenEncryptionEnabled(idToken.getEncryption().getEnabled());
-            if (idToken.getEncryption().getEnabled()) {
-                consumerAppDTO.setIdTokenEncryptionAlgorithm(idToken.getEncryption().getAlgorithm());
-                consumerAppDTO.setIdTokenEncryptionMethod(idToken.getEncryption().getMethod());
+
+            if (idToken.getEncryption() != null) {
+                boolean idTokenEncryptionEnabled = isIdTokenEncryptionEnabled(idToken);
+                consumerAppDTO.setIdTokenEncryptionEnabled(idTokenEncryptionEnabled);
+                if (idTokenEncryptionEnabled) {
+                    consumerAppDTO.setIdTokenEncryptionAlgorithm(idToken.getEncryption().getAlgorithm());
+                    consumerAppDTO.setIdTokenEncryptionMethod(idToken.getEncryption().getMethod());
+                }
             }
         }
+    }
+
+    private boolean isIdTokenEncryptionEnabled(IdTokenConfiguration idToken) {
+
+        return idToken.getEncryption().getEnabled() != null && idToken.getEncryption().getEnabled();
     }
 
     private void updateRefreshTokenConfiguration(OAuthConsumerAppDTO consumerAppDTO,


### PR DESCRIPTION
$subject to fix possible NPE if the OAuth application creation payload does not contain full idToken configs,

For example below payload would lead to a NPE. Since `idToken` section does not contain all elements.

```
{
    "name": "appNameFixed",
    "inboundProtocolConfiguration": {
        "oidc": {
            "allowedOrigins": [
                "https://localhost"
            ],
            "callbackURLs": [
                "http://localhost:8080/playground2/oauth2client"
            ],
            "grantTypes": [
                "refresh_token",
                "authorization_code"
            ],
            "idToken": {
                "audience": [
                    " ",
                    "    ",
                    "testaudience"
                ]
            }
        }
    }
}

```
