### PR TITLE
Add Authenticators API implementation.

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.authenticators/org.wso2.carbon.identity.api.server.authenticators.common/pom.xml
+++ b/components/org.wso2.carbon.identity.api.server.authenticators/org.wso2.carbon.identity.api.server.authenticators.common/pom.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+  ~
+  ~ WSO2 Inc. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.wso2.carbon.identity.server.api</groupId>
+        <artifactId>org.wso2.carbon.identity.api.server.authenticators</artifactId>
+        <version>1.0.229-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>org.wso2.carbon.identity.api.server.authenticators.common</artifactId>
+    <packaging>jar</packaging>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.application.mgt</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-web</artifactId>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+    
+</project>

--- a/components/org.wso2.carbon.identity.api.server.authenticators/org.wso2.carbon.identity.api.server.authenticators.common/pom.xml
+++ b/components/org.wso2.carbon.identity.api.server.authenticators/org.wso2.carbon.identity.api.server.authenticators.common/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.server.api</groupId>
         <artifactId>org.wso2.carbon.identity.api.server.authenticators</artifactId>
-        <version>1.0.230-SNAPSHOT</version>
+        <version>1.0.231-SNAPSHOT</version>
     </parent>
 
     <artifactId>org.wso2.carbon.identity.api.server.authenticators.common</artifactId>

--- a/components/org.wso2.carbon.identity.api.server.authenticators/org.wso2.carbon.identity.api.server.authenticators.common/pom.xml
+++ b/components/org.wso2.carbon.identity.api.server.authenticators/org.wso2.carbon.identity.api.server.authenticators.common/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.server.api</groupId>
         <artifactId>org.wso2.carbon.identity.api.server.authenticators</artifactId>
-        <version>1.0.229-SNAPSHOT</version>
+        <version>1.0.230-SNAPSHOT</version>
     </parent>
 
     <artifactId>org.wso2.carbon.identity.api.server.authenticators.common</artifactId>

--- a/components/org.wso2.carbon.identity.api.server.authenticators/org.wso2.carbon.identity.api.server.authenticators.common/src/main/java/org/wso2/carbon/identity/api/server/authenticators/common/AuthenticatorsServiceHolder.java
+++ b/components/org.wso2.carbon.identity.api.server.authenticators/org.wso2.carbon.identity.api.server.authenticators.common/src/main/java/org/wso2/carbon/identity/api/server/authenticators/common/AuthenticatorsServiceHolder.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *                                                                         
+ * Licensed under the Apache License, Version 2.0 (the "License");         
+ * you may not use this file except in compliance with the License.        
+ * You may obtain a copy of the License at                                 
+ *                                                                         
+ * http://www.apache.org/licenses/LICENSE-2.0                              
+ *                                                                         
+ * Unless required by applicable law or agreed to in writing, software     
+ * distributed under the License is distributed on an "AS IS" BASIS,       
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and     
+ * limitations under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.authenticators.common;
+
+import org.wso2.carbon.identity.application.mgt.ApplicationManagementService;
+import org.wso2.carbon.idp.mgt.IdentityProviderManager;
+
+/**
+ * Service holder class for server configuration related services.
+ */
+public class AuthenticatorsServiceHolder {
+
+    private static AuthenticatorsServiceHolder instance = new AuthenticatorsServiceHolder();
+
+    private ApplicationManagementService applicationManagementService;
+    private IdentityProviderManager identityProviderManager;
+
+    private AuthenticatorsServiceHolder() {
+
+    }
+
+    public static AuthenticatorsServiceHolder getInstance() {
+
+        return instance;
+    }
+
+    /**
+     * Get ApplicationManagementService osgi service.
+     *
+     * @return ApplicationManagementService
+     */
+    public ApplicationManagementService getApplicationManagementService() {
+
+        return AuthenticatorsServiceHolder.getInstance().applicationManagementService;
+    }
+
+    /**
+     * Set ApplicationManagementService osgi service.
+     *
+     * @param applicationManagementService ApplicationManagementService.
+     */
+    public void setApplicationManagementService(ApplicationManagementService applicationManagementService) {
+
+        AuthenticatorsServiceHolder.getInstance().applicationManagementService = applicationManagementService;
+    }
+
+    /**
+     * Get IdentityProviderManager osgi service.
+     *
+     * @return IdentityProviderManager
+     */
+    public IdentityProviderManager getIdentityProviderManager() {
+
+        return AuthenticatorsServiceHolder.getInstance().identityProviderManager;
+    }
+
+    /**
+     * Set IdentityProviderManager osgi service.
+     *
+     * @param identityProviderManager IdentityProviderManager.
+     */
+    public void setIdentityProviderManager(IdentityProviderManager identityProviderManager) {
+
+        AuthenticatorsServiceHolder.getInstance().identityProviderManager = identityProviderManager;
+    }
+}

--- a/components/org.wso2.carbon.identity.api.server.authenticators/org.wso2.carbon.identity.api.server.authenticators.common/src/main/java/org/wso2/carbon/identity/api/server/authenticators/common/Constants.java
+++ b/components/org.wso2.carbon.identity.api.server.authenticators/org.wso2.carbon.identity.api.server.authenticators.common/src/main/java/org/wso2/carbon/identity/api/server/authenticators/common/Constants.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.authenticators.common;
+
+/**
+ * Common constants for authenticators API.
+ */
+public class Constants {
+
+    private Constants() {
+
+    }
+
+    public static final String AUTHENTICATOR_ERROR_PREFIX = "AUT-";
+    public static final String FEDERATED_AUTHENTICATORS = "federatedAuthenticators";
+
+    /**
+     * Supported filter attributes.
+     */
+    public static class FilterAttributes {
+
+        public static final String TAG = "tag";
+        public static final String NAME = "name";
+    }
+
+    /**
+     * Supported filter operations.
+     */
+    public static class FilterOperations {
+
+        public static final String EQ = "eq";
+        public static final String SW = "sw";
+    }
+
+    /**
+     * Supported complex query operations.
+     */
+    public static class ComplexQueryOperations {
+
+        public static final String AND = "and";
+        public static final String OR = "or";
+    }
+
+    /**
+     * Enum for error messages.
+     */
+    public enum ErrorMessage {
+
+        ERROR_CODE_INVALID_FILTER_FORMAT("60001", "Invalid format used for filtering.",
+                "Filter needs to be in the format <attribute>+<operation>+<value>. Eg: tag+eq+2FA"),
+        ERROR_CODE_UNSUPPORTED_FILTER_ATTRIBUTE("60002", "Unsupported filter attribute.",
+                "The filter attribute '%s' is not supported."),
+        ERROR_CODE_ERROR_LISTING_AUTHENTICATORS("65001", "Unable to list the existing authenticators.",
+                "Server encountered an error while listing the authenticators."),
+        ERROR_CODE_ERROR_LISTING_IDPS("65002", "Unable to list the existing identity providers.",
+                "Server encountered an error while listing the identity providers."),
+        ERROR_CODE_UNSUPPORTED_COMPLEX_QUERY_IN_FILTER("65003", "Unsupported filter.",
+                "The complex query used for filtering is not supported."),
+        ERROR_CODE_UNSUPPORTED_FILTER_OPERATION_FOR_TAG("65004", "Unsupported filter operation.",
+                "Unsupported filter operation '%s' for filter attribute 'tag'"),
+        ERROR_CODE_UNSUPPORTED_FILTER_OPERATION_FOR_NAME("65005", "Unsupported filter operation.",
+                "The filter operation '%s' is not supported for filter attribute 'name'."),
+        ERROR_CODE_UNSUPPORTED_FILTER_FOR_MULTIPLE_NAMES("65006", "Unsupported filter.",
+                "Filtering with multiple 'name' attributes is not supported."),
+        ERROR_CODE_UNSUPPORTED_COMPLEX_QUERY_OPERATION_FOR_NAME("65007", "Unsupported complex query " +
+                "operation in filter.", "Complex query with '%s' operation for filter attribute 'name' is not " +
+                "supported."),
+        ERROR_CODE_UNSUPPORTED_COMPLEX_QUERY_OPERATION_FOR_TAG("65008", "Unsupported complex query " +
+                "operation in filter.", "Complex query with '%s' operation for filter attribute 'tag' is not " +
+                "supported.");
+
+        private final String code;
+        private final String message;
+        private final String description;
+
+        ErrorMessage(String code, String message, String description) {
+
+            this.code = code;
+            this.message = message;
+            this.description = description;
+        }
+
+        public String getCode() {
+
+            return AUTHENTICATOR_ERROR_PREFIX + code;
+        }
+
+        public String getMessage() {
+
+            return message;
+        }
+
+        public String getDescription() {
+
+            return description;
+        }
+
+        @Override
+        public String toString() {
+
+            return code + " | " + message;
+        }
+    }
+}

--- a/components/org.wso2.carbon.identity.api.server.authenticators/org.wso2.carbon.identity.api.server.authenticators.common/src/main/java/org/wso2/carbon/identity/api/server/authenticators/common/Constants.java
+++ b/components/org.wso2.carbon.identity.api.server.authenticators/org.wso2.carbon.identity.api.server.authenticators.common/src/main/java/org/wso2/carbon/identity/api/server/authenticators/common/Constants.java
@@ -81,7 +81,9 @@ public class Constants {
                 "supported."),
         ERROR_CODE_UNSUPPORTED_COMPLEX_QUERY_OPERATION_FOR_TAG("65008", "Unsupported complex query " +
                 "operation in filter.", "Complex query with '%s' operation for filter attribute 'tag' is not " +
-                "supported.");
+                "supported."),
+        ERROR_CODE_PAGINATION_NOT_IMPLEMENTED("65009", "Pagination not supported.", "Pagination " +
+                "capabilities are not supported in this version of the API.");
 
         private final String code;
         private final String message;

--- a/components/org.wso2.carbon.identity.api.server.authenticators/org.wso2.carbon.identity.api.server.authenticators.common/src/main/java/org/wso2/carbon/identity/api/server/authenticators/common/factory/ApplicationMgtOSGIServiceFactory.java
+++ b/components/org.wso2.carbon.identity.api.server.authenticators/org.wso2.carbon.identity.api.server.authenticators.common/src/main/java/org/wso2/carbon/identity/api/server/authenticators/common/factory/ApplicationMgtOSGIServiceFactory.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *                                                                         
+ * Licensed under the Apache License, Version 2.0 (the "License");         
+ * you may not use this file except in compliance with the License.        
+ * You may obtain a copy of the License at                                 
+ *                                                                         
+ * http://www.apache.org/licenses/LICENSE-2.0                              
+ *                                                                         
+ * Unless required by applicable law or agreed to in writing, software     
+ * distributed under the License is distributed on an "AS IS" BASIS,       
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and     
+ * limitations under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.authenticators.common.factory;
+
+import org.springframework.beans.factory.config.AbstractFactoryBean;
+import org.wso2.carbon.context.PrivilegedCarbonContext;
+import org.wso2.carbon.identity.application.mgt.ApplicationManagementService;
+
+/**
+ * Factory Beans serves as a factory for creating other beans within the IOC container. This factory bean is used to
+ * instantiate the ApplicationManagementService type of object inside the container.
+ */
+public class ApplicationMgtOSGIServiceFactory extends AbstractFactoryBean<ApplicationManagementService> {
+
+    private ApplicationManagementService applicationManagementService;
+
+    @Override
+    public Class<?> getObjectType() {
+
+        return Object.class;
+    }
+
+    @Override
+    protected ApplicationManagementService createInstance() throws Exception {
+
+        if (this.applicationManagementService == null) {
+            ApplicationManagementService taskOperationService = (ApplicationManagementService) PrivilegedCarbonContext.
+                    getThreadLocalCarbonContext().getOSGiService(ApplicationManagementService.class, null);
+            if (taskOperationService != null) {
+                this.applicationManagementService = taskOperationService;
+            } else {
+                throw new Exception("Unable to retrieve applicationManagementService service.");
+            }
+        }
+        return this.applicationManagementService;
+    }
+}

