### PR TITLE
404 Respone for Non-existing SAML SP metadeta URL

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/functions/application/inbound/saml/SAMLInboundFunctions.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/functions/application/inbound/saml/SAMLInboundFunctions.java
@@ -40,6 +40,8 @@ import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.List;
 
+import static org.wso2.carbon.identity.sso.saml.Error.URL_NOT_FOUND;
+
 /**
  * Helper functions for SAML inbound management.
  */
@@ -220,6 +222,9 @@ public class SAMLInboundFunctions {
 
         String msg = "Error while creating/updating SAML inbound of application.";
         if (e instanceof IdentitySAML2ClientException) {
+            if (URL_NOT_FOUND.getErrorCode().equals(e.getErrorCode())) {
+                return buildNotFoundError(msg, e);
+            }
             return buildBadRequestError(msg, e);
         } else {
             return buildServerError(msg, e);
@@ -232,6 +237,14 @@ public class SAMLInboundFunctions {
         String errorDescription = ex.getMessage();
 
         return Utils.buildClientError(errorCode, message, errorDescription);
+    }
+
+    private static APIError buildNotFoundError(String message, IdentityException ex) {
+
+        String errorCode = ex.getErrorCode();
+        String errorDescription = ex.getMessage();
+
+        return Utils.buildNotFoundError(errorCode, message, errorDescription);
     }
 
     private static APIError buildServerError(String message, IdentityException e) {

--- a/pom.xml
+++ b/pom.xml
@@ -499,7 +499,7 @@
         <maven.checkstyleplugin.excludes>**/gen/**/*</maven.checkstyleplugin.excludes>
         <identity.event.handler.version>1.3.14</identity.event.handler.version>
         <identity.inbound.oauth2.version>6.4.60</identity.inbound.oauth2.version>
-        <identity.inbound.saml2.version>5.7.6</identity.inbound.saml2.version>
+        <identity.inbound.saml2.version>5.8.44</identity.inbound.saml2.version>
         <commons.beanutils.version>1.9.4</commons.beanutils.version>
         <mavan.findbugsplugin.exclude.file>findbugs-exclude-filter.xml</mavan.findbugsplugin.exclude.file>
         <carbon.kernel.version>4.7.0-m1</carbon.kernel.version>


### PR DESCRIPTION
Related to https://github.com/wso2-enterprise/asgardeo-product/issues/6505

Merge after following PR is merged
- https://github.com/wso2-extensions/identity-inbound-auth-saml/pull/344

Send `404 Response`, when the provided metadata URL for SAML application creation is non-existing URL by handling the `IdentitySAML2ClientException` exception.