### PR TITLE
Log client error as a debug log

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/ServerApplicationManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/ServerApplicationManagementService.java
@@ -454,7 +454,9 @@ public class ServerApplicationManagementService {
              we need to return 204.
              */
             if (ERROR_CODE_INVALID_APP_ID.getCode().equals(e.getErrorCode())) {
-                log.error("Invalid application id: " + applicationId, e);
+                if (log.isDebugEnabled()) {
+                    log.debug("Invalid application id: " + applicationId, e);
+                }
                 return;
             }
             String msg = "Error while trying to remove CORS origins associated with the application: " + applicationId;


### PR DESCRIPTION
## Purpose
With this PR changes, the log will be set as a debug log when trying to delete an already deleted application instead of the error log.