### PR TITLE
Fixing default userstore in idpResponse

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/main/java/org/wso2/carbon/identity/api/server/idp/v1/core/ServerIdpManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/main/java/org/wso2/carbon/identity/api/server/idp/v1/core/ServerIdpManagementService.java
@@ -2192,7 +2192,11 @@ public class ServerIdpManagementService {
                     jitConfig.setScheme(JustInTimeProvisioning.SchemeEnum.PROVISION_SILENTLY);
                 }
             }
-            jitConfig.setUserstore(idp.getJustInTimeProvisioningConfig().getProvisioningUserStore());
+            if (idp.getJustInTimeProvisioningConfig().getProvisioningUserStore() == null) {
+                jitConfig.setUserstore("PRIMARY");
+            } else {
+                jitConfig.setUserstore(idp.getJustInTimeProvisioningConfig().getProvisioningUserStore());
+            }
         }
         return jitConfig;
     }

--- a/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/main/java/org/wso2/carbon/identity/api/server/idp/v1/core/ServerIdpManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/main/java/org/wso2/carbon/identity/api/server/idp/v1/core/ServerIdpManagementService.java
@@ -2191,8 +2191,8 @@ public class ServerIdpManagementService {
                 } else {
                     jitConfig.setScheme(JustInTimeProvisioning.SchemeEnum.PROVISION_SILENTLY);
                 }
-                jitConfig.setUserstore(idp.getJustInTimeProvisioningConfig().getProvisioningUserStore());
             }
+            jitConfig.setUserstore(idp.getJustInTimeProvisioningConfig().getProvisioningUserStore());
         }
         return jitConfig;
     }


### PR DESCRIPTION
### Purpose

Fixing the user store send with the create Idp request's response when JIT provisioning is disabled.

Related Issue : [https://github.com/wso2/product-is#12996](https://github.com/wso2/product-is/issues/12996)