### PR TITLE
Improve userstore attributes api to exclude identity claim mappings

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.userstore/org.wso2.carbon.identity.api.server.userstore.v1/src/gen/java/org/wso2/carbon/identity/api/server/userstore/v1/UserstoresApi.java
+++ b/components/org.wso2.carbon.identity.api.server.userstore/org.wso2.carbon.identity.api.server.userstore.v1/src/gen/java/org/wso2/carbon/identity/api/server/userstore/v1/UserstoresApi.java
@@ -166,6 +166,29 @@ public class UserstoresApi  {
 
     @Valid
     @GET
+    @Path("/meta/types/{type-id}/attributes")
+    
+    @Produces({ "application/json" })
+    @ApiOperation(value = "Retrieve the meta attributes of a user store of a given user store type.", notes = "This API provides the capability to retrieve the attribute mappings of a given user store type   <b>Permission required:</b>  *_/permission/admin ", response = UserStoreAttributeMapping.class, authorizations = {
+        @Authorization(value = "BasicAuth"),
+        @Authorization(value = "OAuth2", scopes = {
+            
+        })
+    }, tags={ "Meta", })
+    @ApiResponses(value = { 
+        @ApiResponse(code = 200, message = "Successful Response.", response = UserStoreAttributeMapping.class),
+        @ApiResponse(code = 400, message = "Invalid input request.", response = Error.class),
+        @ApiResponse(code = 401, message = "Unauthorized.", response = Void.class),
+        @ApiResponse(code = 404, message = "The specified resource is not found.", response = Error.class),
+        @ApiResponse(code = 500, message = "Internal Server Error.", response = Error.class)
+    })
+    public Response getUserStoreAttributeMappings(@ApiParam(value = "Id of the user store type",required=true) @PathParam("type-id") String typeId,     @Valid@ApiParam(value = "Whether to exlcude the identity claim mappings from userstore attributes.")  @QueryParam("excludeIdentityClaimMappings") Boolean excludeIdentityClaimMappings) {
+
+        return delegate.getUserStoreAttributeMappings(typeId,  excludeIdentityClaimMappings );
+    }
+
+    @Valid
+    @GET
     @Path("/{userstore-domain-id}")
     
     @Produces({ "application/json" })
@@ -208,30 +231,6 @@ public class UserstoresApi  {
     public Response getUserStoreManagerProperties(@ApiParam(value = "Id of the user store type",required=true) @PathParam("type-id") String typeId) {
 
         return delegate.getUserStoreManagerProperties(typeId );
-    }
-
-    @Valid
-    @PATCH
-    @Path("/{userstore-domain-id}/attribute-mappings")
-    @Consumes({ "application/json" })
-    @Produces({ "application/json" })
-    @ApiOperation(value = "Update the secondary user store attribute mappings by it's domain id.", notes = "This API provides the capability to update the secondary user store's attribute mappings using patch request by using its domain id.  <b>Permission required:</b>  *_/permission/admin ", response = Void.class, authorizations = {
-        @Authorization(value = "BasicAuth"),
-        @Authorization(value = "OAuth2", scopes = {
-            
-        })
-    }, tags={ "User Store", })
-    @ApiResponses(value = { 
-        @ApiResponse(code = 200, message = "OK.", response = Void.class),
-        @ApiResponse(code = 400, message = "Invalid input request.", response = Error.class),
-        @ApiResponse(code = 401, message = "Unauthorized.", response = Void.class),
-        @ApiResponse(code = 403, message = "Resource Forbidden.", response = Void.class),
-        @ApiResponse(code = 404, message = "The specified resource is not found.", response = Error.class),
-        @ApiResponse(code = 500, message = "Internal Server Error.", response = Error.class)
-    })
-    public Response updateAttributeMappings(@ApiParam(value = "The unique name of the user store domain",required=true) @PathParam("userstore-domain-id") String userstoreDomainId, @ApiParam(value = "" ,required=true) @Valid List<ClaimAttributeMapping> claimAttributeMapping) {
-
-        return delegate.updateAttributeMappings(userstoreDomainId,  claimAttributeMapping );
     }
 
     @Valid
@@ -281,6 +280,30 @@ public class UserstoresApi  {
     }
 
     @Valid
+    @PATCH
+    @Path("/{userstore-domain-id}/attribute-mappings")
+    @Consumes({ "application/json" })
+    @Produces({ "application/json" })
+    @ApiOperation(value = "Update the secondary user store attribute mappings by it's domain id.", notes = "This API provides the capability to update the secondary user store's attribute mappings using patch request by using its domain id.  <b>Permission required:</b>  *_/permission/admin ", response = Void.class, authorizations = {
+        @Authorization(value = "BasicAuth"),
+        @Authorization(value = "OAuth2", scopes = {
+            
+        })
+    }, tags={ "User Store", })
+    @ApiResponses(value = { 
+        @ApiResponse(code = 200, message = "OK.", response = Void.class),
+        @ApiResponse(code = 400, message = "Invalid input request.", response = Error.class),
+        @ApiResponse(code = 401, message = "Unauthorized.", response = Void.class),
+        @ApiResponse(code = 403, message = "Resource Forbidden.", response = Void.class),
+        @ApiResponse(code = 404, message = "The specified resource is not found.", response = Error.class),
+        @ApiResponse(code = 500, message = "Internal Server Error.", response = Error.class)
+    })
+    public Response updateAttributeMappings(@ApiParam(value = "The unique name of the user store domain",required=true) @PathParam("userstore-domain-id") String userstoreDomainId, @ApiParam(value = "" ,required=true) @Valid List<ClaimAttributeMapping> claimAttributeMapping) {
+
+        return delegate.updateAttributeMappings(userstoreDomainId,  claimAttributeMapping );
+    }
+
+    @Valid
     @PUT
     @Path("/{userstore-domain-id}")
     @Consumes({ "application/json" })
@@ -303,29 +326,5 @@ public class UserstoresApi  {
 
         return delegate.updateUserStore(userstoreDomainId,  userStoreReq );
     }
-
-    @Valid
-    @GET
-    @Path("/meta/types/{type-id}/attributes")
-
-    @Produces({ "application/json" })
-    @ApiOperation(value = "Retrieve the meta attributes of a user store of a given user store type.", notes = "This API provides the capability to retrieve the attribute mappings of a given user store type.   <b>Permission required:</b>  *_/permission/admin ", response = UserStoreAttributeMapping.class, authorizations = {
-            @Authorization(value = "BasicAuth"),
-            @Authorization(value = "OAuth2", scopes = {
-
-            })
-    }, tags={ "Meta", })
-    @ApiResponses(value = {
-            @ApiResponse(code = 200, message = "Successful Response.", response = UserStoreAttributeMapping.class),
-            @ApiResponse(code = 400, message = "Invalid input request.", response = Error.class),
-            @ApiResponse(code = 401, message = "Unauthorized.", response = Void.class),
-            @ApiResponse(code = 404, message = "The specified resource is not found.", response = Error.class),
-            @ApiResponse(code = 500, message = "Internal Server Error.", response = Error.class)
-    })
-    public Response getUserStoreMappingAttributes(@ApiParam(value = "Id of the user store type",required=true) @PathParam("type-id") String typeId) {
-
-        return delegate.getUserStoreMappingAttributes(typeId);
-    }
-
 
 }

--- a/components/org.wso2.carbon.identity.api.server.userstore/org.wso2.carbon.identity.api.server.userstore.v1/src/gen/java/org/wso2/carbon/identity/api/server/userstore/v1/UserstoresApiService.java
+++ b/components/org.wso2.carbon.identity.api.server.userstore/org.wso2.carbon.identity.api.server.userstore.v1/src/gen/java/org/wso2/carbon/identity/api/server/userstore/v1/UserstoresApiService.java
@@ -30,6 +30,7 @@ import java.util.List;
 import org.wso2.carbon.identity.api.server.userstore.v1.model.MetaUserStoreType;
 import org.wso2.carbon.identity.api.server.userstore.v1.model.PatchDocument;
 import org.wso2.carbon.identity.api.server.userstore.v1.model.RDBMSConnectionReq;
+import org.wso2.carbon.identity.api.server.userstore.v1.model.UserStoreAttributeMapping;
 import org.wso2.carbon.identity.api.server.userstore.v1.model.UserStoreConfigurationsRes;
 import org.wso2.carbon.identity.api.server.userstore.v1.model.UserStoreListResponse;
 import org.wso2.carbon.identity.api.server.userstore.v1.model.UserStoreReq;
@@ -49,17 +50,17 @@ public interface UserstoresApiService {
 
       public Response getSecondaryUserStores(Integer limit, Integer offset, String filter, String sort, String requiredAttributes);
 
+      public Response getUserStoreAttributeMappings(String typeId, Boolean excludeIdentityClaimMappings);
+
       public Response getUserStoreByDomainId(String userstoreDomainId);
 
       public Response getUserStoreManagerProperties(String typeId);
-
-      public Response updateAttributeMappings(String userstoreDomainId, List<ClaimAttributeMapping> claimAttributeMapping);
 
       public Response patchUserStore(String userstoreDomainId, List<PatchDocument> patchDocument);
 
       public Response testRDBMSConnection(RDBMSConnectionReq rdBMSConnectionReq);
 
-      public Response updateUserStore(String userstoreDomainId, UserStoreReq userStoreReq);
+      public Response updateAttributeMappings(String userstoreDomainId, List<ClaimAttributeMapping> claimAttributeMapping);
 
-      public Response getUserStoreMappingAttributes(String typeId);
+      public Response updateUserStore(String userstoreDomainId, UserStoreReq userStoreReq);
 }

--- a/components/org.wso2.carbon.identity.api.server.userstore/org.wso2.carbon.identity.api.server.userstore.v1/src/main/java/org/wso2/carbon/identity/api/server/userstore/v1/core/ServerUserStoreService.java
+++ b/components/org.wso2.carbon.identity.api.server.userstore/org.wso2.carbon.identity.api.server.userstore.v1/src/main/java/org/wso2/carbon/identity/api/server/userstore/v1/core/ServerUserStoreService.java
@@ -715,6 +715,7 @@ public class ServerUserStoreService {
      */
     private List<LocalClaim> createLocalClaimList(String userStoreId,
                                                   List<ClaimAttributeMapping> claimAttributeMappingList) {
+
         List<LocalClaim> localClaimList = new ArrayList<>();
 
         for (ClaimAttributeMapping claimAttributeMapping : claimAttributeMappingList) {
@@ -1115,6 +1116,7 @@ public class ServerUserStoreService {
      */
     private APIError handleIdentityUserStoreMgtException(IdentityUserStoreMgtException exception,
                                                          UserStoreConstants.ErrorMessage errorEnum) {
+
         Response.Status status;
         ErrorResponse errorResponse = getErrorBuilder(errorEnum).build(LOG, exception, errorEnum.getDescription());
         if (exception instanceof IdentityUserStoreServerException) {
@@ -1275,8 +1277,24 @@ public class ServerUserStoreService {
      *
      * @param typeId String user store type id.
      * @return UserStoreAttributeMapping user store attribute mappings.
+     * @since 1.0.256
+     * @deprecated Method does not support excluding or including identity claim mapped attributes.
      */
+    @Deprecated
     public UserStoreAttributeMapping getUserStoreMappingAttributes(String typeId) {
+
+        return getUserStoreMappingAttributes(typeId, false);
+    }
+
+    /**
+     * Get user store attributes mappings for a given user store type id.
+     *
+     * @param typeId                       String user store type id.
+     * @param excludeIdentityClaimMappings Whether to exclude claim mapping for identity claims.
+     * @return UserStoreAttributeMapping user store attribute mappings.
+     */
+    public UserStoreAttributeMapping getUserStoreMappingAttributes(String typeId,
+                                                                   boolean excludeIdentityClaimMappings) {
 
         Set<String> classNames;
         String userStoreName = getUserStoreType(base64URLDecodeId(typeId));
@@ -1298,7 +1316,8 @@ public class ServerUserStoreService {
             throw handleIdentityUserStoreMgtException(e, errorEnum);
         }
         UserStoreAttributeMapping userStoreAttributeMapping = new UserStoreAttributeMapping();
-        List<UserStoreAttributeDO> attributeMappings = getAttributeMappings(userStoreName);
+        List<UserStoreAttributeDO> attributeMappings = getAttributeMappings(userStoreName,
+                excludeIdentityClaimMappings);
         userStoreAttributeMapping = userStoreAttributeMapping
                 .attributeMapping(attributeMappings)
                 .typeId(typeId)
@@ -1315,10 +1334,12 @@ public class ServerUserStoreService {
     /**
      * Get user store attribute mappings for a given user store typeId.
      *
-     * @param userStoreName String user store name (base64 decoded user store id).
+     * @param userStoreName                String user store name (base64 decoded user store id).
+     * @param excludeIdentityClaimMappings Whether to exclude claim mapping for identity claims.
      * @return List of user store attribute mappings for the given typeId.
      */
-    private List<UserStoreAttributeDO> getAttributeMappings(String userStoreName) {
+    private List<UserStoreAttributeDO> getAttributeMappings(String userStoreName,
+                                                            boolean excludeIdentityClaimMappings) {
 
         UserStoreConfigService userStoreConfigService = UserStoreConfigServiceHolder.getInstance().
                 getUserStoreConfigService();
@@ -1327,11 +1348,35 @@ public class ServerUserStoreService {
                     getUserStoreAttributeMappings();
             Map<String, UserStoreAttributeDO> mapping = userStoreAttributeMappings
                     .getUserStoreAttributeMappings(userStoreName);
+
+            // Remove identity claim mappings by iterating through all the claim mappings.
+            if (excludeIdentityClaimMappings) {
+                return excludeIdentityClaims(mapping);
+            }
             return new ArrayList<>(mapping.values());
         } catch (IdentityUserStoreMgtException e) {
             LOG.error("Error occurred while retrieving user store attribute metadata", e);
             throw handleException(Response.Status.INTERNAL_SERVER_ERROR, UserStoreConstants.ErrorMessage.
                     ERROR_CODE_ERROR_RETRIEVING_USER_STORE_ATTRIBUTE_METADATA);
         }
+    }
+
+    /**
+     * Exclude the userstore attributes with identity claims.
+     *
+     * @param userStoreAttributeDOMap Userstore attribute map.
+     * @return List of UserStoreAttributeDOs.
+     */
+    private List<UserStoreAttributeDO> excludeIdentityClaims(Map<String,
+            UserStoreAttributeDO> userStoreAttributeDOMap) {
+
+        List<UserStoreAttributeDO> userstoreMappings = new ArrayList<>();
+        for (String key : userStoreAttributeDOMap.keySet()) {
+            UserStoreAttributeDO userStoreAttributeDO = userStoreAttributeDOMap.get(key);
+            if (!userStoreAttributeDO.getClaimUri().startsWith(UserCoreConstants.ClaimTypeURIs.IDENTITY_CLAIM_URI)) {
+                userstoreMappings.add(userStoreAttributeDO);
+            }
+        }
+        return userstoreMappings;
     }
 }

--- a/components/org.wso2.carbon.identity.api.server.userstore/org.wso2.carbon.identity.api.server.userstore.v1/src/main/java/org/wso2/carbon/identity/api/server/userstore/v1/core/ServerUserStoreService.java
+++ b/components/org.wso2.carbon.identity.api.server.userstore/org.wso2.carbon.identity.api.server.userstore.v1/src/main/java/org/wso2/carbon/identity/api/server/userstore/v1/core/ServerUserStoreService.java
@@ -1371,8 +1371,8 @@ public class ServerUserStoreService {
             UserStoreAttributeDO> userStoreAttributeDOMap) {
 
         List<UserStoreAttributeDO> userstoreMappings = new ArrayList<>();
-        for (String key : userStoreAttributeDOMap.keySet()) {
-            UserStoreAttributeDO userStoreAttributeDO = userStoreAttributeDOMap.get(key);
+        for (Map.Entry<String, UserStoreAttributeDO> entry : userStoreAttributeDOMap.entrySet()) {
+            UserStoreAttributeDO userStoreAttributeDO = entry.getValue();
             if (!userStoreAttributeDO.getClaimUri().startsWith(UserCoreConstants.ClaimTypeURIs.IDENTITY_CLAIM_URI)) {
                 userstoreMappings.add(userStoreAttributeDO);
             }

--- a/components/org.wso2.carbon.identity.api.server.userstore/org.wso2.carbon.identity.api.server.userstore.v1/src/main/java/org/wso2/carbon/identity/api/server/userstore/v1/impl/UserstoresApiServiceImpl.java
+++ b/components/org.wso2.carbon.identity.api.server.userstore/org.wso2.carbon.identity.api.server.userstore.v1/src/main/java/org/wso2/carbon/identity/api/server/userstore/v1/impl/UserstoresApiServiceImpl.java
@@ -77,6 +77,18 @@ public class UserstoresApiServiceImpl implements UserstoresApiService {
     }
 
     @Override
+    public Response getUserStoreAttributeMappings(String typeId, Boolean excludeIdentityClaimMappings) {
+
+        boolean excludeIdentityClaims = false;
+        // This is added to provide backward compatibility.
+        if (excludeIdentityClaimMappings != null) {
+            excludeIdentityClaims = excludeIdentityClaimMappings;
+        }
+        return Response.ok().entity(serverUserStoreService.getUserStoreMappingAttributes(typeId,
+                excludeIdentityClaims)).build();
+    }
+
+    @Override
     public Response getUserStoreByDomainId(String userstoreDomainId) {
 
         return Response.ok().entity(serverUserStoreService.getUserStoreByDomainId(userstoreDomainId)).build();
@@ -90,7 +102,8 @@ public class UserstoresApiServiceImpl implements UserstoresApiService {
 
     @Override
     public Response updateAttributeMappings(String userstoreDomainId,
-                                           List<ClaimAttributeMapping> claimAttributeMappings) {
+                                            List<ClaimAttributeMapping> claimAttributeMappings) {
+
         serverUserStoreService.updateClaimAttributeMappings(userstoreDomainId,
                 claimAttributeMappings);
         return Response.ok().build();
@@ -112,12 +125,6 @@ public class UserstoresApiServiceImpl implements UserstoresApiService {
     public Response updateUserStore(String userstoreDomainId, UserStoreReq userStoreReq) {
 
         return Response.ok().entity(serverUserStoreService.editUserStore(userstoreDomainId, userStoreReq)).build();
-    }
-
-    @Override
-    public Response getUserStoreMappingAttributes(String typeId) {
-
-        return Response.ok().entity(serverUserStoreService.getUserStoreMappingAttributes(typeId)).build();
     }
 
     private URI getResourceLocation(String id) {

--- a/components/org.wso2.carbon.identity.api.server.userstore/org.wso2.carbon.identity.api.server.userstore.v1/src/main/resources/userstore.yaml
+++ b/components/org.wso2.carbon.identity.api.server.userstore/org.wso2.carbon.identity.api.server.userstore.v1/src/main/resources/userstore.yaml
@@ -368,6 +368,7 @@ paths:
           description: Id of the user store type
           schema:
             type: string
+        - $ref: '#/components/parameters/excludeIdentityClaimsPathParam'
       responses:
         '200':
           description: Successful Response.
@@ -431,6 +432,14 @@ components:
       schema:
         type: string
         example: SkRCQy1TRUNPTkRBUlk
+    excludeIdentityClaimsPathParam:
+      in: query
+      name: excludeIdentityClaimMappings
+      required: false
+      description: Whether to exlcude the identity claim mappings from userstore attributes.
+      example: false
+      schema:
+        type: boolean
     limitQueryParam:
       in: query
       name: limit


### PR DESCRIPTION
## Purpose
Improve userstore attributes API to exclude identity claim mappings.

### Approach
Added a query param `excludeIdentityClaimMappings` to the existing request and process the request in the API side before returning the response.