### PR TITLE
 Support claim attribute mappings in bulk

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.userstore/org.wso2.carbon.identity.api.server.userstore.common/pom.xml
+++ b/components/org.wso2.carbon.identity.api.server.userstore/org.wso2.carbon.identity.api.server.userstore.common/pom.xml
@@ -30,6 +30,10 @@
             <artifactId>org.wso2.carbon.identity.user.store.configuration</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.claim.metadata.mgt</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-web</artifactId>
             <scope>provided</scope>

--- a/components/org.wso2.carbon.identity.api.server.userstore/org.wso2.carbon.identity.api.server.userstore.common/src/main/java/org/wso2/carbon/identity/api/server/userstore/common/UserStoreConfigServiceHolder.java
+++ b/components/org.wso2.carbon.identity.api.server.userstore/org.wso2.carbon.identity.api.server.userstore.common/src/main/java/org/wso2/carbon/identity/api/server/userstore/common/UserStoreConfigServiceHolder.java
@@ -16,6 +16,7 @@
 
 package org.wso2.carbon.identity.api.server.userstore.common;
 
+import org.wso2.carbon.identity.claim.metadata.mgt.ClaimMetadataManagementService;
 import org.wso2.carbon.identity.user.store.configuration.UserStoreConfigService;
 import org.wso2.carbon.user.core.service.RealmService;
 
