### PR TITLE
Introduce a new parameter to exclude identity claims during local claims listing

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.claim.management/org.wso2.carbon.identity.rest.api.server.claim.management.v1/src/gen/java/org/wso2/carbon/identity/rest/api/server/claim/management/v1/ClaimManagementApi.java
+++ b/components/org.wso2.carbon.identity.api.server.claim.management/org.wso2.carbon.identity.rest.api.server.claim.management.v1/src/gen/java/org/wso2/carbon/identity/rest/api/server/claim/management/v1/ClaimManagementApi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,23 +37,23 @@ import java.io.InputStream;
 import org.apache.cxf.jaxrs.ext.multipart.Attachment;
 import org.apache.cxf.jaxrs.ext.multipart.Multipart;
 
+import javax.validation.Valid;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.*;
 
 @Path("/claim-dialects")
-
-
 @io.swagger.annotations.Api(value = "/claim-dialects", description = "the claim-dialects API")
 public class ClaimManagementApi  {
 
-   @Autowired
-   private ClaimManagementApiService delegate;
+    @Autowired
+    private ClaimManagementApiService delegate;
 
+    @Valid
     @POST
-    
     @Consumes({ "application/json" })
-    
-    @io.swagger.annotations.ApiOperation(value = "Add a claim dialect.", notes = "Add a new claim dialect.", response = void.class)
+    @io.swagger.annotations.ApiOperation(value = "Add a claim dialect.",
+            notes = "Add a new claim dialect. <br> <b>Permission required:</b> <br> * /permission/admin/manage/identity/claimmgt/metadata/create <br> <b>Scope required:</b> <br> * internal_claim_meta_create",
+            response = void.class)
     @io.swagger.annotations.ApiResponses(value = { 
         @io.swagger.annotations.ApiResponse(code = 201, message = "Item Created."),
         
@@ -67,15 +67,18 @@ public class ClaimManagementApi  {
         
         @io.swagger.annotations.ApiResponse(code = 500, message = "Internal Server Error.") })
 
-    public Response addClaimDialect(@ApiParam(value = "claim dialect to add."  ) ClaimDialectReqDTO claimDialect)
-    {
-    return delegate.addClaimDialect(claimDialect);
+    public Response addClaimDialect(@ApiParam(value = "claim dialect to add."  ) @Valid ClaimDialectReqDTO claimDialect) {
+
+        return delegate.addClaimDialect(claimDialect);
     }
+
+    @Valid
     @POST
     @Path("/{dialect-id}/claims")
     @Consumes({ "application/json" })
-    
-    @io.swagger.annotations.ApiOperation(value = "Add an external claim.", notes = "Add a new external claim.", response = void.class)
+    @io.swagger.annotations.ApiOperation(value = "Add an external claim.",
+            notes = "Add a new external claim. <br> <b>Permission required:</b> <br> * /permission/admin/manage/identity/claimmgt/metadata/create <br> <b>Scope required:</b> <br> * internal_claim_meta_create",
+            response = void.class)
     @io.swagger.annotations.ApiResponses(value = { 
         @io.swagger.annotations.ApiResponse(code = 201, message = "Item Created."),
         
@@ -92,15 +95,18 @@ public class ClaimManagementApi  {
         @io.swagger.annotations.ApiResponse(code = 500, message = "Internal Server Error.") })
 
     public Response addExternalClaim(@ApiParam(value = "Id of the claim dialect.",required=true ) @PathParam("dialect-id")  String dialectId,
-    @ApiParam(value = "External claim to add."  ) ExternalClaimReqDTO externalClaim)
-    {
-    return delegate.addExternalClaim(dialectId,externalClaim);
+    @ApiParam(value = "External claim to add."  ) @Valid ExternalClaimReqDTO externalClaim) {
+
+        return delegate.addExternalClaim(dialectId,externalClaim);
     }
+
+    @Valid
     @POST
     @Path("/local/claims")
     @Consumes({ "application/json" })
-    
-    @io.swagger.annotations.ApiOperation(value = "Add a local claim.", notes = "Add a new claim.", response = void.class)
+    @io.swagger.annotations.ApiOperation(value = "Add a local claim.",
+            notes = "Add a new claim. <br> <b>Permission required:</b> <br> * /permission/admin/manage/identity/claimmgt/metadata/create <br> <b>Scope required:</b> <br> * internal_claim_meta_create",
+            response = void.class)
     @io.swagger.annotations.ApiResponses(value = { 
         @io.swagger.annotations.ApiResponse(code = 201, message = "Item Created."),
         
@@ -114,15 +120,17 @@ public class ClaimManagementApi  {
         
         @io.swagger.annotations.ApiResponse(code = 500, message = "Internal Server Error.") })
 
-    public Response addLocalClaim(@ApiParam(value = "Local claim to add."  ) LocalClaimReqDTO localClaim)
-    {
-    return delegate.addLocalClaim(localClaim);
+    public Response addLocalClaim(@ApiParam(value = "Local claim to be added."  ) @Valid LocalClaimReqDTO localClaim) {
+
+        return delegate.addLocalClaim(localClaim);
     }
+
+    @Valid
     @DELETE
     @Path("/{dialect-id}")
-    
-    
-    @io.swagger.annotations.ApiOperation(value = "Delete a claim dialect.", notes = "Delete a claim dialect by claim id.", response = void.class)
+    @io.swagger.annotations.ApiOperation(value = "Delete a claim dialect.",
+            notes = "Delete a claim dialect by claim ID. <br> <b>Permission required:</b> <br> * /permission/admin/manage/identity/claimmgt/metadata/delete <br> <b>Scope required:</b> <br> * internal_claim_meta_delete",
+            response = void.class)
     @io.swagger.annotations.ApiResponses(value = { 
         @io.swagger.annotations.ApiResponse(code = 204, message = "No Content."),
         
@@ -134,15 +142,17 @@ public class ClaimManagementApi  {
         
         @io.swagger.annotations.ApiResponse(code = 500, message = "Internal Server Error.") })
 
-    public Response deleteClaimDialect(@ApiParam(value = "Id of the claim dialect.",required=true ) @PathParam("dialect-id")  String dialectId)
-    {
-    return delegate.deleteClaimDialect(dialectId);
+    public Response deleteClaimDialect(@ApiParam(value = "Id of the claim dialect.",required=true ) @PathParam("dialect-id")  String dialectId) {
+
+        return delegate.deleteClaimDialect(dialectId);
     }
+
+    @Valid
     @DELETE
     @Path("/{dialect-id}/claims/{claim-id}")
-    
-    
-    @io.swagger.annotations.ApiOperation(value = "Delete an external claim.", notes = "Delete a claim by dialect id and claim id.", response = void.class)
+    @io.swagger.annotations.ApiOperation(value = "Delete an external claim.",
+            notes = "Delete a claim by dialect ID and claim ID. <br> <b>Permission required:</b> <br> * /permission/admin/manage/identity/claimmgt/metadata/delete <br> <b>Scope required:</b> <br> * internal_claim_meta_delete",
+            response = void.class)
     @io.swagger.annotations.ApiResponses(value = { 
         @io.swagger.annotations.ApiResponse(code = 204, message = "No Content."),
         
@@ -155,15 +165,17 @@ public class ClaimManagementApi  {
         @io.swagger.annotations.ApiResponse(code = 500, message = "Internal Server Error.") })
 
     public Response deleteExternalClaim(@ApiParam(value = "Id of the claim dialect.",required=true ) @PathParam("dialect-id")  String dialectId,
-    @ApiParam(value = "Id of the claim.",required=true ) @PathParam("claim-id")  String claimId)
-    {
-    return delegate.deleteExternalClaim(dialectId,claimId);
+    @ApiParam(value = "Id of the claim.",required=true ) @PathParam("claim-id")  String claimId) {
+
+        return delegate.deleteExternalClaim(dialectId,claimId);
     }
+
+    @Valid
     @DELETE
     @Path("/local/claims/{claim-id}")
-    
-    
-    @io.swagger.annotations.ApiOperation(value = "Delete a local claim.", notes = "Delete a claim by claim id.", response = void.class)
+    @io.swagger.annotations.ApiOperation(value = "Delete a local claim.",
+            notes = "Delete a claim by claim ID. <br> <b>Permission required:</b> <br> * /permission/admin/manage/identity/claimmgt/metadata/delete <br> <b>Scope required:</b> <br> * internal_claim_meta_delete",
+            response = void.class)
     @io.swagger.annotations.ApiResponses(value = { 
         @io.swagger.annotations.ApiResponse(code = 204, message = "No Content."),
         
@@ -175,15 +187,18 @@ public class ClaimManagementApi  {
         
         @io.swagger.annotations.ApiResponse(code = 500, message = "Internal Server Error.") })
 
-    public Response deleteLocalClaim(@ApiParam(value = "Id of the claim.",required=true ) @PathParam("claim-id")  String claimId)
-    {
-    return delegate.deleteLocalClaim(claimId);
+    public Response deleteLocalClaim(@ApiParam(value = "Id of the claim.",required=true ) @PathParam("claim-id")  String claimId) {
+
+        return delegate.deleteLocalClaim(claimId);
     }
+
+    @Valid
     @GET
     @Path("/{dialect-id}")
-    
     @Produces({ "application/json" })
-    @io.swagger.annotations.ApiOperation(value = "Retrieve claim dialect.", notes = "Retrieve a claim dialect matching the given dialect id.", response = ClaimDialectResDTO.class)
+    @io.swagger.annotations.ApiOperation(value = "Retrieve claim dialect.",
+            notes = "Retrieve a claim dialect matching the given dialect id. <br> <b>Permission required:</b> <br> * /permission/admin/manage/identity/claimmgt/metadata/view <br> <b>Scope required:</b> <br> * internal_claim_meta_view <br>",
+            response = ClaimDialectResDTO.class)
     @io.swagger.annotations.ApiResponses(value = { 
         @io.swagger.annotations.ApiResponse(code = 200, message = "Requested claim dialect."),
         
@@ -197,15 +212,17 @@ public class ClaimManagementApi  {
         
         @io.swagger.annotations.ApiResponse(code = 500, message = "Internal Server Error.") })
 
-    public Response getClaimDialect(@ApiParam(value = "Id of the claim dialect.",required=true ) @PathParam("dialect-id")  String dialectId)
-    {
-    return delegate.getClaimDialect(dialectId);
+    public Response getClaimDialect(@ApiParam(value = "Id of the claim dialect.",required=true ) @PathParam("dialect-id")  String dialectId) {
+
+        return delegate.getClaimDialect(dialectId);
     }
+
+    @Valid
     @GET
-    
-    
     @Produces({ "application/json" })
-    @io.swagger.annotations.ApiOperation(value = "Retrieve claim dialects.", notes = "Retrieve claim dialects.", response = ClaimDialectResDTO.class, responseContainer = "List")
+    @io.swagger.annotations.ApiOperation(value = "Retrieve claim dialects.",
+            notes = "Retrieve claim dialects. <br> <b>Permission required:</b> <br> * /permission/admin/manage/identity/claimmgt/metadata/view <br> <b>Scope required:</b> <br> * internal_claim_meta_view",
+            response = ClaimDialectResDTO.class, responseContainer = "List")
     @io.swagger.annotations.ApiResponses(value = { 
         @io.swagger.annotations.ApiResponse(code = 200, message = "Claim dialects."),
         
@@ -215,18 +232,21 @@ public class ClaimManagementApi  {
         
         @io.swagger.annotations.ApiResponse(code = 501, message = "Not Implemented.") })
 
-    public Response getClaimDialects(@ApiParam(value = "maximum number of records to return") @QueryParam("limit")  Integer limit,
-    @ApiParam(value = "number of records to skip for pagination") @QueryParam("offset")  Integer offset,
-    @ApiParam(value = "Condition to filter the retrival of records.") @QueryParam("filter")  String filter,
-    @ApiParam(value = "Define the order how the retrieved records should be sorted.") @QueryParam("sort")  String sort)
-    {
-    return delegate.getClaimDialects(limit,offset,filter,sort);
+    public Response getClaimDialects(@ApiParam(value = "Maximum number of records to return.") @QueryParam("limit")  Integer limit,
+    @ApiParam(value = "Number of records to skip for pagination.") @QueryParam("offset")  Integer offset,
+    @ApiParam(value = "Condition to filter the retrieval of records.") @QueryParam("filter")  String filter,
+    @ApiParam(value = "Define the order by which the retrieved records should be sorted.") @QueryParam("sort")  String sort) {
+
+        return delegate.getClaimDialects(limit,offset,filter,sort);
     }
+
+    @Valid
     @GET
     @Path("/{dialect-id}/claims/{claim-id}")
-    
     @Produces({ "application/json" })
-    @io.swagger.annotations.ApiOperation(value = "Retrieve external claim.", notes = "Retrieve an external claim matching the given dialect id and claim id.", response = ExternalClaimResDTO.class)
+    @io.swagger.annotations.ApiOperation(value = "Retrieve external claim.",
+            notes = "Retrieve an external claim matching the given dialect ID and claim ID. <br> <b>Permission required:</b> <br> * /permission/admin/manage/identity/claimmgt/metadata/view <br> <b>Scope required:</b> <br> * internal_claim_meta_view",
+            response = ExternalClaimResDTO.class)
     @io.swagger.annotations.ApiResponses(value = { 
         @io.swagger.annotations.ApiResponse(code = 200, message = "Requested claim."),
         
@@ -241,15 +261,18 @@ public class ClaimManagementApi  {
         @io.swagger.annotations.ApiResponse(code = 500, message = "Internal Server Error.") })
 
     public Response getExternalClaim(@ApiParam(value = "Id of the claim dialect.",required=true ) @PathParam("dialect-id")  String dialectId,
-    @ApiParam(value = "Id of the claim.",required=true ) @PathParam("claim-id")  String claimId)
-    {
-    return delegate.getExternalClaim(dialectId,claimId);
+    @ApiParam(value = "Id of the claim.",required=true ) @PathParam("claim-id")  String claimId) {
+
+        return delegate.getExternalClaim(dialectId,claimId);
     }
+
+    @Valid
     @GET
     @Path("/{dialect-id}/claims")
-    
     @Produces({ "application/json" })
-    @io.swagger.annotations.ApiOperation(value = "Retrieve external claims.", notes = "Retrieve External claims.", response = ExternalClaimResDTO.class, responseContainer = "List")
+    @io.swagger.annotations.ApiOperation(value = "Retrieve external claims.",
+            notes = "Retrieve External claims. <br> <b>Permission required:</b> <br> * /permission/admin/manage/identity/claimmgt/metadata/view <br> <b>Scope required:</b> <br> * internal_claim_meta_view",
+            response = ExternalClaimResDTO.class, responseContainer = "List")
     @io.swagger.annotations.ApiResponses(value = { 
         @io.swagger.annotations.ApiResponse(code = 200, message = "External claims."),
         
@@ -262,18 +285,21 @@ public class ClaimManagementApi  {
         @io.swagger.annotations.ApiResponse(code = 501, message = "Not Implemented.") })
 
     public Response getExternalClaims(@ApiParam(value = "Id of the claim dialect.",required=true ) @PathParam("dialect-id")  String dialectId,
-    @ApiParam(value = "maximum number of records to return") @QueryParam("limit")  Integer limit,
-    @ApiParam(value = "number of records to skip for pagination") @QueryParam("offset")  Integer offset,
-    @ApiParam(value = "Condition to filter the retrival of records.") @QueryParam("filter")  String filter,
-    @ApiParam(value = "Define the order how the retrieved records should be sorted.") @QueryParam("sort")  String sort)
-    {
-    return delegate.getExternalClaims(dialectId,limit,offset,filter,sort);
+    @ApiParam(value = "Maximum number of records to return.") @QueryParam("limit")  Integer limit,
+    @ApiParam(value = "Number of records to skip for pagination.") @QueryParam("offset")  Integer offset,
+    @ApiParam(value = "Condition to filter the retrieval of records.") @QueryParam("filter")  String filter,
+    @ApiParam(value = "Define the order by which the retrieved records should be sorted.") @QueryParam("sort")  String sort) {
+
+        return delegate.getExternalClaims(dialectId,limit,offset,filter,sort);
     }
+
+    @Valid
     @GET
     @Path("/local/claims/{claim-id}")
-    
     @Produces({ "application/json" })
-    @io.swagger.annotations.ApiOperation(value = "Retrieve local claim.", notes = "Retrieve a local claim matching the given claim id.", response = LocalClaimResDTO.class)
+    @io.swagger.annotations.ApiOperation(value = "Retrieve local claim.",
+            notes = "Retrieve a local claim matching the given claim ID. <br> <b>Permission required:</b> <br> * /permission/admin/manage/identity/claimmgt/metadata/view <br> <b>Scope required:</b> <br> * internal_claim_meta_view",
+            response = LocalClaimResDTO.class)
     @io.swagger.annotations.ApiResponses(value = { 
         @io.swagger.annotations.ApiResponse(code = 200, message = "Requested claim."),
         
@@ -287,15 +313,18 @@ public class ClaimManagementApi  {
         
         @io.swagger.annotations.ApiResponse(code = 500, message = "Internal Server Error.") })
 
-    public Response getLocalClaim(@ApiParam(value = "Id of the claim.",required=true ) @PathParam("claim-id")  String claimId)
-    {
-    return delegate.getLocalClaim(claimId);
+    public Response getLocalClaim(@ApiParam(value = "Id of the claim.",required=true ) @PathParam("claim-id")  String claimId) {
+
+        return delegate.getLocalClaim(claimId);
     }
+
+    @Valid
     @GET
     @Path("/local/claims")
-    
     @Produces({ "application/json" })
-    @io.swagger.annotations.ApiOperation(value = "Retrieve local claims.", notes = "Retrieve local claims.", response = LocalClaimResDTO.class, responseContainer = "List")
+    @io.swagger.annotations.ApiOperation(value = "Retrieve local claims.",
+            notes = "Retrieve local claims. <br> <b>Permission required:</b> <br> * /permission/admin/manage/identity/claimmgt/metadata/view <br> <b>Scope required:</b> <br> * internal_claim_meta_view",
+            response = LocalClaimResDTO.class, responseContainer = "List")
     @io.swagger.annotations.ApiResponses(value = { 
         @io.swagger.annotations.ApiResponse(code = 200, message = "Local claims."),
         
@@ -306,18 +335,22 @@ public class ClaimManagementApi  {
         @io.swagger.annotations.ApiResponse(code = 501, message = "Not Implemented.") })
 
     public Response getLocalClaims(@ApiParam(value = "Define only the required attributes to be sent in the response object.") @QueryParam("attributes")  String attributes,
-    @ApiParam(value = "maximum number of records to return") @QueryParam("limit")  Integer limit,
-    @ApiParam(value = "number of records to skip for pagination") @QueryParam("offset")  Integer offset,
-    @ApiParam(value = "Condition to filter the retrival of records.") @QueryParam("filter")  String filter,
-    @ApiParam(value = "Define the order how the retrieved records should be sorted.") @QueryParam("sort")  String sort)
-    {
-    return delegate.getLocalClaims(attributes,limit,offset,filter,sort);
+    @ApiParam(value = "Maximum number of records to return.") @QueryParam("limit")  Integer limit,
+    @ApiParam(value = "Number of records to skip for pagination.") @QueryParam("offset")  Integer offset,
+    @ApiParam(value = "Condition to filter the retrieval of records.") @QueryParam("filter")  String filter,
+    @ApiParam(value = "Define the order by which the retrieved records should be sorted.") @QueryParam("sort")  String sort,
+    @ApiParam(value = "Exclude identity claims when listing local claims.") @QueryParam("exclude-identity-claims")  Boolean excludeIdentityClaims) {
+
+        return delegate.getLocalClaims(attributes,limit,offset,filter,sort,excludeIdentityClaims);
     }
+
+    @Valid
     @PUT
     @Path("/{dialect-id}")
     @Consumes({ "application/json" })
-    
-    @io.swagger.annotations.ApiOperation(value = "Update a claim dialect.", notes = "Update a claim dialect.", response = void.class)
+    @io.swagger.annotations.ApiOperation(value = "Update a claim dialect.",
+            notes = "Update a claim dialect. <br> <b>Permission required:</b> <br> * /permission/admin/manage/identity/claimmgt/metadata/update <br> <b>Scope required:</b> <br> * internal_claim_meta_update",
+            response = void.class)
     @io.swagger.annotations.ApiResponses(value = { 
         @io.swagger.annotations.ApiResponse(code = 200, message = "OK."),
         
@@ -330,15 +363,18 @@ public class ClaimManagementApi  {
         @io.swagger.annotations.ApiResponse(code = 500, message = "Internal Server Error.") })
 
     public Response updateClaimDialect(@ApiParam(value = "Id of the claim dialect.",required=true ) @PathParam("dialect-id")  String dialectId,
-    @ApiParam(value = "Updated claim dialect."  ) ClaimDialectReqDTO claimDialect)
-    {
-    return delegate.updateClaimDialect(dialectId,claimDialect);
+    @ApiParam(value = "Updated claim dialect."  ) @Valid ClaimDialectReqDTO claimDialect) {
+
+        return delegate.updateClaimDialect(dialectId,claimDialect);
     }
+
+    @Valid
     @PUT
     @Path("/{dialect-id}/claims/{claim-id}")
     @Consumes({ "application/json" })
-    
-    @io.swagger.annotations.ApiOperation(value = "Update an external claim.", notes = "Update an external claim.", response = void.class)
+    @io.swagger.annotations.ApiOperation(value = "Update an external claim.",
+            notes = "Update an external claim. <br> <b>Permission required:</b> <br> * /permission/admin/manage/identity/claimmgt/metadata/update <br> <b>Scope required:</b> <br> * internal_claim_meta_update",
+            response = void.class)
     @io.swagger.annotations.ApiResponses(value = { 
         @io.swagger.annotations.ApiResponse(code = 200, message = "OK."),
         
@@ -354,15 +390,18 @@ public class ClaimManagementApi  {
 
     public Response updateExternalClaim(@ApiParam(value = "Id of the claim dialect.",required=true ) @PathParam("dialect-id")  String dialectId,
     @ApiParam(value = "Id of the claim.",required=true ) @PathParam("claim-id")  String claimId,
-    @ApiParam(value = "Updated external claim."  ) ExternalClaimReqDTO externalClaim)
-    {
-    return delegate.updateExternalClaim(dialectId,claimId,externalClaim);
+    @ApiParam(value = "Updated external claim."  ) @Valid ExternalClaimReqDTO externalClaim) {
+
+        return delegate.updateExternalClaim(dialectId,claimId,externalClaim);
     }
+
+    @Valid
     @PUT
     @Path("/local/claims/{claim-id}")
     @Consumes({ "application/json" })
-    
-    @io.swagger.annotations.ApiOperation(value = "Update a local claim.", notes = "Update a local claim.", response = void.class)
+    @io.swagger.annotations.ApiOperation(value = "Update a local claim.",
+            notes = "Update a local claim. <br> <b>Permission required:</b> <br> * /permission/admin/manage/identity/claimmgt/metadata/update <br> <b>Scope required:</b> <br> * internal_claim_meta_update",
+            response = void.class)
     @io.swagger.annotations.ApiResponses(value = { 
         @io.swagger.annotations.ApiResponse(code = 200, message = "OK."),
         
@@ -377,9 +416,9 @@ public class ClaimManagementApi  {
         @io.swagger.annotations.ApiResponse(code = 500, message = "Internal Server Error.") })
 
     public Response updateLocalClaim(@ApiParam(value = "Id of the claim.",required=true ) @PathParam("claim-id")  String claimId,
-    @ApiParam(value = "Updated local claim."  ) LocalClaimReqDTO localClaim)
-    {
-    return delegate.updateLocalClaim(claimId,localClaim);
-    }
-}
+    @ApiParam(value = "Updated local claim."  ) @Valid LocalClaimReqDTO localClaim) {
 
+        return delegate.updateLocalClaim(claimId,localClaim);
+    }
+
+}

--- a/components/org.wso2.carbon.identity.api.server.claim.management/org.wso2.carbon.identity.rest.api.server.claim.management.v1/src/gen/java/org/wso2/carbon/identity/rest/api/server/claim/management/v1/ClaimManagementApiService.java
+++ b/components/org.wso2.carbon.identity.api.server.claim.management/org.wso2.carbon.identity.rest.api.server.claim.management.v1/src/gen/java/org/wso2/carbon/identity/rest/api/server/claim/management/v1/ClaimManagementApiService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,20 +35,35 @@ import org.apache.cxf.jaxrs.ext.multipart.Attachment;
 import javax.ws.rs.core.Response;
 
 public abstract class ClaimManagementApiService {
-    public abstract Response addClaimDialect(ClaimDialectReqDTO claimDialect);
-    public abstract Response addExternalClaim(String dialectId,ExternalClaimReqDTO externalClaim);
-    public abstract Response addLocalClaim(LocalClaimReqDTO localClaim);
-    public abstract Response deleteClaimDialect(String dialectId);
-    public abstract Response deleteExternalClaim(String dialectId,String claimId);
-    public abstract Response deleteLocalClaim(String claimId);
-    public abstract Response getClaimDialect(String dialectId);
-    public abstract Response getClaimDialects(Integer limit,Integer offset,String filter,String sort);
-    public abstract Response getExternalClaim(String dialectId,String claimId);
-    public abstract Response getExternalClaims(String dialectId,Integer limit,Integer offset,String filter,String sort);
-    public abstract Response getLocalClaim(String claimId);
-    public abstract Response getLocalClaims(String attributes,Integer limit,Integer offset,String filter,String sort);
-    public abstract Response updateClaimDialect(String dialectId,ClaimDialectReqDTO claimDialect);
-    public abstract Response updateExternalClaim(String dialectId,String claimId,ExternalClaimReqDTO externalClaim);
-    public abstract Response updateLocalClaim(String claimId,LocalClaimReqDTO localClaim);
-}
 
+    public abstract Response addClaimDialect(ClaimDialectReqDTO claimDialect);
+
+    public abstract Response addExternalClaim(String dialectId, ExternalClaimReqDTO externalClaim);
+
+    public abstract Response addLocalClaim(LocalClaimReqDTO localClaim);
+
+    public abstract Response deleteClaimDialect(String dialectId);
+
+    public abstract Response deleteExternalClaim(String dialectId, String claimId);
+
+    public abstract Response deleteLocalClaim(String claimId);
+
+    public abstract Response getClaimDialect(String dialectId);
+
+    public abstract Response getClaimDialects(Integer limit, Integer offset, String filter, String sort);
+
+    public abstract Response getExternalClaim(String dialectId, String claimId);
+
+    public abstract Response getExternalClaims(String dialectId, Integer limit, Integer offset, String filter, String sort);
+
+    public abstract Response getLocalClaim(String claimId);
+
+    public abstract Response getLocalClaims(String attributes, Integer limit, Integer offset, String filter, String sort, Boolean excludeIdentityClaims);
+
+    public abstract Response updateClaimDialect(String dialectId, ClaimDialectReqDTO claimDialect);
+
+    public abstract Response updateExternalClaim(String dialectId, String claimId, ExternalClaimReqDTO externalClaim);
+
+    public abstract Response updateLocalClaim(String claimId, LocalClaimReqDTO localClaim);
+
+}

--- a/components/org.wso2.carbon.identity.api.server.claim.management/org.wso2.carbon.identity.rest.api.server.claim.management.v1/src/gen/java/org/wso2/carbon/identity/rest/api/server/claim/management/v1/dto/AttributeMappingDTO.java
+++ b/components/org.wso2.carbon.identity.api.server.claim.management/org.wso2.carbon.identity.rest.api.server.claim.management.v1/src/gen/java/org/wso2/carbon/identity/rest/api/server/claim/management/v1/dto/AttributeMappingDTO.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,66 +17,61 @@
 package org.wso2.carbon.identity.rest.api.server.claim.management.v1.dto;
 
 import io.swagger.annotations.ApiModel;
-
 import io.swagger.annotations.*;
 import com.fasterxml.jackson.annotation.*;
 
+import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Pattern;
 
-
-
-/**
- * Claim userstore attribute mapping.
- **/
-
-
+    /**
+    * Claim userstore attribute mapping.
+    **/
 @ApiModel(description = "Claim userstore attribute mapping.")
-public class AttributeMappingDTO  {
-  
-  
-  @NotNull 
-  private String mappedAttribute = null;
-  
-  @NotNull 
-  private String userstore = null;
+public class AttributeMappingDTO {
 
-  
-  /**
-   * Userstore attribute to be mapped to.
-   **/
-  @ApiModelProperty(required = true, value = "Userstore attribute to be mapped to.")
-  @JsonProperty("mappedAttribute")
-  public String getMappedAttribute() {
-    return mappedAttribute;
-  }
-  public void setMappedAttribute(String mappedAttribute) {
-    this.mappedAttribute = mappedAttribute;
-  }
+    @Valid 
+    @NotNull(message = "Property mappedAttribute cannot be null.") 
+    private String mappedAttribute = null;
 
-  
-  /**
-   * Userstore domain name.
-   **/
-  @ApiModelProperty(required = true, value = "Userstore domain name.")
-  @JsonProperty("userstore")
-  public String getUserstore() {
-    return userstore;
-  }
-  public void setUserstore(String userstore) {
-    this.userstore = userstore;
-  }
+    @Valid 
+    @NotNull(message = "Property userstore cannot be null.") 
+    private String userstore = null;
 
-  
+    /**
+    * Userstore attribute to be mapped to.
+    **/
+    @ApiModelProperty(required = true, value = "Userstore attribute to be mapped to.")
+    @JsonProperty("mappedAttribute")
+    public String getMappedAttribute() {
+        return mappedAttribute;
+    }
+    public void setMappedAttribute(String mappedAttribute) {
+        this.mappedAttribute = mappedAttribute;
+    }
 
-  @Override
-  public String toString()  {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class AttributeMappingDTO {\n");
-    
-    sb.append("  mappedAttribute: ").append(mappedAttribute).append("\n");
-    sb.append("  userstore: ").append(userstore).append("\n");
-    sb.append("}\n");
-    return sb.toString();
-  }
+    /**
+    * Userstore domain name.
+    **/
+    @ApiModelProperty(required = true, value = "Userstore domain name.")
+    @JsonProperty("userstore")
+    public String getUserstore() {
+        return userstore;
+    }
+    public void setUserstore(String userstore) {
+        this.userstore = userstore;
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class AttributeMappingDTO {\n");
+        
+        sb.append("    mappedAttribute: ").append(mappedAttribute).append("\n");
+        sb.append("    userstore: ").append(userstore).append("\n");
+        
+        sb.append("}\n");
+        return sb.toString();
+    }
 }

--- a/components/org.wso2.carbon.identity.api.server.claim.management/org.wso2.carbon.identity.rest.api.server.claim.management.v1/src/gen/java/org/wso2/carbon/identity/rest/api/server/claim/management/v1/dto/ClaimDialectReqDTO.java
+++ b/components/org.wso2.carbon.identity.api.server.claim.management/org.wso2.carbon.identity.rest.api.server.claim.management.v1/src/gen/java/org/wso2/carbon/identity/rest/api/server/claim/management/v1/dto/ClaimDialectReqDTO.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,49 +17,44 @@
 package org.wso2.carbon.identity.rest.api.server.claim.management.v1.dto;
 
 import io.swagger.annotations.ApiModel;
-
 import io.swagger.annotations.*;
 import com.fasterxml.jackson.annotation.*;
 
+import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Pattern;
 
-
-
-/**
- * Claim dialect request.
- **/
-
-
+    /**
+    * Claim dialect request.
+    **/
 @ApiModel(description = "Claim dialect request.")
-public class ClaimDialectReqDTO  {
-  
-  
-  @NotNull 
-  private String dialectURI = null;
+public class ClaimDialectReqDTO {
 
-  
-  /**
-   * URI of the claim dialect.
-   **/
-  @ApiModelProperty(required = true, value = "URI of the claim dialect.")
-  @JsonProperty("dialectURI")
-  public String getDialectURI() {
-    return dialectURI;
-  }
-  public void setDialectURI(String dialectURI) {
-    this.dialectURI = dialectURI;
-  }
+    @Valid 
+    @NotNull(message = "Property dialectURI cannot be null.") 
+    private String dialectURI = null;
 
-  
+    /**
+    * URI of the claim dialect.
+    **/
+    @ApiModelProperty(required = true, value = "URI of the claim dialect.")
+    @JsonProperty("dialectURI")
+    public String getDialectURI() {
+        return dialectURI;
+    }
+    public void setDialectURI(String dialectURI) {
+        this.dialectURI = dialectURI;
+    }
 
-  @Override
-  public String toString()  {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class ClaimDialectReqDTO {\n");
-    
-    sb.append("  dialectURI: ").append(dialectURI).append("\n");
-    sb.append("}\n");
-    return sb.toString();
-  }
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class ClaimDialectReqDTO {\n");
+        
+        sb.append("    dialectURI: ").append(dialectURI).append("\n");
+        
+        sb.append("}\n");
+        return sb.toString();
+    }
 }

--- a/components/org.wso2.carbon.identity.api.server.claim.management/org.wso2.carbon.identity.rest.api.server.claim.management.v1/src/gen/java/org/wso2/carbon/identity/rest/api/server/claim/management/v1/dto/ClaimDialectResDTO.java
+++ b/components/org.wso2.carbon.identity.api.server.claim.management/org.wso2.carbon.identity.rest.api.server.claim.management.v1/src/gen/java/org/wso2/carbon/identity/rest/api/server/claim/management/v1/dto/ClaimDialectResDTO.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,82 +18,74 @@ package org.wso2.carbon.identity.rest.api.server.claim.management.v1.dto;
 
 import io.swagger.annotations.ApiModel;
 import org.wso2.carbon.identity.rest.api.server.claim.management.v1.dto.LinkDTO;
-
 import io.swagger.annotations.*;
 import com.fasterxml.jackson.annotation.*;
 
+import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Pattern;
 
-
-
-/**
- * Claim dialect response.
- **/
-
-
+    /**
+    * Claim dialect response.
+    **/
 @ApiModel(description = "Claim dialect response.")
-public class ClaimDialectResDTO  {
-  
-  
-  
-  private String id = null;
-  
-  
-  private String dialectURI = null;
-  
-  
-  private LinkDTO link = null;
+public class ClaimDialectResDTO {
 
-  
-  /**
-   * Dialect id.
-   **/
-  @ApiModelProperty(value = "Dialect id.")
-  @JsonProperty("id")
-  public String getId() {
-    return id;
-  }
-  public void setId(String id) {
-    this.id = id;
-  }
+    @Valid 
+    private String id = null;
 
-  
-  /**
-   * URI of the claim dialect.
-   **/
-  @ApiModelProperty(value = "URI of the claim dialect.")
-  @JsonProperty("dialectURI")
-  public String getDialectURI() {
-    return dialectURI;
-  }
-  public void setDialectURI(String dialectURI) {
-    this.dialectURI = dialectURI;
-  }
+    @Valid 
+    private String dialectURI = null;
 
-  
-  /**
-   **/
-  @ApiModelProperty(value = "")
-  @JsonProperty("link")
-  public LinkDTO getLink() {
-    return link;
-  }
-  public void setLink(LinkDTO link) {
-    this.link = link;
-  }
+    @Valid 
+    private LinkDTO link = null;
 
-  
+    /**
+    * Dialect id.
+    **/
+    @ApiModelProperty(value = "Dialect id.")
+    @JsonProperty("id")
+    public String getId() {
+        return id;
+    }
+    public void setId(String id) {
+        this.id = id;
+    }
 
-  @Override
-  public String toString()  {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class ClaimDialectResDTO {\n");
-    
-    sb.append("  id: ").append(id).append("\n");
-    sb.append("  dialectURI: ").append(dialectURI).append("\n");
-    sb.append("  link: ").append(link).append("\n");
-    sb.append("}\n");
-    return sb.toString();
-  }
+    /**
+    * URI of the claim dialect.
+    **/
+    @ApiModelProperty(value = "URI of the claim dialect.")
+    @JsonProperty("dialectURI")
+    public String getDialectURI() {
+        return dialectURI;
+    }
+    public void setDialectURI(String dialectURI) {
+        this.dialectURI = dialectURI;
+    }
+
+    /**
+    **/
+    @ApiModelProperty(value = "")
+    @JsonProperty("link")
+    public LinkDTO getLink() {
+        return link;
+    }
+    public void setLink(LinkDTO link) {
+        this.link = link;
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class ClaimDialectResDTO {\n");
+        
+        sb.append("    id: ").append(id).append("\n");
+        sb.append("    dialectURI: ").append(dialectURI).append("\n");
+        sb.append("    link: ").append(link).append("\n");
+        
+        sb.append("}\n");
+        return sb.toString();
+    }
 }

--- a/components/org.wso2.carbon.identity.api.server.claim.management/org.wso2.carbon.identity.rest.api.server.claim.management.v1/src/gen/java/org/wso2/carbon/identity/rest/api/server/claim/management/v1/dto/ErrorDTO.java
+++ b/components/org.wso2.carbon.identity.api.server.claim.management/org.wso2.carbon.identity.rest.api.server.claim.management.v1/src/gen/java/org/wso2/carbon/identity/rest/api/server/claim/management/v1/dto/ErrorDTO.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,93 +16,86 @@
 
 package org.wso2.carbon.identity.rest.api.server.claim.management.v1.dto;
 
-
 import io.swagger.annotations.*;
 import com.fasterxml.jackson.annotation.*;
 
+import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Pattern;
 
-
-
-
-
 @ApiModel(description = "")
-public class ErrorDTO  {
-  
-  
-  @NotNull 
-  private String code = null;
-  
-  @NotNull 
-  private String message = null;
-  
-  
-  private String description = null;
-  
-  
-  private String traceId = null;
+public class ErrorDTO {
 
-  
-  /**
-   **/
-  @ApiModelProperty(required = true, value = "")
-  @JsonProperty("code")
-  public String getCode() {
-    return code;
-  }
-  public void setCode(String code) {
-    this.code = code;
-  }
+    @Valid 
+    @NotNull(message = "Property code cannot be null.") 
+    private String code = null;
 
-  
-  /**
-   **/
-  @ApiModelProperty(required = true, value = "")
-  @JsonProperty("message")
-  public String getMessage() {
-    return message;
-  }
-  public void setMessage(String message) {
-    this.message = message;
-  }
+    @Valid 
+    @NotNull(message = "Property message cannot be null.") 
+    private String message = null;
 
-  
-  /**
-   **/
-  @ApiModelProperty(value = "")
-  @JsonProperty("description")
-  public String getDescription() {
-    return description;
-  }
-  public void setDescription(String description) {
-    this.description = description;
-  }
+    @Valid 
+    private String description = null;
 
-  
-  /**
-   **/
-  @ApiModelProperty(value = "")
-  @JsonProperty("traceId")
-  public String getTraceId() {
-    return traceId;
-  }
-  public void setTraceId(String traceId) {
-    this.traceId = traceId;
-  }
+    @Valid 
+    private String traceId = null;
 
-  
+    /**
+    **/
+    @ApiModelProperty(required = true, value = "")
+    @JsonProperty("code")
+    public String getCode() {
+        return code;
+    }
+    public void setCode(String code) {
+        this.code = code;
+    }
 
-  @Override
-  public String toString()  {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class ErrorDTO {\n");
-    
-    sb.append("  code: ").append(code).append("\n");
-    sb.append("  message: ").append(message).append("\n");
-    sb.append("  description: ").append(description).append("\n");
-    sb.append("  traceId: ").append(traceId).append("\n");
-    sb.append("}\n");
-    return sb.toString();
-  }
+    /**
+    **/
+    @ApiModelProperty(required = true, value = "")
+    @JsonProperty("message")
+    public String getMessage() {
+        return message;
+    }
+    public void setMessage(String message) {
+        this.message = message;
+    }
+
+    /**
+    **/
+    @ApiModelProperty(value = "")
+    @JsonProperty("description")
+    public String getDescription() {
+        return description;
+    }
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    /**
+    **/
+    @ApiModelProperty(value = "")
+    @JsonProperty("traceId")
+    public String getTraceId() {
+        return traceId;
+    }
+    public void setTraceId(String traceId) {
+        this.traceId = traceId;
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class ErrorDTO {\n");
+        
+        sb.append("    code: ").append(code).append("\n");
+        sb.append("    message: ").append(message).append("\n");
+        sb.append("    description: ").append(description).append("\n");
+        sb.append("    traceId: ").append(traceId).append("\n");
+        
+        sb.append("}\n");
+        return sb.toString();
+    }
 }

--- a/components/org.wso2.carbon.identity.api.server.claim.management/org.wso2.carbon.identity.rest.api.server.claim.management.v1/src/gen/java/org/wso2/carbon/identity/rest/api/server/claim/management/v1/dto/ExternalClaimReqDTO.java
+++ b/components/org.wso2.carbon.identity.api.server.claim.management/org.wso2.carbon.identity.rest.api.server.claim.management.v1/src/gen/java/org/wso2/carbon/identity/rest/api/server/claim/management/v1/dto/ExternalClaimReqDTO.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,66 +17,61 @@
 package org.wso2.carbon.identity.rest.api.server.claim.management.v1.dto;
 
 import io.swagger.annotations.ApiModel;
-
 import io.swagger.annotations.*;
 import com.fasterxml.jackson.annotation.*;
 
+import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Pattern;
 
-
-
-/**
- * External claim request.
- **/
-
-
+    /**
+    * External claim request.
+    **/
 @ApiModel(description = "External claim request.")
-public class ExternalClaimReqDTO  {
-  
-  
-  @NotNull 
-  private String claimURI = null;
-  
-  @NotNull 
-  private String mappedLocalClaimURI = null;
+public class ExternalClaimReqDTO {
 
-  
-  /**
-   * Claim URI of the external claim.
-   **/
-  @ApiModelProperty(required = true, value = "Claim URI of the external claim.")
-  @JsonProperty("claimURI")
-  public String getClaimURI() {
-    return claimURI;
-  }
-  public void setClaimURI(String claimURI) {
-    this.claimURI = claimURI;
-  }
+    @Valid 
+    @NotNull(message = "Property claimURI cannot be null.") 
+    private String claimURI = null;
 
-  
-  /**
-   * The local claim URI to map with the external claim.
-   **/
-  @ApiModelProperty(required = true, value = "The local claim URI to map with the external claim.")
-  @JsonProperty("mappedLocalClaimURI")
-  public String getMappedLocalClaimURI() {
-    return mappedLocalClaimURI;
-  }
-  public void setMappedLocalClaimURI(String mappedLocalClaimURI) {
-    this.mappedLocalClaimURI = mappedLocalClaimURI;
-  }
+    @Valid 
+    @NotNull(message = "Property mappedLocalClaimURI cannot be null.") 
+    private String mappedLocalClaimURI = null;
 
-  
+    /**
+    * Claim URI of the external claim.
+    **/
+    @ApiModelProperty(required = true, value = "Claim URI of the external claim.")
+    @JsonProperty("claimURI")
+    public String getClaimURI() {
+        return claimURI;
+    }
+    public void setClaimURI(String claimURI) {
+        this.claimURI = claimURI;
+    }
 
-  @Override
-  public String toString()  {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class ExternalClaimReqDTO {\n");
-    
-    sb.append("  claimURI: ").append(claimURI).append("\n");
-    sb.append("  mappedLocalClaimURI: ").append(mappedLocalClaimURI).append("\n");
-    sb.append("}\n");
-    return sb.toString();
-  }
+    /**
+    * The local claim URI to map with the external claim.
+    **/
+    @ApiModelProperty(required = true, value = "The local claim URI to map with the external claim.")
+    @JsonProperty("mappedLocalClaimURI")
+    public String getMappedLocalClaimURI() {
+        return mappedLocalClaimURI;
+    }
+    public void setMappedLocalClaimURI(String mappedLocalClaimURI) {
+        this.mappedLocalClaimURI = mappedLocalClaimURI;
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class ExternalClaimReqDTO {\n");
+        
+        sb.append("    claimURI: ").append(claimURI).append("\n");
+        sb.append("    mappedLocalClaimURI: ").append(mappedLocalClaimURI).append("\n");
+        
+        sb.append("}\n");
+        return sb.toString();
+    }
 }

--- a/components/org.wso2.carbon.identity.api.server.claim.management/org.wso2.carbon.identity.rest.api.server.claim.management.v1/src/gen/java/org/wso2/carbon/identity/rest/api/server/claim/management/v1/dto/ExternalClaimResDTO.java
+++ b/components/org.wso2.carbon.identity.api.server.claim.management/org.wso2.carbon.identity.rest.api.server.claim.management.v1/src/gen/java/org/wso2/carbon/identity/rest/api/server/claim/management/v1/dto/ExternalClaimResDTO.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,100 +17,91 @@
 package org.wso2.carbon.identity.rest.api.server.claim.management.v1.dto;
 
 import io.swagger.annotations.ApiModel;
-
 import io.swagger.annotations.*;
 import com.fasterxml.jackson.annotation.*;
 
+import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Pattern;
 
-
-
-/**
- * External claim response.
- **/
-
-
+    /**
+    * External claim response.
+    **/
 @ApiModel(description = "External claim response.")
-public class ExternalClaimResDTO  {
-  
-  
-  
-  private String id = null;
-  
-  
-  private String claimURI = null;
-  
-  
-  private String claimDialectURI = null;
-  
-  
-  private String mappedLocalClaimURI = null;
+public class ExternalClaimResDTO {
 
-  
-  /**
-   * External claim id.
-   **/
-  @ApiModelProperty(value = "External claim id.")
-  @JsonProperty("id")
-  public String getId() {
-    return id;
-  }
-  public void setId(String id) {
-    this.id = id;
-  }
+    @Valid 
+    private String id = null;
 
-  
-  /**
-   * Claim URI of the external claim.
-   **/
-  @ApiModelProperty(value = "Claim URI of the external claim.")
-  @JsonProperty("claimURI")
-  public String getClaimURI() {
-    return claimURI;
-  }
-  public void setClaimURI(String claimURI) {
-    this.claimURI = claimURI;
-  }
+    @Valid 
+    private String claimURI = null;
 
-  
-  /**
-   * Dialect URI of the external claim.
-   **/
-  @ApiModelProperty(value = "Dialect URI of the external claim.")
-  @JsonProperty("claimDialectURI")
-  public String getClaimDialectURI() {
-    return claimDialectURI;
-  }
-  public void setClaimDialectURI(String claimDialectURI) {
-    this.claimDialectURI = claimDialectURI;
-  }
+    @Valid 
+    private String claimDialectURI = null;
 
-  
-  /**
-   * The local claim URI to map with the external claim.
-   **/
-  @ApiModelProperty(value = "The local claim URI to map with the external claim.")
-  @JsonProperty("mappedLocalClaimURI")
-  public String getMappedLocalClaimURI() {
-    return mappedLocalClaimURI;
-  }
-  public void setMappedLocalClaimURI(String mappedLocalClaimURI) {
-    this.mappedLocalClaimURI = mappedLocalClaimURI;
-  }
+    @Valid 
+    private String mappedLocalClaimURI = null;
 
-  
+    /**
+    * External claim ID.
+    **/
+    @ApiModelProperty(value = "External claim ID.")
+    @JsonProperty("id")
+    public String getId() {
+        return id;
+    }
+    public void setId(String id) {
+        this.id = id;
+    }
 
-  @Override
-  public String toString()  {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class ExternalClaimResDTO {\n");
-    
-    sb.append("  id: ").append(id).append("\n");
-    sb.append("  claimURI: ").append(claimURI).append("\n");
-    sb.append("  claimDialectURI: ").append(claimDialectURI).append("\n");
-    sb.append("  mappedLocalClaimURI: ").append(mappedLocalClaimURI).append("\n");
-    sb.append("}\n");
-    return sb.toString();
-  }
+    /**
+    * Claim URI of the external claim.
+    **/
+    @ApiModelProperty(value = "Claim URI of the external claim.")
+    @JsonProperty("claimURI")
+    public String getClaimURI() {
+        return claimURI;
+    }
+    public void setClaimURI(String claimURI) {
+        this.claimURI = claimURI;
+    }
+
+    /**
+    * Dialect URI of the external claim.
+    **/
+    @ApiModelProperty(value = "Dialect URI of the external claim.")
+    @JsonProperty("claimDialectURI")
+    public String getClaimDialectURI() {
+        return claimDialectURI;
+    }
+    public void setClaimDialectURI(String claimDialectURI) {
+        this.claimDialectURI = claimDialectURI;
+    }
+
+    /**
+    * The local claim URI to map with the external claim.
+    **/
+    @ApiModelProperty(value = "The local claim URI to map with the external claim.")
+    @JsonProperty("mappedLocalClaimURI")
+    public String getMappedLocalClaimURI() {
+        return mappedLocalClaimURI;
+    }
+    public void setMappedLocalClaimURI(String mappedLocalClaimURI) {
+        this.mappedLocalClaimURI = mappedLocalClaimURI;
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class ExternalClaimResDTO {\n");
+        
+        sb.append("    id: ").append(id).append("\n");
+        sb.append("    claimURI: ").append(claimURI).append("\n");
+        sb.append("    claimDialectURI: ").append(claimDialectURI).append("\n");
+        sb.append("    mappedLocalClaimURI: ").append(mappedLocalClaimURI).append("\n");
+        
+        sb.append("}\n");
+        return sb.toString();
+    }
 }

--- a/components/org.wso2.carbon.identity.api.server.claim.management/org.wso2.carbon.identity.rest.api.server.claim.management.v1/src/gen/java/org/wso2/carbon/identity/rest/api/server/claim/management/v1/dto/LinkDTO.java
+++ b/components/org.wso2.carbon.identity.api.server.claim.management/org.wso2.carbon.identity.rest.api.server.claim.management.v1/src/gen/java/org/wso2/carbon/identity/rest/api/server/claim/management/v1/dto/LinkDTO.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,63 +16,56 @@
 
 package org.wso2.carbon.identity.rest.api.server.claim.management.v1.dto;
 
-
 import io.swagger.annotations.*;
 import com.fasterxml.jackson.annotation.*;
 
+import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Pattern;
 
-
-
-
-
 @ApiModel(description = "")
-public class LinkDTO  {
-  
-  
-  
-  private String href = null;
-  
-  
-  private String rel = null;
+public class LinkDTO {
 
-  
-  /**
-   * Relative path to the target resource.
-   **/
-  @ApiModelProperty(value = "Relative path to the target resource.")
-  @JsonProperty("href")
-  public String getHref() {
-    return href;
-  }
-  public void setHref(String href) {
-    this.href = href;
-  }
+    @Valid 
+    private String href = null;
 
-  
-  /**
-   * Describes how the current context is related to the target resource.
-   **/
-  @ApiModelProperty(value = "Describes how the current context is related to the target resource.")
-  @JsonProperty("rel")
-  public String getRel() {
-    return rel;
-  }
-  public void setRel(String rel) {
-    this.rel = rel;
-  }
+    @Valid 
+    private String rel = null;
 
-  
+    /**
+    * Relative path to the target resource.
+    **/
+    @ApiModelProperty(value = "Relative path to the target resource.")
+    @JsonProperty("href")
+    public String getHref() {
+        return href;
+    }
+    public void setHref(String href) {
+        this.href = href;
+    }
 
-  @Override
-  public String toString()  {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class LinkDTO {\n");
-    
-    sb.append("  href: ").append(href).append("\n");
-    sb.append("  rel: ").append(rel).append("\n");
-    sb.append("}\n");
-    return sb.toString();
-  }
+    /**
+    * Describes how the current context is related to the target resource.
+    **/
+    @ApiModelProperty(value = "Describes how the current context is related to the target resource.")
+    @JsonProperty("rel")
+    public String getRel() {
+        return rel;
+    }
+    public void setRel(String rel) {
+        this.rel = rel;
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class LinkDTO {\n");
+        
+        sb.append("    href: ").append(href).append("\n");
+        sb.append("    rel: ").append(rel).append("\n");
+        
+        sb.append("}\n");
+        return sb.toString();
+    }
 }

--- a/components/org.wso2.carbon.identity.api.server.claim.management/org.wso2.carbon.identity.rest.api.server.claim.management.v1/src/gen/java/org/wso2/carbon/identity/rest/api/server/claim/management/v1/dto/LocalClaimReqDTO.java
+++ b/components/org.wso2.carbon.identity.api.server.claim.management/org.wso2.carbon.identity.rest.api.server.claim.management.v1/src/gen/java/org/wso2/carbon/identity/rest/api/server/claim/management/v1/dto/LocalClaimReqDTO.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,202 +21,191 @@ import java.util.ArrayList;
 import java.util.List;
 import org.wso2.carbon.identity.rest.api.server.claim.management.v1.dto.AttributeMappingDTO;
 import org.wso2.carbon.identity.rest.api.server.claim.management.v1.dto.PropertyDTO;
-
 import io.swagger.annotations.*;
 import com.fasterxml.jackson.annotation.*;
 
+import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Pattern;
 
-
-
-/**
- * Local claim request.
- **/
-
-
+    /**
+    * Local claim request.
+    **/
 @ApiModel(description = "Local claim request.")
-public class LocalClaimReqDTO  {
-  
-  
-  @NotNull 
-  private String claimURI = null;
-  
-  @NotNull 
-  private String description = null;
-  
-  
-  private Integer displayOrder = null;
-  
-  @NotNull 
-  private String displayName = null;
-  
-  
-  private Boolean readOnly = null;
-  
-  
-  private String regEx = null;
-  
-  
-  private Boolean required = null;
-  
-  
-  private Boolean supportedByDefault = null;
-  
-  @NotNull 
-  private List<AttributeMappingDTO> attributeMapping = new ArrayList<AttributeMappingDTO>();
-  
-  
-  private List<PropertyDTO> properties = new ArrayList<PropertyDTO>();
+public class LocalClaimReqDTO {
 
-  
-  /**
-   * A unique URI specific to the claim.
-   **/
-  @ApiModelProperty(required = true, value = "A unique URI specific to the claim.")
-  @JsonProperty("claimURI")
-  public String getClaimURI() {
-    return claimURI;
-  }
-  public void setClaimURI(String claimURI) {
-    this.claimURI = claimURI;
-  }
+    @Valid 
+    @NotNull(message = "Property claimURI cannot be null.") 
+    private String claimURI = null;
 
-  
-  /**
-   * Description of the claim.
-   **/
-  @ApiModelProperty(required = true, value = "Description of the claim.")
-  @JsonProperty("description")
-  public String getDescription() {
-    return description;
-  }
-  public void setDescription(String description) {
-    this.description = description;
-  }
+    @Valid 
+    @NotNull(message = "Property description cannot be null.") 
+    private String description = null;
 
-  
-  /**
-   * The order in which the claim is displayed among other claims under the same dialect.
-   **/
-  @ApiModelProperty(value = "The order in which the claim is displayed among other claims under the same dialect.")
-  @JsonProperty("displayOrder")
-  public Integer getDisplayOrder() {
-    return displayOrder;
-  }
-  public void setDisplayOrder(Integer displayOrder) {
-    this.displayOrder = displayOrder;
-  }
+    @Valid 
+    private Integer displayOrder = null;
 
-  
-  /**
-   * Name of the claim to be displayed in the UI.
-   **/
-  @ApiModelProperty(required = true, value = "Name of the claim to be displayed in the UI.")
-  @JsonProperty("displayName")
-  public String getDisplayName() {
-    return displayName;
-  }
-  public void setDisplayName(String displayName) {
-    this.displayName = displayName;
-  }
+    @Valid 
+    @NotNull(message = "Property displayName cannot be null.") 
+    private String displayName = null;
 
-  
-  /**
-   * Specifies if the claim is read-only.
-   **/
-  @ApiModelProperty(value = "Specifies if the claim is read-only.")
-  @JsonProperty("readOnly")
-  public Boolean getReadOnly() {
-    return readOnly;
-  }
-  public void setReadOnly(Boolean readOnly) {
-    this.readOnly = readOnly;
-  }
+    @Valid 
+    private Boolean readOnly = null;
 
-  
-  /**
-   * Regular expression used to validate inputs.
-   **/
-  @ApiModelProperty(value = "Regular expression used to validate inputs.")
-  @JsonProperty("regEx")
-  public String getRegEx() {
-    return regEx;
-  }
-  public void setRegEx(String regEx) {
-    this.regEx = regEx;
-  }
+    @Valid 
+    private String regEx = null;
 
-  
-  /**
-   * Specifies if the claim is required for user registration.
-   **/
-  @ApiModelProperty(value = "Specifies if the claim is required for user registration.")
-  @JsonProperty("required")
-  public Boolean getRequired() {
-    return required;
-  }
-  public void setRequired(Boolean required) {
-    this.required = required;
-  }
+    @Valid 
+    private Boolean required = null;
 
-  
-  /**
-   * Specifies if the claim will be prompted during user registration and displayed on the user profile.
-   **/
-  @ApiModelProperty(value = "Specifies if the claim will be prompted during user registration and displayed on the user profile.")
-  @JsonProperty("supportedByDefault")
-  public Boolean getSupportedByDefault() {
-    return supportedByDefault;
-  }
-  public void setSupportedByDefault(Boolean supportedByDefault) {
-    this.supportedByDefault = supportedByDefault;
-  }
+    @Valid 
+    private Boolean supportedByDefault = null;
 
-  
-  /**
-   * Userstore attribute mappings.
-   **/
-  @ApiModelProperty(required = true, value = "Userstore attribute mappings.")
-  @JsonProperty("attributeMapping")
-  public List<AttributeMappingDTO> getAttributeMapping() {
-    return attributeMapping;
-  }
-  public void setAttributeMapping(List<AttributeMappingDTO> attributeMapping) {
-    this.attributeMapping = attributeMapping;
-  }
+    @Valid 
+    @NotNull(message = "Property attributeMapping cannot be null.") 
+    private List<AttributeMappingDTO> attributeMapping = new ArrayList<AttributeMappingDTO>();
 
-  
-  /**
-   * Define any additional properties if required.
-   **/
-  @ApiModelProperty(value = "Define any additional properties if required.")
-  @JsonProperty("properties")
-  public List<PropertyDTO> getProperties() {
-    return properties;
-  }
-  public void setProperties(List<PropertyDTO> properties) {
-    this.properties = properties;
-  }
+    @Valid 
+    private List<PropertyDTO> properties = new ArrayList<PropertyDTO>();
 
-  
+    /**
+    * A unique URI specific to the claim.
+    **/
+    @ApiModelProperty(required = true, value = "A unique URI specific to the claim.")
+    @JsonProperty("claimURI")
+    public String getClaimURI() {
+        return claimURI;
+    }
+    public void setClaimURI(String claimURI) {
+        this.claimURI = claimURI;
+    }
 
-  @Override
-  public String toString()  {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class LocalClaimReqDTO {\n");
-    
-    sb.append("  claimURI: ").append(claimURI).append("\n");
-    sb.append("  description: ").append(description).append("\n");
-    sb.append("  displayOrder: ").append(displayOrder).append("\n");
-    sb.append("  displayName: ").append(displayName).append("\n");
-    sb.append("  readOnly: ").append(readOnly).append("\n");
-    sb.append("  regEx: ").append(regEx).append("\n");
-    sb.append("  required: ").append(required).append("\n");
-    sb.append("  supportedByDefault: ").append(supportedByDefault).append("\n");
-    sb.append("  attributeMapping: ").append(attributeMapping).append("\n");
-    sb.append("  properties: ").append(properties).append("\n");
-    sb.append("}\n");
-    return sb.toString();
-  }
+    /**
+    * Description of the claim.
+    **/
+    @ApiModelProperty(required = true, value = "Description of the claim.")
+    @JsonProperty("description")
+    public String getDescription() {
+        return description;
+    }
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    /**
+    * The order in which the claim is displayed among other claims under the same dialect.
+    **/
+    @ApiModelProperty(value = "The order in which the claim is displayed among other claims under the same dialect.")
+    @JsonProperty("displayOrder")
+    public Integer getDisplayOrder() {
+        return displayOrder;
+    }
+    public void setDisplayOrder(Integer displayOrder) {
+        this.displayOrder = displayOrder;
+    }
+
+    /**
+    * Name of the claim to be displayed in the UI.
+    **/
+    @ApiModelProperty(required = true, value = "Name of the claim to be displayed in the UI.")
+    @JsonProperty("displayName")
+    public String getDisplayName() {
+        return displayName;
+    }
+    public void setDisplayName(String displayName) {
+        this.displayName = displayName;
+    }
+
+    /**
+    * Specifies if the claim is read-only.
+    **/
+    @ApiModelProperty(value = "Specifies if the claim is read-only.")
+    @JsonProperty("readOnly")
+    public Boolean getReadOnly() {
+        return readOnly;
+    }
+    public void setReadOnly(Boolean readOnly) {
+        this.readOnly = readOnly;
+    }
+
+    /**
+    * Regular expression used to validate inputs.
+    **/
+    @ApiModelProperty(value = "Regular expression used to validate inputs.")
+    @JsonProperty("regEx")
+    public String getRegEx() {
+        return regEx;
+    }
+    public void setRegEx(String regEx) {
+        this.regEx = regEx;
+    }
+
+    /**
+    * Specifies if the claim is required for user registration.
+    **/
+    @ApiModelProperty(value = "Specifies if the claim is required for user registration.")
+    @JsonProperty("required")
+    public Boolean getRequired() {
+        return required;
+    }
+    public void setRequired(Boolean required) {
+        this.required = required;
+    }
+
+    /**
+    * Specifies if the claim will be prompted during user registration and displayed on the user profile.
+    **/
+    @ApiModelProperty(value = "Specifies if the claim will be prompted during user registration and displayed on the user profile.")
+    @JsonProperty("supportedByDefault")
+    public Boolean getSupportedByDefault() {
+        return supportedByDefault;
+    }
+    public void setSupportedByDefault(Boolean supportedByDefault) {
+        this.supportedByDefault = supportedByDefault;
+    }
+
+    /**
+    * Userstore attribute mappings.
+    **/
+    @ApiModelProperty(required = true, value = "Userstore attribute mappings.")
+    @JsonProperty("attributeMapping")
+    public List<AttributeMappingDTO> getAttributeMapping() {
+        return attributeMapping;
+    }
+    public void setAttributeMapping(List<AttributeMappingDTO> attributeMapping) {
+        this.attributeMapping = attributeMapping;
+    }
+
+    /**
+    * Define any additional properties if required.
+    **/
+    @ApiModelProperty(value = "Define any additional properties if required.")
+    @JsonProperty("properties")
+    public List<PropertyDTO> getProperties() {
+        return properties;
+    }
+    public void setProperties(List<PropertyDTO> properties) {
+        this.properties = properties;
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class LocalClaimReqDTO {\n");
+        
+        sb.append("    claimURI: ").append(claimURI).append("\n");
+        sb.append("    description: ").append(description).append("\n");
+        sb.append("    displayOrder: ").append(displayOrder).append("\n");
+        sb.append("    displayName: ").append(displayName).append("\n");
+        sb.append("    readOnly: ").append(readOnly).append("\n");
+        sb.append("    regEx: ").append(regEx).append("\n");
+        sb.append("    required: ").append(required).append("\n");
+        sb.append("    supportedByDefault: ").append(supportedByDefault).append("\n");
+        sb.append("    attributeMapping: ").append(attributeMapping).append("\n");
+        sb.append("    properties: ").append(properties).append("\n");
+        
+        sb.append("}\n");
+        return sb.toString();
+    }
 }

--- a/components/org.wso2.carbon.identity.api.server.claim.management/org.wso2.carbon.identity.rest.api.server.claim.management.v1/src/gen/java/org/wso2/carbon/identity/rest/api/server/claim/management/v1/dto/LocalClaimResDTO.java
+++ b/components/org.wso2.carbon.identity.api.server.claim.management/org.wso2.carbon.identity.rest.api.server.claim.management.v1/src/gen/java/org/wso2/carbon/identity/rest/api/server/claim/management/v1/dto/LocalClaimResDTO.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,236 +21,219 @@ import java.util.ArrayList;
 import java.util.List;
 import org.wso2.carbon.identity.rest.api.server.claim.management.v1.dto.AttributeMappingDTO;
 import org.wso2.carbon.identity.rest.api.server.claim.management.v1.dto.PropertyDTO;
-
 import io.swagger.annotations.*;
 import com.fasterxml.jackson.annotation.*;
 
+import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Pattern;
 
-
-
-/**
- * Local claim response.
- **/
-
-
+    /**
+    * Local claim response.
+    **/
 @ApiModel(description = "Local claim response.")
-public class LocalClaimResDTO  {
-  
-  
-  
-  private String id = null;
-  
-  
-  private String claimURI = null;
-  
-  
-  private String dialectURI = null;
-  
-  
-  private String description = null;
-  
-  
-  private Integer displayOrder = null;
-  
-  
-  private String displayName = null;
-  
-  
-  private Boolean readOnly = null;
-  
-  
-  private String regEx = null;
-  
-  
-  private Boolean required = null;
-  
-  
-  private Boolean supportedByDefault = null;
-  
-  
-  private List<AttributeMappingDTO> attributeMapping = new ArrayList<AttributeMappingDTO>();
-  
-  
-  private List<PropertyDTO> properties = new ArrayList<PropertyDTO>();
+public class LocalClaimResDTO {
 
-  
-  /**
-   * Claim id.
-   **/
-  @ApiModelProperty(value = "Claim id.")
-  @JsonProperty("id")
-  public String getId() {
-    return id;
-  }
-  public void setId(String id) {
-    this.id = id;
-  }
+    @Valid 
+    private String id = null;
 
-  
-  /**
-   * A unique URI specific to the claim.
-   **/
-  @ApiModelProperty(value = "A unique URI specific to the claim.")
-  @JsonProperty("claimURI")
-  public String getClaimURI() {
-    return claimURI;
-  }
-  public void setClaimURI(String claimURI) {
-    this.claimURI = claimURI;
-  }
+    @Valid 
+    private String claimURI = null;
 
-  
-  /**
-   * URI of the claim dialect.
-   **/
-  @ApiModelProperty(value = "URI of the claim dialect.")
-  @JsonProperty("dialectURI")
-  public String getDialectURI() {
-    return dialectURI;
-  }
-  public void setDialectURI(String dialectURI) {
-    this.dialectURI = dialectURI;
-  }
+    @Valid 
+    private String dialectURI = null;
 
-  
-  /**
-   * Description of the claim.
-   **/
-  @ApiModelProperty(value = "Description of the claim.")
-  @JsonProperty("description")
-  public String getDescription() {
-    return description;
-  }
-  public void setDescription(String description) {
-    this.description = description;
-  }
+    @Valid 
+    private String description = null;
 
-  
-  /**
-   * The order in which the claim is displayed among other claims under the same dialect.
-   **/
-  @ApiModelProperty(value = "The order in which the claim is displayed among other claims under the same dialect.")
-  @JsonProperty("displayOrder")
-  public Integer getDisplayOrder() {
-    return displayOrder;
-  }
-  public void setDisplayOrder(Integer displayOrder) {
-    this.displayOrder = displayOrder;
-  }
+    @Valid 
+    private Integer displayOrder = null;
 
-  
-  /**
-   * Name of the claim to be displayed in the UI.
-   **/
-  @ApiModelProperty(value = "Name of the claim to be displayed in the UI.")
-  @JsonProperty("displayName")
-  public String getDisplayName() {
-    return displayName;
-  }
-  public void setDisplayName(String displayName) {
-    this.displayName = displayName;
-  }
+    @Valid 
+    private String displayName = null;
 
-  
-  /**
-   * Specifies if the claim is read-only.
-   **/
-  @ApiModelProperty(value = "Specifies if the claim is read-only.")
-  @JsonProperty("readOnly")
-  public Boolean getReadOnly() {
-    return readOnly;
-  }
-  public void setReadOnly(Boolean readOnly) {
-    this.readOnly = readOnly;
-  }
+    @Valid 
+    private Boolean readOnly = null;
 
-  
-  /**
-   * Regular expression used to validate inputs.
-   **/
-  @ApiModelProperty(value = "Regular expression used to validate inputs.")
-  @JsonProperty("regEx")
-  public String getRegEx() {
-    return regEx;
-  }
-  public void setRegEx(String regEx) {
-    this.regEx = regEx;
-  }
+    @Valid 
+    private String regEx = null;
 
-  
-  /**
-   * Specifies if the claim is required for user registration.
-   **/
-  @ApiModelProperty(value = "Specifies if the claim is required for user registration.")
-  @JsonProperty("required")
-  public Boolean getRequired() {
-    return required;
-  }
-  public void setRequired(Boolean required) {
-    this.required = required;
-  }
+    @Valid 
+    private Boolean required = null;
 
-  
-  /**
-   * Specifies if the claim will be prompted during user registration and displayed on the user profile.
-   **/
-  @ApiModelProperty(value = "Specifies if the claim will be prompted during user registration and displayed on the user profile.")
-  @JsonProperty("supportedByDefault")
-  public Boolean getSupportedByDefault() {
-    return supportedByDefault;
-  }
-  public void setSupportedByDefault(Boolean supportedByDefault) {
-    this.supportedByDefault = supportedByDefault;
-  }
+    @Valid 
+    private Boolean supportedByDefault = null;
 
-  
-  /**
-   * Userstore attribute mappings.
-   **/
-  @ApiModelProperty(value = "Userstore attribute mappings.")
-  @JsonProperty("attributeMapping")
-  public List<AttributeMappingDTO> getAttributeMapping() {
-    return attributeMapping;
-  }
-  public void setAttributeMapping(List<AttributeMappingDTO> attributeMapping) {
-    this.attributeMapping = attributeMapping;
-  }
+    @Valid 
+    private List<AttributeMappingDTO> attributeMapping = new ArrayList<AttributeMappingDTO>();
 
-  
-  /**
-   * Define any additional properties if required.
-   **/
-  @ApiModelProperty(value = "Define any additional properties if required.")
-  @JsonProperty("properties")
-  public List<PropertyDTO> getProperties() {
-    return properties;
-  }
-  public void setProperties(List<PropertyDTO> properties) {
-    this.properties = properties;
-  }
+    @Valid 
+    private List<PropertyDTO> properties = new ArrayList<PropertyDTO>();
 
-  
+    /**
+    * claim ID.
+    **/
+    @ApiModelProperty(value = "claim ID.")
+    @JsonProperty("id")
+    public String getId() {
+        return id;
+    }
+    public void setId(String id) {
+        this.id = id;
+    }
 
-  @Override
-  public String toString()  {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class LocalClaimResDTO {\n");
-    
-    sb.append("  id: ").append(id).append("\n");
-    sb.append("  claimURI: ").append(claimURI).append("\n");
-    sb.append("  dialectURI: ").append(dialectURI).append("\n");
-    sb.append("  description: ").append(description).append("\n");
-    sb.append("  displayOrder: ").append(displayOrder).append("\n");
-    sb.append("  displayName: ").append(displayName).append("\n");
-    sb.append("  readOnly: ").append(readOnly).append("\n");
-    sb.append("  regEx: ").append(regEx).append("\n");
-    sb.append("  required: ").append(required).append("\n");
-    sb.append("  supportedByDefault: ").append(supportedByDefault).append("\n");
-    sb.append("  attributeMapping: ").append(attributeMapping).append("\n");
-    sb.append("  properties: ").append(properties).append("\n");
-    sb.append("}\n");
-    return sb.toString();
-  }
+    /**
+    * A unique URI specific to the claim.
+    **/
+    @ApiModelProperty(value = "A unique URI specific to the claim.")
+    @JsonProperty("claimURI")
+    public String getClaimURI() {
+        return claimURI;
+    }
+    public void setClaimURI(String claimURI) {
+        this.claimURI = claimURI;
+    }
+
+    /**
+    * URI of the claim dialect.
+    **/
+    @ApiModelProperty(value = "URI of the claim dialect.")
+    @JsonProperty("dialectURI")
+    public String getDialectURI() {
+        return dialectURI;
+    }
+    public void setDialectURI(String dialectURI) {
+        this.dialectURI = dialectURI;
+    }
+
+    /**
+    * Description of the claim.
+    **/
+    @ApiModelProperty(value = "Description of the claim.")
+    @JsonProperty("description")
+    public String getDescription() {
+        return description;
+    }
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    /**
+    * The order in which the claim is displayed among other claims under the same dialect.
+    **/
+    @ApiModelProperty(value = "The order in which the claim is displayed among other claims under the same dialect.")
+    @JsonProperty("displayOrder")
+    public Integer getDisplayOrder() {
+        return displayOrder;
+    }
+    public void setDisplayOrder(Integer displayOrder) {
+        this.displayOrder = displayOrder;
+    }
+
+    /**
+    * Name of the claim to be displayed in the UI.
+    **/
+    @ApiModelProperty(value = "Name of the claim to be displayed in the UI.")
+    @JsonProperty("displayName")
+    public String getDisplayName() {
+        return displayName;
+    }
+    public void setDisplayName(String displayName) {
+        this.displayName = displayName;
+    }
+
+    /**
+    * Specifies if the claim is read-only.
+    **/
+    @ApiModelProperty(value = "Specifies if the claim is read-only.")
+    @JsonProperty("readOnly")
+    public Boolean getReadOnly() {
+        return readOnly;
+    }
+    public void setReadOnly(Boolean readOnly) {
+        this.readOnly = readOnly;
+    }
+
+    /**
+    * Regular expression used to validate inputs.
+    **/
+    @ApiModelProperty(value = "Regular expression used to validate inputs.")
+    @JsonProperty("regEx")
+    public String getRegEx() {
+        return regEx;
+    }
+    public void setRegEx(String regEx) {
+        this.regEx = regEx;
+    }
+
+    /**
+    * Specifies if the claim is required for user registration.
+    **/
+    @ApiModelProperty(value = "Specifies if the claim is required for user registration.")
+    @JsonProperty("required")
+    public Boolean getRequired() {
+        return required;
+    }
+    public void setRequired(Boolean required) {
+        this.required = required;
+    }
+
+    /**
+    * Specifies if the claim will be prompted during user registration and displayed on the user profile.
+    **/
+    @ApiModelProperty(value = "Specifies if the claim will be prompted during user registration and displayed on the user profile.")
+    @JsonProperty("supportedByDefault")
+    public Boolean getSupportedByDefault() {
+        return supportedByDefault;
+    }
+    public void setSupportedByDefault(Boolean supportedByDefault) {
+        this.supportedByDefault = supportedByDefault;
+    }
+
+    /**
+    * Userstore attribute mappings.
+    **/
+    @ApiModelProperty(value = "Userstore attribute mappings.")
+    @JsonProperty("attributeMapping")
+    public List<AttributeMappingDTO> getAttributeMapping() {
+        return attributeMapping;
+    }
+    public void setAttributeMapping(List<AttributeMappingDTO> attributeMapping) {
+        this.attributeMapping = attributeMapping;
+    }
+
+    /**
+    * Define any additional properties if required.
+    **/
+    @ApiModelProperty(value = "Define any additional properties if required.")
+    @JsonProperty("properties")
+    public List<PropertyDTO> getProperties() {
+        return properties;
+    }
+    public void setProperties(List<PropertyDTO> properties) {
+        this.properties = properties;
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class LocalClaimResDTO {\n");
+        
+        sb.append("    id: ").append(id).append("\n");
+        sb.append("    claimURI: ").append(claimURI).append("\n");
+        sb.append("    dialectURI: ").append(dialectURI).append("\n");
+        sb.append("    description: ").append(description).append("\n");
+        sb.append("    displayOrder: ").append(displayOrder).append("\n");
+        sb.append("    displayName: ").append(displayName).append("\n");
+        sb.append("    readOnly: ").append(readOnly).append("\n");
+        sb.append("    regEx: ").append(regEx).append("\n");
+        sb.append("    required: ").append(required).append("\n");
+        sb.append("    supportedByDefault: ").append(supportedByDefault).append("\n");
+        sb.append("    attributeMapping: ").append(attributeMapping).append("\n");
+        sb.append("    properties: ").append(properties).append("\n");
+        
+        sb.append("}\n");
+        return sb.toString();
+    }
 }

--- a/components/org.wso2.carbon.identity.api.server.claim.management/org.wso2.carbon.identity.rest.api.server.claim.management.v1/src/gen/java/org/wso2/carbon/identity/rest/api/server/claim/management/v1/dto/PropertyDTO.java
+++ b/components/org.wso2.carbon.identity.api.server.claim.management/org.wso2.carbon.identity.rest.api.server.claim.management.v1/src/gen/java/org/wso2/carbon/identity/rest/api/server/claim/management/v1/dto/PropertyDTO.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,61 +16,56 @@
 
 package org.wso2.carbon.identity.rest.api.server.claim.management.v1.dto;
 
-
 import io.swagger.annotations.*;
 import com.fasterxml.jackson.annotation.*;
 
+import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Pattern;
 
-
-
-
-
 @ApiModel(description = "")
-public class PropertyDTO  {
-  
-  
-  @NotNull 
-  private String key = null;
-  
-  @NotNull 
-  private String value = null;
+public class PropertyDTO {
 
-  
-  /**
-   **/
-  @ApiModelProperty(required = true, value = "")
-  @JsonProperty("key")
-  public String getKey() {
-    return key;
-  }
-  public void setKey(String key) {
-    this.key = key;
-  }
+    @Valid 
+    @NotNull(message = "Property key cannot be null.") 
+    private String key = null;
 
-  
-  /**
-   **/
-  @ApiModelProperty(required = true, value = "")
-  @JsonProperty("value")
-  public String getValue() {
-    return value;
-  }
-  public void setValue(String value) {
-    this.value = value;
-  }
+    @Valid 
+    @NotNull(message = "Property value cannot be null.") 
+    private String value = null;
 
-  
+    /**
+    **/
+    @ApiModelProperty(required = true, value = "")
+    @JsonProperty("key")
+    public String getKey() {
+        return key;
+    }
+    public void setKey(String key) {
+        this.key = key;
+    }
 
-  @Override
-  public String toString()  {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class PropertyDTO {\n");
-    
-    sb.append("  key: ").append(key).append("\n");
-    sb.append("  value: ").append(value).append("\n");
-    sb.append("}\n");
-    return sb.toString();
-  }
+    /**
+    **/
+    @ApiModelProperty(required = true, value = "")
+    @JsonProperty("value")
+    public String getValue() {
+        return value;
+    }
+    public void setValue(String value) {
+        this.value = value;
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class PropertyDTO {\n");
+        
+        sb.append("    key: ").append(key).append("\n");
+        sb.append("    value: ").append(value).append("\n");
+        
+        sb.append("}\n");
+        return sb.toString();
+    }
 }

--- a/components/org.wso2.carbon.identity.api.server.claim.management/org.wso2.carbon.identity.rest.api.server.claim.management.v1/src/main/java/org/wso2/carbon/identity/rest/api/server/claim/management/v1/impl/ClaimManagementApiServiceImpl.java
+++ b/components/org.wso2.carbon.identity.api.server.claim.management/org.wso2.carbon.identity.rest.api.server.claim.management.v1/src/main/java/org/wso2/carbon/identity/rest/api/server/claim/management/v1/impl/ClaimManagementApiServiceImpl.java
@@ -115,10 +115,11 @@ public class ClaimManagementApiServiceImpl extends ClaimManagementApiService {
     }
 
     @Override
-    public Response getLocalClaims(String attributes, Integer limit, Integer offset, String filter, String sort) {
+    public Response getLocalClaims(String attributes, Integer limit, Integer offset, String filter,
+                                   String sort, Boolean excludeIdentityClaims) {
 
         return Response.ok().entity(claimManagementService.getLocalClaims(
-                attributes, limit, offset, filter, sort)).build();
+                excludeIdentityClaims, attributes, limit, offset, filter, sort)).build();
     }
 
     @Override

--- a/components/org.wso2.carbon.identity.api.server.claim.management/org.wso2.carbon.identity.rest.api.server.claim.management.v1/src/main/resources/claim-management.yaml
+++ b/components/org.wso2.carbon.identity.api.server.claim.management/org.wso2.carbon.identity.rest.api.server.claim.management.v1/src/main/resources/claim-management.yaml
@@ -78,6 +78,7 @@ paths:
       - $ref : '#/parameters/offsetQueryParam'
       - $ref : '#/parameters/filterQueryParam'
       - $ref : '#/parameters/sortQueryParam'
+      - $ref : '#/parameters/excludeIdentityClaimsQueryParam'
       x-wso2-curl: |
       responses:
         200:
@@ -541,6 +542,12 @@ parameters:
     required: false
     description: Define only the required attributes to be sent in the response object.
     type: string
+  excludeIdentityClaimsQueryParam:
+    in: query
+    name: exclude-identity-claims
+    required: false
+    type: boolean
+    description: Exclude identity claims when listing local claims.
   dialectIdPathParam:
     in: path
     name: dialect-id


### PR DESCRIPTION
## Purpose
> This PR introduces a new query parameter to `/claim-dialects/local/claims` path in _claim-mgt-api_ to list local claims excluding the identity claims. 
> If **exclude-identity-claims** parameter is set to `true`, then API returns the list of local claims excluding identity claims.
> Fixing https://github.com/wso2-enterprise/asgardeo-product/issues/1741