### PR TITLE
Add metadata section to return json in Retrieve governance connector, GET endpoint (Resolved Merge Conflict)

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.identity.governance/org.wso2.carbon.identity.api.server.identity.governance.v1/src/gen/java/org/wso2/carbon/identity/api/server/identity/governance/v1/model/MetaRes.java
+++ b/components/org.wso2.carbon.identity.api.server.identity.governance/org.wso2.carbon.identity.api.server.identity.governance.v1/src/gen/java/org/wso2/carbon/identity/api/server/identity/governance/v1/model/MetaRes.java
@@ -1,5 +1,5 @@
 /*
-* Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+* Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/components/org.wso2.carbon.identity.api.server.identity.governance/org.wso2.carbon.identity.api.server.identity.governance.v1/src/gen/java/org/wso2/carbon/identity/api/server/identity/governance/v1/model/MetaRes.java
+++ b/components/org.wso2.carbon.identity.api.server.identity.governance/org.wso2.carbon.identity.api.server.identity.governance.v1/src/gen/java/org/wso2/carbon/identity/api/server/identity/governance/v1/model/MetaRes.java
@@ -1,0 +1,100 @@
+/*
+* Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package org.wso2.carbon.identity.api.server.identity.governance.v1.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import javax.validation.constraints.*;
+
+/**
+ * Meta data information
+ **/
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+import javax.validation.Valid;
+import javax.xml.bind.annotation.*;
+@ApiModel(description = "Meta data information")
+public class MetaRes  {
+  
+    private String type;
+
+    /**
+    * Data type of the property
+    **/
+    public MetaRes type(String type) {
+
+        this.type = type;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "boolean", value = "Data type of the property")
+    @JsonProperty("type")
+    @Valid
+    public String getType() {
+        return type;
+    }
+    public void setType(String type) {
+        this.type = type;
+    }
+
+
+
+    @Override
+    public boolean equals(java.lang.Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        MetaRes metaRes = (MetaRes) o;
+        return Objects.equals(this.type, metaRes.type);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(type);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class MetaRes {\n");
+        
+        sb.append("    type: ").append(toIndentedString(type)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+    * Convert the given object to string with each line indented by 4 spaces
+    * (except the first line).
+    */
+    private String toIndentedString(java.lang.Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}
+

--- a/components/org.wso2.carbon.identity.api.server.identity.governance/org.wso2.carbon.identity.api.server.identity.governance.v1/src/gen/java/org/wso2/carbon/identity/api/server/identity/governance/v1/model/MetaRes.java
+++ b/components/org.wso2.carbon.identity.api.server.identity.governance/org.wso2.carbon.identity.api.server.identity.governance.v1/src/gen/java/org/wso2/carbon/identity/api/server/identity/governance/v1/model/MetaRes.java
@@ -1,5 +1,5 @@
 /*
-* Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+* Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -35,6 +35,7 @@ public class MetaRes  {
   
     private String type;
     private String regex;
+    private Integer groupID;
 
     /**
     * Data type of the property
@@ -74,6 +75,25 @@ public class MetaRes  {
         this.regex = regex;
     }
 
+    /**
+    * Group id of the property if any
+    **/
+    public MetaRes groupID(Integer groupID) {
+
+        this.groupID = groupID;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "0", value = "Group id of the property if any")
+    @JsonProperty("groupID")
+    @Valid
+    public Integer getGroupID() {
+        return groupID;
+    }
+    public void setGroupID(Integer groupID) {
+        this.groupID = groupID;
+    }
+
 
 
     @Override
@@ -87,12 +107,13 @@ public class MetaRes  {
         }
         MetaRes metaRes = (MetaRes) o;
         return Objects.equals(this.type, metaRes.type) &&
-            Objects.equals(this.regex, metaRes.regex);
+            Objects.equals(this.regex, metaRes.regex) &&
+            Objects.equals(this.groupID, metaRes.groupID);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(type, regex);
+        return Objects.hash(type, regex, groupID);
     }
 
     @Override
@@ -103,6 +124,7 @@ public class MetaRes  {
         
         sb.append("    type: ").append(toIndentedString(type)).append("\n");
         sb.append("    regex: ").append(toIndentedString(regex)).append("\n");
+        sb.append("    groupID: ").append(toIndentedString(groupID)).append("\n");
         sb.append("}");
         return sb.toString();
     }

--- a/components/org.wso2.carbon.identity.api.server.identity.governance/org.wso2.carbon.identity.api.server.identity.governance.v1/src/gen/java/org/wso2/carbon/identity/api/server/identity/governance/v1/model/MetaRes.java
+++ b/components/org.wso2.carbon.identity.api.server.identity.governance/org.wso2.carbon.identity.api.server.identity.governance.v1/src/gen/java/org/wso2/carbon/identity/api/server/identity/governance/v1/model/MetaRes.java
@@ -23,17 +23,18 @@ import io.swagger.annotations.ApiModelProperty;
 import javax.validation.constraints.*;
 
 /**
- * Meta data information
+ * Meta Data related to each property
  **/
 
 import io.swagger.annotations.*;
 import java.util.Objects;
 import javax.validation.Valid;
 import javax.xml.bind.annotation.*;
-@ApiModel(description = "Meta data information")
+@ApiModel(description = "Meta Data related to each property")
 public class MetaRes  {
   
     private String type;
+    private String regex;
 
     /**
     * Data type of the property
@@ -54,6 +55,25 @@ public class MetaRes  {
         this.type = type;
     }
 
+    /**
+    * regular expression
+    **/
+    public MetaRes regex(String regex) {
+
+        this.regex = regex;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "[a-zA-Z0-9]{6}", value = "regular expression")
+    @JsonProperty("regex")
+    @Valid
+    public String getRegex() {
+        return regex;
+    }
+    public void setRegex(String regex) {
+        this.regex = regex;
+    }
+
 
 
     @Override
@@ -66,12 +86,13 @@ public class MetaRes  {
             return false;
         }
         MetaRes metaRes = (MetaRes) o;
-        return Objects.equals(this.type, metaRes.type);
+        return Objects.equals(this.type, metaRes.type) &&
+            Objects.equals(this.regex, metaRes.regex);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(type);
+        return Objects.hash(type, regex);
     }
 
     @Override
@@ -81,6 +102,7 @@ public class MetaRes  {
         sb.append("class MetaRes {\n");
         
         sb.append("    type: ").append(toIndentedString(type)).append("\n");
+        sb.append("    regex: ").append(toIndentedString(regex)).append("\n");
         sb.append("}");
         return sb.toString();
     }

--- a/components/org.wso2.carbon.identity.api.server.identity.governance/org.wso2.carbon.identity.api.server.identity.governance.v1/src/gen/java/org/wso2/carbon/identity/api/server/identity/governance/v1/model/PropertyRes.java
+++ b/components/org.wso2.carbon.identity.api.server.identity.governance/org.wso2.carbon.identity.api.server.identity.governance.v1/src/gen/java/org/wso2/carbon/identity/api/server/identity/governance/v1/model/PropertyRes.java
@@ -1,5 +1,5 @@
 /*
-* Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+* Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/components/org.wso2.carbon.identity.api.server.identity.governance/org.wso2.carbon.identity.api.server.identity.governance.v1/src/gen/java/org/wso2/carbon/identity/api/server/identity/governance/v1/model/PropertyRes.java
+++ b/components/org.wso2.carbon.identity.api.server.identity.governance/org.wso2.carbon.identity.api.server.identity.governance.v1/src/gen/java/org/wso2/carbon/identity/api/server/identity/governance/v1/model/PropertyRes.java
@@ -1,5 +1,5 @@
 /*
-* Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+* Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -124,7 +124,7 @@ public class PropertyRes  {
         return this;
     }
     
-    @ApiModelProperty(example = "boolean", value = "Data type of the property")
+    @ApiModelProperty(value = "")
     @JsonProperty("meta")
     @Valid
     public MetaRes getMeta() {

--- a/components/org.wso2.carbon.identity.api.server.identity.governance/org.wso2.carbon.identity.api.server.identity.governance.v1/src/gen/java/org/wso2/carbon/identity/api/server/identity/governance/v1/model/PropertyRes.java
+++ b/components/org.wso2.carbon.identity.api.server.identity.governance/org.wso2.carbon.identity.api.server.identity.governance.v1/src/gen/java/org/wso2/carbon/identity/api/server/identity/governance/v1/model/PropertyRes.java
@@ -1,5 +1,5 @@
 /*
-* Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+* Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/components/org.wso2.carbon.identity.api.server.identity.governance/org.wso2.carbon.identity.api.server.identity.governance.v1/src/gen/java/org/wso2/carbon/identity/api/server/identity/governance/v1/model/PropertyRes.java
+++ b/components/org.wso2.carbon.identity.api.server.identity.governance/org.wso2.carbon.identity.api.server.identity.governance.v1/src/gen/java/org/wso2/carbon/identity/api/server/identity/governance/v1/model/PropertyRes.java
@@ -1,5 +1,5 @@
 /*
-* Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+* Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.wso2.carbon.identity.api.server.identity.governance.v1.model.MetaRes;
 import javax.validation.constraints.*;
 
 /**
@@ -37,6 +38,7 @@ public class PropertyRes  {
     private String value;
     private String displayName;
     private String description;
+    private MetaRes meta;
 
     /**
     * Property name.
@@ -114,6 +116,24 @@ public class PropertyRes  {
         this.description = description;
     }
 
+    /**
+    **/
+    public PropertyRes meta(MetaRes meta) {
+
+        this.meta = meta;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "boolean", value = "Data type of the property")
+    @JsonProperty("meta")
+    @Valid
+    public MetaRes getMeta() {
+        return meta;
+    }
+    public void setMeta(MetaRes meta) {
+        this.meta = meta;
+    }
+
 
 
     @Override
@@ -129,12 +149,13 @@ public class PropertyRes  {
         return Objects.equals(this.name, propertyRes.name) &&
             Objects.equals(this.value, propertyRes.value) &&
             Objects.equals(this.displayName, propertyRes.displayName) &&
-            Objects.equals(this.description, propertyRes.description);
+            Objects.equals(this.description, propertyRes.description) &&
+            Objects.equals(this.meta, propertyRes.meta);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(name, value, displayName, description);
+        return Objects.hash(name, value, displayName, description, meta);
     }
 
     @Override
@@ -147,6 +168,7 @@ public class PropertyRes  {
         sb.append("    value: ").append(toIndentedString(value)).append("\n");
         sb.append("    displayName: ").append(toIndentedString(displayName)).append("\n");
         sb.append("    description: ").append(toIndentedString(description)).append("\n");
+        sb.append("    meta: ").append(toIndentedString(meta)).append("\n");
         sb.append("}");
         return sb.toString();
     }

--- a/components/org.wso2.carbon.identity.api.server.identity.governance/org.wso2.carbon.identity.api.server.identity.governance.v1/src/main/java/org/wso2/carbon/identity/api/server/identity/governance/v1/core/ServerIdentityGovernanceService.java
+++ b/components/org.wso2.carbon.identity.api.server.identity.governance/org.wso2.carbon.identity.api.server.identity.governance.v1/src/main/java/org/wso2/carbon/identity/api/server/identity/governance/v1/core/ServerIdentityGovernanceService.java
@@ -390,6 +390,7 @@ public class ServerIdentityGovernanceService {
             MetaRes metaRes = new MetaRes();
             metaRes.setType(property.getType());
             metaRes.setRegex(property.getRegex());
+            metaRes.setGroupID(property.getGroupId());
             propertyRes.setMeta(metaRes);
             properties.add(propertyRes);
         }

--- a/components/org.wso2.carbon.identity.api.server.identity.governance/org.wso2.carbon.identity.api.server.identity.governance.v1/src/main/java/org/wso2/carbon/identity/api/server/identity/governance/v1/core/ServerIdentityGovernanceService.java
+++ b/components/org.wso2.carbon.identity.api.server.identity.governance/org.wso2.carbon.identity.api.server.identity.governance.v1/src/main/java/org/wso2/carbon/identity/api/server/identity/governance/v1/core/ServerIdentityGovernanceService.java
@@ -389,6 +389,7 @@ public class ServerIdentityGovernanceService {
             propertyRes.setDescription(property.getDescription() != null ? property.getDescription() : "");
             MetaRes metaRes = new MetaRes();
             metaRes.setType(property.getType());
+            metaRes.setRegex(property.getRegex());
             propertyRes.setMeta(metaRes);
             properties.add(propertyRes);
         }

--- a/components/org.wso2.carbon.identity.api.server.identity.governance/org.wso2.carbon.identity.api.server.identity.governance.v1/src/main/java/org/wso2/carbon/identity/api/server/identity/governance/v1/core/ServerIdentityGovernanceService.java
+++ b/components/org.wso2.carbon.identity.api.server.identity.governance/org.wso2.carbon.identity.api.server.identity.governance.v1/src/main/java/org/wso2/carbon/identity/api/server/identity/governance/v1/core/ServerIdentityGovernanceService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2019 , WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/org.wso2.carbon.identity.api.server.identity.governance/org.wso2.carbon.identity.api.server.identity.governance.v1/src/main/java/org/wso2/carbon/identity/api/server/identity/governance/v1/core/ServerIdentityGovernanceService.java
+++ b/components/org.wso2.carbon.identity.api.server.identity.governance/org.wso2.carbon.identity.api.server.identity.governance.v1/src/main/java/org/wso2/carbon/identity/api/server/identity/governance/v1/core/ServerIdentityGovernanceService.java
@@ -29,6 +29,7 @@ import org.wso2.carbon.identity.api.server.identity.governance.v1.model.Category
 import org.wso2.carbon.identity.api.server.identity.governance.v1.model.CategoryRes;
 import org.wso2.carbon.identity.api.server.identity.governance.v1.model.ConnectorRes;
 import org.wso2.carbon.identity.api.server.identity.governance.v1.model.ConnectorsPatchReq;
+import org.wso2.carbon.identity.api.server.identity.governance.v1.model.MetaRes;
 import org.wso2.carbon.identity.api.server.identity.governance.v1.model.PreferenceResp;
 import org.wso2.carbon.identity.api.server.identity.governance.v1.model.PreferenceSearchAttribute;
 import org.wso2.carbon.identity.api.server.identity.governance.v1.model.PropertyReq;
@@ -386,9 +387,11 @@ public class ServerIdentityGovernanceService {
             propertyRes.setValue(property.getValue());
             propertyRes.setDisplayName(property.getDisplayName());
             propertyRes.setDescription(property.getDescription() != null ? property.getDescription() : "");
+            MetaRes metaRes = new MetaRes();
+            metaRes.setType(property.getType());
+            propertyRes.setMeta(metaRes);
             properties.add(propertyRes);
         }
-
         connectorsResDTO.setProperties(properties);
         return connectorsResDTO;
     }

--- a/components/org.wso2.carbon.identity.api.server.identity.governance/org.wso2.carbon.identity.api.server.identity.governance.v1/src/main/resources/identity-governance.yaml
+++ b/components/org.wso2.carbon.identity.api.server.identity.governance/org.wso2.carbon.identity.api.server.identity.governance.v1/src/main/resources/identity-governance.yaml
@@ -3,7 +3,7 @@ info:
   description: >-
     This is the RESTful API for identity governance configurations in WSO2
     Identity Server
-  version: v1
+  version: "v1"
   title: WSO2 Identity Server - Governance connectors Admin API
   contact:
     name: WSO2 Identity Server
@@ -173,10 +173,8 @@ paths:
         - Management
       summary: Retrieve preferences of governance connector configurations.
       operationId: getPreferenceByPost
-      description: >
-        This API returns information about configuration preference of
-        governance connectors. This API will accept
-
+      description: |
+        This API returns information about configuration preference of governance connectors. This API will accept
         following keys.
           <table>
             <tr>
@@ -470,7 +468,6 @@ paths:
           </table>
 
         <b>scope required:</b>
-
         * internal_login
       requestBody:
         content:
@@ -488,9 +485,7 @@ paths:
                     - EmailVerification.LockOnCreation
               items:
                 $ref: '#/components/schemas/PreferenceSearchAttribute'
-        description: >-
-          This represents the connector and the properties which preferences
-          needs to be returned.
+        description: This represents the connector and the properties which preferences needs to be returned.
         required: true
       responses:
         '200':
@@ -512,8 +507,10 @@ paths:
                         value: 'true'
                       - name: EmailVerification.LockOnCreation
                         value: 'false'
+
                 items:
                   $ref: '#/components/schemas/PreferenceResp'
+
         '400':
           $ref: '#/components/responses/InvalidInput'
         '401':
@@ -522,8 +519,9 @@ paths:
           $ref: '#/components/responses/Forbidden'
         '404':
           $ref: '#/components/responses/NotFound'
+
 servers:
-  - url: 'https://localhost:9443/t/{tenant-domain}/api/server/v1/'
+  - url: https://localhost:9443/t/{tenant-domain}/api/server/v1/
 components:
   parameters:
     limitQueryParam:
@@ -628,8 +626,7 @@ components:
         self:
           type: string
           description: Path to retrieve the full connector information.
-          example: >-
-            /t/carbon.super/api/server/v1/identity-governance/QWNjb3VudCBNYW5hZ2VtZW50IFBvbGljaWVz
+          example: /t/carbon.super/api/server/v1/identity-governance/QWNjb3VudCBNYW5hZ2VtZW50IFBvbGljaWVz
         connectors:
           type: array
           description: Connectors of the category with minimal attributes.

--- a/components/org.wso2.carbon.identity.api.server.identity.governance/org.wso2.carbon.identity.api.server.identity.governance.v1/src/main/resources/identity-governance.yaml
+++ b/components/org.wso2.carbon.identity.api.server.identity.governance/org.wso2.carbon.identity.api.server.identity.governance.v1/src/main/resources/identity-governance.yaml
@@ -3,7 +3,7 @@ info:
   description: >-
     This is the RESTful API for identity governance configurations in WSO2
     Identity Server
-  version: "v1"
+  version: v1
   title: WSO2 Identity Server - Governance connectors Admin API
   contact:
     name: WSO2 Identity Server
@@ -173,8 +173,10 @@ paths:
         - Management
       summary: Retrieve preferences of governance connector configurations.
       operationId: getPreferenceByPost
-      description: |
-        This API returns information about configuration preference of governance connectors. This API will accept
+      description: >
+        This API returns information about configuration preference of
+        governance connectors. This API will accept
+
         following keys.
           <table>
             <tr>
@@ -468,6 +470,7 @@ paths:
           </table>
 
         <b>scope required:</b>
+
         * internal_login
       requestBody:
         content:
@@ -475,17 +478,19 @@ paths:
             schema:
               type: array
               example:
-                  - connector-name: self-sign-up
-                    properties:
-                           - SelfRegistration.Enable
-                           - SelfRegistration.LockOnCreation
-                  - connector-name: user-email-verification
-                    properties:
-                           - EmailVerification.Enable
-                           - EmailVerification.LockOnCreation
+                - connector-name: self-sign-up
+                  properties:
+                    - SelfRegistration.Enable
+                    - SelfRegistration.LockOnCreation
+                - connector-name: user-email-verification
+                  properties:
+                    - EmailVerification.Enable
+                    - EmailVerification.LockOnCreation
               items:
                 $ref: '#/components/schemas/PreferenceSearchAttribute'
-        description: This represents the connector and the properties which preferences needs to be returned.
+        description: >-
+          This represents the connector and the properties which preferences
+          needs to be returned.
         required: true
       responses:
         '200':
@@ -497,20 +502,18 @@ paths:
                 example:
                   - connector-name: self-sign-up
                     properties:
-                             - name: SelfRegistration.Enable
-                               value: 'false'
-                             - name: SelfRegistration.LockOnCreation
-                               value: 'false'
+                      - name: SelfRegistration.Enable
+                        value: 'false'
+                      - name: SelfRegistration.LockOnCreation
+                        value: 'false'
                   - connector-name: user-email-verification
                     properties:
-                             - name: EmailVerification.Enable
-                               value: 'true'
-                             - name: EmailVerification.LockOnCreation
-                               value: 'false'
-
+                      - name: EmailVerification.Enable
+                        value: 'true'
+                      - name: EmailVerification.LockOnCreation
+                        value: 'false'
                 items:
                   $ref: '#/components/schemas/PreferenceResp'
-
         '400':
           $ref: '#/components/responses/InvalidInput'
         '401':
@@ -519,9 +522,8 @@ paths:
           $ref: '#/components/responses/Forbidden'
         '404':
           $ref: '#/components/responses/NotFound'
-
 servers:
-  - url: https://localhost:9443/t/{tenant-domain}/api/server/v1/
+  - url: 'https://localhost:9443/t/{tenant-domain}/api/server/v1/'
 components:
   parameters:
     limitQueryParam:
@@ -626,7 +628,8 @@ components:
         self:
           type: string
           description: Path to retrieve the full connector information.
-          example: /t/carbon.super/api/server/v1/identity-governance/QWNjb3VudCBNYW5hZ2VtZW50IFBvbGljaWVz
+          example: >-
+            /t/carbon.super/api/server/v1/identity-governance/QWNjb3VudCBNYW5hZ2VtZW50IFBvbGljaWVz
         connectors:
           type: array
           description: Connectors of the category with minimal attributes.
@@ -643,7 +646,8 @@ components:
         self:
           type: string
           description: Path to retrieve the full connector information.
-          example: /t/carbon.super/api/server/v1/identity-governance/QWNjb3VudCBNYW5hZ2VtZW50IFBvbGljaWVz/connectors/c3VzcGVuc2lvbi5ub3RpZmljYXRpb24
+          example: >-
+            /t/carbon.super/api/server/v1/identity-governance/QWNjb3VudCBNYW5hZ2VtZW50IFBvbGljaWVz/connectors/c3VzcGVuc2lvbi5ub3RpZmljYXRpb24
     CategoryRes:
       type: object
       description: Governance connector category response.
@@ -710,6 +714,18 @@ components:
           type: string
           description: Property description.
           example: Enable account suspend notifications.
+        meta:
+          type: object
+          description: Meta data properties
+          $ref: '#/components/schemas/MetaRes'
+    MetaRes:
+      type: object
+      description: Meta data information
+      properties:
+        type:
+          type: string
+          description: Data type of the property
+          example: boolean
     ConnectorsPatchReq:
       type: object
       description: Governance connector property patch request.

--- a/components/org.wso2.carbon.identity.api.server.identity.governance/org.wso2.carbon.identity.api.server.identity.governance.v1/src/main/resources/identity-governance.yaml
+++ b/components/org.wso2.carbon.identity.api.server.identity.governance/org.wso2.carbon.identity.api.server.identity.governance.v1/src/main/resources/identity-governance.yaml
@@ -646,8 +646,7 @@ components:
         self:
           type: string
           description: Path to retrieve the full connector information.
-          example: >-
-            /t/carbon.super/api/server/v1/identity-governance/QWNjb3VudCBNYW5hZ2VtZW50IFBvbGljaWVz/connectors/c3VzcGVuc2lvbi5ub3RpZmljYXRpb24
+          example: /t/carbon.super/api/server/v1/identity-governance/QWNjb3VudCBNYW5hZ2VtZW50IFBvbGljaWVz/connectors/c3VzcGVuc2lvbi5ub3RpZmljYXRpb24
     CategoryRes:
       type: object
       description: Governance connector category response.
@@ -720,7 +719,7 @@ components:
           $ref: '#/components/schemas/MetaRes'
     MetaRes:
       type: object
-      description: Meta data information
+      description: Meta Data related to each property
       properties:
         type:
           type: string

--- a/components/org.wso2.carbon.identity.api.server.identity.governance/org.wso2.carbon.identity.api.server.identity.governance.v1/src/main/resources/identity-governance.yaml
+++ b/components/org.wso2.carbon.identity.api.server.identity.governance/org.wso2.carbon.identity.api.server.identity.governance.v1/src/main/resources/identity-governance.yaml
@@ -725,6 +725,10 @@ components:
           type: string
           description: Data type of the property
           example: boolean
+        regex:
+          type: string
+          description: regular expression
+          example: "[a-zA-Z0-9]{6}"
     ConnectorsPatchReq:
       type: object
       description: Governance connector property patch request.

--- a/components/org.wso2.carbon.identity.api.server.identity.governance/org.wso2.carbon.identity.api.server.identity.governance.v1/src/main/resources/identity-governance.yaml
+++ b/components/org.wso2.carbon.identity.api.server.identity.governance/org.wso2.carbon.identity.api.server.identity.governance.v1/src/main/resources/identity-governance.yaml
@@ -726,6 +726,10 @@ components:
           type: string
           description: regular expression
           example: "[a-zA-Z0-9]{6}"
+        groupID:
+          type: integer
+          description: Group id of the property if any
+          example: 0
     ConnectorsPatchReq:
       type: object
       description: Governance connector property patch request.

--- a/components/org.wso2.carbon.identity.api.server.identity.governance/org.wso2.carbon.identity.api.server.identity.governance.v1/src/main/resources/identity-governance.yaml
+++ b/components/org.wso2.carbon.identity.api.server.identity.governance/org.wso2.carbon.identity.api.server.identity.governance.v1/src/main/resources/identity-governance.yaml
@@ -802,3 +802,4 @@ components:
         traceId:
           type: string
           example: e0fbcfeb-3617-43c4-8dd0-7b7d38e13047
+

--- a/pom.xml
+++ b/pom.xml
@@ -553,7 +553,7 @@
         <maven.buildnumber.plugin.version>1.4</maven.buildnumber.plugin.version>
         <org.apache.felix.annotations.version>1.2.4</org.apache.felix.annotations.version>
         <identity.governance.version>1.5.25</identity.governance.version>
-        <carbon.identity.framework.version>5.19.20</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.20.101</carbon.identity.framework.version>
         <maven.findbugsplugin.version>3.0.5</maven.findbugsplugin.version>
         <identity.workflow.impl.bps.version>5.2.0</identity.workflow.impl.bps.version>
         <maven.checkstyleplugin.excludes>**/gen/**/*</maven.checkstyleplugin.excludes>

--- a/pom.xml
+++ b/pom.xml
@@ -552,7 +552,7 @@
         <junit.version>4.12</junit.version>
         <maven.buildnumber.plugin.version>1.4</maven.buildnumber.plugin.version>
         <org.apache.felix.annotations.version>1.2.4</org.apache.felix.annotations.version>
-        <identity.governance.version>1.4.75</identity.governance.version>
+        <identity.governance.version>1.5.25</identity.governance.version>
         <carbon.identity.framework.version>5.19.20</carbon.identity.framework.version>
         <maven.findbugsplugin.version>3.0.5</maven.findbugsplugin.version>
         <identity.workflow.impl.bps.version>5.2.0</identity.workflow.impl.bps.version>

--- a/pom.xml
+++ b/pom.xml
@@ -552,7 +552,7 @@
         <junit.version>4.12</junit.version>
         <maven.buildnumber.plugin.version>1.4</maven.buildnumber.plugin.version>
         <org.apache.felix.annotations.version>1.2.4</org.apache.felix.annotations.version>
-        <identity.governance.version>1.5.25</identity.governance.version>
+        <identity.governance.version>1.4.75</identity.governance.version>
         <carbon.identity.framework.version>5.20.101</carbon.identity.framework.version>
         <maven.findbugsplugin.version>3.0.5</maven.findbugsplugin.version>
         <identity.workflow.impl.bps.version>5.2.0</identity.workflow.impl.bps.version>

--- a/pom.xml
+++ b/pom.xml
@@ -480,7 +480,7 @@
         <javax.ws.rs-api.version>2.1.1</javax.ws.rs-api.version>
         <maven.buildnumber.plugin.version>1.4</maven.buildnumber.plugin.version>
         <org.apache.felix.annotations.version>1.2.4</org.apache.felix.annotations.version>
-        <identity.governance.version>1.4.75</identity.governance.version>
+       <identity.governance.version>1.5.25</identity.governance.version>
         <carbon.identity.framework.version>5.20.101</carbon.identity.framework.version>
         <maven.findbugsplugin.version>3.0.5</maven.findbugsplugin.version>
         <identity.workflow.impl.bps.version>5.2.0</identity.workflow.impl.bps.version>


### PR DESCRIPTION
## Purpose
Add metadata section to return json in ``Retrieve governance connector`` , GET endpoint. 

### Changes in this pull request
Updated openApi 3.0 definition in ``src/main/resources/identity-governance.yaml`` and regenerated the API of  `` org.wso2.carbon.identity.api.server.identity.governance.v1 `` and passed the metadata properties.

New Response
```
  "properties": [
        { "name": "Recovery.AdminPasswordReset.RecoveryLink",
            "value": "false",
            "displayName": "Enable password reset via recovery e-mail",
            "description": "User gets notified with a link to reset password",
            "meta": {
                "type": "boolean"
            }
       }
 ]
```

Related issue [10084](https://github.com/wso2/product-is/issues/10084)

* * *

New response after adding ``groupID``  to meta data section return JSON.

```       {
            "name": "SelfRegistration.CallbackRegex",
            "value": "[https://localhost:9443].*[/authenticationendpoint/login.do]",
            "displayName": "User self registration callback URL regex",
            "description": "This prefix will be used to validate the callback URL.",
            "meta": {
                "type": "string",
                "regex": ".*",
                "groupID": 0
            }
        },
```
* * *

* This PR is been made to fix the PR builder failure of [Original PR](https://github.com/wso2/identity-api-server/pull/275) 

* * * 
Tests
Following test scenarios were passed locally.
```
 <class name="org.wso2.identity.integration.test.rest.api.server.identity.governance.v1.IdentityGovernanceSuccessTest"/>
 <class name="org.wso2.identity.integration.test.rest.api.server.identity.governance.v1.IdentityGovernanceFailureTest"/>
```