### PR TITLE
Add user store type to listing.

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.userstore/org.wso2.carbon.identity.api.server.userstore.v1/src/gen/java/org/wso2/carbon/identity/api/server/userstore/v1/model/UserStoreListResponse.java
+++ b/components/org.wso2.carbon.identity.api.server.userstore/org.wso2.carbon.identity.api.server.userstore.v1/src/gen/java/org/wso2/carbon/identity/api/server/userstore/v1/model/UserStoreListResponse.java
@@ -38,6 +38,7 @@ public class UserStoreListResponse  {
     private Boolean enabled;
     private String description;
     private boolean isLocal;
+    private String typeName;
     private String self;
     private List<AddUserStorePropertiesRes> properties = null;
 
@@ -243,6 +244,24 @@ public class UserStoreListResponse  {
             return "null";
         }
         return o.toString().replace("\n", "\n");
+    }
+
+    @ApiModelProperty(example = "UniqueIDJDBCUserStoreManager", value = "User store type name")
+    @JsonProperty("typeName")
+    @Valid
+    public String getTypeName() {
+
+        return typeName;
+    }
+
+    /**
+     * Set the user store type name.
+     *
+     * @param typeName User store type.
+     */
+    public void setTypeName(String typeName) {
+
+        this.typeName = typeName;
     }
 }
 

--- a/components/org.wso2.carbon.identity.api.server.userstore/org.wso2.carbon.identity.api.server.userstore.v1/src/main/java/org/wso2/carbon/identity/api/server/userstore/v1/core/ServerUserStoreService.java
+++ b/components/org.wso2.carbon.identity.api.server.userstore/org.wso2.carbon.identity.api.server.userstore.v1/src/main/java/org/wso2/carbon/identity/api/server/userstore/v1/core/ServerUserStoreService.java
@@ -748,6 +748,7 @@ public class ServerUserStoreService {
                                 UserStoreConstants.USER_STORE_PATH_COMPONENT + "/%s",
                         base64URLEncodeId(jsonObject.getDomainId()))).toString());
                 userStoreList.setEnabled(jsonObject.getDisabled() != null && !jsonObject.getDisabled());
+                userStoreList.setTypeName(getUserStoreTypeName(jsonObject.getClassName()));
 
                 if (StringUtils.isNotBlank(requiredAttributes)) {
                     String[] requiredAttributesArray = requiredAttributes.split(REGEX_COMMA);

--- a/components/org.wso2.carbon.identity.api.server.userstore/org.wso2.carbon.identity.api.server.userstore.v1/src/main/resources/userstore.yaml
+++ b/components/org.wso2.carbon.identity.api.server.userstore/org.wso2.carbon.identity.api.server.userstore.v1/src/main/resources/userstore.yaml
@@ -693,6 +693,10 @@ components:
           type: string
           example: /t/{tenant-domain}/api/server/v1/userstores/SkRCQy1TRUNPTkRBUlk
           description: Location of the created/updated resource.
+        typeName:
+          type: string
+          example: UniqueIDJDBCUserStoreManager
+          description: User store type name.
         properties:
           type: array
           description: Requested configured user store property for the set


### PR DESCRIPTION
## Purpose
> Adds the user store type name to the user store listing response.

Example output
```
[
    {
        "id": "Q1VTVE9NRV",
        "name": "TEST",
        "enabled": true,
        "description": "",
        "isLocal": true,
        "typeName": "UniqueIDJDBCUserStoreManager",
        "self": "/t/test/api/server/v1/userstores/Q1VTVE9NRVItREVGQVVMVA"
    }
]
```