### PR TITLE
Allow adding email config without username and password

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.notification.sender/org.wso2.carbon.identity.api.server.notification.sender.v1/src/gen/java/org/wso2/carbon/identity/api/server/notification/sender/v1/model/EmailSender.java
+++ b/components/org.wso2.carbon.identity.api.server.notification.sender/org.wso2.carbon.identity.api.server.notification.sender.v1/src/gen/java/org/wso2/carbon/identity/api/server/notification/sender/v1/model/EmailSender.java
@@ -126,11 +126,9 @@ public class EmailSender  {
         return this;
     }
     
-    @ApiModelProperty(example = "iam", required = true, value = "")
+    @ApiModelProperty(example = "iam", value = "")
     @JsonProperty("userName")
     @Valid
-    @NotNull(message = "Property userName cannot be null.")
-
     public String getUserName() {
         return userName;
     }
@@ -146,11 +144,9 @@ public class EmailSender  {
         return this;
     }
     
-    @ApiModelProperty(example = "iam123", required = true, value = "")
+    @ApiModelProperty(example = "iam123", value = "")
     @JsonProperty("password")
     @Valid
-    @NotNull(message = "Property password cannot be null.")
-
     public String getPassword() {
         return password;
     }

--- a/components/org.wso2.carbon.identity.api.server.notification.sender/org.wso2.carbon.identity.api.server.notification.sender.v1/src/gen/java/org/wso2/carbon/identity/api/server/notification/sender/v1/model/EmailSenderAdd.java
+++ b/components/org.wso2.carbon.identity.api.server.notification.sender/org.wso2.carbon.identity.api.server.notification.sender.v1/src/gen/java/org/wso2/carbon/identity/api/server/notification/sender/v1/model/EmailSenderAdd.java
@@ -124,11 +124,9 @@ public class EmailSenderAdd  {
         return this;
     }
     
-    @ApiModelProperty(example = "iam", required = true, value = "")
+    @ApiModelProperty(example = "iam", value = "")
     @JsonProperty("userName")
     @Valid
-    @NotNull(message = "Property userName cannot be null.")
-
     public String getUserName() {
         return userName;
     }
@@ -144,11 +142,9 @@ public class EmailSenderAdd  {
         return this;
     }
     
-    @ApiModelProperty(example = "iam123", required = true, value = "")
+    @ApiModelProperty(example = "iam123", value = "")
     @JsonProperty("password")
     @Valid
-    @NotNull(message = "Property password cannot be null.")
-
     public String getPassword() {
         return password;
     }

--- a/components/org.wso2.carbon.identity.api.server.notification.sender/org.wso2.carbon.identity.api.server.notification.sender.v1/src/gen/java/org/wso2/carbon/identity/api/server/notification/sender/v1/model/EmailSenderUpdateRequest.java
+++ b/components/org.wso2.carbon.identity.api.server.notification.sender/org.wso2.carbon.identity.api.server.notification.sender.v1/src/gen/java/org/wso2/carbon/identity/api/server/notification/sender/v1/model/EmailSenderUpdateRequest.java
@@ -105,11 +105,9 @@ public class EmailSenderUpdateRequest  {
         return this;
     }
     
-    @ApiModelProperty(example = "iam", required = true, value = "")
+    @ApiModelProperty(example = "iam", value = "")
     @JsonProperty("userName")
     @Valid
-    @NotNull(message = "Property userName cannot be null.")
-
     public String getUserName() {
         return userName;
     }
@@ -125,11 +123,9 @@ public class EmailSenderUpdateRequest  {
         return this;
     }
     
-    @ApiModelProperty(example = "iam123", required = true, value = "")
+    @ApiModelProperty(example = "iam123", value = "")
     @JsonProperty("password")
     @Valid
-    @NotNull(message = "Property password cannot be null.")
-
     public String getPassword() {
         return password;
     }

--- a/components/org.wso2.carbon.identity.api.server.notification.sender/org.wso2.carbon.identity.api.server.notification.sender.v1/src/main/java/org/wso2/carbon/identity/api/server/notification/sender/v1/core/NotificationSenderManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.notification.sender/org.wso2.carbon.identity.api.server.notification.sender.v1/src/main/java/org/wso2/carbon/identity/api/server/notification/sender/v1/core/NotificationSenderManagementService.java
@@ -665,8 +665,12 @@ public class NotificationSenderManagementService {
         resource.setResourceName(emailSenderAdd.getName());
         Map<String, String> emailSenderAttributes = new HashMap<>();
         emailSenderAttributes.put(FROM_ADDRESS, emailSenderAdd.getFromAddress());
-        emailSenderAttributes.put(USERNAME, emailSenderAdd.getUserName());
-        emailSenderAttributes.put(PASSWORD, emailSenderAdd.getPassword());
+        if (StringUtils.isNotEmpty(emailSenderAdd.getUserName())) {
+            emailSenderAttributes.put(USERNAME, emailSenderAdd.getUserName());
+        }
+        if (StringUtils.isNotEmpty(emailSenderAdd.getPassword())) {
+            emailSenderAttributes.put(PASSWORD, emailSenderAdd.getPassword());
+        }
         emailSenderAttributes.put(SMTP_SERVER_HOST, emailSenderAdd.getSmtpServerHost());
         emailSenderAttributes.put(SMTP_PORT, String.valueOf(emailSenderAdd.getSmtpPort()));
         emailSenderAdd.getProperties().stream()

--- a/components/org.wso2.carbon.identity.api.server.notification.sender/org.wso2.carbon.identity.api.server.notification.sender.v1/src/main/resources/notification-sender.yaml
+++ b/components/org.wso2.carbon.identity.api.server.notification.sender/org.wso2.carbon.identity.api.server.notification.sender.v1/src/main/resources/notification-sender.yaml
@@ -626,8 +626,6 @@ components:
     EmailSenderAdd:
       required:
         - fromAddress
-        - password
-        - userName
       type: object
       properties:
         name:
@@ -689,8 +687,6 @@ components:
       required:
         - fromAddress
         - name
-        - password
-        - userName
       type: object
       properties:
         name:
@@ -755,8 +751,6 @@ components:
     EmailSenderUpdateRequest:
       required:
         - fromAddress
-        - password
-        - userName
       type: object
       properties:
         smtpServerHost:


### PR DESCRIPTION
## Purpose
- We have a requirement to add different 'from' email addresses for different organizations but use the default SMTP username and password and send emails to organization customers. ATM, this is not possible as we've made the username and password attributes required in the API. This PR changes that behavior.
