### PR TITLE
Fix page limit issue with application list API response

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/ServerApplicationManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/ServerApplicationManagementService.java
@@ -237,6 +237,12 @@ public class ServerApplicationManagementService {
         final int maximumItemPerPage = IdentityUtil.getMaximumItemPerPage();
         if (limit != null && limit > 0 && limit <= maximumItemPerPage) {
             return limit;
+        } else if (limit != null && limit > maximumItemPerPage) {
+            if (log.isDebugEnabled()) {
+                log.debug("Given limit exceeds the maximum limit. Therefore the configured default limit: "
+                        + maximumItemPerPage + " is set as the limit.");
+            }
+            return maximumItemPerPage;
         } else {
             return IdentityUtil.getDefaultItemsPerPage();
         }


### PR DESCRIPTION
## Purpose
With this fix, if the limit sent in the request exceeds the `MaximumItemsPerPage` config value, the limit is capped at `MaximumItemsPerPage` config value.
Resolves: wso2/product-is#12442