### PR TITLE
Update error codes of Patch operation-IDP Management REST API

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/main/java/org/wso2/carbon/identity/api/server/idp/v1/core/ServerIdpManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/main/java/org/wso2/carbon/identity/api/server/idp/v1/core/ServerIdpManagementService.java
@@ -2705,7 +2705,8 @@ public class ServerIdpManagementService {
                         }
                         certificates.set(index, value);
                         idpToUpdate.setCertificate(base64Encode(StringUtils.join(certificates, "")));
-                    } else if (ArrayUtils.isEmpty(idpToUpdate.getCertificateInfoArray()) || index >= idpToUpdate.getCertificateInfoArray().length) {
+                    } else if (ArrayUtils.isEmpty(idpToUpdate.getCertificateInfoArray()) ||
+                            index >= idpToUpdate.getCertificateInfoArray().length) {
                         throw handleException(Response.Status.NOT_FOUND, Constants.ErrorMessage
                                 .ERROR_CODE_ERROR_UPDATING_IDP, "Cannot replace certificate as it does not exist");
                     } else {

--- a/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/main/java/org/wso2/carbon/identity/api/server/idp/v1/core/ServerIdpManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/main/java/org/wso2/carbon/identity/api/server/idp/v1/core/ServerIdpManagementService.java
@@ -2880,7 +2880,7 @@ public class ServerIdpManagementService {
         }
 
         throw handleException(Response.Status.NOT_FOUND, Constants.ErrorMessage.ERROR_CODE_ERROR_UPDATING_IDP,
-                String.format("Cannot replace  %s as it does not exist", propertyName));
+                String.format("Cannot replace %s as it does not exist.", propertyName));
     }
 
     /**

--- a/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/main/java/org/wso2/carbon/identity/api/server/idp/v1/core/ServerIdpManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/main/java/org/wso2/carbon/identity/api/server/idp/v1/core/ServerIdpManagementService.java
@@ -2878,7 +2878,6 @@ public class ServerIdpManagementService {
                 return;
             }
         }
-
         throw handleException(Response.Status.NOT_FOUND, Constants.ErrorMessage.ERROR_CODE_ERROR_UPDATING_IDP,
                 String.format("Cannot replace %s as it does not exist.", propertyName));
     }

--- a/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/main/java/org/wso2/carbon/identity/api/server/idp/v1/core/ServerIdpManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/main/java/org/wso2/carbon/identity/api/server/idp/v1/core/ServerIdpManagementService.java
@@ -2701,14 +2701,14 @@ public class ServerIdpManagementService {
                         if (certificates.contains(value)) {
                             throw handleException(Response.Status.CONFLICT,
                                     Constants.ErrorMessage.ERROR_CODE_ERROR_UPDATING_IDP,
-                                    "Cannot replace certificate as this certificate is already exists.");
+                                    "Cannot replace certificate as this certificate already exists.");
                         }
                         certificates.set(index, value);
                         idpToUpdate.setCertificate(base64Encode(StringUtils.join(certificates, "")));
                     } else if (ArrayUtils.isEmpty(idpToUpdate.getCertificateInfoArray()) ||
                             index >= idpToUpdate.getCertificateInfoArray().length) {
                         throw handleException(Response.Status.NOT_FOUND, Constants.ErrorMessage
-                                .ERROR_CODE_ERROR_UPDATING_IDP, "Cannot replace certificate as it does not exist");
+                                .ERROR_CODE_ERROR_UPDATING_IDP, "Cannot replace certificate as it does not exist.");
                     } else {
                         throw handleException(Response.Status.BAD_REQUEST, Constants.ErrorMessage
                                 .ERROR_CODE_INVALID_INPUT, null);
@@ -2775,7 +2775,7 @@ public class ServerIdpManagementService {
                     if (certificates.contains(value)) {
                         throw handleException(Response.Status.CONFLICT,
                                 Constants.ErrorMessage.ERROR_CODE_ERROR_UPDATING_IDP,
-                                "Cannot add certificate as it already exists");
+                                "Cannot add certificate as it already exists.");
                     }
                     certificates.add(index, value);
                     idpToUpdate.setCertificate(base64Encode(StringUtils.join(certificates, "")));
@@ -2831,7 +2831,7 @@ public class ServerIdpManagementService {
                     } else if (ArrayUtils.isEmpty(idpToUpdate.getCertificateInfoArray()) ||
                             index >= idpToUpdate.getCertificateInfoArray().length) {
                         throw handleException(Response.Status.NOT_FOUND, Constants.ErrorMessage
-                                .ERROR_CODE_ERROR_UPDATING_IDP, "Cannot replace certificate as it does not exist");
+                                .ERROR_CODE_ERROR_UPDATING_IDP, "Cannot replace certificate as it does not exist.");
                     } else {
                         throw handleException(Response.Status.BAD_REQUEST,
                                 Constants.ErrorMessage.ERROR_CODE_INVALID_INPUT, "Invalid index in 'path' attribute");
@@ -2853,7 +2853,7 @@ public class ServerIdpManagementService {
                     if (propertyDTOS.length == idpNewProperties.size()) {
                         throw handleException(Response.Status.NOT_FOUND,
                                 Constants.ErrorMessage.ERROR_CODE_ERROR_UPDATING_IDP,
-                                "Cannot remove JWKS URI as it does not exist");
+                                "Cannot remove JWKS URI as it does not exist.");
                     }
 
                     idpToUpdate.setIdpProperties(idpNewProperties.toArray(new IdentityProviderProperty[0]));
@@ -2881,7 +2881,6 @@ public class ServerIdpManagementService {
 
         throw handleException(Response.Status.NOT_FOUND, Constants.ErrorMessage.ERROR_CODE_ERROR_UPDATING_IDP,
                 String.format("Cannot replace  %s as it does not exist", propertyName));
-
     }
 
     /**

--- a/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/main/java/org/wso2/carbon/identity/api/server/idp/v1/core/ServerIdpManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/main/java/org/wso2/carbon/identity/api/server/idp/v1/core/ServerIdpManagementService.java
@@ -2879,10 +2879,9 @@ public class ServerIdpManagementService {
             }
         }
 
-        if (Constants.JWKS_URI.equals(propertyName)) {
-            throw handleException(Response.Status.NOT_FOUND, Constants.ErrorMessage.ERROR_CODE_ERROR_UPDATING_IDP,
-                    "Cannot replace JWKS URI as it does not exist");
-        }
+        throw handleException(Response.Status.NOT_FOUND, Constants.ErrorMessage.ERROR_CODE_ERROR_UPDATING_IDP,
+                String.format("Cannot replace  %s as it does not exist", propertyName));
+
     }
 
     /**


### PR DESCRIPTION
## Purpose
fixes - [#12499](https://github.com/wso2/product-is/issues/12499)

**Updated the following error status codes.**

1. JWKS URI update

- PATCH REMOVE non existing property - 404 not found
- PATCH REPLACE non existing property - 404 not found

2. Certificate update

- PATCH ADD existing certificate  - 409 conflict
- PATCH ADD with invalid path index - 400 bad requet
- PATCH REMOVE non existing certifiacte - 404 not found
- PATCH REPLACE non existing certifiacte - 404 not found
- PATCH REPLACE certifiacte with other exiting certifiacte - 409 conflict

#### Merge after [identity-api-server#308](https://github.com/wso2/identity-api-server/pull/308)