### PR TITLE
Add branding-preference-management API

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.branding.preference.management/org.wso2.carbon.identity.api.server.branding.preference.management.common/pom.xml
+++ b/components/org.wso2.carbon.identity.api.server.branding.preference.management/org.wso2.carbon.identity.api.server.branding.preference.management.common/pom.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2021, WSO2 Inc. (http://www.wso2.com).
+  ~
+  ~ WSO2 Inc. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.wso2.carbon.identity.server.api</groupId>
+        <artifactId>org.wso2.carbon.identity.api.server.branding.preference.management</artifactId>
+        <relativePath>../pom.xml</relativePath>
+        <version>1.0.272-SNAPSHOT</version>
+    </parent>
+
+    <groupId>org.wso2.carbon.identity.server.api</groupId>
+    <artifactId>org.wso2.carbon.identity.api.server.branding.preference.management.common</artifactId>
+    <packaging>jar</packaging>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <version>1.8</version>
+                <executions>
+                    <execution>
+                        <id>add-source</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>add-source</goal>
+                        </goals>
+                        <configuration>
+                            <sources>
+                                <source>src/gen/java</source>
+                            </sources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.configuration.mgt.core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-web</artifactId>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/components/org.wso2.carbon.identity.api.server.branding.preference.management/org.wso2.carbon.identity.api.server.branding.preference.management.common/src/main/java/org/wso2/carbon/identity/api/server/branding/preference/management/common/BrandingPreferenceManagementConstants.java
+++ b/components/org.wso2.carbon.identity.api.server.branding.preference.management/org.wso2.carbon.identity.api.server.branding.preference.management.common/src/main/java/org/wso2/carbon/identity/api/server/branding/preference/management/common/BrandingPreferenceManagementConstants.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.com).
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.branding.preference.management.common;
+
+/**
+ * Branding preference management related constant class.
+ */
+public class BrandingPreferenceManagementConstants {
+
+    public static final String BRANDING_PREFERENCE_ERROR_PREFIX = "BPM-";
+    public static final String BRANDING_PREFERENCE_CONTEXT_PATH = "/branding-preference";
+    public static final String BRANDING_RESOURCE_TYPE = "BRANDING_PREFERENCES";
+    public static final String GET_PREFERENCE_COMPONENT_WITH_QUERY_PARAM = "?type=%s&name=%s&locale=%s";
+    public static final String ORGANIZATION_TYPE = "ORG";
+    public static final String APPLICATION_TYPE = "APP";
+    public static final String CUSTOM_TYPE = "CUSTOM";
+    public static final String DEFAULT_LOCALE = "en-US";
+    public static final String CONFIG_MGT_ERROR_CODE_DELIMITER = "_";
+    public static final String RESOURCE_NAME_SEPARATOR = "_";
+
+    public static final String RESOURCE_NOT_EXISTS_ERROR_CODE = "CONFIGM_00017";
+    public static final String RESOURCE_ALREADY_EXISTS_ERROR_CODE = "CONFIGM_00013";
+
+    /**
+     * Enums for error messages.
+     */
+    public enum ErrorMessage {
+
+        // Client errors 600xx.
+        ERROR_CODE_INVALID_BRANDING_PREFERENCE("60001",
+                "Invalid Branding Preference resource in request.",
+                "Invalid Branding Preference resource in request"),
+        ERROR_CODE_BRANDING_PREFERENCE_NOT_EXISTS("60002",
+                "No matching branding preference resource found.",
+                "Can not find a branding preference resource in tenant: %s."),
+        ERROR_CODE_CONFLICT_BRANDING_PREFERENCE("60003", "Branding preference already exists.",
+                "There exists a branding preference resource in the tenant: %s."),
+
+        // Server errors 650xx.
+        ERROR_CODE_ERROR_GETTING_BRANDING_PREFERENCE("65001", "Error while getting branding preference.",
+                "Error while retrieving notification branding preference resource: %s."),
+        ERROR_CODE_ERROR_ADDING_BRANDING_PREFERENCE("65002", "Unable to add branding preference.",
+                "Server encountered an error while adding the branding preference resource for tenant: %s"),
+        ERROR_CODE_ERROR_DELETING_BRANDING_PREFERENCE("65003", "Unable to delete branding preference.",
+                "Server encountered an error while deleting the branding preference resource: %s"),
+        ERROR_CODE_ERROR_UPDATING_BRANDING_PREFERENCE("65004", "Unable to update branding preference.",
+                "Error while updating branding preference for tenant: %s."),
+        ERROR_CODE_JSON_PROCESSING_EXCEPTION("65005", "Json Processing Exception.",
+                "Json Processing Exception: %s."),
+        ERROR_CODE_UNSUPPORTED_ENCODING_EXCEPTION("65006", "Unsupported Encoding Exception.",
+                "Unsupported Encoding Exception: %s."),
+        ERROR_CODE_ERROR_BUILDING_RESPONSE_EXCEPTION("65007",
+                "Unable to build response from preference resources.",
+                "Error while building response from preference resources.");
+
+        private final String code;
+        private final String message;
+        private final String description;
+
+        ErrorMessage(String code, String message, String description) {
+
+            this.code = code;
+            this.message = message;
+            this.description = description;
+        }
+
+        public String getCode() {
+
+            return BRANDING_PREFERENCE_ERROR_PREFIX + code;
+        }
+
+        public String getMessage() {
+
+            return message;
+        }
+
+        public String getDescription() {
+
+            return description;
+        }
+
+        @Override
+        public String toString() {
+
+            return code + " | " + message;
+        }
+    }
+}

--- a/components/org.wso2.carbon.identity.api.server.branding.preference.management/org.wso2.carbon.identity.api.server.branding.preference.management.common/src/main/java/org/wso2/carbon/identity/api/server/branding/preference/management/common/BrandingPreferenceServiceHolder.java
+++ b/components/org.wso2.carbon.identity.api.server.branding.preference.management/org.wso2.carbon.identity.api.server.branding.preference.management.common/src/main/java/org/wso2/carbon/identity/api/server/branding/preference/management/common/BrandingPreferenceServiceHolder.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.com).
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.branding.preference.management.common;
+
+import org.wso2.carbon.identity.configuration.mgt.core.ConfigurationManager;
+
+/**
+ * Service holder class for branding preference management.
+ */
+public class BrandingPreferenceServiceHolder {
+
+    private static ConfigurationManager brandingPreferenceConfigManager;
+
+    /**
+     * Get ConfigurationManager OSGi service.
+     *
+     * @return BrandingPreferenceConfig Manager.
+     */
+    public static ConfigurationManager getBrandingPreferenceConfigManager() {
+
+        return brandingPreferenceConfigManager;
+    }
+
+    /**
+     * Set ConfigurationManager OSGi service.
+     *
+     * @param configManager Configuration Manager.
+     */
+    public static void setBrandingPreferenceConfigManager(ConfigurationManager configManager) {
+
+        BrandingPreferenceServiceHolder.brandingPreferenceConfigManager = configManager;
+    }
+}

--- a/components/org.wso2.carbon.identity.api.server.branding.preference.management/org.wso2.carbon.identity.api.server.branding.preference.management.common/src/main/java/org/wso2/carbon/identity/api/server/branding/preference/management/common/factory/ConfigurationMgtOSGiServiceFactory.java
+++ b/components/org.wso2.carbon.identity.api.server.branding.preference.management/org.wso2.carbon.identity.api.server.branding.preference.management.common/src/main/java/org/wso2/carbon/identity/api/server/branding/preference/management/common/factory/ConfigurationMgtOSGiServiceFactory.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.com).
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.branding.preference.management.common.factory;
+
+import org.springframework.beans.factory.config.AbstractFactoryBean;
+import org.wso2.carbon.context.PrivilegedCarbonContext;
+import org.wso2.carbon.identity.configuration.mgt.core.ConfigurationManager;
+
+/**
+ * Factory Beans serve as a factory for creating other beans within the IOC container. This factory bean is used to
+ * instantiate the ConfigurationManager type of object inside the container.
+ */
+public class ConfigurationMgtOSGiServiceFactory extends AbstractFactoryBean<ConfigurationManager> {
+
+    private ConfigurationManager configurationManager;
+
+    @Override
+    public Class<?> getObjectType() {
+
+        return Object.class;
+    }
+
+    @Override
+    protected ConfigurationManager createInstance() throws Exception {
+
+        if (this.configurationManager == null) {
+            ConfigurationManager taskOperationService = (ConfigurationManager) PrivilegedCarbonContext.
+                    getThreadLocalCarbonContext().getOSGiService(ConfigurationManager.class, null);
+
+            if (taskOperationService != null) {
+                this.configurationManager = taskOperationService;
+            } else {
+                throw new Exception("Unable to retrieve ConfigurationManager service.");
+            }
+        }
+        return this.configurationManager;
+    }
+}