--- a/components/org.wso2.carbon.identity.api.server.authenticators/org.wso2.carbon.identity.api.server.authenticators.common/src/main/java/org/wso2/carbon/identity/api/server/authenticators/common/factory/IdPMgtOSGIServiceFactory.java
+++ b/components/org.wso2.carbon.identity.api.server.authenticators/org.wso2.carbon.identity.api.server.authenticators.common/src/main/java/org/wso2/carbon/identity/api/server/authenticators/common/factory/IdPMgtOSGIServiceFactory.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *                                                                         
+ * Licensed under the Apache License, Version 2.0 (the "License");         
+ * you may not use this file except in compliance with the License.        
+ * You may obtain a copy of the License at                                 
+ *                                                                         
+ * http://www.apache.org/licenses/LICENSE-2.0                              
+ *                                                                         
+ * Unless required by applicable law or agreed to in writing, software     
+ * distributed under the License is distributed on an "AS IS" BASIS,       
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and     
+ * limitations under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.authenticators.common.factory;
+
+import org.springframework.beans.factory.config.AbstractFactoryBean;
+import org.wso2.carbon.context.PrivilegedCarbonContext;
+import org.wso2.carbon.idp.mgt.IdpManager;
+
+/**
+ * Factory Beans serves as a factory for creating other beans within the IOC container. This factory bean is used to
+ * instantiate the IdentityProviderManager type of object inside the container.
+ */
+public class IdPMgtOSGIServiceFactory extends AbstractFactoryBean<IdpManager> {
+
+    private IdpManager identityProviderManager;
+
+    @Override
+    public Class<?> getObjectType() {
+
+        return Object.class;
+    }
+
+    @Override
+    protected IdpManager createInstance() throws Exception {
+
+        if (this.identityProviderManager == null) {
+            IdpManager taskOperationService = (IdpManager) PrivilegedCarbonContext.
+                    getThreadLocalCarbonContext().getOSGiService(IdpManager.class, null);
+            if (taskOperationService != null) {
+                this.identityProviderManager = taskOperationService;
+            } else {
+                throw new Exception("Unable to retrieve identityProviderManager service.");
+            }
+        }
+        return this.identityProviderManager;
+    }
+}

--- a/components/org.wso2.carbon.identity.api.server.authenticators/org.wso2.carbon.identity.api.server.authenticators.v1/pom.xml
+++ b/components/org.wso2.carbon.identity.api.server.authenticators/org.wso2.carbon.identity.api.server.authenticators.v1/pom.xml
@@ -1,0 +1,180 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+  ~
+  ~ WSO2 Inc. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.wso2.carbon.identity.server.api</groupId>
+        <artifactId>org.wso2.carbon.identity.api.server.authenticators</artifactId>
+        <version>1.0.229-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>org.wso2.carbon.identity.api.server.authenticators.v1</artifactId>
+    <packaging>jar</packaging>
+
+    <build>
+        <plugins>
+<!--            <plugin>
+                <groupId>org.openapitools</groupId>
+                <artifactId>openapi-generator-maven-plugin</artifactId>
+                <version>4.1.2</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>generate</goal>
+                        </goals>
+                        <configuration>
+                            <inputSpec>${project.basedir}/src/main/resources/authenticators.yaml</inputSpec>
+                            <generatorName>org.wso2.carbon.codegen.CxfWso2Generator</generatorName>
+                            <configOptions>
+                                <sourceFolder>src/gen/java</sourceFolder>
+                                <apiPackage>org.wso2.carbon.identity.api.server.authenticators.v1</apiPackage>
+                                <modelPackage>org.wso2.carbon.identity.api.server.authenticators.v1.model</modelPackage>
+                                <packageName>org.wso2.carbon.identity.api.server.authenticators.v1</packageName>
+                                <dateLibrary>java8</dateLibrary>
+                                <hideGenerationTimestamp>true</hideGenerationTimestamp>
+                            </configOptions>
+                            <output>.</output>
+                            <skipOverwrite>false</skipOverwrite>
+                        </configuration>
+                    </execution>
+                </executions>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.openapitools</groupId>
+                        <artifactId>cxf-wso2-openapi-generator</artifactId>
+                        <version>1.0.0</version>
+                    </dependency>
+                </dependencies>
+            </plugin>-->
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <version>1.8</version>
+                <executions>
+                    <execution>
+                        <id>add-source</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>add-source</goal>
+                        </goals>
+                        <configuration>
+                            <sources>
+                                <source>src/gen/java</source>
+                            </sources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>${maven.compiler.plugin.version}</version>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.cxf</groupId>
+            <artifactId>cxf-rt-frontend-jaxrs</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.cxf</groupId>
+            <artifactId>cxf-rt-rs-service-description</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-web</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>javax.ws.rs</groupId>
+            <artifactId>javax.ws.rs-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.swagger</groupId>
+            <artifactId>swagger-jaxrs</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-databind</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-annotations</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.dataformat</groupId>
+                    <artifactId>jackson-dataformat-yaml</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>javax.ws.rs</groupId>
+                    <artifactId>jsr311-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.google.guava</groupId>
+                    <artifactId>guava</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.jaxrs</groupId>
+            <artifactId>jackson-jaxrs-json-provider</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.server.api</groupId>
+            <artifactId>org.wso2.carbon.identity.api.server.common</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.server.api</groupId>
+            <artifactId>org.wso2.carbon.identity.api.server.authenticators.common</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.application.mgt</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>commons-beanutils</groupId>
+            <artifactId>commons-beanutils</artifactId>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/components/org.wso2.carbon.identity.api.server.authenticators/org.wso2.carbon.identity.api.server.authenticators.v1/pom.xml
+++ b/components/org.wso2.carbon.identity.api.server.authenticators/org.wso2.carbon.identity.api.server.authenticators.v1/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.server.api</groupId>
         <artifactId>org.wso2.carbon.identity.api.server.authenticators</artifactId>
-        <version>1.0.229-SNAPSHOT</version>
+        <version>1.0.230-SNAPSHOT</version>
     </parent>
 
     <artifactId>org.wso2.carbon.identity.api.server.authenticators.v1</artifactId>
@@ -110,11 +110,6 @@
             <groupId>org.springframework</groupId>
             <artifactId>spring-web</artifactId>
             <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>javax.ws.rs</groupId>

--- a/components/org.wso2.carbon.identity.api.server.authenticators/org.wso2.carbon.identity.api.server.authenticators.v1/pom.xml
+++ b/components/org.wso2.carbon.identity.api.server.authenticators/org.wso2.carbon.identity.api.server.authenticators.v1/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.server.api</groupId>
         <artifactId>org.wso2.carbon.identity.api.server.authenticators</artifactId>
-        <version>1.0.230-SNAPSHOT</version>
+        <version>1.0.231-SNAPSHOT</version>
     </parent>
 
     <artifactId>org.wso2.carbon.identity.api.server.authenticators.v1</artifactId>