@@ -27,6 +28,7 @@ public class UserStoreConfigServiceHolder {
     private static UserStoreConfigServiceHolder instance = new UserStoreConfigServiceHolder();
     private UserStoreConfigService userStoreConfigService;
     private RealmService realmService;
+    private ClaimMetadataManagementService claimMetadataManagementService;
 
     private UserStoreConfigServiceHolder() {}
 
@@ -53,5 +55,15 @@ public class UserStoreConfigServiceHolder {
     public void setRealmService(RealmService realmService) {
 
         UserStoreConfigServiceHolder.getInstance().realmService = realmService;
+    }
+
+    public ClaimMetadataManagementService getClaimMetadataManagementService() {
+
+        return UserStoreConfigServiceHolder.getInstance().claimMetadataManagementService;
+    }
+
+    public void setClaimMetadataManagementService(ClaimMetadataManagementService claimMetadataManagementService) {
+
+        UserStoreConfigServiceHolder.getInstance().claimMetadataManagementService = claimMetadataManagementService;
     }
 }

--- a/components/org.wso2.carbon.identity.api.server.userstore/org.wso2.carbon.identity.api.server.userstore.common/src/main/java/org/wso2/carbon/identity/api/server/userstore/common/UserStoreConstants.java
+++ b/components/org.wso2.carbon.identity.api.server.userstore/org.wso2.carbon.identity.api.server.userstore.common/src/main/java/org/wso2/carbon/identity/api/server/userstore/common/UserStoreConstants.java
@@ -107,12 +107,12 @@ public class UserStoreConstants {
                 "Userstore update request is either NULL or empty"),
         ERROR_CODE_USER_STORE_LIMIT_REACHED("60011", "Unable to create a user store.",
                 "Maximum number of allowed user stores have been reached."),
-        ERROR_CODE_ERROR_UPDATING_CLAIM_MAPPING("60012", "Unable to add local claims",
-                "Error occurred while adding local claims"),
-        ERROR_CODE_ERROR_RETRIEVING_CLAIM_MAPPING("60013", "Invalid attribute mapping.",
-                "Invalid userstore provided for attribute mapping"),
-        ERROR_CODE_EMPTY_ATTRIBUTE_MAPPINGS("60014", "Attribute mapping not specified",
-                "Attribute mapping cannot be empty");
+        ERROR_CODE_ERROR_UPDATING_CLAIM_MAPPING("60012", "Unable to update local claim mappings",
+                "Error occurred while updating local claim mappings."),
+        ERROR_CODE_ERROR_RETRIEVING_CLAIM_MAPPING("60013", "Unable to retrieve claim mappings.",
+                "Error occurred while retrieving claim attribute mappings."),
+        ERROR_CODE_EMPTY_ATTRIBUTE_MAPPINGS("60014", "Attribute mapping not specified.",
+                "Attribute mapping cannot be empty.");
 
         private final String code;
         private final String message;

--- a/components/org.wso2.carbon.identity.api.server.userstore/org.wso2.carbon.identity.api.server.userstore.common/src/main/java/org/wso2/carbon/identity/api/server/userstore/common/UserStoreConstants.java
+++ b/components/org.wso2.carbon.identity.api.server.userstore/org.wso2.carbon.identity.api.server.userstore.common/src/main/java/org/wso2/carbon/identity/api/server/userstore/common/UserStoreConstants.java
@@ -29,6 +29,7 @@ public class UserStoreConstants {
     public static final String USER_STORE_DOMAIN_NAME = "/domainName";
     public static final String USER_STORE_PROPERTIES = "/properties/";
     public static final String USER_STORE_PROPERTY_MASK = "************";
+    public static final String CLAIM_MANAGEMENT_PREFIX = "CMT-";
 
     /**
      * Enum for user store related errors in the format of
@@ -106,12 +107,12 @@ public class UserStoreConstants {
                 "Userstore update request is either NULL or empty"),
         ERROR_CODE_USER_STORE_LIMIT_REACHED("60011", "Unable to create a user store.",
                 "Maximum number of allowed user stores have been reached."),
-        ERROR_CODE_ERROR_ADDING_CLAIM_MAPPING("60012", "Unable to add local claims",
-                                                "Error occurred while adding local claims"),
-        ERROR_CODE_EMPTY_ATTRIBUTE_MAPPINGS("60013", "Attribute mapping not specified",
-                "Attribute mapping cannot be empty"),
-        ERROR_CODE_INVALID_USERSTORE("60014", "Invalid attribute mapping.",
-                "Invalid userstore provided for attribute mapping");
+        ERROR_CODE_ERROR_UPDATING_CLAIM_MAPPING("60012", "Unable to add local claims",
+                "Error occurred while adding local claims"),
+        ERROR_CODE_ERROR_RETRIEVING_CLAIM_MAPPING("60013", "Invalid attribute mapping.",
+                "Invalid userstore provided for attribute mapping"),
+        ERROR_CODE_EMPTY_ATTRIBUTE_MAPPINGS("60014", "Attribute mapping not specified",
+                "Attribute mapping cannot be empty");
 
         private final String code;
         private final String message;

--- a/components/org.wso2.carbon.identity.api.server.userstore/org.wso2.carbon.identity.api.server.userstore.common/src/main/java/org/wso2/carbon/identity/api/server/userstore/common/UserStoreConstants.java
+++ b/components/org.wso2.carbon.identity.api.server.userstore/org.wso2.carbon.identity.api.server.userstore.common/src/main/java/org/wso2/carbon/identity/api/server/userstore/common/UserStoreConstants.java
@@ -105,7 +105,13 @@ public class UserStoreConstants {
         ERROR_CODE_REQUEST_BODY_NOT_FOUND("60010", "Invalid userstore update request",
                 "Userstore update request is either NULL or empty"),
         ERROR_CODE_USER_STORE_LIMIT_REACHED("60011", "Unable to create a user store.",
-                "Maximum number of allowed user stores have been reached.");
+                "Maximum number of allowed user stores have been reached."),
+        ERROR_CODE_ERROR_ADDING_CLAIM_MAPPING("60012", "Unable to add local claims",
+                                                "Error occurred while adding local claims"),
+        ERROR_CODE_EMPTY_ATTRIBUTE_MAPPINGS("60013", "Attribute mapping not specified",
+                "Attribute mapping cannot be empty"),
+        ERROR_CODE_INVALID_USERSTORE("60014", "Invalid attribute mapping.",
+                "Invalid userstore provided for attribute mapping");
 
         private final String code;
         private final String message;

--- a/components/org.wso2.carbon.identity.api.server.userstore/org.wso2.carbon.identity.api.server.userstore.common/src/main/java/org/wso2/carbon/identity/api/server/userstore/common/factory/ClaimMetadataManagementServiceFactory.java
+++ b/components/org.wso2.carbon.identity.api.server.userstore/org.wso2.carbon.identity.api.server.userstore.common/src/main/java/org/wso2/carbon/identity/api/server/userstore/common/factory/ClaimMetadataManagementServiceFactory.java
@@ -49,8 +49,7 @@ public class ClaimMetadataManagementServiceFactory extends AbstractFactoryBean<C
         if (claimMetadataManagementService != null) {
             this.claimMetadataManagementService = claimMetadataManagementService;
             return this.claimMetadataManagementService;
-        } else {
-            throw new Exception("Unable to retrieve Claim Metadata Management Service.");
         }
+        throw new Exception("Unable to retrieve Claim Metadata Management Service.");
     }
 }

--- a/components/org.wso2.carbon.identity.api.server.userstore/org.wso2.carbon.identity.api.server.userstore.common/src/main/java/org/wso2/carbon/identity/api/server/userstore/common/factory/ClaimMetadataManagementServiceFactory.java
+++ b/components/org.wso2.carbon.identity.api.server.userstore/org.wso2.carbon.identity.api.server.userstore.common/src/main/java/org/wso2/carbon/identity/api/server/userstore/common/factory/ClaimMetadataManagementServiceFactory.java
@@ -1,17 +1,19 @@
 /*
- * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.com).
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
  * You may obtain a copy of the License at
  *
  * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 
 package org.wso2.carbon.identity.api.server.userstore.common.factory;
@@ -39,16 +41,16 @@ public class ClaimMetadataManagementServiceFactory extends AbstractFactoryBean<C
 
         if (this.claimMetadataManagementService != null) {
             return this.claimMetadataManagementService;
-        } else {
-            ClaimMetadataManagementService claimMetadataManagementService = (ClaimMetadataManagementService)
+        }
+
+        ClaimMetadataManagementService claimMetadataManagementService = (ClaimMetadataManagementService)
                     PrivilegedCarbonContext.getThreadLocalCarbonContext()
                             .getOSGiService(ClaimMetadataManagementService.class, null);
-            if (claimMetadataManagementService != null) {
-                this.claimMetadataManagementService = claimMetadataManagementService;
-                return this.claimMetadataManagementService;
-            } else {
-                throw new Exception("Unable to retrieve Claim Metadata Management Service.");
-            }
+        if (claimMetadataManagementService != null) {
+            this.claimMetadataManagementService = claimMetadataManagementService;
+            return this.claimMetadataManagementService;
+        } else {
+            throw new Exception("Unable to retrieve Claim Metadata Management Service.");
         }
     }
 }

--- a/components/org.wso2.carbon.identity.api.server.userstore/org.wso2.carbon.identity.api.server.userstore.common/src/main/java/org/wso2/carbon/identity/api/server/userstore/common/factory/ClaimMetadataManagementServiceFactory.java
+++ b/components/org.wso2.carbon.identity.api.server.userstore/org.wso2.carbon.identity.api.server.userstore.common/src/main/java/org/wso2/carbon/identity/api/server/userstore/common/factory/ClaimMetadataManagementServiceFactory.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.userstore.common.factory;
+
+import org.springframework.beans.factory.config.AbstractFactoryBean;
+import org.wso2.carbon.context.PrivilegedCarbonContext;
+import org.wso2.carbon.identity.claim.metadata.mgt.ClaimMetadataManagementService;
+
+/**
+ * Factory Beans serves as a factory for creating other beans within the IOC container. This factory bean is used to
+ * instantiate the ClaimMetadataManagementService type of object inside the container.
+ */
+public class ClaimMetadataManagementServiceFactory extends AbstractFactoryBean<ClaimMetadataManagementService> {
+
+    private ClaimMetadataManagementService claimMetadataManagementService;
+
+    @Override
+    public Class<ClaimMetadataManagementService> getObjectType() {
+
+        return ClaimMetadataManagementService.class;
+    }
+
+    @Override
+    protected ClaimMetadataManagementService createInstance() throws Exception {
+
+        if (this.claimMetadataManagementService == null) {
+            ClaimMetadataManagementService claimMetadataManagementService = (ClaimMetadataManagementService)
+                    PrivilegedCarbonContext.getThreadLocalCarbonContext()
+                            .getOSGiService(ClaimMetadataManagementService.class, null);
+            if (claimMetadataManagementService != null) {
+                this.claimMetadataManagementService = claimMetadataManagementService;
+            } else {
+                throw new Exception("Unable to retrieve Claim Metadata Management Service.");
+            }
+        }
+        return this.claimMetadataManagementService;
+    }
+}

--- a/components/org.wso2.carbon.identity.api.server.userstore/org.wso2.carbon.identity.api.server.userstore.common/src/main/java/org/wso2/carbon/identity/api/server/userstore/common/factory/ClaimMetadataManagementServiceFactory.java
+++ b/components/org.wso2.carbon.identity.api.server.userstore/org.wso2.carbon.identity.api.server.userstore.common/src/main/java/org/wso2/carbon/identity/api/server/userstore/common/factory/ClaimMetadataManagementServiceFactory.java
@@ -37,16 +37,18 @@ public class ClaimMetadataManagementServiceFactory extends AbstractFactoryBean<C
     @Override
     protected ClaimMetadataManagementService createInstance() throws Exception {
 
-        if (this.claimMetadataManagementService == null) {
+        if (this.claimMetadataManagementService != null) {
+            return this.claimMetadataManagementService;
+        } else {
             ClaimMetadataManagementService claimMetadataManagementService = (ClaimMetadataManagementService)
                     PrivilegedCarbonContext.getThreadLocalCarbonContext()
                             .getOSGiService(ClaimMetadataManagementService.class, null);
             if (claimMetadataManagementService != null) {
                 this.claimMetadataManagementService = claimMetadataManagementService;
+                return this.claimMetadataManagementService;
             } else {
                 throw new Exception("Unable to retrieve Claim Metadata Management Service.");
             }
         }
-        return this.claimMetadataManagementService;
     }
 }

--- a/components/org.wso2.carbon.identity.api.server.userstore/org.wso2.carbon.identity.api.server.userstore.v1/pom.xml
+++ b/components/org.wso2.carbon.identity.api.server.userstore/org.wso2.carbon.identity.api.server.userstore.v1/pom.xml
@@ -163,5 +163,9 @@
             <groupId>org.wso2.carbon.identity.framework</groupId>
             <artifactId>org.wso2.carbon.identity.user.store.configuration</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.claim.metadata.mgt</artifactId>
+        </dependency>
     </dependencies>
 </project>

--- a/components/org.wso2.carbon.identity.api.server.userstore/org.wso2.carbon.identity.api.server.userstore.v1/src/gen/java/org/wso2/carbon/identity/api/server/userstore/v1/UserstoresApi.java
+++ b/components/org.wso2.carbon.identity.api.server.userstore/org.wso2.carbon.identity.api.server.userstore.v1/src/gen/java/org/wso2/carbon/identity/api/server/userstore/v1/UserstoresApi.java
@@ -214,7 +214,7 @@ public class UserstoresApi  {
     @Path("/{userstore-domain-id}/attribute-mappings")
     @Consumes({ "application/json" })
     @Produces({ "application/json" })
-    @ApiOperation(value = "Patch the secondary user store attribute mappings by it's domain id.", notes = "This API provides the capability to update the secondary user store's attribute mappings using patch request by using its domain id.  <b>Permission required:</b>  *_/permission/admin ", response = Void.class, authorizations = {
+    @ApiOperation(value = "Update the secondary user store attribute mappings by it's domain id.", notes = "This API provides the capability to update the secondary user store's attribute mappings using patch request by using its domain id.  <b>Permission required:</b>  *_/permission/admin ", response = Void.class, authorizations = {
         @Authorization(value = "BasicAuth"),
         @Authorization(value = "OAuth2", scopes = {
             
@@ -230,7 +230,7 @@ public class UserstoresApi  {
     })
     public Response patchAttributeMappings(@ApiParam(value = "The unique name of the user store domain",required=true) @PathParam("userstore-domain-id") String userstoreDomainId, @ApiParam(value = "" ,required=true) @Valid List<ClaimAttributeMapping> claimAttributeMapping) {
 
-        return delegate.patchAttributeMappings(userstoreDomainId,  claimAttributeMapping );
+        return delegate.updateAttributeMappings(userstoreDomainId,  claimAttributeMapping );
     }
 
     @Valid

--- a/components/org.wso2.carbon.identity.api.server.userstore/org.wso2.carbon.identity.api.server.userstore.v1/src/gen/java/org/wso2/carbon/identity/api/server/userstore/v1/UserstoresApi.java
+++ b/components/org.wso2.carbon.identity.api.server.userstore/org.wso2.carbon.identity.api.server.userstore.v1/src/gen/java/org/wso2/carbon/identity/api/server/userstore/v1/UserstoresApi.java
@@ -23,6 +23,7 @@ import java.io.InputStream;
 import java.util.List;
 
 import org.wso2.carbon.identity.api.server.userstore.v1.model.AvailableUserStoreClassesRes;
+import org.wso2.carbon.identity.api.server.userstore.v1.model.ClaimAttributeMapping;
 import org.wso2.carbon.identity.api.server.userstore.v1.model.ConnectionEstablishedResponse;
 import org.wso2.carbon.identity.api.server.userstore.v1.model.Error;
 import java.util.List;
@@ -206,6 +207,30 @@ public class UserstoresApi  {
     public Response getUserStoreManagerProperties(@ApiParam(value = "Id of the user store type",required=true) @PathParam("type-id") String typeId) {
 
         return delegate.getUserStoreManagerProperties(typeId );
+    }
+
+    @Valid
+    @PATCH
+    @Path("/{userstore-domain-id}/attribute-mappings")
+    @Consumes({ "application/json" })
+    @Produces({ "application/json" })
+    @ApiOperation(value = "Patch the secondary user store attribute mappings by it's domain id.", notes = "This API provides the capability to update the secondary user store's attribute mappings using patch request by using its domain id.  <b>Permission required:</b>  *_/permission/admin ", response = Void.class, authorizations = {
+        @Authorization(value = "BasicAuth"),
+        @Authorization(value = "OAuth2", scopes = {
+            
+        })
+    }, tags={ "User Store", })
+    @ApiResponses(value = { 
+        @ApiResponse(code = 200, message = "OK.", response = Void.class),
+        @ApiResponse(code = 400, message = "Invalid input request.", response = Error.class),
+        @ApiResponse(code = 401, message = "Unauthorized.", response = Void.class),
+        @ApiResponse(code = 403, message = "Resource Forbidden.", response = Void.class),
+        @ApiResponse(code = 404, message = "The specified resource is not found.", response = Error.class),
+        @ApiResponse(code = 500, message = "Internal Server Error.", response = Error.class)
+    })
+    public Response patchAttributeMappings(@ApiParam(value = "The unique name of the user store domain",required=true) @PathParam("userstore-domain-id") String userstoreDomainId, @ApiParam(value = "" ,required=true) @Valid List<ClaimAttributeMapping> claimAttributeMapping) {
+
+        return delegate.patchAttributeMappings(userstoreDomainId,  claimAttributeMapping );
     }
 
     @Valid

--- a/components/org.wso2.carbon.identity.api.server.userstore/org.wso2.carbon.identity.api.server.userstore.v1/src/gen/java/org/wso2/carbon/identity/api/server/userstore/v1/UserstoresApi.java
+++ b/components/org.wso2.carbon.identity.api.server.userstore/org.wso2.carbon.identity.api.server.userstore.v1/src/gen/java/org/wso2/carbon/identity/api/server/userstore/v1/UserstoresApi.java
@@ -228,7 +228,7 @@ public class UserstoresApi  {
         @ApiResponse(code = 404, message = "The specified resource is not found.", response = Error.class),
         @ApiResponse(code = 500, message = "Internal Server Error.", response = Error.class)
     })
-    public Response patchAttributeMappings(@ApiParam(value = "The unique name of the user store domain",required=true) @PathParam("userstore-domain-id") String userstoreDomainId, @ApiParam(value = "" ,required=true) @Valid List<ClaimAttributeMapping> claimAttributeMapping) {
+    public Response updateAttributeMappings(@ApiParam(value = "The unique name of the user store domain",required=true) @PathParam("userstore-domain-id") String userstoreDomainId, @ApiParam(value = "" ,required=true) @Valid List<ClaimAttributeMapping> claimAttributeMapping) {
 
         return delegate.updateAttributeMappings(userstoreDomainId,  claimAttributeMapping );
     }

--- a/components/org.wso2.carbon.identity.api.server.userstore/org.wso2.carbon.identity.api.server.userstore.v1/src/gen/java/org/wso2/carbon/identity/api/server/userstore/v1/UserstoresApiService.java
+++ b/components/org.wso2.carbon.identity.api.server.userstore/org.wso2.carbon.identity.api.server.userstore.v1/src/gen/java/org/wso2/carbon/identity/api/server/userstore/v1/UserstoresApiService.java
@@ -53,7 +53,7 @@ public interface UserstoresApiService {
 
       public Response getUserStoreManagerProperties(String typeId);
 
-      public Response patchAttributeMappings(String userstoreDomainId, List<ClaimAttributeMapping> claimAttributeMapping);
+      public Response updateAttributeMappings(String userstoreDomainId, List<ClaimAttributeMapping> claimAttributeMapping);
 
       public Response patchUserStore(String userstoreDomainId, List<PatchDocument> patchDocument);
 

--- a/components/org.wso2.carbon.identity.api.server.userstore/org.wso2.carbon.identity.api.server.userstore.v1/src/gen/java/org/wso2/carbon/identity/api/server/userstore/v1/UserstoresApiService.java
+++ b/components/org.wso2.carbon.identity.api.server.userstore/org.wso2.carbon.identity.api.server.userstore.v1/src/gen/java/org/wso2/carbon/identity/api/server/userstore/v1/UserstoresApiService.java
@@ -23,6 +23,7 @@ import org.apache.cxf.jaxrs.ext.multipart.Multipart;
 import java.io.InputStream;
 import java.util.List;
 import org.wso2.carbon.identity.api.server.userstore.v1.model.AvailableUserStoreClassesRes;
+import org.wso2.carbon.identity.api.server.userstore.v1.model.ClaimAttributeMapping;
 import org.wso2.carbon.identity.api.server.userstore.v1.model.ConnectionEstablishedResponse;
 import org.wso2.carbon.identity.api.server.userstore.v1.model.Error;
 import java.util.List;
@@ -51,6 +52,8 @@ public interface UserstoresApiService {
       public Response getUserStoreByDomainId(String userstoreDomainId);
 
       public Response getUserStoreManagerProperties(String typeId);
+
+      public Response patchAttributeMappings(String userstoreDomainId, List<ClaimAttributeMapping> claimAttributeMapping);
 
       public Response patchUserStore(String userstoreDomainId, List<PatchDocument> patchDocument);
 

--- a/components/org.wso2.carbon.identity.api.server.userstore/org.wso2.carbon.identity.api.server.userstore.v1/src/gen/java/org/wso2/carbon/identity/api/server/userstore/v1/model/ClaimAttributeMapping.java
+++ b/components/org.wso2.carbon.identity.api.server.userstore/org.wso2.carbon.identity.api.server.userstore.v1/src/gen/java/org/wso2/carbon/identity/api/server/userstore/v1/model/ClaimAttributeMapping.java
@@ -1,18 +1,20 @@
 /*
-* Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-* http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.com).
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 
 package org.wso2.carbon.identity.api.server.userstore.v1.model;
 

--- a/components/org.wso2.carbon.identity.api.server.userstore/org.wso2.carbon.identity.api.server.userstore.v1/src/gen/java/org/wso2/carbon/identity/api/server/userstore/v1/model/ClaimAttributeMapping.java
+++ b/components/org.wso2.carbon.identity.api.server.userstore/org.wso2.carbon.identity.api.server.userstore.v1/src/gen/java/org/wso2/carbon/identity/api/server/userstore/v1/model/ClaimAttributeMapping.java
@@ -1,0 +1,123 @@
+/*
+* Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package org.wso2.carbon.identity.api.server.userstore.v1.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import javax.validation.constraints.*;
+
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+import javax.validation.Valid;
+import javax.xml.bind.annotation.*;
+
+public class ClaimAttributeMapping  {
+  
+    private String claimURI;
+    private String mappedAttribute;
+
+    /**
+    * A unique URI specific to the claim.
+    **/
+    public ClaimAttributeMapping claimURI(String claimURI) {
+
+        this.claimURI = claimURI;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "http://wso2.org/claims/username", required = true, value = "A unique URI specific to the claim.")
+    @JsonProperty("claimURI")
+    @Valid
+    @NotNull(message = "Property claimURI cannot be null.")
+
+    public String getClaimURI() {
+        return claimURI;
+    }
+    public void setClaimURI(String claimURI) {
+        this.claimURI = claimURI;
+    }
+
+    /**
+    * Userstore attribute to be mapped to.
+    **/
+    public ClaimAttributeMapping mappedAttribute(String mappedAttribute) {
+
+        this.mappedAttribute = mappedAttribute;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "username", required = true, value = "Userstore attribute to be mapped to.")
+    @JsonProperty("mappedAttribute")
+    @Valid
+    @NotNull(message = "Property mappedAttribute cannot be null.")
+
+    public String getMappedAttribute() {
+        return mappedAttribute;
+    }
+    public void setMappedAttribute(String mappedAttribute) {
+        this.mappedAttribute = mappedAttribute;
+    }
+
+
+
+    @Override
+    public boolean equals(java.lang.Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ClaimAttributeMapping claimAttributeMapping = (ClaimAttributeMapping) o;
+        return Objects.equals(this.claimURI, claimAttributeMapping.claimURI) &&
+            Objects.equals(this.mappedAttribute, claimAttributeMapping.mappedAttribute);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(claimURI, mappedAttribute);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class ClaimAttributeMapping {\n");
+        
+        sb.append("    claimURI: ").append(toIndentedString(claimURI)).append("\n");
+        sb.append("    mappedAttribute: ").append(toIndentedString(mappedAttribute)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+    * Convert the given object to string with each line indented by 4 spaces
+    * (except the first line).
+    */
+    private String toIndentedString(java.lang.Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}
+

--- a/components/org.wso2.carbon.identity.api.server.userstore/org.wso2.carbon.identity.api.server.userstore.v1/src/gen/java/org/wso2/carbon/identity/api/server/userstore/v1/model/UserStoreConfigurationsRes.java
+++ b/components/org.wso2.carbon.identity.api.server.userstore/org.wso2.carbon.identity.api.server.userstore.v1/src/gen/java/org/wso2/carbon/identity/api/server/userstore/v1/model/UserStoreConfigurationsRes.java
@@ -197,7 +197,7 @@ public class UserStoreConfigurationsRes  {
     }
 
     /**
-     * Requested configured user store claim attribute mappings
+     * Requested configured user store claim attribute mappings.
      **/
     public UserStoreConfigurationsRes claimAttributeMappings(List<ClaimAttributeMapping> claimAttributeMappings) {
 

--- a/components/org.wso2.carbon.identity.api.server.userstore/org.wso2.carbon.identity.api.server.userstore.v1/src/gen/java/org/wso2/carbon/identity/api/server/userstore/v1/model/UserStoreConfigurationsRes.java
+++ b/components/org.wso2.carbon.identity.api.server.userstore/org.wso2.carbon.identity.api.server.userstore.v1/src/gen/java/org/wso2/carbon/identity/api/server/userstore/v1/model/UserStoreConfigurationsRes.java
@@ -23,6 +23,7 @@ import io.swagger.annotations.ApiModelProperty;
 import java.util.ArrayList;
 import java.util.List;
 import org.wso2.carbon.identity.api.server.userstore.v1.model.AddUserStorePropertiesRes;
+import org.wso2.carbon.identity.api.server.userstore.v1.model.ClaimAttributeMapping;
 import javax.validation.constraints.*;
 
 /**
@@ -36,7 +37,7 @@ import javax.xml.bind.annotation.*;
 
 @ApiModel(description = "Available User Store Configurations Response.")
 public class UserStoreConfigurationsRes  {
-  
+
     private String typeName;
     private String typeId;
     private String name;
@@ -44,6 +45,7 @@ public class UserStoreConfigurationsRes  {
     private String className;
     private boolean isLocal;
     private List<AddUserStorePropertiesRes> properties = null;
+    private List<ClaimAttributeMapping> claimAttributeMappings = null;
 
 
     /**
@@ -53,7 +55,7 @@ public class UserStoreConfigurationsRes  {
         this.typeName = typeName;
         return this;
     }
-    
+
     @ApiModelProperty(example = "UniqueIDJDBCUserStoreManager", value = "")
     @JsonProperty("typeName")
     @Valid
@@ -71,7 +73,7 @@ public class UserStoreConfigurationsRes  {
         this.typeId = typeId;
         return this;
     }
-    
+
     @ApiModelProperty(example = "VW5pcXVlSURKREJDVXNlclN0b3JlTWFuYWdlcg", value = "")
     @JsonProperty("typeId")
     @Valid
@@ -89,7 +91,7 @@ public class UserStoreConfigurationsRes  {
         this.name = name;
         return this;
     }
-    
+
     @ApiModelProperty(example = "JDBC-SECONDARY", value = "")
     @JsonProperty("name")
     @Valid
@@ -107,7 +109,7 @@ public class UserStoreConfigurationsRes  {
         this.description = description;
         return this;
     }
-    
+
     @ApiModelProperty(example = "Some description of the user store", value = "")
     @JsonProperty("description")
     @Valid
@@ -125,7 +127,7 @@ public class UserStoreConfigurationsRes  {
         this.className = className;
         return this;
     }
-    
+
     @ApiModelProperty(example = "org.wso2.carbon.user.core.jdbc.UniqueIDJDBCUserStoreManager", value = "")
     @JsonProperty("className")
     @Valid
@@ -144,7 +146,7 @@ public class UserStoreConfigurationsRes  {
         this.properties = properties;
         return this;
     }
-    
+
     @ApiModelProperty(value = "Configured user store property for the set")
     @JsonProperty("properties")
     @Valid
@@ -194,6 +196,35 @@ public class UserStoreConfigurationsRes  {
         return this;
     }
 
+    /**
+     * Requested configured user store claim attribute mappings
+     **/
+    public UserStoreConfigurationsRes claimAttributeMappings(List<ClaimAttributeMapping> claimAttributeMappings) {
+
+        this.claimAttributeMappings = claimAttributeMappings;
+        return this;
+    }
+
+    @ApiModelProperty(value = "Requested configured user store claim attribute mappings")
+    @JsonProperty("claimAttributeMappings")
+    @Valid
+    public List<ClaimAttributeMapping> getClaimAttributeMappings() {
+        return claimAttributeMappings;
+    }
+    public void setClaimAttributeMappings(List<ClaimAttributeMapping> claimAttributeMappings) {
+        this.claimAttributeMappings = claimAttributeMappings;
+    }
+
+    public UserStoreConfigurationsRes addClaimAttributeMappingsItem(ClaimAttributeMapping claimAttributeMappingsItem) {
+        if (this.claimAttributeMappings == null) {
+            this.claimAttributeMappings = new ArrayList<>();
+        }
+        this.claimAttributeMappings.add(claimAttributeMappingsItem);
+        return this;
+    }
+
+
+
     @Override
     public boolean equals(java.lang.Object o) {
 
@@ -209,12 +240,13 @@ public class UserStoreConfigurationsRes  {
             Objects.equals(this.name, userStoreConfigurationsRes.name) &&
             Objects.equals(this.description, userStoreConfigurationsRes.description) &&
             Objects.equals(this.className, userStoreConfigurationsRes.className) &&
-            Objects.equals(this.properties, userStoreConfigurationsRes.properties);
+            Objects.equals(this.properties, userStoreConfigurationsRes.properties) &&
+            Objects.equals(this.claimAttributeMappings, userStoreConfigurationsRes.claimAttributeMappings);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(typeName, typeId, name, description, className, properties);
+        return Objects.hash(typeName, typeId, name, description, className, properties, claimAttributeMappings);
     }
 
     @Override
@@ -222,13 +254,14 @@ public class UserStoreConfigurationsRes  {
 
         StringBuilder sb = new StringBuilder();
         sb.append("class UserStoreConfigurationsRes {\n");
-        
+
         sb.append("    typeName: ").append(toIndentedString(typeName)).append("\n");
         sb.append("    typeId: ").append(toIndentedString(typeId)).append("\n");
         sb.append("    name: ").append(toIndentedString(name)).append("\n");
         sb.append("    description: ").append(toIndentedString(description)).append("\n");
         sb.append("    className: ").append(toIndentedString(className)).append("\n");
         sb.append("    properties: ").append(toIndentedString(properties)).append("\n");
+        sb.append("    claimAttributeMappings: ").append(toIndentedString(claimAttributeMappings)).append("\n");
         sb.append("}");
         return sb.toString();
     }

--- a/components/org.wso2.carbon.identity.api.server.userstore/org.wso2.carbon.identity.api.server.userstore.v1/src/gen/java/org/wso2/carbon/identity/api/server/userstore/v1/model/UserStoreReq.java
+++ b/components/org.wso2.carbon.identity.api.server.userstore/org.wso2.carbon.identity.api.server.userstore.v1/src/gen/java/org/wso2/carbon/identity/api/server/userstore/v1/model/UserStoreReq.java
@@ -22,6 +22,7 @@ import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import java.util.ArrayList;
 import java.util.List;
+import org.wso2.carbon.identity.api.server.userstore.v1.model.ClaimAttributeMapping;
 import org.wso2.carbon.identity.api.server.userstore.v1.model.Property;
 import javax.validation.constraints.*;
 
@@ -40,7 +41,7 @@ public class UserStoreReq  {
     private String description;
     private String name;
     private List<Property> properties = new ArrayList<>();
-
+    private List<ClaimAttributeMapping> claimAttributeMappings = null;
 
     /**
     * The id of the user store manager class type.
@@ -131,7 +132,32 @@ public class UserStoreReq  {
         return this;
     }
 
+    /**
+    * Claim attribute mappings.
+    **/
+    public UserStoreReq claimAttributeMappings(List<ClaimAttributeMapping> claimAttributeMappings) {
+
+        this.claimAttributeMappings = claimAttributeMappings;
+        return this;
+    }
     
+    @ApiModelProperty(value = "Claim attribute mappings.")
+    @JsonProperty("claimAttributeMappings")
+    @Valid
+    public List<ClaimAttributeMapping> getClaimAttributeMappings() {
+        return claimAttributeMappings;
+    }
+    public void setClaimAttributeMappings(List<ClaimAttributeMapping> claimAttributeMappings) {
+        this.claimAttributeMappings = claimAttributeMappings;
+    }
+
+    public UserStoreReq addClaimAttributeMappingsItem(ClaimAttributeMapping claimAttributeMappingsItem) {
+        if (this.claimAttributeMappings == null) {
+            this.claimAttributeMappings = new ArrayList<>();
+        }
+        this.claimAttributeMappings.add(claimAttributeMappingsItem);
+        return this;
+    }
 
     @Override
     public boolean equals(java.lang.Object o) {
@@ -146,12 +172,13 @@ public class UserStoreReq  {
         return Objects.equals(this.typeId, userStoreReq.typeId) &&
             Objects.equals(this.description, userStoreReq.description) &&
             Objects.equals(this.name, userStoreReq.name) &&
-            Objects.equals(this.properties, userStoreReq.properties);
+            Objects.equals(this.properties, userStoreReq.properties) &&
+            Objects.equals(this.claimAttributeMappings, userStoreReq.claimAttributeMappings);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(typeId, description, name, properties);
+        return Objects.hash(typeId, description, name, properties, claimAttributeMappings);
     }
 
     @Override
@@ -164,6 +191,7 @@ public class UserStoreReq  {
         sb.append("    description: ").append(toIndentedString(description)).append("\n");
         sb.append("    name: ").append(toIndentedString(name)).append("\n");
         sb.append("    properties: ").append(toIndentedString(properties)).append("\n");
+        sb.append("    claimAttributeMappings: ").append(toIndentedString(claimAttributeMappings)).append("\n");
         sb.append("}");
         return sb.toString();
     }

--- a/components/org.wso2.carbon.identity.api.server.userstore/org.wso2.carbon.identity.api.server.userstore.v1/src/main/java/org/wso2/carbon/identity/api/server/userstore/v1/core/ServerUserStoreService.java
+++ b/components/org.wso2.carbon.identity.api.server.userstore/org.wso2.carbon.identity.api.server.userstore.v1/src/main/java/org/wso2/carbon/identity/api/server/userstore/v1/core/ServerUserStoreService.java
@@ -469,7 +469,7 @@ public class ServerUserStoreService {
     /**
      * To check whether user store is exist.
      *
-     * @param userStoreDomain     user store domain name
+     * @param userStoreDomain     user store domain name.
      * @return boolean
      */
     private boolean isUserStoreExists(String userStoreDomain) throws UserStoreException {
@@ -622,9 +622,9 @@ public class ServerUserStoreService {
     /**
      * To update claim attribute mappings in bulk for specific user store.
      *
-     * @param userstoreDomain user store domain name
-     * @param tenantDomain tenant domain name
-     * @param localClaimList list of claim attribute mappings
+     * @param userstoreDomain user store domain name.
+     * @param tenantDomain tenant domain name.
+     * @param localClaimList list of claim attribute mappings.
      */
     private void updateClaimMappings(String userstoreDomain, String tenantDomain, List<LocalClaim> localClaimList) {
 
@@ -642,8 +642,8 @@ public class ServerUserStoreService {
     /**
      * To validate claim existence of claim attribute mappings.
      *
-     * @param tenantDomain tenant domain name
-     * @param localClaimList list of claim attribute mappings
+     * @param tenantDomain tenant domain name.
+     * @param localClaimList list of claim attribute mappings.
      */
     private void validateClaimMappings(String tenantDomain, List<LocalClaim> localClaimList) {
 

--- a/components/org.wso2.carbon.identity.api.server.userstore/org.wso2.carbon.identity.api.server.userstore.v1/src/main/java/org/wso2/carbon/identity/api/server/userstore/v1/core/ServerUserStoreService.java
+++ b/components/org.wso2.carbon.identity.api.server.userstore/org.wso2.carbon.identity.api.server.userstore.v1/src/main/java/org/wso2/carbon/identity/api/server/userstore/v1/core/ServerUserStoreService.java
@@ -109,8 +109,7 @@ public class ServerUserStoreService {
 
             List<ClaimAttributeMapping> claimAttributeMappingList = userStoreReq.getClaimAttributeMappings();
             if (claimAttributeMappingList != null) {
-                localClaimList =  createLocalClaimList(userstoreDomain,
-                        claimAttributeMappingList);
+                localClaimList =  createLocalClaimList(userstoreDomain, claimAttributeMappingList);
                 validateClaimMappings(tenantDomain, localClaimList);
             }
 
@@ -440,11 +439,11 @@ public class ServerUserStoreService {
     /**
      * To make a partial update single or multiple claim attribute mappings of a specific user store.
      *
-     * @param userstoreDomainId     user store domain id
-     * @param claimAttributeMapping list of claim attribute mappings in patch request
+     * @param userstoreDomainId     user store domain id.
+     * @param claimAttributeMapping list of claim attribute mappings in patch request.
      */
-    public void patchClaimAttributeMapping(String userstoreDomainId,
-                                           List<ClaimAttributeMapping> claimAttributeMapping) {
+    public void updateClaimAttributeMappings(String userstoreDomainId,
+                                             List<ClaimAttributeMapping> claimAttributeMapping) {
 
         if (claimAttributeMapping == null) {
             throw handleException(Response.Status.BAD_REQUEST,
@@ -1154,8 +1153,8 @@ public class ServerUserStoreService {
      * Handle ClaimManagementException, extract the error code and the error message from the corresponding
      * exception and set it to the API Error Response.
      *
-     * @param exception     Exception thrown
-     * @param errorEnum     Corresponding error enum
+     * @param exception     Exception thrown.
+     * @param errorEnum     Corresponding error enum.
      * @return API Error object.
      */
     private APIError handleClaimManagementException(ClaimMetadataException exception,
@@ -1177,9 +1176,9 @@ public class ServerUserStoreService {
      * Handle ClaimManagementException, extract the error code and the error message from the corresponding
      * exception and set it to the API Error Response.
      *
-     * @param exception     Exception thrown
-     * @param errorResponse Corresponding error response
-     * @param status        Corresponding status response
+     * @param exception     Exception thrown.
+     * @param errorResponse Corresponding error response.
+     * @param status        Corresponding status response.
      * @return API Error object.
      */
     private APIError handleClaimManagementClientException(ClaimMetadataException  exception,
@@ -1230,7 +1229,7 @@ public class ServerUserStoreService {
     /**
      * Validate userstore domain Id.
      *
-     * @param userstoreDomainId    Userstore domain ID
+     * @param userstoreDomainId    Userstore domain ID.
      * @throws IdentityUserStoreClientException If request is invalid.
      */
     private void validateUserstore(String userstoreDomainId) throws UserStoreException,

--- a/components/org.wso2.carbon.identity.api.server.userstore/org.wso2.carbon.identity.api.server.userstore.v1/src/main/java/org/wso2/carbon/identity/api/server/userstore/v1/core/ServerUserStoreService.java
+++ b/components/org.wso2.carbon.identity.api.server.userstore/org.wso2.carbon.identity.api.server.userstore.v1/src/main/java/org/wso2/carbon/identity/api/server/userstore/v1/core/ServerUserStoreService.java
@@ -105,17 +105,20 @@ public class ServerUserStoreService {
 
             String userstoreDomain = userStoreReq.getName();
             String tenantDomain = ContextLoader.getTenantDomainFromContext();
+            List<LocalClaim> localClaimList = new ArrayList<>();
 
-            List<LocalClaim> localClaimList =  createLocalClaimList(userstoreDomain,
-                    userStoreReq.getClaimAttributeMappings());
-            validateClaimMappings(tenantDomain, localClaimList);
+            List<ClaimAttributeMapping> claimAttributeMappingList = userStoreReq.getClaimAttributeMappings();
+            if (claimAttributeMappingList != null) {
+                localClaimList =  createLocalClaimList(userstoreDomain,
+                        claimAttributeMappingList);
+                validateClaimMappings(tenantDomain, localClaimList);
+            }
 
             UserStoreConfigService userStoreConfigService = UserStoreConfigServiceHolder.getInstance()
                     .getUserStoreConfigService();
             UserStoreDTO userStoreDTO = createUserStoreDTO(userStoreReq);
             userStoreConfigService.addUserStore(userStoreDTO);
 
-            List<ClaimAttributeMapping> claimAttributeMappingList = userStoreReq.getClaimAttributeMappings();
             if (claimAttributeMappingList != null) {
                 updateClaimMappings(userstoreDomain, tenantDomain, localClaimList);
             }

--- a/components/org.wso2.carbon.identity.api.server.userstore/org.wso2.carbon.identity.api.server.userstore.v1/src/main/java/org/wso2/carbon/identity/api/server/userstore/v1/impl/UserstoresApiServiceImpl.java
+++ b/components/org.wso2.carbon.identity.api.server.userstore/org.wso2.carbon.identity.api.server.userstore.v1/src/main/java/org/wso2/carbon/identity/api/server/userstore/v1/impl/UserstoresApiServiceImpl.java
@@ -89,10 +89,10 @@ public class UserstoresApiServiceImpl implements UserstoresApiService {
     }
 
     @Override
-    public Response patchAttributeMappings(String userstoreDomainId,
-                                           List<ClaimAttributeMapping> claimAttributeMapping) {
-        serverUserStoreService.patchClaimAttributeMapping(userstoreDomainId,
-                claimAttributeMapping);
+    public Response updateAttributeMappings(String userstoreDomainId,
+                                           List<ClaimAttributeMapping> claimAttributeMappings) {
+        serverUserStoreService.updateClaimAttributeMappings(userstoreDomainId,
+                claimAttributeMappings);
         return Response.ok().build();
     }
 

--- a/components/org.wso2.carbon.identity.api.server.userstore/org.wso2.carbon.identity.api.server.userstore.v1/src/main/java/org/wso2/carbon/identity/api/server/userstore/v1/impl/UserstoresApiServiceImpl.java
+++ b/components/org.wso2.carbon.identity.api.server.userstore/org.wso2.carbon.identity.api.server.userstore.v1/src/main/java/org/wso2/carbon/identity/api/server/userstore/v1/impl/UserstoresApiServiceImpl.java
@@ -19,6 +19,7 @@ package org.wso2.carbon.identity.api.server.userstore.v1.impl;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.wso2.carbon.identity.api.server.userstore.v1.UserstoresApiService;
 import org.wso2.carbon.identity.api.server.userstore.v1.core.ServerUserStoreService;
+import org.wso2.carbon.identity.api.server.userstore.v1.model.ClaimAttributeMapping;
 import org.wso2.carbon.identity.api.server.userstore.v1.model.PatchDocument;
 import org.wso2.carbon.identity.api.server.userstore.v1.model.RDBMSConnectionReq;
 import org.wso2.carbon.identity.api.server.userstore.v1.model.UserStoreReq;
@@ -85,6 +86,14 @@ public class UserstoresApiServiceImpl implements UserstoresApiService {
     public Response getUserStoreManagerProperties(String typeId) {
 
         return Response.ok().entity(serverUserStoreService.getUserStoreManagerProperties(typeId)).build();
+    }
+
+    @Override
+    public Response patchAttributeMappings(String userstoreDomainId,
+                                           List<ClaimAttributeMapping> claimAttributeMapping) {
+        serverUserStoreService.patchClaimAttributeMapping(userstoreDomainId,
+                claimAttributeMapping);
+        return Response.ok().build();
     }
 
     @Override

--- a/components/org.wso2.carbon.identity.api.server.userstore/org.wso2.carbon.identity.api.server.userstore.v1/src/main/resources/META-INF/cxf/user-store-v1-cxf.xml
+++ b/components/org.wso2.carbon.identity.api.server.userstore/org.wso2.carbon.identity.api.server.userstore.v1/src/main/resources/META-INF/cxf/user-store-v1-cxf.xml
@@ -27,9 +27,12 @@
           class="org.wso2.carbon.identity.api.server.userstore.common.UserStoreConfigServiceHolder">
         <property name="userStoreConfigService" ref="userStoreConfigServiceFactoryBean"/>
         <property name="realmService" ref="RealmServiceFactoryBean"/>
+        <property name="claimMetadataManagementService" ref="ClaimMetadataManagementServiceBean"/>
     </bean>
     <bean id="userStoreConfigServiceFactoryBean"
           class="org.wso2.carbon.identity.api.server.userstore.common.factory.UserStoreConfigServiceFactory"/>
     <bean id="RealmServiceFactoryBean"
           class="org.wso2.carbon.identity.api.server.userstore.common.factory.RealmServiceFactory"/>
+    <bean id="ClaimMetadataManagementServiceBean"
+          class="org.wso2.carbon.identity.api.server.userstore.common.factory.ClaimMetadataManagementServiceFactory"/>
 </beans>

--- a/components/org.wso2.carbon.identity.api.server.userstore/org.wso2.carbon.identity.api.server.userstore.v1/src/main/resources/userstore.yaml
+++ b/components/org.wso2.carbon.identity.api.server.userstore/org.wso2.carbon.identity.api.server.userstore.v1/src/main/resources/userstore.yaml
@@ -256,7 +256,7 @@ paths:
     patch:
       tags:
         - User Store
-      summary: Patch the secondary user store attribute mappings by it's domain id.
+      summary: Update the secondary user store attribute mappings by it's domain id.
       operationId: patchAttributeMappings
       description: >
         This API provides the capability to update the secondary user store's attribute mappings using patch request by using its domain id.

--- a/components/org.wso2.carbon.identity.api.server.userstore/org.wso2.carbon.identity.api.server.userstore.v1/src/main/resources/userstore.yaml
+++ b/components/org.wso2.carbon.identity.api.server.userstore/org.wso2.carbon.identity.api.server.userstore.v1/src/main/resources/userstore.yaml
@@ -251,6 +251,38 @@ paths:
             schema:
               $ref: '#/components/schemas/PatchRequest'
         required: true
+
+  /userstores/{userstore-domain-id}/attribute-mappings:
+    patch:
+      tags:
+        - User Store
+      summary: Patch the secondary user store attribute mappings by it's domain id.
+      operationId: patchAttributeMappings
+      description: >
+        This API provides the capability to update the secondary user store's attribute mappings using patch request by using its domain id.
+         <b>Permission required:</b>
+         */permission/admin
+      parameters:
+        - $ref: '#/components/parameters/domainNamePathParam'
+      responses:
+        '200':
+          $ref: '#/components/responses/OK'
+        '400':
+          $ref: '#/components/responses/InvalidInput'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/ServerError'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AttributeMappingsReq'
+        required: true
   /userstores/meta/types:
     get:
       tags:
@@ -488,6 +520,11 @@ components:
             connection password etc.
           items:
             $ref: '#/components/schemas/Property'
+        claimAttributeMappings:
+          type: array
+          description: Claim attribute mappings.
+          items:
+            $ref: '#/components/schemas/ClaimAttributeMapping'
     PatchRequest:
       type: array
       items:
@@ -548,6 +585,25 @@ components:
           type: string
           description: The password.
           example: root
+    ClaimAttributeMapping:
+      type: object
+      required:
+        - claimURI
+        - mappedAttribute
+      properties:
+        claimURI:
+          type: string
+          description: A unique URI specific to the claim.
+          example: "http://wso2.org/claims/username"
+        mappedAttribute:
+          type: string
+          description: Userstore attribute to be mapped to.
+          example: "username"
+    AttributeMappingsReq:
+      type: array
+      description: Array of ClaimURI attribute mappings.
+      items:
+        $ref: '#/components/schemas/ClaimAttributeMapping'
     Error:
       type: object
       required:

--- a/components/org.wso2.carbon.identity.api.server.userstore/org.wso2.carbon.identity.api.server.userstore.v1/src/main/resources/userstore.yaml
+++ b/components/org.wso2.carbon.identity.api.server.userstore/org.wso2.carbon.identity.api.server.userstore.v1/src/main/resources/userstore.yaml
@@ -753,6 +753,11 @@ components:
           description: Configured user store property for the set
           items:
             $ref: '#/components/schemas/AddUserStorePropertiesRes'
+        claimAttributeMappings:
+          type: array
+          description: Requested configured user store claim attribute mappings
+          items:
+            $ref: '#/components/schemas/ClaimAttributeMapping'
     AddUserStorePropertiesRes:
       type: object
       description: Available User Store Properties.

--- a/components/org.wso2.carbon.identity.api.server.userstore/org.wso2.carbon.identity.api.server.userstore.v1/src/main/resources/userstore.yaml
+++ b/components/org.wso2.carbon.identity.api.server.userstore/org.wso2.carbon.identity.api.server.userstore.v1/src/main/resources/userstore.yaml
@@ -257,7 +257,7 @@ paths:
       tags:
         - User Store
       summary: Update the secondary user store attribute mappings by it's domain id.
-      operationId: patchAttributeMappings
+      operationId: updateAttributeMappings
       description: >
         This API provides the capability to update the secondary user store's attribute mappings using patch request by using its domain id.
          <b>Permission required:</b>

--- a/pom.xml
+++ b/pom.xml
@@ -493,7 +493,7 @@
         <maven.buildnumber.plugin.version>1.4</maven.buildnumber.plugin.version>
         <org.apache.felix.annotations.version>1.2.4</org.apache.felix.annotations.version>
        <identity.governance.version>1.5.25</identity.governance.version>
-        <carbon.identity.framework.version>5.20.144</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.20.150</carbon.identity.framework.version>
         <maven.findbugsplugin.version>3.0.5</maven.findbugsplugin.version>
         <identity.workflow.impl.bps.version>5.2.0</identity.workflow.impl.bps.version>
         <maven.checkstyleplugin.excludes>**/gen/**/*</maven.checkstyleplugin.excludes>


### PR DESCRIPTION
Related issue:
- https://github.com/wso2/product-is/issues/12253

After following PR is merged
- https://github.com/wso2/carbon-identity-framework/pull/3647

Implementation changes
- Modify https://is.docs.wso2.com/en/latest/develop/userstore-rest-api/#/User%20Store `/userstores` API to support claim attribute mappings in bulk at user store creation.
- Introduce a new API to update the claim attribute mapping in bulk for a specific user store.'

Validated against the following scenarios
```
<class name="org.wso2.identity.integration.test.rest.api.server.user.store.v1.UserStoreSuccessTest"/>
<class name="org.wso2.identity.integration.test.rest.api.server.user.store.v1.UserStoreFailureTest"/>
```