--- a/components/org.wso2.carbon.identity.api.server.branding.preference.management/org.wso2.carbon.identity.api.server.branding.preference.management.v1/pom.xml
+++ b/components/org.wso2.carbon.identity.api.server.branding.preference.management/org.wso2.carbon.identity.api.server.branding.preference.management.v1/pom.xml
@@ -1,0 +1,172 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2021, WSO2 Inc. (http://www.wso2.com).
+  ~
+  ~ WSO2 Inc. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <parent>
+        <artifactId>org.wso2.carbon.identity.api.server.branding.preference.management</artifactId>
+        <groupId>org.wso2.carbon.identity.server.api</groupId>
+        <relativePath>../pom.xml</relativePath>
+        <version>1.0.272-SNAPSHOT</version>
+    </parent>
+
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>org.wso2.carbon.identity.api.server.branding.preference.management.v1</artifactId>
+    <packaging>jar</packaging>
+
+    <build>
+        <plugins>
+<!--            <plugin>-->
+<!--                <groupId>org.openapitools</groupId>-->
+<!--                <artifactId>openapi-generator-maven-plugin</artifactId>-->
+<!--                <version>4.1.2</version>-->
+<!--                <executions>-->
+<!--                    <execution>-->
+<!--                        <goals>-->
+<!--                            <goal>generate</goal>-->
+<!--                        </goals>-->
+<!--                        <configuration>-->
+<!--                            <inputSpec>${project.basedir}/src/main/resources/branding-preference.yaml</inputSpec>-->
+<!--                            <generatorName>org.wso2.carbon.codegen.CxfWso2Generator</generatorName>-->
+<!--                            <configOptions>-->
+<!--                                <sourceFolder>src/gen/java</sourceFolder>-->
+<!--                                <apiPackage>org.wso2.carbon.identity.api.server.branding.preference.management.v1</apiPackage>-->
+<!--                                <modelPackage>org.wso2.carbon.identity.api.server.branding.preference.management.v1.model</modelPackage>-->
+<!--                                <packageName>org.wso2.carbon.identity.api.server.branding.preference.management.v1</packageName>-->
+<!--                                <dateLibrary>java8</dateLibrary>-->
+<!--                                <hideGenerationTimestamp>true</hideGenerationTimestamp>-->
+<!--                            </configOptions>-->
+<!--                            <output>.</output>-->
+<!--                            <skipOverwrite>false</skipOverwrite>-->
+<!--                        </configuration>-->
+<!--                    </execution>-->
+<!--                </executions>-->
+<!--                <dependencies>-->
+<!--                    <dependency>-->
+<!--                        <groupId>org.openapitools</groupId>-->
+<!--                        <artifactId>cxf-wso2-openapi-generator</artifactId>-->
+<!--                        <version>1.0.0</version>-->
+<!--                    </dependency>-->
+<!--                </dependencies>-->
+<!--            </plugin>-->
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <version>1.8</version>
+                <executions>
+                    <execution>
+                        <id>add-source</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>add-source</goal>
+                        </goals>
+                        <configuration>
+                            <sources>
+                                <source>src/gen/java</source>
+                            </sources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>${maven.compiler.plugin.version}</version>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.cxf</groupId>
+            <artifactId>cxf-rt-frontend-jaxrs</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.cxf</groupId>
+            <artifactId>cxf-rt-rs-service-description</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-web</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>javax.ws.rs</groupId>
+            <artifactId>javax.ws.rs-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.swagger</groupId>
+            <artifactId>swagger-jaxrs</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-databind</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-annotations</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.dataformat</groupId>
+                    <artifactId>jackson-dataformat-yaml</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>javax.ws.rs</groupId>
+                    <artifactId>jsr311-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.google.guava</groupId>
+                    <artifactId>guava</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.jaxrs</groupId>
+            <artifactId>jackson-jaxrs-json-provider</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.server.api</groupId>
+            <artifactId>org.wso2.carbon.identity.api.server.common</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.server.api</groupId>
+            <artifactId>org.wso2.carbon.identity.api.server.branding.preference.management.common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.configuration.mgt.core</artifactId>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/components/org.wso2.carbon.identity.api.server.branding.preference.management/org.wso2.carbon.identity.api.server.branding.preference.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/branding/preference/management/v1/BrandingPreferenceApi.java
+++ b/components/org.wso2.carbon.identity.api.server.branding.preference.management/org.wso2.carbon.identity.api.server.branding.preference.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/branding/preference/management/v1/BrandingPreferenceApi.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.com).
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.branding.preference.management.v1;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.apache.cxf.jaxrs.ext.multipart.Attachment;
+import org.apache.cxf.jaxrs.ext.multipart.Multipart;
+import java.io.InputStream;
+import java.util.List;
+
+import org.wso2.carbon.identity.api.server.branding.preference.management.v1.model.BrandingPreferenceModel;
+import org.wso2.carbon.identity.api.server.branding.preference.management.v1.model.Error;
+import org.wso2.carbon.identity.api.server.branding.preference.management.v1.BrandingPreferenceApiService;
+
+import javax.validation.Valid;
+import javax.ws.rs.*;
+import javax.ws.rs.core.Response;
+import io.swagger.annotations.*;
+
+import javax.validation.constraints.*;
+
+@Path("/branding-preference")
+@Api(description = "The branding-preference API")
+
+public class BrandingPreferenceApi  {
+
+    @Autowired
+    private BrandingPreferenceApiService delegate;
+
+    @Valid
+    @POST
+    
+    @Consumes({ "application/json" })
+    @Produces({ "application/json" })
+    @ApiOperation(value = "Add branding preferences for Tenant.", notes = "This API provides the capability to Add a custom branding preference of the tenant.<br>   <b>Permission required:</b> <br>     * /permission/admin/manage/identity/configmgt/add <br>   <b>Scope required:</b> <br>     * internal_config_mgt_add ", response = Void.class, authorizations = {
+        @Authorization(value = "BasicAuth"),
+        @Authorization(value = "OAuth2", scopes = {
+            
+        })
+    }, tags={ "Branding Preference", })
+    @ApiResponses(value = { 
+        @ApiResponse(code = 201, message = "Successfully created.", response = Void.class),
+        @ApiResponse(code = 400, message = "Invalid input in the request.", response = Error.class),
+        @ApiResponse(code = 401, message = "Authentication information is missing or invalid.", response = Void.class),
+        @ApiResponse(code = 403, message = "Access forbidden.", response = Void.class),
+        @ApiResponse(code = 409, message = "Conflict.", response = Error.class),
+        @ApiResponse(code = 500, message = "Internal server error.", response = Error.class),
+        @ApiResponse(code = 501, message = "Not Implemented.", response = Error.class)
+    })
+    public Response addBrandingPreference(@ApiParam(value = "This represents the branding preferences to be added." ,required=true) @Valid BrandingPreferenceModel brandingPreferenceModel) {
+
+        return delegate.addBrandingPreference(brandingPreferenceModel );
+    }
+
+    @Valid
+    @DELETE
+    
+    
+    @Produces({ "application/json" })
+    @ApiOperation(value = "Deletes branding preferences of Tenant.", notes = "This API provides the capability to delete the branding preferences of the tenant.<br>   <b>Permission required:</b> <br>     * /permission/admin/manage/identity/configmgt/delete <br>   <b>Scope required:</b> <br>     * internal_config_mgt_delete ", response = Void.class, authorizations = {
+        @Authorization(value = "BasicAuth"),
+        @Authorization(value = "OAuth2", scopes = {
+            
+        })
+    }, tags={ "Branding Preference", })
+    @ApiResponses(value = { 
+        @ApiResponse(code = 204, message = "Successfully deleted.", response = Void.class),
+        @ApiResponse(code = 400, message = "Invalid input in the request.", response = Error.class),
+        @ApiResponse(code = 401, message = "Authentication information is missing or invalid.", response = Void.class),
+        @ApiResponse(code = 403, message = "Access forbidden.", response = Void.class),
+        @ApiResponse(code = 404, message = "Requested resource is not found.", response = Error.class),
+        @ApiResponse(code = 500, message = "Internal server error.", response = Error.class)
+    })
+    public Response deleteBrandingPreference(    @Valid@ApiParam(value = "Resource Type to filter the retrieval of themes.", allowableValues="ORG, APP, CUSTOM")  @QueryParam("type") String type,     @Valid@ApiParam(value = "Application name/ Tenant name to filter the retrieval of themes.")  @QueryParam("name") String name,     @Valid@ApiParam(value = "Resource Localye to filter the retrieval of themes.")  @QueryParam("locale") String locale) {
+
+        return delegate.deleteBrandingPreference(type,  name,  locale );
+    }
+
+    @Valid
+    @GET
+    
+    
+    @Produces({ "application/json" })
+    @ApiOperation(value = "Get branding preference of Tenant.", notes = "This API provides the capability to retrieve the branding preference of the tenant. ", response = BrandingPreferenceModel.class, authorizations = {
+        @Authorization(value = "BasicAuth"),
+        @Authorization(value = "OAuth2", scopes = {
+            
+        })
+    }, tags={ "Branding Preference", })
+    @ApiResponses(value = { 
+        @ApiResponse(code = 200, message = "OK", response = BrandingPreferenceModel.class),
+        @ApiResponse(code = 400, message = "Invalid input in the request.", response = Error.class),
+        @ApiResponse(code = 401, message = "Authentication information is missing or invalid.", response = Void.class),
+        @ApiResponse(code = 403, message = "Access forbidden.", response = Void.class),
+        @ApiResponse(code = 404, message = "Requested resource is not found.", response = Error.class),
+        @ApiResponse(code = 500, message = "Internal server error.", response = Error.class)
+    })
+    public Response getBrandingPreference(    @Valid@ApiParam(value = "Resource Type to filter the retrieval of themes.", allowableValues="ORG, APP, CUSTOM")  @QueryParam("type") String type,     @Valid@ApiParam(value = "Application name/ Tenant name to filter the retrieval of themes.")  @QueryParam("name") String name,     @Valid@ApiParam(value = "Resource Localye to filter the retrieval of themes.")  @QueryParam("locale") String locale) {
+
+        return delegate.getBrandingPreference(type,  name,  locale );
+    }
+
+    @Valid
+    @PUT
+    
+    @Consumes({ "application/json" })
+    @Produces({ "application/json" })
+    @ApiOperation(value = "Update branding preferences of Tenant.", notes = "This API provides the capability to update the branding preference of the tenant.<br>   <b>Permission required:</b> <br>     * /permission/admin/manage/identity/configmgt/update <br>   <b>Scope required:</b> <br>     * internal_config_mgt_update ", response = Void.class, authorizations = {
+        @Authorization(value = "BasicAuth"),
+        @Authorization(value = "OAuth2", scopes = {
+            
+        })
+    }, tags={ "Branding Preference" })
+    @ApiResponses(value = { 
+        @ApiResponse(code = 200, message = "Successfully updated", response = Void.class),
+        @ApiResponse(code = 400, message = "Invalid input in the request.", response = Error.class),
+        @ApiResponse(code = 401, message = "Authentication information is missing or invalid.", response = Void.class),
+        @ApiResponse(code = 403, message = "Access forbidden.", response = Void.class),
+        @ApiResponse(code = 404, message = "Requested resource is not found.", response = Error.class),
+        @ApiResponse(code = 500, message = "Internal server error.", response = Error.class)
+    })
+    public Response updateBrandingPreference(@ApiParam(value = "This represents the branding preferences to be updated." ,required=true) @Valid BrandingPreferenceModel brandingPreferenceModel) {
+
+        return delegate.updateBrandingPreference(brandingPreferenceModel );
+    }
+
+}

