### PR TITLE
Revert "Validate enabling Proxy mode when federated IDP is already configured along with MFA for an application"

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/main/java/org/wso2/carbon/identity/api/server/idp/v1/core/ServerIdpManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/main/java/org/wso2/carbon/identity/api/server/idp/v1/core/ServerIdpManagementService.java
@@ -101,7 +101,6 @@ import org.wso2.carbon.identity.template.mgt.model.Template;
 import org.wso2.carbon.idp.mgt.IdentityProviderManagementClientException;
 import org.wso2.carbon.idp.mgt.IdentityProviderManagementException;
 import org.wso2.carbon.idp.mgt.IdentityProviderManagementServerException;
-import org.wso2.carbon.idp.mgt.IdentityProviderManager;
 import org.wso2.carbon.idp.mgt.model.ConnectedAppsResult;
 import org.wso2.carbon.idp.mgt.model.IdpSearchResult;
 
@@ -908,7 +907,6 @@ public class ServerIdpManagementService {
                 throw handleException(Response.Status.NOT_FOUND, Constants.ErrorMessage.ERROR_CODE_IDP_NOT_FOUND,
                         idpId);
             }
-            validateJitProvisioningConfig(idP, justInTimeProvisioningConfig);
             updateJIT(idP, justInTimeProvisioningConfig);
 
             IdentityProvider updatedIdP =
@@ -998,22 +996,6 @@ public class ServerIdpManagementService {
             }
         }
         return null;
-    }
-
-    private void validateJitProvisioningConfig(IdentityProvider identityProvider,
-                                               JustInTimeProvisioning justInTimeProvisioningConfig)
-            throws IdentityProviderManagementException {
-
-        int configuredAppCount =
-                IdentityProviderManager.getInstance().getConnectedApplications(identityProvider.getResourceId(),
-                        null, 0, ContextLoader.getTenantDomainFromContext()).getTotalAppCount();
-        boolean currentProxyModeStatus = justInTimeProvisioningConfig.getIsEnabled();
-        boolean previousProxyModeStatus = identityProvider.getJustInTimeProvisioningConfig().isProvisioningEnabled();
-        if (configuredAppCount > 0 && currentProxyModeStatus != previousProxyModeStatus) {
-            String msg = "Enabling proxy mode is not allowed since an application has been already configured " +
-                    "with the identity provider: " + identityProvider.getIdentityProviderName();
-            throw new IdentityProviderManagementClientException(msg);
-        }
     }
 
     private Condition buildSearchCondition(SearchCondition searchCondition) {


### PR DESCRIPTION
Reverts wso2/identity-api-server#329, as validate disabling JIT provisioning when federated IDP is already configured along with MFA for an application is obsolete as that was decided to handle through a warning message to the end-user considering adaptive authentication scenarios.  

Related issue: https://github.com/wso2-enterprise/asgardeo-product/issues/4488