--- a/components/org.wso2.carbon.identity.api.server.authenticators/org.wso2.carbon.identity.api.server.authenticators.v1/src/gen/java/org/wso2/carbon/identity/api/server/authenticators/v1/AuthenticatorsApi.java
+++ b/components/org.wso2.carbon.identity.api.server.authenticators/org.wso2.carbon.identity.api.server.authenticators.v1/src/gen/java/org/wso2/carbon/identity/api/server/authenticators/v1/AuthenticatorsApi.java
@@ -1,0 +1,92 @@
+/*
+* Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package org.wso2.carbon.identity.api.server.authenticators.v1;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.apache.cxf.jaxrs.ext.multipart.Attachment;
+import org.apache.cxf.jaxrs.ext.multipart.Multipart;
+import java.io.InputStream;
+import java.util.List;
+
+import org.wso2.carbon.identity.api.server.authenticators.v1.model.Authenticator;
+import org.wso2.carbon.identity.api.server.authenticators.v1.model.Error;
+import org.wso2.carbon.identity.api.server.authenticators.v1.AuthenticatorsApiService;
+
+import javax.validation.Valid;
+import javax.ws.rs.*;
+import javax.ws.rs.core.Response;
+import io.swagger.annotations.*;
+
+import javax.validation.constraints.*;
+
+@Path("/authenticators")
+@Api(description = "The authenticators API")
+
+public class AuthenticatorsApi  {
+
+    @Autowired
+    private AuthenticatorsApiService delegate;
+
+    @Valid
+    @GET
+    
+    
+    @Produces({ "application/json" })
+    @ApiOperation(value = "List all authenticators in the server", notes = "List all authenticators in the server", response = Authenticator.class, responseContainer = "List", authorizations = {
+        @Authorization(value = "BasicAuth"),
+        @Authorization(value = "OAuth2", scopes = {
+            
+        })
+    }, tags={ "Authenticators", })
+    @ApiResponses(value = { 
+        @ApiResponse(code = 200, message = "Successful response", response = Authenticator.class, responseContainer = "List"),
+        @ApiResponse(code = 400, message = "Invalid input in the request.", response = Error.class),
+        @ApiResponse(code = 401, message = "Authentication information is missing or invalid.", response = Void.class),
+        @ApiResponse(code = 403, message = "Access forbidden.", response = Void.class),
+        @ApiResponse(code = 404, message = "Requested resource is not found.", response = Error.class),
+        @ApiResponse(code = 500, message = "Internal server error.", response = Error.class)
+    })
+    public Response authenticatorsGet(    @Valid@ApiParam(value = "Condition to filter the retrieval of records. Only supports filtering based on the 'tag' and 'name' attribute. For local authenticators and request path authenticators, the 'displayName' is considered as the 'name' attribute during filtering. The 'name' attribute only supports 'eq' and 'sw operations. Filtering with multiple 'name' attributes is not supported. The 'tag' attribute only supports 'eq' operation. Filtering with multiple 'tag' attributes is supported with only 'or' as the complex query operation. E.g. /configs/authenticators?filter=name+sw+fi+and+(tag+eq+2FA+or+tag+eq+MFA) ")  @QueryParam("filter") String filter) {
+
+        return delegate.authenticatorsGet(filter );
+    }
+
+    @Valid
+    @GET
+    @Path("/meta/tags")
+    
+    @Produces({ "application/json" })
+    @ApiOperation(value = "List all authenticator tags", notes = "List all authenticator tags", response = String.class, responseContainer = "List", authorizations = {
+        @Authorization(value = "BasicAuth"),
+        @Authorization(value = "OAuth2", scopes = {
+            
+        })
+    }, tags={ "Authenticators" })
+    @ApiResponses(value = { 
+        @ApiResponse(code = 200, message = "Successful Response", response = String.class, responseContainer = "List"),
+        @ApiResponse(code = 400, message = "Invalid input in the request.", response = Error.class),
+        @ApiResponse(code = 401, message = "Authentication information is missing or invalid.", response = Void.class),
+        @ApiResponse(code = 403, message = "Access forbidden.", response = Void.class),
+        @ApiResponse(code = 404, message = "Requested resource is not found.", response = Error.class),
+        @ApiResponse(code = 500, message = "Internal server error.", response = Error.class)
+    })
+    public Response authenticatorsMetaTagsGet() {
+
+        return delegate.authenticatorsMetaTagsGet();
+    }
+
+}

--- a/components/org.wso2.carbon.identity.api.server.authenticators/org.wso2.carbon.identity.api.server.authenticators.v1/src/gen/java/org/wso2/carbon/identity/api/server/authenticators/v1/AuthenticatorsApi.java
+++ b/components/org.wso2.carbon.identity.api.server.authenticators/org.wso2.carbon.identity.api.server.authenticators.v1/src/gen/java/org/wso2/carbon/identity/api/server/authenticators/v1/AuthenticatorsApi.java
@@ -58,11 +58,12 @@ public class AuthenticatorsApi  {
         @ApiResponse(code = 401, message = "Authentication information is missing or invalid.", response = Void.class),
         @ApiResponse(code = 403, message = "Access forbidden.", response = Void.class),
         @ApiResponse(code = 404, message = "Requested resource is not found.", response = Error.class),
-        @ApiResponse(code = 500, message = "Internal server error.", response = Error.class)
+        @ApiResponse(code = 500, message = "Internal server error.", response = Error.class),
+        @ApiResponse(code = 501, message = "Not Implemented.", response = Error.class)
     })
-    public Response authenticatorsGet(    @Valid@ApiParam(value = "Condition to filter the retrieval of records. Only supports filtering based on the 'tag' and 'name' attribute. For local authenticators and request path authenticators, the 'displayName' is considered as the 'name' attribute during filtering. The 'name' attribute only supports 'eq' and 'sw operations. Filtering with multiple 'name' attributes is not supported. The 'tag' attribute only supports 'eq' operation. Filtering with multiple 'tag' attributes is supported with only 'or' as the complex query operation. E.g. /configs/authenticators?filter=name+sw+fi+and+(tag+eq+2FA+or+tag+eq+MFA) ")  @QueryParam("filter") String filter) {
+    public Response authenticatorsGet(    @Valid@ApiParam(value = "Condition to filter the retrieval of records. Only supports filtering based on the 'tag' and 'name' attribute. For local authenticators and request path authenticators, the 'displayName' is considered as the 'name' attribute during filtering. The 'name' attribute only supports 'eq' and 'sw operations. Filtering with multiple 'name' attributes is not supported. The 'tag' attribute only supports 'eq' operation. Filtering with multiple 'tag' attributes is supported with only 'or' as the complex query operation. E.g. /configs/authenticators?filter=name+sw+fi+and+(tag+eq+2FA+or+tag+eq+MFA) ")  @QueryParam("filter") String filter,     @Valid @Min(0)@ApiParam(value = "Maximum number of records to return. _<b>This option is not yet supported.<b>_ ")  @QueryParam("limit") Integer limit,     @Valid @Min(0)@ApiParam(value = "Number of records to skip for pagination. _<b>This option is not yet supported.<b>_ ")  @QueryParam("offset") Integer offset) {
 
-        return delegate.authenticatorsGet(filter );
+        return delegate.authenticatorsGet(filter,  limit,  offset );
     }
 
     @Valid

--- a/components/org.wso2.carbon.identity.api.server.authenticators/org.wso2.carbon.identity.api.server.authenticators.v1/src/gen/java/org/wso2/carbon/identity/api/server/authenticators/v1/AuthenticatorsApiService.java
+++ b/components/org.wso2.carbon.identity.api.server.authenticators/org.wso2.carbon.identity.api.server.authenticators.v1/src/gen/java/org/wso2/carbon/identity/api/server/authenticators/v1/AuthenticatorsApiService.java
@@ -1,0 +1,35 @@
+/*
+* Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package org.wso2.carbon.identity.api.server.authenticators.v1;
+
+import org.wso2.carbon.identity.api.server.authenticators.v1.*;
+import org.wso2.carbon.identity.api.server.authenticators.v1.model.*;
+import org.apache.cxf.jaxrs.ext.multipart.Attachment;
+import org.apache.cxf.jaxrs.ext.multipart.Multipart;
+import java.io.InputStream;
+import java.util.List;
+import org.wso2.carbon.identity.api.server.authenticators.v1.model.Authenticator;
+import org.wso2.carbon.identity.api.server.authenticators.v1.model.Error;
+import javax.ws.rs.core.Response;
+
+
+public interface AuthenticatorsApiService {
+
+      public Response authenticatorsGet(String filter);
+
+      public Response authenticatorsMetaTagsGet();
+}

--- a/components/org.wso2.carbon.identity.api.server.authenticators/org.wso2.carbon.identity.api.server.authenticators.v1/src/gen/java/org/wso2/carbon/identity/api/server/authenticators/v1/AuthenticatorsApiService.java
+++ b/components/org.wso2.carbon.identity.api.server.authenticators/org.wso2.carbon.identity.api.server.authenticators.v1/src/gen/java/org/wso2/carbon/identity/api/server/authenticators/v1/AuthenticatorsApiService.java
@@ -29,7 +29,7 @@ import javax.ws.rs.core.Response;
 
 public interface AuthenticatorsApiService {
 
-      public Response authenticatorsGet(String filter);
+      public Response authenticatorsGet(String filter, Integer limit, Integer offset);
 
       public Response authenticatorsMetaTagsGet();
 }

--- a/components/org.wso2.carbon.identity.api.server.authenticators/org.wso2.carbon.identity.api.server.authenticators.v1/src/gen/java/org/wso2/carbon/identity/api/server/authenticators/v1/factories/AuthenticatorsApiServiceFactory.java
+++ b/components/org.wso2.carbon.identity.api.server.authenticators/org.wso2.carbon.identity.api.server.authenticators.v1/src/gen/java/org/wso2/carbon/identity/api/server/authenticators/v1/factories/AuthenticatorsApiServiceFactory.java
@@ -1,0 +1,30 @@
+/*
+* Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package org.wso2.carbon.identity.api.server.authenticators.v1.factories;
+
+import org.wso2.carbon.identity.api.server.authenticators.v1.AuthenticatorsApiService;
+import org.wso2.carbon.identity.api.server.authenticators.v1.impl.AuthenticatorsApiServiceImpl;
+
+public class AuthenticatorsApiServiceFactory {
+
+   private final static AuthenticatorsApiService service = new AuthenticatorsApiServiceImpl();
+
+   public static AuthenticatorsApiService getAuthenticatorsApi()
+   {
+      return service;
+   }
+}

--- a/components/org.wso2.carbon.identity.api.server.authenticators/org.wso2.carbon.identity.api.server.authenticators.v1/src/gen/java/org/wso2/carbon/identity/api/server/authenticators/v1/model/Authenticator.java
+++ b/components/org.wso2.carbon.identity.api.server.authenticators/org.wso2.carbon.identity.api.server.authenticators.v1/src/gen/java/org/wso2/carbon/identity/api/server/authenticators/v1/model/Authenticator.java
@@ -1,0 +1,287 @@
+/*
+* Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package org.wso2.carbon.identity.api.server.authenticators.v1.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import java.util.ArrayList;
+import java.util.List;
+import javax.validation.constraints.*;
+
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+import javax.validation.Valid;
+import javax.xml.bind.annotation.*;
+
+public class Authenticator  {
+  
+    private String id;
+    private String name;
+    private String displayName;
+    private Boolean isEnabled;
+
+@XmlType(name="TypeEnum")
+@XmlEnum(String.class)
+public enum TypeEnum {
+
+    @XmlEnumValue("LOCAL") LOCAL(String.valueOf("LOCAL")), @XmlEnumValue("FEDERATED") FEDERATED(String.valueOf("FEDERATED"));
+
+
+    private String value;
+
+    TypeEnum(String v) {
+        value = v;
+    }
+
+    public String value() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    public static TypeEnum fromValue(String value) {
+        for (TypeEnum b : TypeEnum.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
+}
+
+    private TypeEnum type;
+    private String image;
+    private List<String> tags = null;
+
+    private String self;
+
+    /**
+    **/
+    public Authenticator id(String id) {
+
+        this.id = id;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "QmFzaWNBdXRoZW50aWNhdG9y", value = "")
+    @JsonProperty("id")
+    @Valid
+    public String getId() {
+        return id;
+    }
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    /**
+    **/
+    public Authenticator name(String name) {
+
+        this.name = name;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "BasicAuthenticator", value = "")
+    @JsonProperty("name")
+    @Valid
+    public String getName() {
+        return name;
+    }
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    /**
+    **/
+    public Authenticator displayName(String displayName) {
+
+        this.displayName = displayName;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "basic", value = "")
+    @JsonProperty("displayName")
+    @Valid
+    public String getDisplayName() {
+        return displayName;
+    }
+    public void setDisplayName(String displayName) {
+        this.displayName = displayName;
+    }
+
+    /**
+    **/
+    public Authenticator isEnabled(Boolean isEnabled) {
+
+        this.isEnabled = isEnabled;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "true", value = "")
+    @JsonProperty("isEnabled")
+    @Valid
+    public Boolean getIsEnabled() {
+        return isEnabled;
+    }
+    public void setIsEnabled(Boolean isEnabled) {
+        this.isEnabled = isEnabled;
+    }
+
+    /**
+    **/
+    public Authenticator type(TypeEnum type) {
+
+        this.type = type;
+        return this;
+    }
+    
+    @ApiModelProperty(value = "")
+    @JsonProperty("type")
+    @Valid
+    public TypeEnum getType() {
+        return type;
+    }
+    public void setType(TypeEnum type) {
+        this.type = type;
+    }
+
+    /**
+    **/
+    public Authenticator image(String image) {
+
+        this.image = image;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "basic-authenticator-logo-url", value = "")
+    @JsonProperty("image")
+    @Valid
+    public String getImage() {
+        return image;
+    }
+    public void setImage(String image) {
+        this.image = image;
+    }
+
+    /**
+    **/
+    public Authenticator tags(List<String> tags) {
+
+        this.tags = tags;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "[\"2FA\",\"MFA\"]", value = "")
+    @JsonProperty("tags")
+    @Valid
+    public List<String> getTags() {
+        return tags;
+    }
+    public void setTags(List<String> tags) {
+        this.tags = tags;
+    }
+
+    public Authenticator addTagsItem(String tagsItem) {
+        if (this.tags == null) {
+            this.tags = new ArrayList<>();
+        }
+        this.tags.add(tagsItem);
+        return this;
+    }
+
+        /**
+    **/
+    public Authenticator self(String self) {
+
+        this.self = self;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "/t/carbon.super/api/server/v1/configs/authenticators/eDUwOUNlcnRpZmljYXRlQXV0aGVudGljYXRvcg", value = "")
+    @JsonProperty("self")
+    @Valid
+    public String getSelf() {
+        return self;
+    }
+    public void setSelf(String self) {
+        this.self = self;
+    }
+
+
+
+    @Override
+    public boolean equals(java.lang.Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Authenticator authenticator = (Authenticator) o;
+        return Objects.equals(this.id, authenticator.id) &&
+            Objects.equals(this.name, authenticator.name) &&
+            Objects.equals(this.displayName, authenticator.displayName) &&
+            Objects.equals(this.isEnabled, authenticator.isEnabled) &&
+            Objects.equals(this.type, authenticator.type) &&
+            Objects.equals(this.image, authenticator.image) &&
+            Objects.equals(this.tags, authenticator.tags) &&
+            Objects.equals(this.self, authenticator.self);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, name, displayName, isEnabled, type, image, tags, self);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class Authenticator {\n");
+        
+        sb.append("    id: ").append(toIndentedString(id)).append("\n");
+        sb.append("    name: ").append(toIndentedString(name)).append("\n");
+        sb.append("    displayName: ").append(toIndentedString(displayName)).append("\n");
+        sb.append("    isEnabled: ").append(toIndentedString(isEnabled)).append("\n");
+        sb.append("    type: ").append(toIndentedString(type)).append("\n");
+        sb.append("    image: ").append(toIndentedString(image)).append("\n");
+        sb.append("    tags: ").append(toIndentedString(tags)).append("\n");
+        sb.append("    self: ").append(toIndentedString(self)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+    * Convert the given object to string with each line indented by 4 spaces
+    * (except the first line).
+    */
+    private String toIndentedString(java.lang.Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}
+

--- a/components/org.wso2.carbon.identity.api.server.authenticators/org.wso2.carbon.identity.api.server.authenticators.v1/src/gen/java/org/wso2/carbon/identity/api/server/authenticators/v1/model/Error.java
+++ b/components/org.wso2.carbon.identity.api.server.authenticators/org.wso2.carbon.identity.api.server.authenticators.v1/src/gen/java/org/wso2/carbon/identity/api/server/authenticators/v1/model/Error.java
@@ -1,0 +1,167 @@
+/*
+* Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package org.wso2.carbon.identity.api.server.authenticators.v1.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import javax.validation.constraints.*;
+
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+import javax.validation.Valid;
+import javax.xml.bind.annotation.*;
+
+public class Error  {
+  
+    private String code;
+    private String message;
+    private String description;
+    private String traceId;
+
+    /**
+    * An error code.
+    **/
+    public Error code(String code) {
+
+        this.code = code;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "AAA-00000", required = true, value = "An error code.")
+    @JsonProperty("code")
+    @Valid
+    @NotNull(message = "Property code cannot be null.")
+
+    public String getCode() {
+        return code;
+    }
+    public void setCode(String code) {
+        this.code = code;
+    }
+
+    /**
+    * An error message.
+    **/
+    public Error message(String message) {
+
+        this.message = message;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "Some Error Message", required = true, value = "An error message.")
+    @JsonProperty("message")
+    @Valid
+    @NotNull(message = "Property message cannot be null.")
+
+    public String getMessage() {
+        return message;
+    }
+    public void setMessage(String message) {
+        this.message = message;
+    }
+
+    /**
+    * An error description.
+    **/
+    public Error description(String description) {
+
+        this.description = description;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "Some Error Description", value = "An error description.")
+    @JsonProperty("description")
+    @Valid
+    public String getDescription() {
+        return description;
+    }
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    /**
+    * An error trace identifier.
+    **/
+    public Error traceId(String traceId) {
+
+        this.traceId = traceId;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "e0fbcfeb-3617-43c4-8dd0-7b7d38e13047", value = "An error trace identifier.")
+    @JsonProperty("traceId")
+    @Valid
+    public String getTraceId() {
+        return traceId;
+    }
+    public void setTraceId(String traceId) {
+        this.traceId = traceId;
+    }
+
+
+
+    @Override
+    public boolean equals(java.lang.Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Error error = (Error) o;
+        return Objects.equals(this.code, error.code) &&
+            Objects.equals(this.message, error.message) &&
+            Objects.equals(this.description, error.description) &&
+            Objects.equals(this.traceId, error.traceId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(code, message, description, traceId);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class Error {\n");
+        
+        sb.append("    code: ").append(toIndentedString(code)).append("\n");
+        sb.append("    message: ").append(toIndentedString(message)).append("\n");
+        sb.append("    description: ").append(toIndentedString(description)).append("\n");
+        sb.append("    traceId: ").append(toIndentedString(traceId)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+    * Convert the given object to string with each line indented by 4 spaces
+    * (except the first line).
+    */
+    private String toIndentedString(java.lang.Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}
+

--- a/components/org.wso2.carbon.identity.api.server.authenticators/org.wso2.carbon.identity.api.server.authenticators.v1/src/gen/java/org/wso2/carbon/identity/api/server/authenticators/v1/model/Error.java
+++ b/components/org.wso2.carbon.identity.api.server.authenticators/org.wso2.carbon.identity.api.server.authenticators.v1/src/gen/java/org/wso2/carbon/identity/api/server/authenticators/v1/model/Error.java
@@ -44,7 +44,7 @@ public class Error  {
         return this;
     }
     
-    @ApiModelProperty(example = "AAA-00000", required = true, value = "An error code.")
+    @ApiModelProperty(example = "AUT-00000", required = true, value = "An error code.")
     @JsonProperty("code")
     @Valid
     @NotNull(message = "Property code cannot be null.")

--- a/components/org.wso2.carbon.identity.api.server.authenticators/org.wso2.carbon.identity.api.server.authenticators.v1/src/main/java/org/wso2/carbon/identity/api/server/authenticators/v1/core/ServerAuthenticatorManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.authenticators/org.wso2.carbon.identity.api.server.authenticators.v1/src/main/java/org/wso2/carbon/identity/api/server/authenticators/v1/core/ServerAuthenticatorManagementService.java
@@ -100,7 +100,11 @@ public class ServerAuthenticatorManagementService {
 
             int localAuthenticatorsCount = localAuthenticatorConfigs.length;
             RequestPathAuthenticatorConfig[] requestPathAuthenticatorConfigs = new RequestPathAuthenticatorConfig[0];
-            if (localAuthenticatorsCount < maximumItemPerPage) {
+
+            /* If there is no filter string available in the request, the request path authenticators are required to
+            be fetched only if the  no. of local authenticators retrieved are less than the maximum items per page
+            count as the no. of items returned in the response will be capped at the maximum items per page count. */
+            if (StringUtils.isBlank(filter) && localAuthenticatorsCount < maximumItemPerPage) {
                 requestPathAuthenticatorConfigs = AuthenticatorsServiceHolder.getInstance()
                         .getApplicationManagementService().getAllRequestPathAuthenticators(ContextLoader
                                 .getTenantDomainFromContext());
@@ -113,6 +117,10 @@ public class ServerAuthenticatorManagementService {
                     requestPathAuthenticatorConfigs.length);
             List<IdentityProvider> identityProviders = null;
 
+            /* If there is no filter string available in the request, the identity providers are required to
+            be fetched only if the total of local authenticators and request path authenticators retrieved above is
+            less than the maximum items per page count as the no. of items returned in the response will be capped
+            at the maximum items per page count. */
             if (idPCountToBeRetrieved > 0 && StringUtils.isBlank(filter)) {
                 IdpSearchResult idpSearchResult = AuthenticatorsServiceHolder.getInstance().getIdentityProviderManager()
                         .getIdPs(idPCountToBeRetrieved, null, null, null, null,

--- a/components/org.wso2.carbon.identity.api.server.authenticators/org.wso2.carbon.identity.api.server.authenticators.v1/src/main/java/org/wso2/carbon/identity/api/server/authenticators/v1/core/ServerAuthenticatorManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.authenticators/org.wso2.carbon.identity.api.server.authenticators.v1/src/main/java/org/wso2/carbon/identity/api/server/authenticators/v1/core/ServerAuthenticatorManagementService.java
@@ -1,0 +1,865 @@
+/*
+ * Copyright (c) 2021 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.authenticators.v1.core;
+
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.lang.ArrayUtils;
+import org.apache.commons.lang.StringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.identity.api.server.authenticators.common.AuthenticatorsServiceHolder;
+import org.wso2.carbon.identity.api.server.authenticators.common.Constants;
+import org.wso2.carbon.identity.api.server.authenticators.v1.model.Authenticator;
+import org.wso2.carbon.identity.api.server.authenticators.v1.model.NameFilter;
+import org.wso2.carbon.identity.api.server.common.ContextLoader;
+import org.wso2.carbon.identity.api.server.common.error.APIError;
+import org.wso2.carbon.identity.api.server.common.error.ErrorResponse;
+import org.wso2.carbon.identity.application.common.ApplicationAuthenticatorService;
+import org.wso2.carbon.identity.application.common.IdentityApplicationManagementClientException;
+import org.wso2.carbon.identity.application.common.IdentityApplicationManagementException;
+import org.wso2.carbon.identity.application.common.IdentityApplicationManagementServerException;
+import org.wso2.carbon.identity.application.common.model.FederatedAuthenticatorConfig;
+import org.wso2.carbon.identity.application.common.model.IdentityProvider;
+import org.wso2.carbon.identity.application.common.model.LocalAuthenticatorConfig;
+import org.wso2.carbon.identity.application.common.model.RequestPathAuthenticatorConfig;
+import org.wso2.carbon.identity.base.IdentityException;
+import org.wso2.carbon.identity.core.model.ExpressionNode;
+import org.wso2.carbon.identity.core.model.FilterTreeBuilder;
+import org.wso2.carbon.identity.core.model.Node;
+import org.wso2.carbon.identity.core.model.OperationNode;
+import org.wso2.carbon.identity.core.util.IdentityUtil;
+import org.wso2.carbon.idp.mgt.IdentityProviderManagementClientException;
+import org.wso2.carbon.idp.mgt.IdentityProviderManagementException;
+import org.wso2.carbon.idp.mgt.IdentityProviderManagementServerException;
+import org.wso2.carbon.idp.mgt.model.IdpSearchResult;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+import javax.ws.rs.core.Response;
+
+import static org.wso2.carbon.identity.api.server.common.Util.base64URLEncode;
+
+/**
+ * Call internal osgi services to perform server authenticators related operations.
+ */
+public class ServerAuthenticatorManagementService {
+
+    private static final Log log = LogFactory.getLog(ServerAuthenticatorManagementService.class);
+
+    /**
+     * Retrieves the list of available authenticators.
+     *
+     * @param filter The filter string
+     * @return The list of authenticators
+     */
+    public List<Authenticator> getAuthenticators(String filter) {
+
+        try {
+            String filterAuthenticatorName = null;
+            String filterOperationForName = null;
+            ArrayList<String> filterTagsList = null;
+            int maximumItemPerPage = IdentityUtil.getMaximumItemPerPage();
+            if (StringUtils.isNotBlank(filter)) {
+                List<ExpressionNode> expressionNodes = getExpressionNodesForAuthenticator(filter);
+                if (CollectionUtils.isNotEmpty(expressionNodes)) {
+                    NameFilter nameFilter = getFilterAuthenticatorNameAndOperation(expressionNodes);
+                    if (nameFilter != null) {
+                        filterAuthenticatorName = nameFilter.getName();
+                        filterOperationForName = nameFilter.getOperation();
+                    }
+                    filterTagsList = getFilterTagsList(expressionNodes);
+                }
+            }
+
+            LocalAuthenticatorConfig[] localAuthenticatorConfigs = AuthenticatorsServiceHolder.getInstance()
+                    .getApplicationManagementService().getAllLocalAuthenticators(ContextLoader
+                            .getTenantDomainFromContext());
+
+            int localAuthenticatorsCount = localAuthenticatorConfigs.length;
+            RequestPathAuthenticatorConfig[] requestPathAuthenticatorConfigs = new RequestPathAuthenticatorConfig[0];
+            if (localAuthenticatorsCount < maximumItemPerPage) {
+                requestPathAuthenticatorConfigs = AuthenticatorsServiceHolder.getInstance()
+                        .getApplicationManagementService().getAllRequestPathAuthenticators(ContextLoader
+                                .getTenantDomainFromContext());
+            }
+
+            List<String> requestedAttributeList = new ArrayList<>();
+            requestedAttributeList.add(Constants.FEDERATED_AUTHENTICATORS);
+
+            int idPCountToBeRetrieved = maximumItemPerPage - (localAuthenticatorsCount +
+                    requestPathAuthenticatorConfigs.length);
+            List<IdentityProvider> identityProviders = null;
+
+            if (idPCountToBeRetrieved > 0 && StringUtils.isBlank(filter)) {
+                IdpSearchResult idpSearchResult = AuthenticatorsServiceHolder.getInstance().getIdentityProviderManager()
+                        .getIdPs(idPCountToBeRetrieved, null, null, null, null,
+                                ContextLoader.getTenantDomainFromContext(), requestedAttributeList);
+                identityProviders = idpSearchResult.getIdPs();
+            }
+
+            return buildAuthenticatorsListResponse(filter, requestedAttributeList, filterAuthenticatorName,
+                    filterOperationForName, filterTagsList, localAuthenticatorConfigs, requestPathAuthenticatorConfigs,
+                    identityProviders);
+        } catch (IdentityApplicationManagementException e) {
+            throw handleApplicationMgtException(e, Constants.ErrorMessage.ERROR_CODE_ERROR_LISTING_AUTHENTICATORS,
+                    null);
+        } catch (IdentityProviderManagementException e) {
+            throw handleIdPException(e, Constants.ErrorMessage.ERROR_CODE_ERROR_LISTING_IDPS, null);
+        }
+    }
+
+    /**
+     * Retrieves the list of tags defined for the authenticators.
+     *
+     * @return The list of tags.
+     */
+    public List<String> getTags() {
+
+        try {
+            LocalAuthenticatorConfig[] localAuthenticatorConfigs = AuthenticatorsServiceHolder.getInstance()
+                    .getApplicationManagementService().getAllLocalAuthenticators(ContextLoader
+                            .getTenantDomainFromContext());
+
+            RequestPathAuthenticatorConfig[] requestPathAuthenticatorConfigs = AuthenticatorsServiceHolder.getInstance()
+                    .getApplicationManagementService().getAllRequestPathAuthenticators(ContextLoader
+                            .getTenantDomainFromContext());
+
+            List<String> requestedAttributeList = new ArrayList<>();
+            requestedAttributeList.add(Constants.FEDERATED_AUTHENTICATORS);
+
+            int limit;
+            int offSet = 0;
+            int totalIdpCount;
+
+            List<IdentityProvider> identityProviders = new ArrayList<>();
+            do {
+                IdpSearchResult idpSearchResult = AuthenticatorsServiceHolder.getInstance().getIdentityProviderManager()
+                        .getIdPs(IdentityUtil.getMaximumItemPerPage(), offSet, null, null, null,
+                                ContextLoader.getTenantDomainFromContext(), requestedAttributeList);
+                identityProviders.addAll(idpSearchResult.getIdPs());
+                limit = idpSearchResult.getLimit();
+                totalIdpCount = idpSearchResult.getTotalIDPCount();
+                offSet = idpSearchResult.getOffSet() + limit;
+            } while (limit > 0 && offSet >= 0 && totalIdpCount > offSet);
+
+            return buildTagsListResponse(localAuthenticatorConfigs, requestPathAuthenticatorConfigs, identityProviders);
+        } catch (IdentityApplicationManagementException e) {
+            throw handleApplicationMgtException(e, Constants.ErrorMessage.ERROR_CODE_ERROR_LISTING_AUTHENTICATORS,
+                    null);
+        } catch (IdentityProviderManagementException e) {
+            throw handleIdPException(e, Constants.ErrorMessage.ERROR_CODE_ERROR_LISTING_IDPS, null);
+        }
+    }
+
+    private List<Authenticator> buildAuthenticatorsListResponse(String filter, List<String> requestedAttributeList,
+                                                                String localAuthNames,
+                                                                String authenticatorNameFilterOperator,
+                                                                ArrayList<String> filterTagsList,
+                                                                LocalAuthenticatorConfig[] localAuthenticatorConfigs,
+                                                                RequestPathAuthenticatorConfig[]
+                                                                        requestPathAuthenticatorConfigs,
+                                                                List<IdentityProvider> identityProviders) {
+
+        int maximumItemsPerPage = IdentityUtil.getMaximumItemPerPage();
+
+        List<Authenticator> authenticators = new ArrayList<>();
+        if (localAuthenticatorConfigs != null) {
+            for (LocalAuthenticatorConfig config : localAuthenticatorConfigs) {
+                addLocalAuthenticator(config, authenticators, localAuthNames, authenticatorNameFilterOperator,
+                        filterTagsList, maximumItemsPerPage);
+            }
+        }
+
+        if ((authenticators.size() < maximumItemsPerPage) && requestPathAuthenticatorConfigs != null) {
+            for (RequestPathAuthenticatorConfig config : requestPathAuthenticatorConfigs) {
+                addLocalAuthenticator(config, authenticators, localAuthNames, authenticatorNameFilterOperator,
+                        filterTagsList, maximumItemsPerPage);
+            }
+        }
+
+        if (StringUtils.isBlank(filter)) {
+            if ((authenticators.size() < maximumItemsPerPage) && identityProviders != null) {
+                for (IdentityProvider identityProvider : identityProviders) {
+                    if (authenticators.size() < maximumItemsPerPage) {
+                        List<String> configTagsListDistinct = getDistinctTags(identityProvider);
+                        addIdp(identityProvider, authenticators, configTagsListDistinct);
+                    }
+                }
+            }
+        } else {
+            List<ExpressionNode> expressionNodesForIdp = getExpressionNodesForIdp(filter);
+            int idPCountToBeRetrieved = maximumItemsPerPage - authenticators.size();
+            IdpSearchResult idpSearchResult;
+            try {
+                idpSearchResult = AuthenticatorsServiceHolder.getInstance().getIdentityProviderManager()
+                        .getIdPs(idPCountToBeRetrieved, null, null, null,
+                                ContextLoader.getTenantDomainFromContext(), requestedAttributeList,
+                                expressionNodesForIdp);
+                identityProviders = idpSearchResult.getIdPs();
+                if (identityProviders != null) {
+                    addIdPsToAuthenticatorList(maximumItemsPerPage, identityProviders, authenticators,
+                            filterTagsList);
+                    int limit = idpSearchResult.getLimit();
+                    int offSet = idpSearchResult.getOffSet();
+                    int totalIdpCount = idpSearchResult.getTotalIDPCount();
+                    while (authenticators.size() < maximumItemsPerPage && limit > 0 && offSet >= 0 &&
+                            totalIdpCount > (limit + offSet)) {
+                        identityProviders = new ArrayList<>();
+                        getFilteredIdPs(limit, offSet, requestedAttributeList, identityProviders,
+                                expressionNodesForIdp);
+                        addIdPsToAuthenticatorList(maximumItemsPerPage, identityProviders, authenticators,
+                                filterTagsList);
+                        offSet = offSet + limit;
+                    }
+                }
+            } catch (IdentityProviderManagementException e) {
+                throw handleIdPException(e, Constants.ErrorMessage.ERROR_CODE_ERROR_LISTING_IDPS, null);
+            }
+        }
+        return authenticators;
+    }
+
+    private void addIdPsToAuthenticatorList(int maximumItemsPerPage, List<IdentityProvider> identityProviders,
+                                            List<Authenticator> authenticators, ArrayList<String> filterTagsList) {
+
+        for (IdentityProvider identityProvider : identityProviders) {
+            if (authenticators.size() < maximumItemsPerPage) {
+                List<String> configTagsListDistinct = getDistinctTags(identityProvider);
+                if (CollectionUtils.isNotEmpty(filterTagsList) &&
+                        CollectionUtils.isNotEmpty(configTagsListDistinct)) {
+                    boolean tagFound = false;
+                    for (String filterTag : filterTagsList) {
+                        if (tagFound) {
+                            break;
+                        }
+                        for (String configTag : configTagsListDistinct) {
+                            if (StringUtils.equalsIgnoreCase(configTag, filterTag)) {
+                                addIdp(identityProvider, authenticators, configTagsListDistinct);
+                                tagFound = true;
+                                break;
+                            }
+                        }
+                    }
+                } else if (CollectionUtils.isEmpty(filterTagsList)) {
+                    addIdp(identityProvider, authenticators, configTagsListDistinct);
+                }
+            }
+        }
+    }
+
+    /**
+     * Retrieves a distinct list of tags defined for the federated authenticators of an identity provider.
+     *
+     * @param identityProvider The identity provider.
+     * @return A distinct list of tags defined for the federated authenticators of an identity provider.
+     */
+    private List<String> getDistinctTags(IdentityProvider identityProvider) {
+
+        ArrayList<String> tagsList = new ArrayList<>();
+
+        FederatedAuthenticatorConfig[] fedAuthConfigs = identityProvider
+                .getFederatedAuthenticatorConfigs();
+        if (fedAuthConfigs != null) {
+            for (FederatedAuthenticatorConfig config : fedAuthConfigs) {
+                if (config.isEnabled()) {
+                    FederatedAuthenticatorConfig federatedAuthenticatorConfig =
+                            ApplicationAuthenticatorService.getInstance()
+                                    .getFederatedAuthenticatorByName(config.getName());
+                    if (federatedAuthenticatorConfig != null) {
+                        String[] tags = federatedAuthenticatorConfig.getTags();
+                        if (ArrayUtils.isNotEmpty(tags)) {
+                            tagsList.addAll(Arrays.asList(tags));
+                        }
+                    }
+                }
+            }
+            return tagsList.stream().distinct().collect(Collectors.toList());
+        }
+        return null;
+    }
+
+    /**
+     * Adds the identity provider to the list of authenticators.
+     *
+     * @param identityProvider       The identity provider.
+     * @param authenticators         The list of authenticators.
+     * @param configTagsListDistinct The distinct list of tags available for the identity provider.
+     */
+    private void addIdp(IdentityProvider identityProvider, List<Authenticator> authenticators,
+                        List<String> configTagsListDistinct) {
+
+        Authenticator authenticator = new Authenticator();
+        authenticator.setId(identityProvider.getResourceId());
+        authenticator.setName(identityProvider.getIdentityProviderName());
+        String displayName = identityProvider.getDisplayName();
+        if (StringUtils.isNotBlank(displayName)) {
+            authenticator.setDisplayName(identityProvider.getIdentityProviderName());
+        } else {
+            authenticator.setDisplayName(identityProvider.getDisplayName());
+        }
+        authenticator.setIsEnabled(identityProvider.isEnable());
+        authenticator.setType(Authenticator.TypeEnum.FEDERATED);
+        if (CollectionUtils.isNotEmpty(configTagsListDistinct)) {
+            authenticator.setTags(configTagsListDistinct);
+        }
+        authenticators.add(authenticator);
+        authenticator.setSelf(ContextLoader.buildURIForBody(
+                String.format("/v1/identity-providers/%s", identityProvider.getResourceId())).toString());
+    }
+
+    /**
+     * Adds the local authenticator to the list of authenticators.
+     *
+     * @param config                          The local authenticator configuration.
+     * @param authenticators                  The list of authenticators.
+     * @param filterAuthenticatorName         The authenticator name passed in the filter string.
+     * @param authenticatorNameFilterOperator The filter operator passed for the authenticator name in the filter
+     *                                        string.
+     * @param tagsList                        The list of tags available for the local authenticator.
+     * @param maximumItemsPerPage             The defined maximum items per page limit.
+     */
+    private void addLocalAuthenticator(LocalAuthenticatorConfig config, List<Authenticator> authenticators,
+                                       String filterAuthenticatorName, String authenticatorNameFilterOperator,
+                                       ArrayList<String> tagsList, int maximumItemsPerPage) {
+
+        if (authenticators.size() < maximumItemsPerPage) {
+
+            // For local authenticators and request path authenticators, the 'displayName' is considered as the
+            // 'name' attribute during filtering.
+            if (StringUtils.isNotBlank(filterAuthenticatorName) && CollectionUtils.isNotEmpty(tagsList) &&
+                    ((StringUtils.equalsIgnoreCase(authenticatorNameFilterOperator, Constants.FilterOperations.SW) &&
+                            StringUtils.startsWithIgnoreCase(config.getDisplayName(), filterAuthenticatorName)) ||
+                            (StringUtils.equalsIgnoreCase(authenticatorNameFilterOperator,
+                                    Constants.FilterOperations.EQ) &&
+                                    StringUtils.equalsIgnoreCase(config.getDisplayName(), filterAuthenticatorName)))) {
+                filterTags(config, authenticators, tagsList);
+            } else if (StringUtils.isNotBlank(filterAuthenticatorName)) {
+                if (StringUtils.equalsIgnoreCase(authenticatorNameFilterOperator, Constants.FilterOperations.SW) &&
+                        StringUtils.startsWithIgnoreCase(config.getDisplayName(), filterAuthenticatorName)) {
+                    Authenticator authenticator = addLocalAuthenticator(config);
+                    authenticators.add(authenticator);
+                } else if (StringUtils.equalsIgnoreCase(authenticatorNameFilterOperator, Constants.FilterOperations.EQ)
+                        && StringUtils.equalsIgnoreCase(config.getDisplayName(), filterAuthenticatorName)) {
+                    Authenticator authenticator = addLocalAuthenticator(config);
+                    authenticators.add(authenticator);
+                }
+            } else if (CollectionUtils.isNotEmpty(tagsList)) {
+                filterTags(config, authenticators, tagsList);
+            } else {
+                Authenticator authenticator = addLocalAuthenticator(config);
+                authenticators.add(authenticator);
+            }
+        }
+    }
+
+    /**
+     * Adds local authenticator to the list of authenticators if it satisfies the given filter.
+     *
+     * @param config         The local authenticator configuration.
+     * @param authenticators The list of authenticators.
+     * @param filterTagsList The list of tags passed in the filter string.
+     */
+    private void filterTags(LocalAuthenticatorConfig config, List<Authenticator> authenticators,
+                            ArrayList<String> filterTagsList) {
+
+        boolean tagFound = false;
+        for (String filterTag : filterTagsList) {
+            if (tagFound) {
+                break;
+            }
+            String[] authenticatorConfigTags = config.getTags();
+            if (ArrayUtils.isNotEmpty(authenticatorConfigTags)) {
+                for (String tag : authenticatorConfigTags) {
+                    if (StringUtils.equalsIgnoreCase(tag, filterTag)) {
+                        Authenticator authenticator = addLocalAuthenticator(config);
+                        authenticators.add(authenticator);
+                        tagFound = true;
+                        break;
+                    }
+                }
+            }
+        }
+    }
+
+    private Authenticator addLocalAuthenticator(LocalAuthenticatorConfig config) {
+
+        Authenticator authenticator = new Authenticator();
+        String authenticatorId = base64URLEncode(config.getName());
+        authenticator.setId(authenticatorId);
+        authenticator.setName(config.getName());
+        authenticator.setDisplayName(config.getDisplayName());
+        authenticator.setIsEnabled(config.isEnabled());
+        authenticator.setType(Authenticator.TypeEnum.LOCAL);
+        String[] tags = config.getTags();
+        if (ArrayUtils.isNotEmpty(tags)) {
+            authenticator.setTags(Arrays.asList(tags));
+        }
+        authenticator.setSelf(ContextLoader.buildURIForBody
+                (String.format("/v1/configs/authenticators/%s", authenticatorId)).toString());
+        return authenticator;
+    }
+
+    private List<String> buildTagsListResponse(LocalAuthenticatorConfig[] localAuthenticatorConfigs,
+                                               RequestPathAuthenticatorConfig[] requestPathAuthenticatorConfigs,
+                                               List<IdentityProvider> identityProviders) {
+
+        ArrayList<String> tagsList = new ArrayList<>();
+        if (localAuthenticatorConfigs != null) {
+            for (LocalAuthenticatorConfig config : localAuthenticatorConfigs) {
+                String[] tags = config.getTags();
+                if (ArrayUtils.isNotEmpty(tags)) {
+                    tagsList.addAll(Arrays.asList(tags));
+                }
+            }
+        }
+        if (requestPathAuthenticatorConfigs != null) {
+            for (RequestPathAuthenticatorConfig config : requestPathAuthenticatorConfigs) {
+                String[] tags = config.getTags();
+                if (ArrayUtils.isNotEmpty(tags)) {
+                    tagsList.addAll(Arrays.asList(tags));
+                }
+            }
+        }
+        if (identityProviders != null) {
+            for (IdentityProvider identityProvider : identityProviders) {
+                FederatedAuthenticatorConfig[] fedAuthConfigs = identityProvider.getFederatedAuthenticatorConfigs();
+                if (fedAuthConfigs != null) {
+                    for (FederatedAuthenticatorConfig config : fedAuthConfigs) {
+                        if (config.isEnabled()) {
+                            FederatedAuthenticatorConfig federatedAuthenticatorConfig =
+                                    ApplicationAuthenticatorService.getInstance()
+                                            .getFederatedAuthenticatorByName(config.getName());
+                            if (federatedAuthenticatorConfig != null) {
+                                String[] tags = federatedAuthenticatorConfig.getTags();
+                                if (ArrayUtils.isNotEmpty(tags)) {
+                                    tagsList.addAll(Arrays.asList(tags));
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        return tagsList.stream().distinct().collect(Collectors.toList());
+    }
+
+    private List<ExpressionNode> getExpressionNodesForAuthenticator(String filter) {
+
+        // Filter example : name sw go and (tag eq 2fa or tag eq Social-Login)
+        List<ExpressionNode> expressionNodes = new ArrayList<>();
+        FilterTreeBuilder filterTreeBuilder;
+        try {
+            if (StringUtils.isNotBlank(filter)) {
+                filterTreeBuilder = new FilterTreeBuilder(filter);
+                Node rootNode = filterTreeBuilder.buildTree();
+                validateFilter(rootNode);
+                setExpressionNodeListForAuthenticator(rootNode, expressionNodes);
+            }
+        } catch (IOException | IdentityException e) {
+            throw buildClientError(Constants.ErrorMessage.ERROR_CODE_INVALID_FILTER_FORMAT, null);
+        }
+        return expressionNodes;
+    }
+
+    private void validateFilter(Node rootNode) {
+
+        if (!(rootNode instanceof OperationNode)) {
+
+            String attributeValue = ((ExpressionNode) rootNode).getAttributeValue();
+            String operation = ((ExpressionNode) rootNode).getOperation();
+
+            if (StringUtils.equalsIgnoreCase(attributeValue, Constants.FilterAttributes.NAME)) {
+                if (StringUtils.equalsIgnoreCase(operation, Constants.FilterOperations.SW) ||
+                        StringUtils.equalsIgnoreCase(operation, Constants.FilterOperations.EQ)) {
+                    return;
+                } else {
+                    throw handleException(Response.Status.NOT_IMPLEMENTED,
+                            Constants.ErrorMessage.ERROR_CODE_UNSUPPORTED_FILTER_OPERATION_FOR_NAME, operation);
+                }
+            } else if (StringUtils.equalsIgnoreCase(attributeValue, Constants.FilterAttributes.TAG)) {
+                if (StringUtils.equalsIgnoreCase(operation, Constants.FilterOperations.EQ)) {
+                    return;
+                } else {
+                    throw handleException(Response.Status.NOT_IMPLEMENTED,
+                            Constants.ErrorMessage.ERROR_CODE_UNSUPPORTED_FILTER_OPERATION_FOR_TAG, operation);
+                }
+            } else {
+                throw buildClientError(Constants.ErrorMessage.ERROR_CODE_UNSUPPORTED_FILTER_ATTRIBUTE, attributeValue);
+            }
+        }
+
+        Node rootNodeLeftNode = rootNode.getLeftNode();
+        Node rootNodeRightNode = rootNode.getRightNode();
+        boolean nameFiltering = false;
+        boolean tagAvailableInLeftNode = false;
+        boolean tagAvailableInRightNode = false;
+
+        if (rootNodeLeftNode instanceof ExpressionNode) {
+            String attributeValue = ((ExpressionNode) rootNodeLeftNode).getAttributeValue();
+            nameFiltering = attributeValue.equals(Constants.FilterAttributes.NAME);
+            tagAvailableInLeftNode = attributeValue.equals(Constants.FilterAttributes.TAG);
+
+            if (!(nameFiltering || tagAvailableInLeftNode)) {
+                throw buildClientError(Constants.ErrorMessage.ERROR_CODE_UNSUPPORTED_FILTER_ATTRIBUTE, attributeValue);
+            }
+            String operation = ((ExpressionNode) rootNodeLeftNode).getOperation();
+
+            if (nameFiltering && (!(StringUtils.equalsIgnoreCase(operation, Constants.FilterOperations.SW) ||
+                    StringUtils.equalsIgnoreCase(operation, Constants.FilterOperations.EQ)))) {
+                throw handleException(Response.Status.NOT_IMPLEMENTED,
+                        Constants.ErrorMessage.ERROR_CODE_UNSUPPORTED_FILTER_OPERATION_FOR_NAME, operation);
+            }
+
+            if (tagAvailableInLeftNode && !StringUtils.equalsIgnoreCase(operation, Constants.FilterOperations.EQ)) {
+                throw handleException(Response.Status.NOT_IMPLEMENTED,
+                        Constants.ErrorMessage.ERROR_CODE_UNSUPPORTED_FILTER_OPERATION_FOR_TAG, operation);
+            }
+        } else {
+            validateChildNode(rootNodeLeftNode);
+        }
+
+        if (rootNodeRightNode instanceof ExpressionNode) {
+            String attributeValue = ((ExpressionNode) rootNodeRightNode).getAttributeValue();
+            tagAvailableInRightNode = attributeValue.equals(Constants.FilterAttributes.TAG);
+            boolean nameAvailableInRightNode = attributeValue.equals(Constants.FilterAttributes.NAME);
+
+            if (!(tagAvailableInRightNode || nameAvailableInRightNode)) {
+                throw buildClientError(Constants.ErrorMessage.ERROR_CODE_UNSUPPORTED_FILTER_ATTRIBUTE, attributeValue);
+            }
+
+            if (nameFiltering && nameAvailableInRightNode) {
+                throw handleException(Response.Status.NOT_IMPLEMENTED,
+                        Constants.ErrorMessage.ERROR_CODE_UNSUPPORTED_FILTER_FOR_MULTIPLE_NAMES, null);
+            }
+
+            String operation = ((ExpressionNode) rootNodeRightNode).getOperation();
+
+            if (!nameFiltering) {
+                nameFiltering = nameAvailableInRightNode;
+                if (nameFiltering && (!(StringUtils.equalsIgnoreCase(operation, Constants.FilterOperations.SW) ||
+                        StringUtils.equalsIgnoreCase(operation, Constants.FilterOperations.EQ)))) {
+                    throw handleException(Response.Status.NOT_IMPLEMENTED,
+                            Constants.ErrorMessage.ERROR_CODE_UNSUPPORTED_FILTER_OPERATION_FOR_NAME, operation);
+                }
+            }
+
+            if (tagAvailableInRightNode && !StringUtils.equalsIgnoreCase(operation, Constants.FilterOperations.EQ)) {
+                throw handleException(Response.Status.NOT_IMPLEMENTED,
+                        Constants.ErrorMessage.ERROR_CODE_UNSUPPORTED_FILTER_OPERATION_FOR_TAG, operation);
+            }
+
+        } else {
+            validateChildNode(rootNodeRightNode);
+        }
+
+        String operation = ((OperationNode) rootNode).getOperation();
+
+        if (nameFiltering && !StringUtils.equalsIgnoreCase(operation, Constants.ComplexQueryOperations.AND)) {
+            throw handleException(Response.Status.NOT_IMPLEMENTED,
+                    Constants.ErrorMessage.ERROR_CODE_UNSUPPORTED_COMPLEX_QUERY_OPERATION_FOR_NAME, operation);
+        }
+
+        if (tagAvailableInLeftNode && tagAvailableInRightNode &&
+                !StringUtils.equalsIgnoreCase(operation, Constants.ComplexQueryOperations.OR)) {
+            throw handleException(Response.Status.NOT_IMPLEMENTED,
+                    Constants.ErrorMessage.ERROR_CODE_UNSUPPORTED_COMPLEX_QUERY_OPERATION_FOR_TAG, operation);
+        }
+    }
+
+    private void validateChildNode(Node childNode) {
+
+        if (childNode instanceof OperationNode) {
+            String operation = ((OperationNode) childNode).getOperation();
+            if (!StringUtils.equalsIgnoreCase(operation, Constants.ComplexQueryOperations.OR)) {
+                throw handleException(Response.Status.NOT_IMPLEMENTED,
+                        Constants.ErrorMessage.ERROR_CODE_UNSUPPORTED_COMPLEX_QUERY_IN_FILTER, operation);
+            }
+        }
+        validateChildNodeFilter(childNode.getLeftNode());
+        validateChildNodeFilter(childNode.getRightNode());
+    }
+
+    private void validateChildNodeFilter(Node childNode) {
+
+        if (childNode instanceof OperationNode) {
+            validateChildNode(childNode);
+        } else {
+            String attributeValue = ((ExpressionNode) childNode).getAttributeValue();
+            String operation = ((ExpressionNode) childNode).getOperation();
+            if (!attributeValue.equals(Constants.FilterAttributes.TAG)) {
+                throw buildClientError(Constants.ErrorMessage.ERROR_CODE_UNSUPPORTED_FILTER_ATTRIBUTE, attributeValue);
+            } else if (!StringUtils.equalsIgnoreCase(operation, Constants.FilterOperations.EQ)) {
+                throw handleException(Response.Status.NOT_IMPLEMENTED,
+                        Constants.ErrorMessage.ERROR_CODE_UNSUPPORTED_FILTER_OPERATION_FOR_TAG, operation);
+            }
+        }
+    }
+
+    private void setExpressionNodeListForAuthenticator(Node node, List<ExpressionNode> expression) {
+
+        if (node instanceof ExpressionNode) {
+            expression.add((ExpressionNode) node);
+        } else if (node instanceof OperationNode) {
+            setExpressionNodeListForAuthenticator(node.getLeftNode(), expression);
+            setExpressionNodeListForAuthenticator(node.getRightNode(), expression);
+        }
+    }
+
+    private List<ExpressionNode> getExpressionNodesForIdp(String filter) {
+
+        // Filter example : name sw go and (tag eq 2fa or tag eq Social-Login)
+        List<ExpressionNode> expressionNodes = new ArrayList<>();
+        FilterTreeBuilder filterTreeBuilder;
+        try {
+            if (StringUtils.isNotBlank(filter)) {
+                filterTreeBuilder = new FilterTreeBuilder(filter);
+                Node rootNode = filterTreeBuilder.buildTree();
+                setExpressionNodeListForIdp(rootNode, expressionNodes);
+            }
+        } catch (IOException | IdentityException e) {
+            throw buildClientError(Constants.ErrorMessage.ERROR_CODE_INVALID_FILTER_FORMAT, null);
+
+        }
+        return expressionNodes;
+    }
+
+    /**
+     * Sets the expression nodes required for the retrieval of identity providers from the database.
+     *
+     * @param node       The node
+     * @param expression The list of expression nodes.
+     */
+    private void setExpressionNodeListForIdp(Node node, List<ExpressionNode> expression) {
+
+        if (node instanceof ExpressionNode) {
+            if (StringUtils.isNotBlank(((ExpressionNode) node).getAttributeValue())) {
+                if (StringUtils.equalsIgnoreCase(((ExpressionNode) node).getAttributeValue(),
+                        Constants.FilterAttributes.NAME)) {
+                    expression.add((ExpressionNode) node);
+                }
+            }
+        } else if (node instanceof OperationNode) {
+            setExpressionNodeListForIdp(node.getLeftNode(), expression);
+            setExpressionNodeListForIdp(node.getRightNode(), expression);
+        }
+    }
+
+    private void getFilteredIdPs(int limit, int offSet, List<String> requestedAttributeList,
+                                 List<IdentityProvider> identityProviders, List<ExpressionNode> expressionNodes) {
+
+        try {
+            IdpSearchResult idpSearchResult = AuthenticatorsServiceHolder.getInstance().getIdentityProviderManager()
+                    .getIdPs(limit, (offSet + limit), null, null,
+                            ContextLoader.getTenantDomainFromContext(), requestedAttributeList, expressionNodes);
+            identityProviders.addAll(idpSearchResult.getIdPs());
+        } catch (IdentityProviderManagementException e) {
+            throw handleIdPException(e, Constants.ErrorMessage.ERROR_CODE_ERROR_LISTING_IDPS, null);
+        }
+    }
+
+    /**
+     * The authenticator name and the filter operation for authenticator name passed in the filter string.
+     *
+     * @param expressionNodes The list of expression nodes.
+     * @return NameFilter object containing the authenticator name and the filter operation for authenticator name
+     * passed in the filter string.
+     */
+    private NameFilter getFilterAuthenticatorNameAndOperation(List<ExpressionNode> expressionNodes) {
+
+        for (ExpressionNode expressionNode : expressionNodes) {
+            if (expressionNode.getAttributeValue().equals(Constants.FilterAttributes.NAME)) {
+                return new NameFilter(expressionNode.getValue(), expressionNode.getOperation());
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Retrieves the list of tags passed in the filter string.
+     *
+     * @param expressionNodes The list of expression nodes.
+     * @return The list of tags passed in the filter string.
+     */
+    private ArrayList<String> getFilterTagsList(List<ExpressionNode> expressionNodes) {
+
+        ArrayList<String> tags = new ArrayList<>();
+        if (expressionNodes != null) {
+            for (ExpressionNode expressionNode : expressionNodes) {
+                if (StringUtils.equalsIgnoreCase(expressionNode.getAttributeValue(), Constants.FilterAttributes.TAG)) {
+                    String tag = expressionNode.getValue();
+                    if (StringUtils.isNotBlank(tag)) {
+                        tags.add(tag);
+                    }
+                }
+            }
+        }
+        return tags;
+    }
+
+    /**
+     * Handle IdentityApplicationManagementException, extract error code, error description and status code to be sent
+     * in the response.
+     *
+     * @param e         IdentityApplicationManagementException
+     * @param errorEnum Error information.
+     * @return APIError.
+     */
+    private APIError handleApplicationMgtException(IdentityApplicationManagementException e,
+                                                   Constants.ErrorMessage errorEnum, String data) {
+
+        ErrorResponse errorResponse = getErrorBuilder(errorEnum, data).build(log, e, errorEnum.getDescription());
+
+        Response.Status status;
+
+        if (e instanceof IdentityApplicationManagementClientException) {
+            if (e.getErrorCode() != null) {
+                String errorCode = e.getErrorCode();
+                errorCode =
+                        errorCode.contains(org.wso2.carbon.identity.api.server.common.Constants.ERROR_CODE_DELIMITER) ?
+                                errorCode : Constants.AUTHENTICATOR_ERROR_PREFIX + errorCode;
+                errorResponse.setCode(errorCode);
+            }
+            errorResponse.setDescription(e.getMessage());
+            status = Response.Status.BAD_REQUEST;
+        } else if (e instanceof IdentityApplicationManagementServerException) {
+            if (e.getErrorCode() != null) {
+                String errorCode = e.getErrorCode();
+                errorCode =
+                        errorCode.contains(org.wso2.carbon.identity.api.server.common.Constants.ERROR_CODE_DELIMITER) ?
+                                errorCode : Constants.AUTHENTICATOR_ERROR_PREFIX + errorCode;
+                errorResponse.setCode(errorCode);
+            }
+            errorResponse.setDescription(e.getMessage());
+            status = Response.Status.INTERNAL_SERVER_ERROR;
+        } else {
+            status = Response.Status.INTERNAL_SERVER_ERROR;
+        }
+        return new APIError(status, errorResponse);
+    }
+
+    /**
+     * Handle IdentityProviderManagementException, extract error code, error description and status code to be sent
+     * in the response.
+     *
+     * @param e         IdentityProviderManagementException.
+     * @param errorEnum Error information.
+     * @return APIError.
+     */
+    private APIError handleIdPException(IdentityProviderManagementException e,
+                                        Constants.ErrorMessage errorEnum, String data) {
+
+        ErrorResponse errorResponse = getErrorBuilder(errorEnum, data).build(log, e, errorEnum.getDescription());
+        Response.Status status;
+
+        if (e instanceof IdentityProviderManagementClientException) {
+            if (e.getErrorCode() != null) {
+                String errorCode = e.getErrorCode();
+                errorCode =
+                        errorCode.contains(org.wso2.carbon.identity.api.server.common.Constants.ERROR_CODE_DELIMITER) ?
+                                errorCode : Constants.AUTHENTICATOR_ERROR_PREFIX + errorCode;
+                errorResponse.setCode(errorCode);
+            }
+            errorResponse.setDescription(e.getMessage());
+            status = Response.Status.BAD_REQUEST;
+
+        } else if (e instanceof IdentityProviderManagementServerException) {
+            if (e.getErrorCode() != null) {
+                String errorCode = e.getErrorCode();
+                errorCode =
+                        errorCode.contains(org.wso2.carbon.identity.api.server.common.Constants.ERROR_CODE_DELIMITER) ?
+                                errorCode : Constants.AUTHENTICATOR_ERROR_PREFIX + errorCode;
+                errorResponse.setCode(errorCode);
+            }
+            errorResponse.setDescription(e.getMessage());
+            status = Response.Status.INTERNAL_SERVER_ERROR;
+        } else {
+            status = Response.Status.INTERNAL_SERVER_ERROR;
+        }
+        return new APIError(status, errorResponse);
+    }
+
+    /**
+     * Handle exceptions generated in the API.
+     *
+     * @param status HTTP status.
+     * @param error  Error message information.
+     * @param data   Context data.
+     * @return APIError.
+     */
+    private APIError handleException(Response.Status status, Constants.ErrorMessage error, String data) {
+
+        return new APIError(status, getErrorBuilder(error, data).build());
+    }
+
+    /**
+     * Return error builder.
+     *
+     * @param errorMsg Error message information.
+     * @param data     Context data.
+     * @return ErrorResponse.Builder.
+     */
+    private ErrorResponse.Builder getErrorBuilder(Constants.ErrorMessage errorMsg, String data) {
+
+        return new ErrorResponse.Builder().withCode(errorMsg.getCode()).withMessage(errorMsg.getMessage())
+                .withDescription(includeData(errorMsg, data));
+    }
+
+    /**
+     * Include context data to error message.
+     *
+     * @param error Error message information.
+     * @param data  Context data.
+     * @return Formatted error message.
+     */
+    private static String includeData(Constants.ErrorMessage error, String data) {
+
+        String message;
+        if (StringUtils.isNotBlank(data)) {
+            message = String.format(error.getDescription(), data);
+        } else {
+            message = String.format(error.getDescription(), "");
+        }
+        return message;
+    }
+
+    /**
+     * Handle client exceptions generated in API.
+     *
+     * @param errorEnum Error message information.
+     * @param data      Context data.
+     * @return APIError.
+     */
+    private APIError buildClientError(Constants.ErrorMessage errorEnum, String data) {
+
+        String description = includeData(errorEnum, data);
+        return buildClientError(errorEnum.getCode(), errorEnum.getMessage(), description);
+    }
+
+    private static APIError buildClientError(String errorCode, String message, String description) {
+
+        ErrorResponse errorResponse = new ErrorResponse.Builder().withCode(errorCode).withMessage(message)
+                .withDescription(description).build(log, description);
+
+        Response.Status status = Response.Status.BAD_REQUEST;
+        return new APIError(status, errorResponse);
+    }
+}

--- a/components/org.wso2.carbon.identity.api.server.authenticators/org.wso2.carbon.identity.api.server.authenticators.v1/src/main/java/org/wso2/carbon/identity/api/server/authenticators/v1/core/ServerAuthenticatorManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.authenticators/org.wso2.carbon.identity.api.server.authenticators.v1/src/main/java/org/wso2/carbon/identity/api/server/authenticators/v1/core/ServerAuthenticatorManagementService.java
@@ -68,10 +68,14 @@ public class ServerAuthenticatorManagementService {
     /**
      * Retrieves the list of available authenticators.
      *
-     * @param filter The filter string
+     * @param filter The filter string.
+     * @param limit  The items per page. **Not supported at the moment.**
+     * @param offset The offset to be used with the limit parameter. **Not supported at the moment.**
      * @return The list of authenticators
      */
-    public List<Authenticator> getAuthenticators(String filter) {
+    public List<Authenticator> getAuthenticators(String filter, Integer limit, Integer offset) {
+
+        handleNotImplementedCapabilities(limit, offset);
 
         try {
             String filterAuthenticatorName = null;
@@ -835,5 +839,18 @@ public class ServerAuthenticatorManagementService {
 
         Response.Status status = Response.Status.BAD_REQUEST;
         return new APIError(status, errorResponse);
+    }
+
+    private void handleNotImplementedCapabilities(Integer limit, Integer offset) {
+
+        Constants.ErrorMessage errorEnum = null;
+        if (limit != null || offset != null) {
+            errorEnum = Constants.ErrorMessage.ERROR_CODE_PAGINATION_NOT_IMPLEMENTED;
+        }
+        if (errorEnum != null) {
+            ErrorResponse errorResponse = getErrorBuilder(errorEnum, null).build(log, errorEnum.getDescription());
+            Response.Status status = Response.Status.NOT_IMPLEMENTED;
+            throw new APIError(status, errorResponse);
+        }
     }
 }

--- a/components/org.wso2.carbon.identity.api.server.authenticators/org.wso2.carbon.identity.api.server.authenticators.v1/src/main/java/org/wso2/carbon/identity/api/server/authenticators/v1/impl/AuthenticatorsApiServiceImpl.java
+++ b/components/org.wso2.carbon.identity.api.server.authenticators/org.wso2.carbon.identity.api.server.authenticators.v1/src/main/java/org/wso2/carbon/identity/api/server/authenticators/v1/impl/AuthenticatorsApiServiceImpl.java
@@ -31,9 +31,9 @@ public class AuthenticatorsApiServiceImpl implements AuthenticatorsApiService {
     private ServerAuthenticatorManagementService authenticatorManagementService;
 
     @Override
-    public Response authenticatorsGet(String filter) {
+    public Response authenticatorsGet(String filter, Integer limit, Integer offset) {
 
-        return Response.ok().entity(authenticatorManagementService.getAuthenticators(filter)).build();
+        return Response.ok().entity(authenticatorManagementService.getAuthenticators(filter, limit, offset)).build();
     }
 
     @Override

--- a/components/org.wso2.carbon.identity.api.server.authenticators/org.wso2.carbon.identity.api.server.authenticators.v1/src/main/java/org/wso2/carbon/identity/api/server/authenticators/v1/impl/AuthenticatorsApiServiceImpl.java
+++ b/components/org.wso2.carbon.identity.api.server.authenticators/org.wso2.carbon.identity.api.server.authenticators.v1/src/main/java/org/wso2/carbon/identity/api/server/authenticators/v1/impl/AuthenticatorsApiServiceImpl.java
@@ -1,0 +1,44 @@
+/*
+* Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package org.wso2.carbon.identity.api.server.authenticators.v1.impl;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.wso2.carbon.identity.api.server.authenticators.v1.AuthenticatorsApiService;
+import org.wso2.carbon.identity.api.server.authenticators.v1.core.ServerAuthenticatorManagementService;
+
+import javax.ws.rs.core.Response;
+
+/**
+ * Implementation of the Server Authenticators Rest API.
+ */
+public class AuthenticatorsApiServiceImpl implements AuthenticatorsApiService {
+
+    @Autowired
+    private ServerAuthenticatorManagementService authenticatorManagementService;
+
+    @Override
+    public Response authenticatorsGet(String filter) {
+
+        return Response.ok().entity(authenticatorManagementService.getAuthenticators(filter)).build();
+    }
+
+    @Override
+    public Response authenticatorsMetaTagsGet() {
+
+        return Response.ok().entity(authenticatorManagementService.getTags()).build();
+    }
+}

--- a/components/org.wso2.carbon.identity.api.server.authenticators/org.wso2.carbon.identity.api.server.authenticators.v1/src/main/java/org/wso2/carbon/identity/api/server/authenticators/v1/model/NameFilter.java
+++ b/components/org.wso2.carbon.identity.api.server.authenticators/org.wso2.carbon.identity.api.server.authenticators.v1/src/main/java/org/wso2/carbon/identity/api/server/authenticators/v1/model/NameFilter.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2021 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.authenticators.v1.model;
+
+/**
+ * The object model to hold name filter.
+ */
+public class NameFilter {
+
+    private String name;
+    private String operation;
+
+    public NameFilter(String name, String operation) {
+
+        this.name = name;
+        this.operation = operation;
+    }
+
+    public String getName() {
+
+        return name;
+    }
+
+    public void setName(String name) {
+
+        this.name = name;
+    }
+
+    public String getOperation() {
+
+        return operation;
+    }
+
+    public void setOperation(String operation) {
+
+        this.operation = operation;
+    }
+}

--- a/components/org.wso2.carbon.identity.api.server.authenticators/org.wso2.carbon.identity.api.server.authenticators.v1/src/main/resources/META-INF/cxf/authenticators-server-v1-cxf.xml
+++ b/components/org.wso2.carbon.identity.api.server.authenticators/org.wso2.carbon.identity.api.server.authenticators.v1/src/main/resources/META-INF/cxf/authenticators-server-v1-cxf.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:jaxrs="http://cxf.apache.org/jaxrs" xmlns:context="http://www.springframework.org/schema/context" xsi:schemaLocation=" http://www.springframework.org/schema/beans  http://www.springframework.org/schema/beans/spring-beans-3.0.xsd http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.0.xsd http://cxf.apache.org/jaxrs http://cxf.apache.org/schemas/jaxrs.xsd">
+    <bean class="org.wso2.carbon.identity.api.server.authenticators.v1.core.ServerAuthenticatorManagementService"/>
+    <bean class="org.wso2.carbon.identity.api.server.authenticators.v1.impl.AuthenticatorsApiServiceImpl"/>
+    <bean id="ApplicationMgtServiceFactoryBean"
+          class="org.wso2.carbon.identity.api.server.authenticators.common.factory.ApplicationMgtOSGIServiceFactory"/>
+    <bean id="IdPMgtServiceFactoryBean"
+          class="org.wso2.carbon.identity.api.server.authenticators.common.factory.IdPMgtOSGIServiceFactory"/>
+    <bean id="AuthenticatorsServiceHolderBean"
+          class="org.wso2.carbon.identity.api.server.authenticators.common.AuthenticatorsServiceHolder">
+        <property name="applicationManagementService" ref="ApplicationMgtServiceFactoryBean"/>
+        <property name="identityProviderManager" ref="IdPMgtServiceFactoryBean"/>
+    </bean>
+</beans>

--- a/components/org.wso2.carbon.identity.api.server.authenticators/org.wso2.carbon.identity.api.server.authenticators.v1/src/main/resources/authenticators.yaml
+++ b/components/org.wso2.carbon.identity.api.server.authenticators/org.wso2.carbon.identity.api.server.authenticators.v1/src/main/resources/authenticators.yaml
@@ -1,0 +1,192 @@
+openapi: 3.0.0
+info:
+  version: "v1"
+  title: 'WSO2 Identity Server - Authenticators API Definition'
+  description: 'This document specifies a **RESTful API** for **WSO2 Identity Server Authenticators**'
+  contact:
+    name: WSO2
+    url: 'http://wso2.com/products/identity-server/'
+    email: architecture@wso2.org
+  license:
+    name: Apache 2.0
+    url: 'http://www.apache.org/licenses/LICENSE-2.0.html'
+servers:
+  - url: 'https://localhost:9443/t/{tenant-domain}/api/server/v1'
+    variables:
+      tenant-domain:
+        default: carbon.super
+security:
+  - OAuth2: []
+  - BasicAuth: []
+
+paths:
+  /authenticators:
+    get:
+      tags:
+        - Authenticators
+      summary: List all authenticators in the server
+      description: List all authenticators in the server
+      parameters:
+        - $ref: '#/components/parameters/filterQueryParam'
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Authenticators'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/ServerError'
+  /authenticators/meta/tags:
+    get:
+      tags:
+        - Authenticators
+      summary: List all authenticator tags
+      description: List all authenticator tags
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Tags'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/ServerError'
+
+components:
+  parameters:
+    filterQueryParam:
+      in: query
+      name: filter
+      required: false
+      description: >
+        Condition to filter the retrieval of records.
+        Only supports filtering based on the 'tag' and 'name' attribute.
+        For local authenticators and request path authenticators, the 'displayName' is considered as the 'name' attribute during filtering.
+        The 'name' attribute only supports 'eq' and 'sw operations. Filtering with multiple 'name' attributes is not supported.
+        The 'tag' attribute only supports 'eq' operation. Filtering with multiple 'tag' attributes is supported with only 'or' as the complex query operation.
+        E.g. /configs/authenticators?filter=name+sw+fi+and+(tag+eq+2FA+or+tag+eq+MFA)
+      schema:
+        type: string
+  schemas:
+    Error:
+      type: object
+      required:
+        - code
+        - message
+      properties:
+        code:
+          type: string
+          example: AUT-00000
+          description: An error code.
+        message:
+          type: string
+          example: Some Error Message
+          description: An error message.
+        description:
+          type: string
+          example: Some Error Description
+          description: An error description.
+        traceId:
+          type: string
+          example: e0fbcfeb-3617-43c4-8dd0-7b7d38e13047
+          description: An error trace identifier.
+    Tags:
+      type: array
+      description: The list of tags available for authenticators.
+      items:
+        type: string
+      example: [2FA, MFA]
+    Authenticators:
+      type: array
+      items:
+        $ref: '#/components/schemas/Authenticator'
+    Authenticator:
+      type: object
+      properties:
+        id:
+          type: string
+          example: QmFzaWNBdXRoZW50aWNhdG9y
+        name:
+          type: string
+          example: BasicAuthenticator
+        displayName:
+          type: string
+          example: basic
+        isEnabled:
+          type: boolean
+          example: true
+        type:
+          type: string
+          enum:
+            - LOCAL
+            - FEDERATED
+        image:
+          type: string
+          example: basic-authenticator-logo-url
+        tags:
+          type: array
+          items:
+            type: string
+          example: [2FA, MFA]
+        self:
+          type: string
+          example: /t/carbon.super/api/server/v1/configs/authenticators/eDUwOUNlcnRpZmljYXRlQXV0aGVudGljYXRvcg
+
+  #-----------------------------------------------------
+  # Descriptions of Authenticators API responses.
+  #-----------------------------------------------------
+  responses:
+    BadRequest:
+      description: Invalid input in the request.
+      content:
+        'application/json':
+          schema:
+            $ref: '#/components/schemas/Error'
+    NotFound:
+      description: Requested resource is not found.
+      content:
+        'application/json':
+          schema:
+            $ref: '#/components/schemas/Error'
+    Unauthorized:
+      description: Authentication information is missing or invalid.
+    Forbidden:
+      description: Access forbidden.
+    ServerError:
+      description: Internal server error.
+      content:
+        'application/json':
+          schema:
+            $ref: '#/components/schemas/Error'
+
+  #-----------------------------------------------------
+  # Applicable authentication mechanisms.
+  #-----------------------------------------------------
+  securitySchemes:
+    BasicAuth:
+      type: http
+      scheme: basic
+    OAuth2:
+      type: oauth2
+      flows:
+        authorizationCode:
+          authorizationUrl: 'https://localhost:9443/oauth2/authorize'
+          tokenUrl: 'https://localhost:9443/oauth2/token'
+          scopes: {}

--- a/components/org.wso2.carbon.identity.api.server.authenticators/org.wso2.carbon.identity.api.server.authenticators.v1/src/main/resources/authenticators.yaml
+++ b/components/org.wso2.carbon.identity.api.server.authenticators/org.wso2.carbon.identity.api.server.authenticators.v1/src/main/resources/authenticators.yaml
@@ -28,6 +28,8 @@ paths:
       description: List all authenticators in the server
       parameters:
         - $ref: '#/components/parameters/filterQueryParam'
+        - $ref: '#/components/parameters/limitQueryParam'
+        - $ref: '#/components/parameters/offsetQueryParam'
       responses:
         '200':
           description: Successful response
@@ -45,6 +47,8 @@ paths:
           $ref: '#/components/responses/NotFound'
         '500':
           $ref: '#/components/responses/ServerError'
+        '501':
+          $ref: '#/components/responses/NotImplemented'
   /authenticators/meta/tags:
     get:
       tags:
@@ -84,6 +88,26 @@ components:
         E.g. /configs/authenticators?filter=name+sw+fi+and+(tag+eq+2FA+or+tag+eq+MFA)
       schema:
         type: string
+    limitQueryParam:
+      in: query
+      name: limit
+      description: >
+        Maximum number of records to return. _<b>This option is not yet
+        supported.<b>_
+      schema:
+        type: integer
+        format: int32
+        minimum: 0
+    offsetQueryParam:
+      in: query
+      name: offset
+      description: >
+        Number of records to skip for pagination. _<b>This option is not yet
+        supported.<b>_
+      schema:
+        type: integer
+        format: int32
+        minimum: 0
   schemas:
     Error:
       type: object
@@ -175,7 +199,12 @@ components:
         'application/json':
           schema:
             $ref: '#/components/schemas/Error'
-
+    NotImplemented:
+      description: Not Implemented.
+      content:
+        'application/json':
+          schema:
+            $ref: '#/components/schemas/Error'
   #-----------------------------------------------------
   # Applicable authentication mechanisms.
   #-----------------------------------------------------

--- a/components/org.wso2.carbon.identity.api.server.authenticators/org.wso2.carbon.identity.api.server.authenticators.v1/src/main/resources/authenticators.yaml
+++ b/components/org.wso2.carbon.identity.api.server.authenticators/org.wso2.carbon.identity.api.server.authenticators.v1/src/main/resources/authenticators.yaml
@@ -6,7 +6,7 @@ info:
   contact:
     name: WSO2
     url: 'http://wso2.com/products/identity-server/'
-    email: architecture@wso2.org
+    email: iam-dev@wso2.org
   license:
     name: Apache 2.0
     url: 'http://www.apache.org/licenses/LICENSE-2.0.html'

--- a/components/org.wso2.carbon.identity.api.server.authenticators/pom.xml
+++ b/components/org.wso2.carbon.identity.api.server.authenticators/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>identity-api-server</artifactId>
         <groupId>org.wso2.carbon.identity.server.api</groupId>
-        <version>1.0.229-SNAPSHOT</version>
+        <version>1.0.230-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.api.server.authenticators/pom.xml
+++ b/components/org.wso2.carbon.identity.api.server.authenticators/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>identity-api-server</artifactId>
         <groupId>org.wso2.carbon.identity.server.api</groupId>
-        <version>1.0.230-SNAPSHOT</version>
+        <version>1.0.231-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.api.server.authenticators/pom.xml
+++ b/components/org.wso2.carbon.identity.api.server.authenticators/pom.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+  ~
+  ~ WSO2 Inc. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <parent>
+        <artifactId>identity-api-server</artifactId>
+        <groupId>org.wso2.carbon.identity.server.api</groupId>
+        <version>1.0.229-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>org.wso2.carbon.identity.api.server.authenticators</artifactId>
+
+    <packaging>pom</packaging>
+
+    <modules>
+        <module>org.wso2.carbon.identity.api.server.authenticators.common</module>
+        <module>org.wso2.carbon.identity.api.server.authenticators.v1</module>
+    </modules>
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -329,6 +329,12 @@
             </dependency>
             <dependency>
                 <groupId>org.wso2.carbon.identity.server.api</groupId>
+                <artifactId>org.wso2.carbon.identity.api.server.authenticators.common</artifactId>
+                <version>${project.version}</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.wso2.carbon.identity.server.api</groupId>
                 <artifactId>org.wso2.carbon.identity.api.server.cors.common</artifactId>
                 <version>${project.version}</version>
                 <scope>provided</scope>
@@ -481,7 +487,7 @@
         <maven.buildnumber.plugin.version>1.4</maven.buildnumber.plugin.version>
         <org.apache.felix.annotations.version>1.2.4</org.apache.felix.annotations.version>
         <identity.governance.version>1.4.75</identity.governance.version>
-        <carbon.identity.framework.version>5.19.20</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.20.93</carbon.identity.framework.version>
         <maven.findbugsplugin.version>3.0.5</maven.findbugsplugin.version>
         <identity.workflow.impl.bps.version>5.2.0</identity.workflow.impl.bps.version>
         <maven.checkstyleplugin.excludes>**/gen/**/*</maven.checkstyleplugin.excludes>
@@ -516,6 +522,7 @@
         <module>components/org.wso2.carbon.identity.api.server.cors</module>
         <module>components/org.wso2.carbon.identity.api.server.fetch.remote</module>
         <module>components/org.wso2.carbon.identity.api.server.notification.sender</module>
+        <module>components/org.wso2.carbon.identity.api.server.authenticators</module>
     </modules>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -481,7 +481,7 @@
         <maven.buildnumber.plugin.version>1.4</maven.buildnumber.plugin.version>
         <org.apache.felix.annotations.version>1.2.4</org.apache.felix.annotations.version>
         <identity.governance.version>1.4.75</identity.governance.version>
-        <carbon.identity.framework.version>5.20.93</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.20.101</carbon.identity.framework.version>
         <maven.findbugsplugin.version>3.0.5</maven.findbugsplugin.version>
         <identity.workflow.impl.bps.version>5.2.0</identity.workflow.impl.bps.version>
         <maven.checkstyleplugin.excludes>**/gen/**/*</maven.checkstyleplugin.excludes>


### PR DESCRIPTION
## Purpose
Resolves https://github.com/wso2/product-is/issues/11984

## Goals

- Introduce a new API to retrieve all authenticators defined in identity server.
- Introduce a meta API to retrieve all tags defined for authenticators.

## Related PRs

- https://github.com/wso2/carbon-identity-framework/pull/3570
- https://github.com/wso2/carbon-identity-framework/pull/3577