### PR TITLE
Add patch operation for Secret Management API

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.secret.management/org.wso2.carbon.identity.api.server.secret.management.common/src/main/java/org/wso2/carbon/identity/api/server/secret/management/common/SecretManagementConstants.java
+++ b/components/org.wso2.carbon.identity.api.server.secret.management/org.wso2.carbon.identity.api.server.secret.management.common/src/main/java/org/wso2/carbon/identity/api/server/secret/management/common/SecretManagementConstants.java
@@ -29,6 +29,10 @@ public class SecretManagementConstants {
     public static final String CORRELATION_ID_MDC = "Correlation-ID";
     public static final String V1_API_PATH_COMPONENT = "/v1";
 
+    // Patch operation paths.
+    public static final String VALUE_PATH = "/value";
+    public static final String DESCRIPTION_PATH = "/description";
+
     /**
      * Enums for error messages.
      */
@@ -37,8 +41,12 @@ public class SecretManagementConstants {
         // Client errors 600xx.
         ERROR_CODE_REFERENCE_NAME_NOT_SPECIFIED("60001", "Empty reference name",
                 "Secret reference name is not specified in the request"),
-        ERROR_CODE_SECRET_VALUE_NOT_SPECIFIED("60003", "Empty value",
+        ERROR_CODE_SECRET_VALUE_NOT_SPECIFIED("60002", "Empty value",
                 "Secret value is not specified in the request"),
+        ERROR_CODE_SECRET_NOT_FOUND("60003", "Secret not found.", "Unable to find a secret matching the provided " +
+                "secret name %s."),
+        ERROR_CODE_INVALID_INPUT("60004", "Invalid input.", "One of the given inputs is invalid : %s."),
+
 
         // Server errors 650xx.
         ERROR_CODE_ERROR_GETTING_SECRET("65003", "Error while getting secret.",

--- a/components/org.wso2.carbon.identity.api.server.secret.management/org.wso2.carbon.identity.api.server.secret.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/secret/management/v1/SecretsApi.java
+++ b/components/org.wso2.carbon.identity.api.server.secret.management/org.wso2.carbon.identity.api.server.secret.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/secret/management/v1/SecretsApi.java
@@ -20,6 +20,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 import org.wso2.carbon.identity.api.server.secret.management.v1.model.Error;
 import org.wso2.carbon.identity.api.server.secret.management.v1.model.SecretAddRequest;
+import org.wso2.carbon.identity.api.server.secret.management.v1.model.SecretPatchRequest;
 import org.wso2.carbon.identity.api.server.secret.management.v1.model.SecretResponse;
 import org.wso2.carbon.identity.api.server.secret.management.v1.model.SecretUpdateRequest;
 
@@ -66,15 +67,15 @@ public class SecretsApi  {
     @Valid
     @DELETE
     @Path("/{secret-type}/{name}")
-    
+
     @Produces({ "application/json" })
     @ApiOperation(value = "Delete an secret by name", notes = "This API provides the capability to delete a secret by name. ", response = Void.class, authorizations = {
         @Authorization(value = "BasicAuth"),
         @Authorization(value = "OAuth2", scopes = {
-            
+
         })
     }, tags={ "Secret", })
-    @ApiResponses(value = { 
+    @ApiResponses(value = {
         @ApiResponse(code = 204, message = "No Content", response = Void.class),
         @ApiResponse(code = 400, message = "Bad Request", response = Error.class),
         @ApiResponse(code = 401, message = "Unauthorized", response = Void.class),
@@ -136,6 +137,31 @@ public class SecretsApi  {
     public Response getSecretsList(@ApiParam(value = "name of the secret type",required=true) @PathParam("secret-type") String secretType) {
 
         return delegate.getSecretsList(secretType );
+    }
+
+    @Valid
+    @PATCH
+    @Path("/{secret-type}/{name}")
+    @Consumes({"application/json"})
+    @Produces({"application/json"})
+    @ApiOperation(value = "Patch a secret by name.", notes = "This API provides the capability to update a secret using patch request by using its name. ", response = SecretResponse.class, authorizations = {
+            @Authorization(value = "BasicAuth"),
+            @Authorization(value = "OAuth2", scopes = {
+
+            })
+    }, tags = {"Secret",})
+    @ApiResponses(value = {
+            @ApiResponse(code = 200, message = "Successful Response", response = SecretResponse.class),
+            @ApiResponse(code = 400, message = "Bad Request", response = Error.class),
+            @ApiResponse(code = 401, message = "Unauthorized", response = Void.class),
+            @ApiResponse(code = 403, message = "Forbidden", response = Void.class),
+            @ApiResponse(code = 404, message = "Not Found", response = Error.class),
+            @ApiResponse(code = 405, message = "Method Not Allowed.", response = Error.class),
+            @ApiResponse(code = 500, message = "Server Error", response = Error.class)
+    })
+    public Response patchSecret(@ApiParam(value = "name of the secret type", required = true) @PathParam("secret-type") String secretType, @ApiParam(value = "name of the secret", required = true) @PathParam("name") String name, @ApiParam(value = "", required = true) @Valid SecretPatchRequest secretPatchRequest) {
+
+        return delegate.patchSecret(secretType, name, secretPatchRequest);
     }
 
     @Valid

--- a/components/org.wso2.carbon.identity.api.server.secret.management/org.wso2.carbon.identity.api.server.secret.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/secret/management/v1/SecretsApiService.java
+++ b/components/org.wso2.carbon.identity.api.server.secret.management/org.wso2.carbon.identity.api.server.secret.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/secret/management/v1/SecretsApiService.java
@@ -17,6 +17,7 @@
 package org.wso2.carbon.identity.api.server.secret.management.v1;
 
 import org.wso2.carbon.identity.api.server.secret.management.v1.model.SecretAddRequest;
+import org.wso2.carbon.identity.api.server.secret.management.v1.model.SecretPatchRequest;
 import org.wso2.carbon.identity.api.server.secret.management.v1.model.SecretUpdateRequest;
 import javax.ws.rs.core.Response;
 
@@ -30,6 +31,8 @@ public interface SecretsApiService {
       public Response getSecret(String secretType, String name);
 
       public Response getSecretsList(String secretType);
+
+      public Response patchSecret(String secretType, String name, SecretPatchRequest secretPatchRequest);
 
       public Response updateSecret(String secretType, String name, SecretUpdateRequest secretUpdateRequest);
 }

--- a/components/org.wso2.carbon.identity.api.server.secret.management/org.wso2.carbon.identity.api.server.secret.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/secret/management/v1/model/SecretPatchRequest.java
+++ b/components/org.wso2.carbon.identity.api.server.secret.management/org.wso2.carbon.identity.api.server.secret.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/secret/management/v1/model/SecretPatchRequest.java
@@ -1,0 +1,186 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.secret.management.v1.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+
+import javax.validation.constraints.*;
+
+import java.util.Objects;
+import javax.validation.Valid;
+import javax.xml.bind.annotation.*;
+
+public class SecretPatchRequest {
+
+    @XmlType(name = "OperationEnum")
+    @XmlEnum(String.class)
+    public enum OperationEnum {
+
+        @XmlEnumValue("ADD") ADD(String.valueOf("ADD")), @XmlEnumValue("REMOVE") REMOVE(String.valueOf("REMOVE")), @XmlEnumValue("REPLACE") REPLACE(String.valueOf("REPLACE"));
+
+        private String value;
+
+        OperationEnum(String v) {
+
+            value = v;
+        }
+
+        public String value() {
+
+            return value;
+        }
+
+        @Override
+        public String toString() {
+
+            return String.valueOf(value);
+        }
+
+        public static OperationEnum fromValue(String value) {
+
+            for (OperationEnum b : OperationEnum.values()) {
+                if (b.value.equals(value)) {
+                    return b;
+                }
+            }
+            throw new IllegalArgumentException("Unexpected value '" + value + "'");
+        }
+    }
+
+    private OperationEnum operation;
+    private String path;
+    private String value;
+
+    /**
+     * The operation to be performed
+     **/
+    public SecretPatchRequest operation(OperationEnum operation) {
+
+        this.operation = operation;
+        return this;
+    }
+
+    @ApiModelProperty(example = "REPLACE", required = true, value = "The operation to be performed")
+    @JsonProperty("operation")
+    @Valid
+    @NotNull(message = "Property operation cannot be null.")
+
+    public OperationEnum getOperation() {
+
+        return operation;
+    }
+
+    public void setOperation(OperationEnum operation) {
+
+        this.operation = operation;
+    }
+
+    /**
+     * A JSON-Pointer
+     **/
+    public SecretPatchRequest path(String path) {
+
+        this.path = path;
+        return this;
+    }
+
+    @ApiModelProperty(example = "/value", required = true, value = "A JSON-Pointer")
+    @JsonProperty("path")
+    @Valid
+    @NotNull(message = "Property path cannot be null.")
+
+    public String getPath() {
+
+        return path;
+    }
+
+    public void setPath(String path) {
+
+        this.path = path;
+    }
+
+    /**
+     * The value to be used within the operations
+     **/
+    public SecretPatchRequest value(String value) {
+
+        this.value = value;
+        return this;
+    }
+
+    @ApiModelProperty(example = "dummyValue", value = "The value to be used within the operations")
+    @JsonProperty("value")
+    @Valid
+    public String getValue() {
+
+        return value;
+    }
+
+    public void setValue(String value) {
+
+        this.value = value;
+    }
+
+    @Override
+    public boolean equals(java.lang.Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        SecretPatchRequest secretPatchRequest = (SecretPatchRequest) o;
+        return Objects.equals(this.operation, secretPatchRequest.operation) &&
+                Objects.equals(this.path, secretPatchRequest.path) &&
+                Objects.equals(this.value, secretPatchRequest.value);
+    }
+
+    @Override
+    public int hashCode() {
+
+        return Objects.hash(operation, path, value);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class SecretPatchRequest {\n");
+
+        sb.append("    operation: ").append(toIndentedString(operation)).append("\n");
+        sb.append("    path: ").append(toIndentedString(path)).append("\n");
+        sb.append("    value: ").append(toIndentedString(value)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(java.lang.Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}

--- a/components/org.wso2.carbon.identity.api.server.secret.management/org.wso2.carbon.identity.api.server.secret.management.v1/src/main/java/org/wso2/carbon/identity/api/server/secret/management/v1/core/SecretManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.secret.management/org.wso2.carbon.identity.api.server.secret.management.v1/src/main/java/org/wso2/carbon/identity/api/server/secret/management/v1/core/SecretManagementService.java
@@ -190,21 +190,23 @@ public class SecretManagementService {
             secret = SecretManagementServiceHolder.getSecretConfigManager().getSecret(secretType, name);
             if (secret == null) {
                 throw handleException(Response.Status.NOT_FOUND, SecretManagementConstants.ErrorMessage.
-                                ERROR_CODE_SECRET_NOT_FOUND, name);
+                        ERROR_CODE_SECRET_NOT_FOUND, name);
             }
             String path = secretPatchRequest.getPath();
             SecretPatchRequest.OperationEnum operation = secretPatchRequest.getOperation();
             // Only the Replace operation supported with PATCH request.
             if (SecretPatchRequest.OperationEnum.REPLACE.equals(operation)) {
                 if (SecretManagementConstants.VALUE_PATH.equals(path)) {
-                    secret.setSecretValue(secretPatchRequest.getValue());
+                    responseDTO = SecretManagementServiceHolder.getSecretConfigManager().updateSecretValue(secretType,
+                            name, secretPatchRequest.getValue());
+
                 } else if (SecretManagementConstants.DESCRIPTION_PATH.equals(path)) {
-                    secret.setDescription(secretPatchRequest.getValue());
+                    responseDTO = SecretManagementServiceHolder.getSecretConfigManager().updateSecretDescription
+                            (secretType, name, secretPatchRequest.getValue());
                 } else {
                     throw handleException(Response.Status.BAD_REQUEST, SecretManagementConstants.ErrorMessage
                             .ERROR_CODE_INVALID_INPUT, "Path");
                 }
-                responseDTO = SecretManagementServiceHolder.getSecretConfigManager().replaceSecret(secretType, secret);
             } else {
                 // Throw an error if any other patch operations are sent in the request.
                 throw handleException(Response.Status.BAD_REQUEST, SecretManagementConstants.ErrorMessage

--- a/components/org.wso2.carbon.identity.api.server.secret.management/org.wso2.carbon.identity.api.server.secret.management.v1/src/main/java/org/wso2/carbon/identity/api/server/secret/management/v1/core/SecretManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.secret.management/org.wso2.carbon.identity.api.server.secret.management.v1/src/main/java/org/wso2/carbon/identity/api/server/secret/management/v1/core/SecretManagementService.java
@@ -194,7 +194,7 @@ public class SecretManagementService {
             }
             String path = secretPatchRequest.getPath();
             SecretPatchRequest.OperationEnum operation = secretPatchRequest.getOperation();
-            //Only the Replace operation supported with PATCH request
+            // Only the Replace operation supported with PATCH request.
             if (SecretPatchRequest.OperationEnum.REPLACE.equals(operation)) {
                 if (SecretManagementConstants.VALUE_PATH.equals(path)) {
                     secret.setSecretValue(secretPatchRequest.getValue());

--- a/components/org.wso2.carbon.identity.api.server.secret.management/org.wso2.carbon.identity.api.server.secret.management.v1/src/main/java/org/wso2/carbon/identity/api/server/secret/management/v1/core/SecretManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.secret.management/org.wso2.carbon.identity.api.server.secret.management.v1/src/main/java/org/wso2/carbon/identity/api/server/secret/management/v1/core/SecretManagementService.java
@@ -189,8 +189,8 @@ public class SecretManagementService {
         try {
             secret = SecretManagementServiceHolder.getSecretConfigManager().getSecret(secretType, name);
             if (secret == null) {
-                throw handleException(Response.Status.NOT_FOUND, SecretManagementConstants.ErrorMessage.ERROR_CODE_SECRET_NOT_FOUND,
-                        name);
+                throw handleException(Response.Status.NOT_FOUND, SecretManagementConstants.ErrorMessage.
+                                ERROR_CODE_SECRET_NOT_FOUND, name);
             }
             String path = secretPatchRequest.getPath();
             SecretPatchRequest.OperationEnum operation = secretPatchRequest.getOperation();

--- a/components/org.wso2.carbon.identity.api.server.secret.management/org.wso2.carbon.identity.api.server.secret.management.v1/src/main/java/org/wso2/carbon/identity/api/server/secret/management/v1/impl/SecretsApiServiceImpl.java
+++ b/components/org.wso2.carbon.identity.api.server.secret.management/org.wso2.carbon.identity.api.server.secret.management.v1/src/main/java/org/wso2/carbon/identity/api/server/secret/management/v1/impl/SecretsApiServiceImpl.java
@@ -21,6 +21,7 @@ import org.wso2.carbon.identity.api.server.common.ContextLoader;
 import org.wso2.carbon.identity.api.server.secret.management.v1.SecretsApiService;
 import org.wso2.carbon.identity.api.server.secret.management.v1.core.SecretManagementService;
 import org.wso2.carbon.identity.api.server.secret.management.v1.model.SecretAddRequest;
+import org.wso2.carbon.identity.api.server.secret.management.v1.model.SecretPatchRequest;
 import org.wso2.carbon.identity.api.server.secret.management.v1.model.SecretResponse;
 import org.wso2.carbon.identity.api.server.secret.management.v1.model.SecretUpdateRequest;
 
@@ -65,6 +66,12 @@ public class SecretsApiServiceImpl implements SecretsApiService {
     public Response getSecretsList(String secretType) {
 
         return Response.ok().entity(secretManagementService.getSecretsList(secretType)).build();
+    }
+
+    @Override
+    public Response patchSecret(String secretType, String name, SecretPatchRequest secretPatchRequest) {
+
+        return Response.ok().entity(secretManagementService.patchSecret(secretType, name, secretPatchRequest)).build();
     }
 
     @Override

--- a/components/org.wso2.carbon.identity.api.server.secret.management/org.wso2.carbon.identity.api.server.secret.management.v1/src/main/resources/secretManager.yaml
+++ b/components/org.wso2.carbon.identity.api.server.secret.management/org.wso2.carbon.identity.api.server.secret.management.v1/src/main/resources/secretManager.yaml
@@ -475,10 +475,77 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
+    patch:
+      tags:
+        - Secret
+      summary: Patch a secret by name.
+      description: >
+        This API provides the capability to update a secret using patch request by using its name.
+      operationId: patchSecret
+      parameters:
+        - name: secret-type
+          in: path
+          description: name of the secret type
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+        - name: name
+          in: path
+          description: name of the secret
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SecretPatchRequest'
+
+        required: true
+      responses:
+        "200":
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SecretResponse'
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        "401":
+          description: Unauthorized
+        "403":
+          description: Forbidden
+        "404":
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        "405":
+          description: Method Not Allowed.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        "500":
+          description: Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
     delete:
       tags:
         - Secret
-      summary: Delete an secret by name
+      summary: Delete a secret by name
       description: |
         This API provides the capability to delete a secret by
         name.
@@ -603,6 +670,28 @@ components:
         description:
           type: string
           example: sample_description
+
+    SecretPatchRequest:
+      required:
+        - operation
+        - path
+      properties:
+        operation:
+          type: string
+          description: The operation to be performed
+          enum:
+            - ADD
+            - REMOVE
+            - REPLACE
+          example: REPLACE
+        path:
+          type: string
+          description: A JSON-Pointer
+          example: /value
+        value:
+          type: string
+          description: The value to be used within the operations
+          example: 'dummyValue'
 
     SecretsList:
       type: array

--- a/pom.xml
+++ b/pom.xml
@@ -493,7 +493,7 @@
         <maven.buildnumber.plugin.version>1.4</maven.buildnumber.plugin.version>
         <org.apache.felix.annotations.version>1.2.4</org.apache.felix.annotations.version>
        <identity.governance.version>1.5.25</identity.governance.version>
-        <carbon.identity.framework.version>5.20.150</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.20.189</carbon.identity.framework.version>
         <maven.findbugsplugin.version>3.0.5</maven.findbugsplugin.version>
         <identity.workflow.impl.bps.version>5.2.0</identity.workflow.impl.bps.version>
         <maven.checkstyleplugin.excludes>**/gen/**/*</maven.checkstyleplugin.excludes>


### PR DESCRIPTION
## Purpose
fixes - [#12505](https://github.com/wso2/product-is/issues/12505)

To update the value of a secret use the following body in a **patch** request,

```
{
      "operation":"REPLACE",
      "path":"/value",
      "value": "{value}"
}
```

To update the description of a secret use the following body in a **patch** request,

```
{
      "operation":"REPLACE",
      "path":"/description",
      "value": "{value}"
}
```