--- a/components/org.wso2.carbon.identity.api.server.branding.preference.management/org.wso2.carbon.identity.api.server.branding.preference.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/branding/preference/management/v1/BrandingPreferenceApiService.java
+++ b/components/org.wso2.carbon.identity.api.server.branding.preference.management/org.wso2.carbon.identity.api.server.branding.preference.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/branding/preference/management/v1/BrandingPreferenceApiService.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.com).
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.branding.preference.management.v1;
+
+import org.wso2.carbon.identity.api.server.branding.preference.management.v1.*;
+import org.wso2.carbon.identity.api.server.branding.preference.management.v1.model.*;
+import org.apache.cxf.jaxrs.ext.multipart.Attachment;
+import org.apache.cxf.jaxrs.ext.multipart.Multipart;
+import java.io.InputStream;
+import java.util.List;
+import org.wso2.carbon.identity.api.server.branding.preference.management.v1.model.BrandingPreferenceModel;
+import org.wso2.carbon.identity.api.server.branding.preference.management.v1.model.Error;
+import javax.ws.rs.core.Response;
+
+
+public interface BrandingPreferenceApiService {
+
+      public Response addBrandingPreference(BrandingPreferenceModel brandingPreferenceModel);
+
+      public Response deleteBrandingPreference(String type, String name, String locale);
+
+      public Response getBrandingPreference(String type, String name, String locale);
+
+      public Response updateBrandingPreference(BrandingPreferenceModel brandingPreferenceModel);
+}

--- a/components/org.wso2.carbon.identity.api.server.branding.preference.management/org.wso2.carbon.identity.api.server.branding.preference.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/branding/preference/management/v1/factories/BrandingPreferenceApiServiceFactory.java
+++ b/components/org.wso2.carbon.identity.api.server.branding.preference.management/org.wso2.carbon.identity.api.server.branding.preference.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/branding/preference/management/v1/factories/BrandingPreferenceApiServiceFactory.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.com).
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.branding.preference.management.v1.factories;
+
+import org.wso2.carbon.identity.api.server.branding.preference.management.v1.BrandingPreferenceApiService;
+import org.wso2.carbon.identity.api.server.branding.preference.management.v1.impl.BrandingPreferenceApiServiceImpl;
+
+public class BrandingPreferenceApiServiceFactory {
+
+   private final static BrandingPreferenceApiService service = new BrandingPreferenceApiServiceImpl();
+
+   public static BrandingPreferenceApiService getBrandingPreferenceApi()
+   {
+      return service;
+   }
+}

--- a/components/org.wso2.carbon.identity.api.server.branding.preference.management/org.wso2.carbon.identity.api.server.branding.preference.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/branding/preference/management/v1/model/BrandingPreferenceModel.java
+++ b/components/org.wso2.carbon.identity.api.server.branding.preference.management/org.wso2.carbon.identity.api.server.branding.preference.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/branding/preference/management/v1/model/BrandingPreferenceModel.java
@@ -1,0 +1,197 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.com).
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.branding.preference.management.v1.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import javax.validation.constraints.*;
+
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+import javax.validation.Valid;
+import javax.xml.bind.annotation.*;
+
+public class BrandingPreferenceModel  {
+  
+
+@XmlType(name="TypeEnum")
+@XmlEnum(String.class)
+public enum TypeEnum {
+
+    @XmlEnumValue("ORG") ORG(String.valueOf("ORG")), @XmlEnumValue("APP") APP(String.valueOf("APP")), @XmlEnumValue("CUSTOM") CUSTOM(String.valueOf("CUSTOM"));
+
+
+    private String value;
+
+    TypeEnum(String v) {
+        value = v;
+    }
+
+    public String value() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    public static TypeEnum fromValue(String value) {
+        for (TypeEnum b : TypeEnum.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
+}
+
+    private TypeEnum type;
+    private String name;
+    private String locale;
+    private Object preference;
+
+    /**
+    **/
+    public BrandingPreferenceModel type(TypeEnum type) {
+
+        this.type = type;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "ORG", required = true, value = "")
+    @JsonProperty("type")
+    @Valid
+    @NotNull(message = "Property type cannot be null.")
+
+    public TypeEnum getType() {
+        return type;
+    }
+    public void setType(TypeEnum type) {
+        this.type = type;
+    }
+
+    /**
+    **/
+    public BrandingPreferenceModel name(String name) {
+
+        this.name = name;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "NAME", value = "")
+    @JsonProperty("name")
+    @Valid
+    public String getName() {
+        return name;
+    }
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    /**
+    **/
+    public BrandingPreferenceModel locale(String locale) {
+
+        this.locale = locale;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "en-US", value = "")
+    @JsonProperty("locale")
+    @Valid
+    public String getLocale() {
+        return locale;
+    }
+    public void setLocale(String locale) {
+        this.locale = locale;
+    }
+
+    /**
+    * This is the JSON structured branding preference
+    **/
+    public BrandingPreferenceModel preference(Object preference) {
+
+        this.preference = preference;
+        return this;
+    }
+    
+    @ApiModelProperty(value = "This is the JSON structured branding preference")
+    @JsonProperty("preference")
+    @Valid
+    public Object getPreference() {
+        return preference;
+    }
+    public void setPreference(Object preference) {
+        this.preference = preference;
+    }
+
+
+
+    @Override
+    public boolean equals(java.lang.Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        BrandingPreferenceModel brandingPreferenceModel = (BrandingPreferenceModel) o;
+        return Objects.equals(this.type, brandingPreferenceModel.type) &&
+            Objects.equals(this.name, brandingPreferenceModel.name) &&
+            Objects.equals(this.locale, brandingPreferenceModel.locale) &&
+            Objects.equals(this.preference, brandingPreferenceModel.preference);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(type, name, locale, preference);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class BrandingPreferenceModel {\n");
+        
+        sb.append("    type: ").append(toIndentedString(type)).append("\n");
+        sb.append("    name: ").append(toIndentedString(name)).append("\n");
+        sb.append("    locale: ").append(toIndentedString(locale)).append("\n");
+        sb.append("    preference: ").append(toIndentedString(preference)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+    * Convert the given object to string with each line indented by 4 spaces
+    * (except the first line).
+    */
+    private String toIndentedString(java.lang.Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}
+

--- a/components/org.wso2.carbon.identity.api.server.branding.preference.management/org.wso2.carbon.identity.api.server.branding.preference.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/branding/preference/management/v1/model/Error.java
+++ b/components/org.wso2.carbon.identity.api.server.branding.preference.management/org.wso2.carbon.identity.api.server.branding.preference.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/branding/preference/management/v1/model/Error.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.com).
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.branding.preference.management.v1.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import javax.validation.constraints.*;
+
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+import javax.validation.Valid;
+import javax.xml.bind.annotation.*;
+
+public class Error  {
+  
+    private String code;
+    private String message;
+    private String description;
+    private String traceId;
+
+    /**
+    **/
+    public Error code(String code) {
+
+        this.code = code;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "TBM-60001", required = true, value = "")
+    @JsonProperty("code")
+    @Valid
+    @NotNull(message = "Property code cannot be null.")
+
+    public String getCode() {
+        return code;
+    }
+    public void setCode(String code) {
+        this.code = code;
+    }
+
+    /**
+    **/
+    public Error message(String message) {
+
+        this.message = message;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "Some Error Message", required = true, value = "")
+    @JsonProperty("message")
+    @Valid
+    @NotNull(message = "Property message cannot be null.")
+
+    public String getMessage() {
+        return message;
+    }
+    public void setMessage(String message) {
+        this.message = message;
+    }
+
+    /**
+    **/
+    public Error description(String description) {
+
+        this.description = description;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "Some Error Description", value = "")
+    @JsonProperty("description")
+    @Valid
+    public String getDescription() {
+        return description;
+    }
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    /**
+    **/
+    public Error traceId(String traceId) {
+
+        this.traceId = traceId;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "3erfee-232-efewv-2321-43ferfe24r", value = "")
+    @JsonProperty("traceId")
+    @Valid
+    public String getTraceId() {
+        return traceId;
+    }
+    public void setTraceId(String traceId) {
+        this.traceId = traceId;
+    }
+
+
+
+    @Override
+    public boolean equals(java.lang.Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Error error = (Error) o;
+        return Objects.equals(this.code, error.code) &&
+            Objects.equals(this.message, error.message) &&
+            Objects.equals(this.description, error.description) &&
+            Objects.equals(this.traceId, error.traceId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(code, message, description, traceId);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class Error {\n");
+        
+        sb.append("    code: ").append(toIndentedString(code)).append("\n");
+        sb.append("    message: ").append(toIndentedString(message)).append("\n");
+        sb.append("    description: ").append(toIndentedString(description)).append("\n");
+        sb.append("    traceId: ").append(toIndentedString(traceId)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+    * Convert the given object to string with each line indented by 4 spaces
+    * (except the first line).
+    */
+    private String toIndentedString(java.lang.Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}
+

--- a/components/org.wso2.carbon.identity.api.server.branding.preference.management/org.wso2.carbon.identity.api.server.branding.preference.management.v1/src/main/java/org/wso2/carbon/identity/api/server/branding/preference/management/v1/core/BrandingPreferenceManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.branding.preference.management/org.wso2.carbon.identity.api.server.branding.preference.management.v1/src/main/java/org/wso2/carbon/identity/api/server/branding/preference/management/v1/core/BrandingPreferenceManagementService.java
@@ -1,0 +1,396 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.com).
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.branding.preference.management.v1.core;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang.StringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.context.PrivilegedCarbonContext;
+import org.wso2.carbon.identity.api.server.branding.preference.management.common.BrandingPreferenceManagementConstants;
+import org.wso2.carbon.identity.api.server.branding.preference.management.common.BrandingPreferenceServiceHolder;
+import org.wso2.carbon.identity.api.server.branding.preference.management.v1.core.utils.BrandingPreferenceUtils;
+import org.wso2.carbon.identity.api.server.branding.preference.management.v1.model.BrandingPreferenceModel;
+import org.wso2.carbon.identity.api.server.common.error.APIError;
+import org.wso2.carbon.identity.api.server.common.error.ErrorResponse;
+import org.wso2.carbon.identity.configuration.mgt.core.exception.ConfigurationManagementClientException;
+import org.wso2.carbon.identity.configuration.mgt.core.exception.ConfigurationManagementException;
+import org.wso2.carbon.identity.configuration.mgt.core.exception.ConfigurationManagementServerException;
+import org.wso2.carbon.identity.configuration.mgt.core.model.Resource;
+import org.wso2.carbon.identity.configuration.mgt.core.model.ResourceFile;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import javax.ws.rs.core.Response;
+
+import static org.wso2.carbon.identity.api.server.branding.preference.management.common.BrandingPreferenceManagementConstants.BRANDING_PREFERENCE_ERROR_PREFIX;
+import static org.wso2.carbon.identity.api.server.branding.preference.management.common.BrandingPreferenceManagementConstants.BRANDING_RESOURCE_TYPE;
+import static org.wso2.carbon.identity.api.server.branding.preference.management.common.BrandingPreferenceManagementConstants.CONFIG_MGT_ERROR_CODE_DELIMITER;
+import static org.wso2.carbon.identity.api.server.branding.preference.management.common.BrandingPreferenceManagementConstants.DEFAULT_LOCALE;
+import static org.wso2.carbon.identity.api.server.branding.preference.management.common.BrandingPreferenceManagementConstants.ErrorMessage.ERROR_CODE_BRANDING_PREFERENCE_NOT_EXISTS;
+import static org.wso2.carbon.identity.api.server.branding.preference.management.common.BrandingPreferenceManagementConstants.ErrorMessage.ERROR_CODE_CONFLICT_BRANDING_PREFERENCE;
+import static org.wso2.carbon.identity.api.server.branding.preference.management.common.BrandingPreferenceManagementConstants.ErrorMessage.ERROR_CODE_ERROR_ADDING_BRANDING_PREFERENCE;
+import static org.wso2.carbon.identity.api.server.branding.preference.management.common.BrandingPreferenceManagementConstants.ErrorMessage.ERROR_CODE_ERROR_BUILDING_RESPONSE_EXCEPTION;
+import static org.wso2.carbon.identity.api.server.branding.preference.management.common.BrandingPreferenceManagementConstants.ErrorMessage.ERROR_CODE_ERROR_DELETING_BRANDING_PREFERENCE;
+import static org.wso2.carbon.identity.api.server.branding.preference.management.common.BrandingPreferenceManagementConstants.ErrorMessage.ERROR_CODE_ERROR_GETTING_BRANDING_PREFERENCE;
+import static org.wso2.carbon.identity.api.server.branding.preference.management.common.BrandingPreferenceManagementConstants.ErrorMessage.ERROR_CODE_ERROR_UPDATING_BRANDING_PREFERENCE;
+import static org.wso2.carbon.identity.api.server.branding.preference.management.common.BrandingPreferenceManagementConstants.ErrorMessage.ERROR_CODE_INVALID_BRANDING_PREFERENCE;
+import static org.wso2.carbon.identity.api.server.branding.preference.management.common.BrandingPreferenceManagementConstants.ErrorMessage.ERROR_CODE_JSON_PROCESSING_EXCEPTION;
+import static org.wso2.carbon.identity.api.server.branding.preference.management.common.BrandingPreferenceManagementConstants.ErrorMessage.ERROR_CODE_UNSUPPORTED_ENCODING_EXCEPTION;
+import static org.wso2.carbon.identity.api.server.branding.preference.management.common.BrandingPreferenceManagementConstants.ORGANIZATION_TYPE;
+import static org.wso2.carbon.identity.api.server.branding.preference.management.common.BrandingPreferenceManagementConstants.RESOURCE_ALREADY_EXISTS_ERROR_CODE;
+import static org.wso2.carbon.identity.api.server.branding.preference.management.common.BrandingPreferenceManagementConstants.RESOURCE_NAME_SEPARATOR;
+import static org.wso2.carbon.identity.api.server.branding.preference.management.common.BrandingPreferenceManagementConstants.RESOURCE_NOT_EXISTS_ERROR_CODE;
+import static org.wso2.carbon.identity.api.server.common.ContextLoader.getTenantDomainFromContext;
+
+/**
+ * Invoke internal OSGi service to perform branding preference management operations.
+ */
+public class BrandingPreferenceManagementService {
+
+    private static final Log log = LogFactory.getLog(BrandingPreferenceManagementService.class);
+    //TODO: Improve API to manage application level & language level theming resources in addition to the tenant level.
+
+    /**
+     * Create a branding preference resource with a resource file.
+     *
+     * @param brandingPreferenceModel Branding preference post request.
+     */
+    public void addBrandingPreference(BrandingPreferenceModel brandingPreferenceModel) {
+
+        String tenantDomain = getTenantDomainFromContext();
+        // Check whether a branding resource already exists with the same name in the particular tenant to be added.
+        if (isResourceExists(BRANDING_RESOURCE_TYPE, getDefaultResourceName())) {
+            throw handleException(Response.Status.CONFLICT, ERROR_CODE_CONFLICT_BRANDING_PREFERENCE, tenantDomain);
+        }
+        String preferencesJson = generatePreferencesJsonFromRequest(brandingPreferenceModel.getPreference());
+        if (!BrandingPreferenceUtils.isValidJsonString(preferencesJson)) {
+            throw handleException(Response.Status.BAD_REQUEST, ERROR_CODE_INVALID_BRANDING_PREFERENCE, null);
+        }
+
+        try {
+            InputStream inputStream = BrandingPreferenceUtils.generatePreferenceInputStream(preferencesJson);
+            Resource brandingPreferenceResource =
+                    buildResourceFromBrandingPreference(brandingPreferenceModel, inputStream);
+            BrandingPreferenceServiceHolder.getBrandingPreferenceConfigManager()
+                    .addResource(BRANDING_RESOURCE_TYPE, brandingPreferenceResource);
+        } catch (ConfigurationManagementException e) {
+            throw handleConfigurationMgtException(e, ERROR_CODE_ERROR_ADDING_BRANDING_PREFERENCE, tenantDomain);
+        } catch (JsonProcessingException e) {
+            throw handleException(Response.Status.INTERNAL_SERVER_ERROR, ERROR_CODE_JSON_PROCESSING_EXCEPTION,
+                    e.getMessage());
+        } catch (UnsupportedEncodingException e) {
+            throw handleException(Response.Status.INTERNAL_SERVER_ERROR, ERROR_CODE_UNSUPPORTED_ENCODING_EXCEPTION,
+                    e.getMessage());
+        }
+    }
+
+    /**
+     * Delete branding preference resource.
+     *
+     * @param type   Resource type.
+     * @param name   Name.
+     * @param locale Language preference.
+     */
+    public void deleteBrandingPreference(String type, String name, String locale) {
+
+        String tenantDomain = getTenantDomainFromContext();
+        String resourceName = getDefaultResourceName();
+        // Check whether the branding resource exists in the particular tenant.
+        if (!isResourceExists(BRANDING_RESOURCE_TYPE, getDefaultResourceName())) {
+            throw handleException(Response.Status.NOT_FOUND, ERROR_CODE_BRANDING_PREFERENCE_NOT_EXISTS, tenantDomain);
+        }
+
+        try {
+            BrandingPreferenceServiceHolder.getBrandingPreferenceConfigManager()
+                    .deleteResource(BRANDING_RESOURCE_TYPE, resourceName);
+        } catch (ConfigurationManagementException e) {
+            throw handleConfigurationMgtException(e, ERROR_CODE_ERROR_DELETING_BRANDING_PREFERENCE, resourceName);
+        }
+    }
+
+    /**
+     * Retrieve the requested branding preferences.
+     *
+     * @param type   Resource Type.
+     * @param name   Name.
+     * @param locale Language preference.
+     * @return The requested branding preference resource. If not exists return the default preferences.
+     */
+    public BrandingPreferenceModel getBrandingPreference(String type, String name, String locale) {
+
+        String tenantDomain = getTenantDomainFromContext();
+        String resourceName = getDefaultResourceName();
+        try {
+            // Return default branding preference.
+            List<ResourceFile> resourceFiles = BrandingPreferenceServiceHolder.getBrandingPreferenceConfigManager()
+                    .getFiles(BRANDING_RESOURCE_TYPE, resourceName);
+            if (resourceFiles.isEmpty()) {
+                throw handleException(Response.Status.NOT_FOUND, ERROR_CODE_BRANDING_PREFERENCE_NOT_EXISTS,
+                        tenantDomain);
+            }
+            if (StringUtils.isBlank(resourceFiles.get(0).getId())) {
+                throw handleException(Response.Status.NOT_FOUND, ERROR_CODE_BRANDING_PREFERENCE_NOT_EXISTS,
+                        tenantDomain);
+            }
+
+            InputStream inputStream = BrandingPreferenceServiceHolder.getBrandingPreferenceConfigManager()
+                    .getFileById(BRANDING_RESOURCE_TYPE, resourceName, resourceFiles.get(0).getId());
+            if (inputStream == null) {
+                throw handleException(Response.Status.NOT_FOUND, ERROR_CODE_BRANDING_PREFERENCE_NOT_EXISTS,
+                        tenantDomain);
+            }
+            return buildBrandingPreferenceFromResource(inputStream);
+        } catch (ConfigurationManagementException e) {
+            throw handleConfigurationMgtException(e, ERROR_CODE_ERROR_GETTING_BRANDING_PREFERENCE, resourceName);
+        } catch (IOException e) {
+            throw handleException
+                    (Response.Status.INTERNAL_SERVER_ERROR, ERROR_CODE_ERROR_BUILDING_RESPONSE_EXCEPTION, null);
+        }
+    }
+
+    /**
+     * Update branding preferences.
+     *
+     * @param brandingPreferenceModel Branding Preference Model with new preferences.
+     */
+    public void updateBrandingPreference(BrandingPreferenceModel brandingPreferenceModel) {
+
+        String tenantDomain = getTenantDomainFromContext();
+        // Check whether the branding resource exists in the particular tenant.
+        if (!isResourceExists(BRANDING_RESOURCE_TYPE, getDefaultResourceName())) {
+            throw handleException(Response.Status.NOT_FOUND, ERROR_CODE_BRANDING_PREFERENCE_NOT_EXISTS, tenantDomain);
+        }
+
+        String preferencesJson = generatePreferencesJsonFromRequest(brandingPreferenceModel.getPreference());
+        if (!BrandingPreferenceUtils.isValidJsonString(preferencesJson)) {
+            throw handleException(Response.Status.BAD_REQUEST, ERROR_CODE_INVALID_BRANDING_PREFERENCE, null);
+        }
+
+        try {
+            InputStream inputStream = BrandingPreferenceUtils.generatePreferenceInputStream(preferencesJson);
+            Resource brandingPreferenceResource =
+                    buildResourceFromBrandingPreference(brandingPreferenceModel, inputStream);
+            BrandingPreferenceServiceHolder.getBrandingPreferenceConfigManager()
+                    .replaceResource(BRANDING_RESOURCE_TYPE, brandingPreferenceResource);
+        } catch (ConfigurationManagementException e) {
+            throw handleConfigurationMgtException(e, ERROR_CODE_ERROR_UPDATING_BRANDING_PREFERENCE, tenantDomain);
+        } catch (JsonProcessingException e) {
+            throw handleException(Response.Status.INTERNAL_SERVER_ERROR, ERROR_CODE_JSON_PROCESSING_EXCEPTION,
+                    e.getMessage());
+        } catch (UnsupportedEncodingException e) {
+            throw handleException(Response.Status.INTERNAL_SERVER_ERROR, ERROR_CODE_UNSUPPORTED_ENCODING_EXCEPTION,
+                    e.getMessage());
+        }
+    }
+
+    /**
+     * Check whether a branding preference resource already exists with the same name in the particular tenant.
+     *
+     * @param resourceType Resource type.
+     * @param resourceName Resource name.
+     * @return Return true if the resource already exists. If not return false.
+     */
+    private boolean isResourceExists(String resourceType, String resourceName) {
+
+        Resource resource;
+        try {
+            resource = BrandingPreferenceServiceHolder.getBrandingPreferenceConfigManager()
+                    .getResource(resourceType, resourceName);
+        } catch (ConfigurationManagementException e) {
+            return false;
+        }
+        if (resource == null) {
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * Generate and return resource name of the default branding of the particular tenant.
+     *
+     * @return resource name of the default branding resource.
+     */
+    private String getDefaultResourceName() {
+
+        int tenantId = PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantId();
+        String resourceName = tenantId + RESOURCE_NAME_SEPARATOR + DEFAULT_LOCALE;
+        return resourceName;
+    }
+
+    /**
+     * Build a resource object from Branding Preference Model.
+     *
+     * @param model       Branding Preference Model.
+     * @param inputStream Branding Preference file stream.
+     * @return Resource object.
+     */
+    private Resource buildResourceFromBrandingPreference(BrandingPreferenceModel model, InputStream inputStream) {
+
+        String resourceName = getDefaultResourceName();
+        Resource resource = new Resource();
+        resource.setResourceName(resourceName);
+        // Set file.
+        ResourceFile file = new ResourceFile();
+        file.setName(resourceName);
+        file.setInputStream(inputStream);
+        List<ResourceFile> resourceFiles = new ArrayList<>();
+        resourceFiles.add(file);
+        resource.setFiles(resourceFiles);
+        return resource;
+    }
+
+    /**
+     * Build a Branding Preference Model from branding preference file stream.
+     *
+     * @param inputStream Branding Preference file stream.
+     * @return Branding Preference Model.
+     */
+    private BrandingPreferenceModel buildBrandingPreferenceFromResource(InputStream inputStream)
+            throws IOException {
+
+        String preferencesJson = IOUtils.toString(inputStream, StandardCharsets.UTF_8.name());
+        if (!BrandingPreferenceUtils.isValidJsonString(preferencesJson)) {
+            throw handleException
+                    (Response.Status.INTERNAL_SERVER_ERROR, ERROR_CODE_ERROR_BUILDING_RESPONSE_EXCEPTION, null);
+        }
+
+        ObjectMapper mapper = new ObjectMapper();
+        Object preference = mapper.readValue(preferencesJson, Object.class);
+        BrandingPreferenceModel brandingPreferenceModel = new BrandingPreferenceModel();
+        brandingPreferenceModel.setPreference(preference);
+        brandingPreferenceModel.setType(BrandingPreferenceModel.TypeEnum.valueOf(ORGANIZATION_TYPE));
+        brandingPreferenceModel.setName(getTenantDomainFromContext());
+        brandingPreferenceModel.setLocale(DEFAULT_LOCALE);
+        return brandingPreferenceModel;
+    }
+
+    /**
+     * Build a Json string which contains preferences from a preference object.
+     *
+     * @param object Preference object of Branding Preference Model.
+     * @return Json string which contains preferences.
+     */
+    private String generatePreferencesJsonFromRequest(Object object) {
+
+        ObjectMapper mapper = new ObjectMapper();
+        String json = null;
+        try {
+            json = mapper.writeValueAsString(object);
+        } catch (JsonProcessingException e) {
+            if (log.isDebugEnabled()) {
+                log.debug("Error while generating json string from the branding preference request.", e);
+            }
+        }
+        return json;
+    }
+
+    /**
+     * Handle configuration management exceptions and return an API error.
+     *
+     * @param exception Configuration management exception
+     * @param errorEnum Branding preference management error enum.
+     * @param data      Relevant data.
+     * @return Processed API Error.
+     */
+    private APIError handleConfigurationMgtException(ConfigurationManagementException exception,
+                                                     BrandingPreferenceManagementConstants.ErrorMessage errorEnum,
+                                                     String data) {
+
+        ErrorResponse errorResponse =
+                getErrorBuilder(errorEnum, data).build(log, exception, errorEnum.getDescription());
+        Response.Status status;
+        if (exception instanceof ConfigurationManagementClientException) {
+            if (exception.getErrorCode() != null) {
+                String errorCode = exception.getErrorCode();
+                errorCode = errorCode.contains(CONFIG_MGT_ERROR_CODE_DELIMITER) ? errorCode :
+                        BRANDING_PREFERENCE_ERROR_PREFIX + errorCode;
+                errorResponse.setCode(errorCode);
+            }
+            errorResponse.setDescription(exception.getMessage());
+            if (RESOURCE_ALREADY_EXISTS_ERROR_CODE.equals(exception.getErrorCode())) {
+                status = Response.Status.CONFLICT;
+            } else if (RESOURCE_NOT_EXISTS_ERROR_CODE.equals(exception.getErrorCode())) {
+                status = Response.Status.NOT_FOUND;
+            } else {
+                status = Response.Status.BAD_REQUEST;
+            }
+        } else if (exception instanceof ConfigurationManagementServerException) {
+            if (exception.getErrorCode() != null) {
+                String errorCode = exception.getErrorCode();
+                errorCode = errorCode.contains(CONFIG_MGT_ERROR_CODE_DELIMITER) ? errorCode :
+                        BRANDING_PREFERENCE_ERROR_PREFIX + errorCode;
+                errorResponse.setCode(errorCode);
+            }
+            errorResponse.setDescription(exception.getMessage());
+            status = Response.Status.INTERNAL_SERVER_ERROR;
+        } else {
+            status = Response.Status.INTERNAL_SERVER_ERROR;
+        }
+        return new APIError(status, errorResponse);
+    }
+
+    /**
+     * Handle exceptions generated in API.
+     *
+     * @param status HTTP Status.
+     * @param error  Error Message information.
+     * @return APIError.
+     */
+    private APIError handleException(Response.Status status, BrandingPreferenceManagementConstants.ErrorMessage error,
+                                     String data) {
+
+        return new APIError(status, getErrorBuilder(error, data).build());
+    }
+
+    /**
+     * Return error builder.
+     *
+     * @param errorMsg Error Message information.
+     * @return ErrorResponse.Builder.
+     */
+    private ErrorResponse.Builder getErrorBuilder(BrandingPreferenceManagementConstants.ErrorMessage errorMsg,
+                                                  String data) {
+
+        return new ErrorResponse.Builder().withCode(errorMsg.getCode()).withMessage(errorMsg.getMessage())
+                .withDescription(includeData(errorMsg, data));
+    }
+
+    /**
+     * Include context data to error message.
+     *
+     * @param error Error message.
+     * @param data  Context data.
+     * @return Formatted error message.
+     */
+    private String includeData(BrandingPreferenceManagementConstants.ErrorMessage error, String data) {
+
+        if (StringUtils.isNotBlank(data)) {
+            return String.format(error.getDescription(), data);
+        } else {
+            return error.getDescription();
+        }
+    }
+}

--- a/components/org.wso2.carbon.identity.api.server.branding.preference.management/org.wso2.carbon.identity.api.server.branding.preference.management.v1/src/main/java/org/wso2/carbon/identity/api/server/branding/preference/management/v1/core/utils/BrandingPreferenceUtils.java
+++ b/components/org.wso2.carbon.identity.api.server.branding.preference.management/org.wso2.carbon.identity.api.server.branding.preference.management.v1/src/main/java/org/wso2/carbon/identity/api/server/branding/preference/management/v1/core/utils/BrandingPreferenceUtils.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.com).
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.branding.preference.management.v1.core.utils;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import org.apache.commons.lang.StringUtils;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Util class for branding preference management.
+ */
+public class BrandingPreferenceUtils {
+
+    /**
+     * Generate Branding Preference input stream.
+     *
+     * @param jsonString Json string of preferences.
+     * @return Input stream of the preferences json string.
+     * @throws JsonProcessingException      Json Processing Exception.
+     * @throws UnsupportedEncodingException Unsupported Encoding Exception.
+     */
+    public static InputStream generatePreferenceInputStream(String jsonString)
+            throws JsonProcessingException, UnsupportedEncodingException {
+
+        return new ByteArrayInputStream(jsonString.getBytes(StandardCharsets.UTF_8.name()));
+    }
+
+    /**
+     * Check whether the given string is a valid Json or not.
+     *
+     * @param jsonString Input String.
+     * @return True if the input string is a valid Json.
+     */
+    public static boolean isValidJsonString(String jsonString) {
+
+        if (StringUtils.isBlank(jsonString)) {
+            return false;
+        }
+
+        try {
+            JSONObject jsonObject = new JSONObject(jsonString);
+            if (jsonObject.length() == 0) {
+                return false;
+            }
+        } catch (JSONException exception1) {
+            return false;
+        }
+        return true;
+    }
+}

--- a/components/org.wso2.carbon.identity.api.server.branding.preference.management/org.wso2.carbon.identity.api.server.branding.preference.management.v1/src/main/java/org/wso2/carbon/identity/api/server/branding/preference/management/v1/impl/BrandingPreferenceApiServiceImpl.java
+++ b/components/org.wso2.carbon.identity.api.server.branding.preference.management/org.wso2.carbon.identity.api.server.branding.preference.management.v1/src/main/java/org/wso2/carbon/identity/api/server/branding/preference/management/v1/impl/BrandingPreferenceApiServiceImpl.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.com).
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.branding.preference.management.v1.impl;
+
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.wso2.carbon.identity.api.server.branding.preference.management.v1.BrandingPreferenceApiService;
+import org.wso2.carbon.identity.api.server.branding.preference.management.v1.core.BrandingPreferenceManagementService;
+import org.wso2.carbon.identity.api.server.branding.preference.management.v1.model.BrandingPreferenceModel;
+import org.wso2.carbon.identity.api.server.common.ContextLoader;
+
+import java.net.URI;
+import javax.ws.rs.core.Response;
+
+import static org.wso2.carbon.identity.api.server.branding.preference.management.common.BrandingPreferenceManagementConstants.APPLICATION_TYPE;
+import static org.wso2.carbon.identity.api.server.branding.preference.management.common.BrandingPreferenceManagementConstants.BRANDING_PREFERENCE_CONTEXT_PATH;
+import static org.wso2.carbon.identity.api.server.branding.preference.management.common.BrandingPreferenceManagementConstants.CUSTOM_TYPE;
+import static org.wso2.carbon.identity.api.server.branding.preference.management.common.BrandingPreferenceManagementConstants.DEFAULT_LOCALE;
+import static org.wso2.carbon.identity.api.server.branding.preference.management.common.BrandingPreferenceManagementConstants.GET_PREFERENCE_COMPONENT_WITH_QUERY_PARAM;
+import static org.wso2.carbon.identity.api.server.branding.preference.management.common.BrandingPreferenceManagementConstants.ORGANIZATION_TYPE;
+import static org.wso2.carbon.identity.api.server.common.Constants.V1_API_PATH_COMPONENT;
+import static org.wso2.carbon.identity.api.server.common.ContextLoader.getTenantDomainFromContext;
+
+/**
+ * Implementation of branding preference management REST API.
+ */
+public class BrandingPreferenceApiServiceImpl implements BrandingPreferenceApiService {
+
+    @Autowired
+    private BrandingPreferenceManagementService brandingPreferenceManagementService;
+
+    //TODO: Improve API to manage application level & language level theming resources in addition to the tenant level.
+
+    @Override
+    public Response addBrandingPreference(BrandingPreferenceModel brandingPreferenceModel) {
+
+        if (StringUtils.isBlank(brandingPreferenceModel.getType().toString())) {
+            return Response.status(Response.Status.BAD_REQUEST).build();
+        }
+        if (!StringUtils.equals(brandingPreferenceModel.getType().toString(), ORGANIZATION_TYPE)) {
+            return Response.status(Response.Status.NOT_IMPLEMENTED).build();
+        }
+        if ((!StringUtils.equals(brandingPreferenceModel.getLocale(), DEFAULT_LOCALE)) &&
+                StringUtils.isNotBlank(brandingPreferenceModel.getLocale())) {
+            return Response.status(Response.Status.NOT_IMPLEMENTED).build();
+        }
+
+        brandingPreferenceManagementService.addBrandingPreference(brandingPreferenceModel);
+        URI location = ContextLoader.buildURIForHeader(V1_API_PATH_COMPONENT + BRANDING_PREFERENCE_CONTEXT_PATH
+                + String.format(GET_PREFERENCE_COMPONENT_WITH_QUERY_PARAM, ORGANIZATION_TYPE,
+                getTenantDomainFromContext(), DEFAULT_LOCALE));
+        return Response.created(location).build();
+    }
+
+    @Override
+    public Response deleteBrandingPreference(String type, String name, String locale) {
+
+        if (type != null) {
+            if (!(type.equals(ORGANIZATION_TYPE) || type.equals(APPLICATION_TYPE) || type.equals(CUSTOM_TYPE))) {
+                return Response.status(Response.Status.BAD_REQUEST).build();
+            }
+            if (!StringUtils.equals(type, ORGANIZATION_TYPE)) {
+                return Response.status(Response.Status.NOT_FOUND).build();
+            }
+        }
+        if (locale != null) {
+            if (!StringUtils.equals(locale, DEFAULT_LOCALE)) {
+                return Response.status(Response.Status.NOT_FOUND).build();
+            }
+        }
+
+        brandingPreferenceManagementService.deleteBrandingPreference(type, name, locale);
+        return Response.noContent().build();
+    }
+
+    @Override
+    public Response getBrandingPreference(String type, String name, String locale) {
+
+        if (type != null) {
+            if (!(type.equals(ORGANIZATION_TYPE) || type.equals(APPLICATION_TYPE) || type.equals(CUSTOM_TYPE))) {
+                return Response.status(Response.Status.BAD_REQUEST).build();
+            }
+        }
+        return Response.ok()
+                .entity(brandingPreferenceManagementService.getBrandingPreference(type, name, locale)).build();
+    }
+
+    @Override
+    public Response updateBrandingPreference(BrandingPreferenceModel brandingPreferenceModel) {
+
+        if (StringUtils.isBlank(brandingPreferenceModel.getType().toString())) {
+            return Response.status(Response.Status.BAD_REQUEST).build();
+        }
+        if (!StringUtils.equals(brandingPreferenceModel.getType().toString(), ORGANIZATION_TYPE)) {
+            return Response.status(Response.Status.NOT_FOUND).build();
+        }
+        if ((!StringUtils.equals(brandingPreferenceModel.getLocale(), DEFAULT_LOCALE)) &&
+                StringUtils.isNotBlank(brandingPreferenceModel.getLocale())) {
+            return Response.status(Response.Status.NOT_FOUND).build();
+        }
+
+        brandingPreferenceManagementService.updateBrandingPreference(brandingPreferenceModel);
+        return Response.ok().build();
+    }
+}

--- a/components/org.wso2.carbon.identity.api.server.branding.preference.management/org.wso2.carbon.identity.api.server.branding.preference.management.v1/src/main/resources/META-INF/cxf/branding-preference-server-v1-cxf.xml
+++ b/components/org.wso2.carbon.identity.api.server.branding.preference.management/org.wso2.carbon.identity.api.server.branding.preference.management.v1/src/main/resources/META-INF/cxf/branding-preference-server-v1-cxf.xml
@@ -1,0 +1,27 @@
+<!--
+  ~ Copyright (c) 2021, WSO2 Inc. (http://www.wso2.com).
+  ~
+  ~ WSO2 Inc. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans  http://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
+    <bean class="org.wso2.carbon.identity.api.server.branding.preference.management.v1.core.BrandingPreferenceManagementService"/>
+    <bean class="org.wso2.carbon.identity.api.server.branding.preference.management.v1.impl.BrandingPreferenceApiServiceImpl"/>
+    <bean id="configurationManagerFactoryBean" class="org.wso2.carbon.identity.api.server.branding.preference.management.common.factory.ConfigurationMgtOSGiServiceFactory"/>
+    <bean id="brandingPreferenceServiceImplDataHolderBean" class="org.wso2.carbon.identity.api.server.branding.preference.management.common.BrandingPreferenceServiceHolder">
+        <property name="brandingPreferenceConfigManager" ref="configurationManagerFactoryBean"/>
+    </bean>
+</beans>

--- a/components/org.wso2.carbon.identity.api.server.branding.preference.management/org.wso2.carbon.identity.api.server.branding.preference.management.v1/src/main/resources/branding-preference.yaml
+++ b/components/org.wso2.carbon.identity.api.server.branding.preference.management/org.wso2.carbon.identity.api.server.branding.preference.management.v1/src/main/resources/branding-preference.yaml
@@ -1,0 +1,278 @@
+openapi: 3.0.0
+info:
+  title: WSO2 Identity Server - Branding Preferences API Definition
+  description: >-
+    This document specifies a **RESTful API** for **Managing Branding Preferences of Organizations** in **WSO2 Identity Server**.
+  contact:
+    name: WSO2 Identity Server
+    url: 'https://wso2.com/identity-and-access-management/'
+    email: architecture@wso2.com
+  license:
+    name: Apache 2.0
+    url: http://www.apache.org/licenses/LICENSE-2.0.html
+  version: v1
+
+servers:
+  - url: 'https://{server-url}/t/{tenant-domain}/api/server/v1'
+    variables:
+      server-url:
+        default: "localhost:9443"
+      tenant-domain:
+        default: "carbon.super"
+
+security:
+  - OAuth2: []
+  - BasicAuth: []
+
+paths:
+  '/branding-preference':
+    get:
+      tags:
+        - Branding Preference
+      operationId: getBrandingPreference
+      summary: Get branding preference of Tenant.
+      description: |
+        This API provides the capability to retrieve the branding preference of the tenant.
+      parameters:
+        - $ref: '#/components/parameters/typeQueryParam'
+        - $ref: '#/components/parameters/nameQueryParam'
+        - $ref: '#/components/parameters/localeQueryParam'
+      responses:
+        '200':
+          description: OK
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/BrandingPreferenceModel'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/ServerError'
+
+    post:
+      tags:
+        - Branding Preference
+      operationId: addBrandingPreference
+      summary: Add branding preferences for Tenant.
+      description: |
+        This API provides the capability to Add a custom branding preference of the tenant.<br>
+          <b>Permission required:</b> <br>
+            * /permission/admin/manage/identity/applicationmgt/update <br>
+          <b>Scope required:</b> <br>
+            * internal_application_mgt_update
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/BrandingPreferenceModel'
+        description: This represents the branding preferences to be added.
+        required: true
+      responses:
+        '201':
+          description: Successfully created.
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        "409":
+          $ref: '#/components/responses/Conflict'
+        '500':
+          $ref: '#/components/responses/ServerError'
+        '501':
+          $ref: '#/components/responses/NotImplemented'
+    put:
+      tags:
+        - Branding Preference
+      operationId: updateBrandingPreference
+      summary: Update branding preferences of Tenant.
+      description: |
+        This API provides the capability to update the branding preference of the tenant.<br>
+          <b>Permission required:</b> <br>
+            * /permission/admin/manage/identity/applicationmgt/update <br>
+          <b>Scope required:</b> <br>
+            * internal_application_mgt_update
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/BrandingPreferenceModel'
+        description: This represents the branding preferences to be updated.
+        required: true
+      responses:
+        '200' :
+          description: Successfully updated
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/ServerError'
+
+    delete:
+      tags:
+        - Branding Preference
+      operationId: deleteBrandingPreference
+      summary: Deletes branding preferences of Tenant.
+      description: |
+        This API provides the capability to delete the branding preferences of the tenant.<br>
+          <b>Permission required:</b> <br>
+            * /permission/admin/manage/identity/applicationmgt/update <br>
+          <b>Scope required:</b> <br>
+            * internal_application_mgt_update
+      parameters:
+        - $ref: '#/components/parameters/typeQueryParam'
+        - $ref: '#/components/parameters/nameQueryParam'
+        - $ref: '#/components/parameters/localeQueryParam'
+      responses:
+        '204' :
+          description: Successfully deleted.
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/ServerError'
+
+components:
+  parameters:
+    typeQueryParam:
+      in: query
+      name: type
+      required: false
+      description: Resource Type to filter the retrieval of themes.
+      schema:
+        type: string
+        enum:
+          - ORG
+          - APP
+          - CUSTOM
+      example: "ORG"
+    nameQueryParam:
+      in: query
+      name: name
+      required: false
+      description: Application name/ Tenant name to filter the retrieval of themes.
+      schema:
+        type: string
+      example: "NAME"
+    localeQueryParam:
+      in: query
+      name: locale
+      required: false
+      description: Resource Localye to filter the retrieval of themes.
+      schema:
+        type: string
+      example: "en-US"
+
+  schemas:
+    BrandingPreferenceModel:
+      required:
+        - type
+        - object
+      type: object
+      properties:
+        type:
+          type: string
+          enum:
+            - ORG
+            - APP
+            - CUSTOM
+          example: "ORG"
+        name:
+          type: string
+          example: "NAME"
+        locale:
+          type: string
+          example: "en-US"
+        preference:
+          type: object
+          description: "This is the JSON structured branding preference"
+
+    Error:
+      type: object
+      required:
+        - code
+        - message
+      properties:
+        code:
+          type: string
+          example: TBM-60001
+        message:
+          type: string
+          example: Some Error Message
+        description:
+          type: string
+          example: Some Error Description
+        traceId:
+          type: string
+          example: 3erfee-232-efewv-2321-43ferfe24r
+
+  #-----------------------------------------------------
+  # Descriptions of Branding Preference API responses.
+  #-----------------------------------------------------
+  responses:
+    BadRequest:
+      description: Invalid input in the request.
+      content:
+        'application/json':
+          schema:
+            $ref: '#/components/schemas/Error'
+    Unauthorized:
+      description: Authentication information is missing or invalid.
+    Forbidden:
+      description: Access forbidden.
+    NotFound:
+      description: Requested resource is not found.
+      content:
+        'application/json':
+          schema:
+            $ref: '#/components/schemas/Error'
+    Conflict:
+      description: Conflict.
+      content:
+        'application/json':
+          schema:
+            $ref: '#/components/schemas/Error'
+    ServerError:
+      description: Internal server error.
+      content:
+        'application/json':
+          schema:
+            $ref: '#/components/schemas/Error'
+    NotImplemented:
+      description: Not Implemented.
+      content:
+        'application/json':
+          schema:
+            $ref: '#/components/schemas/Error'
+
+  #-----------------------------------------------------
+  # Applicable authentication mechanisms.
+  #-----------------------------------------------------
+  securitySchemes:
+    BasicAuth:
+      type: http
+      scheme: basic
+    OAuth2:
+      type: oauth2
+      flows:
+        authorizationCode:
+          authorizationUrl: 'https://localhost:9443/oauth2/authorize'
+          tokenUrl: 'https://localhost:9443/oauth2/token'
+          scopes: {}

--- a/components/org.wso2.carbon.identity.api.server.branding.preference.management/pom.xml
+++ b/components/org.wso2.carbon.identity.api.server.branding.preference.management/pom.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2021, WSO2 Inc. (http://www.wso2.com).
+  ~
+  ~ WSO2 Inc. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <parent>
+        <artifactId>identity-api-server</artifactId>
+        <groupId>org.wso2.carbon.identity.server.api</groupId>
+        <version>1.0.272-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>org.wso2.carbon.identity.api.server.branding.preference.management</artifactId>
+    <packaging>pom</packaging>
+
+    <modules>
+        <module>org.wso2.carbon.identity.api.server.branding.preference.management.common</module>
+        <module>org.wso2.carbon.identity.api.server.branding.preference.management.v1</module>
+    </modules>
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -401,6 +401,12 @@
                 <scope>provided</scope>
             </dependency>
             <dependency>
+                <groupId>org.wso2.carbon.identity.server.api</groupId>
+                <artifactId>org.wso2.carbon.identity.api.server.branding.preference.management.common</artifactId>
+                <version>${project.version}</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
                 <groupId>org.wso2.carbon.identity.framework</groupId>
                 <artifactId>org.wso2.carbon.identity.secret.mgt.core</artifactId>
                 <version>${carbon.identity.framework.version}</version>
@@ -530,6 +536,7 @@
         <module>components/org.wso2.carbon.identity.api.server.notification.sender</module>
         <module>components/org.wso2.carbon.identity.api.server.authenticators</module>
         <module>components/org.wso2.carbon.identity.api.server.secret.management</module>
+        <module>components/org.wso2.carbon.identity.api.server.branding.preference.management</module>
     </modules>
 
 </project>


### PR DESCRIPTION
## Purpose
> Branding Preference Management API is needed to manage branding preferences that are required to be stored as tenant-wise.


## Goals
> ATM, Organization admins doesn't have the capability to customize the branding of their end user portals. So we need a backend support for manage these organization specific branding attributes. This API will facilitate backend capability for manage Banding Preferences from organization wise.


## Approach
- This API will invoke configuration-mgt component to store and manage branding preference configurations.
- This API save the branding preferences as a structured text document which has JSON format for extensibility purposes..
- At the API level, when updating the content this document will be evaluated for the valid JSON format only. Schema is not evaluated as it can be extended.
- The API definition was done to support Tenant wise branding, Application wise branding and Language wise branding.
- ATM the API was implemented only for support tenant wise branding.
- In the future phases we hope improve this API to manage application level and different language level theming resources in addition to the tenant level.

## Related PRs
- https://github.com/wso2/carbon-identity-framework/pull/3832
