### PR TITLE
Improve Branding API to invoke new Branding feature

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.branding.preference.management/org.wso2.carbon.identity.api.server.branding.preference.management.common/pom.xml
+++ b/components/org.wso2.carbon.identity.api.server.branding.preference.management/org.wso2.carbon.identity.api.server.branding.preference.management.common/pom.xml
@@ -46,8 +46,9 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.wso2.carbon.identity.framework</groupId>
-            <artifactId>org.wso2.carbon.identity.configuration.mgt.core</artifactId>
+            <groupId>org.wso2.carbon.identity.branding.preference.management</groupId>
+            <artifactId>org.wso2.carbon.identity.branding.preference.management.core</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>

--- a/components/org.wso2.carbon.identity.api.server.branding.preference.management/org.wso2.carbon.identity.api.server.branding.preference.management.common/src/main/java/org/wso2/carbon/identity/api/server/branding/preference/management/common/BrandingPreferenceManagementConstants.java
+++ b/components/org.wso2.carbon.identity.api.server.branding.preference.management/org.wso2.carbon.identity.api.server.branding.preference.management.common/src/main/java/org/wso2/carbon/identity/api/server/branding/preference/management/common/BrandingPreferenceManagementConstants.java
@@ -25,18 +25,16 @@ public class BrandingPreferenceManagementConstants {
 
     public static final String BRANDING_PREFERENCE_ERROR_PREFIX = "BPM-";
     public static final String BRANDING_PREFERENCE_CONTEXT_PATH = "/branding-preference";
-    public static final String BRANDING_RESOURCE_TYPE = "BRANDING_PREFERENCES";
     public static final String QUERY_PARAM_INDICATOR = "?";
     public static final String GET_PREFERENCE_COMPONENT_WITH_QUERY_PARAM = "type=%s&name=%s&locale=%s";
     public static final String ORGANIZATION_TYPE = "ORG";
     public static final String APPLICATION_TYPE = "APP";
     public static final String CUSTOM_TYPE = "CUSTOM";
     public static final String DEFAULT_LOCALE = "en-US";
-    public static final String CONFIG_MGT_ERROR_CODE_DELIMITER = "_";
-    public static final String RESOURCE_NAME_SEPARATOR = "_";
+    public static final String BRANDING_PREFERENCE_MGT_ERROR_CODE_DELIMITER = "_";
 
-    public static final String RESOURCE_NOT_EXISTS_ERROR_CODE = "CONFIGM_00017";
-    public static final String RESOURCE_ALREADY_EXISTS_ERROR_CODE = "CONFIGM_00013";
+    public static final String BRANDING_PREFERENCE_NOT_EXISTS_ERROR_CODE = "BRANDINGM_00002";
+    public static final String BRANDING_PREFERENCE_ALREADY_EXISTS_ERROR_CODE = "BRANDINGM_00003";
 
     /**
      * Enums for error messages.
@@ -65,17 +63,7 @@ public class BrandingPreferenceManagementConstants {
                 "Server encountered an error while deleting branding preference configurations for organization: %s"),
         ERROR_CODE_ERROR_UPDATING_BRANDING_PREFERENCE("65004",
                 "Unable to update branding preference configurations.",
-                "Error while updating branding preference configurations for organization: %s."),
-        ERROR_CODE_JSON_PROCESSING_EXCEPTION("65005", "Json Processing Exception.",
-                "Json Processing Exception: %s."),
-        ERROR_CODE_UNSUPPORTED_ENCODING_EXCEPTION("65006", "Unsupported Encoding Exception.",
-                "Unsupported Encoding Exception: %s."),
-        ERROR_CODE_ERROR_BUILDING_RESPONSE_EXCEPTION("65007",
-                "Unable to build response from branding preference configurations.",
-                "Error while building response from branding preference configurations."),
-        ERROR_CODE_ERROR_CHECKING_BRANDING_PREFERENCE_EXISTS("65008",
-                "Error while checking branding preference configurations existence.",
-                "Error while checking the existence of branding preference configurations for organization: %s.");
+                "Error while updating branding preference configurations for organization: %s.");
 
         private final String code;
         private final String message;

--- a/components/org.wso2.carbon.identity.api.server.branding.preference.management/org.wso2.carbon.identity.api.server.branding.preference.management.common/src/main/java/org/wso2/carbon/identity/api/server/branding/preference/management/common/BrandingPreferenceManagementConstants.java
+++ b/components/org.wso2.carbon.identity.api.server.branding.preference.management/org.wso2.carbon.identity.api.server.branding.preference.management.common/src/main/java/org/wso2/carbon/identity/api/server/branding/preference/management/common/BrandingPreferenceManagementConstants.java
@@ -35,6 +35,7 @@ public class BrandingPreferenceManagementConstants {
 
     public static final String BRANDING_PREFERENCE_NOT_EXISTS_ERROR_CODE = "BRANDINGM_00002";
     public static final String BRANDING_PREFERENCE_ALREADY_EXISTS_ERROR_CODE = "BRANDINGM_00003";
+    public static final String BRANDING_PREFERENCE_NOT_ALLOWED_ERROR_CODE = "BRANDINGM_00011";
 
     /**
      * Enums for error messages.
@@ -50,6 +51,9 @@ public class BrandingPreferenceManagementConstants {
                 "Branding preferences are not configured for organization: %s."),
         ERROR_CODE_CONFLICT_BRANDING_PREFERENCE("60003", "Branding preference already exists.",
                 "There exists a branding preference configurations in the organization: %s."),
+        ERROR_CODE_NOT_ALLOWED_BRANDING_PREFERENCE_CONFIGURATIONS("60004",
+                "Not allowed branding preference configurations.",
+                "Requested branding preference configuration: %s is not allowed for the organization."),
 
         // Server errors 650xx.
         ERROR_CODE_ERROR_GETTING_BRANDING_PREFERENCE("65001",

--- a/components/org.wso2.carbon.identity.api.server.branding.preference.management/org.wso2.carbon.identity.api.server.branding.preference.management.common/src/main/java/org/wso2/carbon/identity/api/server/branding/preference/management/common/BrandingPreferenceServiceHolder.java
+++ b/components/org.wso2.carbon.identity.api.server.branding.preference.management/org.wso2.carbon.identity.api.server.branding.preference.management.common/src/main/java/org/wso2/carbon/identity/api/server/branding/preference/management/common/BrandingPreferenceServiceHolder.java
@@ -18,32 +18,32 @@
 
 package org.wso2.carbon.identity.api.server.branding.preference.management.common;
 
-import org.wso2.carbon.identity.configuration.mgt.core.ConfigurationManager;
+import org.wso2.carbon.identity.branding.preference.management.core.BrandingPreferenceManager;
 
 /**
  * Service holder class for branding preference management.
  */
 public class BrandingPreferenceServiceHolder {
 
-    private static ConfigurationManager brandingPreferenceConfigManager;
+    private static BrandingPreferenceManager brandingPreferenceManager;
 
     /**
-     * Get ConfigurationManager OSGi service.
+     * Get BrandingPreferenceManager OSGi service.
      *
-     * @return BrandingPreferenceConfig Manager.
+     * @return BrandingPreference Manager.
      */
-    public static ConfigurationManager getBrandingPreferenceConfigManager() {
+    public static BrandingPreferenceManager getBrandingPreferenceManager() {
 
-        return brandingPreferenceConfigManager;
+        return brandingPreferenceManager;
     }
 
     /**
-     * Set ConfigurationManager OSGi service.
+     * Set BrandingPreferenceManager OSGi service.
      *
-     * @param configManager Configuration Manager.
+     * @param brandingPreferenceManager Branding Preference Manager.
      */
-    public static void setBrandingPreferenceConfigManager(ConfigurationManager configManager) {
+    public static void setBrandingPreferenceManager(BrandingPreferenceManager brandingPreferenceManager) {
 
-        BrandingPreferenceServiceHolder.brandingPreferenceConfigManager = configManager;
+        BrandingPreferenceServiceHolder.brandingPreferenceManager = brandingPreferenceManager;
     }
 }

--- a/components/org.wso2.carbon.identity.api.server.branding.preference.management/org.wso2.carbon.identity.api.server.branding.preference.management.common/src/main/java/org/wso2/carbon/identity/api/server/branding/preference/management/common/factory/BrandingPreferenceMgtOSGiServiceFactory.java
+++ b/components/org.wso2.carbon.identity.api.server.branding.preference.management/org.wso2.carbon.identity.api.server.branding.preference.management.common/src/main/java/org/wso2/carbon/identity/api/server/branding/preference/management/common/factory/BrandingPreferenceMgtOSGiServiceFactory.java
@@ -20,15 +20,15 @@ package org.wso2.carbon.identity.api.server.branding.preference.management.commo
 
 import org.springframework.beans.factory.config.AbstractFactoryBean;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
-import org.wso2.carbon.identity.configuration.mgt.core.ConfigurationManager;
+import org.wso2.carbon.identity.branding.preference.management.core.BrandingPreferenceManager;
 
 /**
  * Factory Beans serve as a factory for creating other beans within the IOC container. This factory bean is used to
- * instantiate the ConfigurationManager type of object inside the container.
+ * instantiate the BrandingPreferenceManager type of object inside the container.
  */
-public class ConfigurationMgtOSGiServiceFactory extends AbstractFactoryBean<ConfigurationManager> {
+public class BrandingPreferenceMgtOSGiServiceFactory extends AbstractFactoryBean<BrandingPreferenceManager> {
 
-    private ConfigurationManager configurationManager;
+    private BrandingPreferenceManager brandingPreferenceManager;
 
     @Override
     public Class<?> getObjectType() {
@@ -37,18 +37,18 @@ public class ConfigurationMgtOSGiServiceFactory extends AbstractFactoryBean<Conf
     }
 
     @Override
-    protected ConfigurationManager createInstance() throws Exception {
+    protected BrandingPreferenceManager createInstance() throws Exception {
 
-        if (this.configurationManager == null) {
-            ConfigurationManager taskOperationService = (ConfigurationManager) PrivilegedCarbonContext.
-                    getThreadLocalCarbonContext().getOSGiService(ConfigurationManager.class, null);
+        if (this.brandingPreferenceManager == null) {
+            BrandingPreferenceManager taskOperationService = (BrandingPreferenceManager) PrivilegedCarbonContext.
+                    getThreadLocalCarbonContext().getOSGiService(BrandingPreferenceManager.class, null);
 
             if (taskOperationService != null) {
-                this.configurationManager = taskOperationService;
+                this.brandingPreferenceManager = taskOperationService;
             } else {
                 throw new Exception("Unable to retrieve ConfigurationManager service.");
             }
         }
-        return this.configurationManager;
+        return this.brandingPreferenceManager;
     }
 }

--- a/components/org.wso2.carbon.identity.api.server.branding.preference.management/org.wso2.carbon.identity.api.server.branding.preference.management.v1/pom.xml
+++ b/components/org.wso2.carbon.identity.api.server.branding.preference.management/org.wso2.carbon.identity.api.server.branding.preference.management.v1/pom.xml
@@ -162,8 +162,8 @@
             <artifactId>org.wso2.carbon.identity.api.server.branding.preference.management.common</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wso2.carbon.identity.framework</groupId>
-            <artifactId>org.wso2.carbon.identity.configuration.mgt.core</artifactId>
+            <groupId>org.wso2.carbon.identity.branding.preference.management</groupId>
+            <artifactId>org.wso2.carbon.identity.branding.preference.management.core</artifactId>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/components/org.wso2.carbon.identity.api.server.branding.preference.management/org.wso2.carbon.identity.api.server.branding.preference.management.v1/src/main/java/org/wso2/carbon/identity/api/server/branding/preference/management/v1/core/BrandingPreferenceManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.branding.preference.management/org.wso2.carbon.identity.api.server.branding.preference.management.v1/src/main/java/org/wso2/carbon/identity/api/server/branding/preference/management/v1/core/BrandingPreferenceManagementService.java
@@ -75,9 +75,9 @@ public class BrandingPreferenceManagementService {
             throw handleException(Response.Status.BAD_REQUEST, ERROR_CODE_INVALID_BRANDING_PREFERENCE, null);
         }
 
-        BrandingPreference requestDTO, responseDTO;
+        BrandingPreference responseDTO;
         try {
-            requestDTO = buildRequestDTOFromBrandingRequest(brandingPreferenceModel);
+            BrandingPreference requestDTO = buildRequestDTOFromBrandingRequest(brandingPreferenceModel);
             responseDTO = BrandingPreferenceServiceHolder.getBrandingPreferenceManager().
                     addBrandingPreference(requestDTO);
         } catch (BrandingPreferenceMgtException e) {
@@ -177,9 +177,9 @@ public class BrandingPreferenceManagementService {
             throw handleException(Response.Status.BAD_REQUEST, ERROR_CODE_INVALID_BRANDING_PREFERENCE, null);
         }
 
-        BrandingPreference requestDTO, responseDTO;
+        BrandingPreference responseDTO;
         try {
-            requestDTO = buildRequestDTOFromBrandingRequest(brandingPreferenceModel);
+            BrandingPreference requestDTO = buildRequestDTOFromBrandingRequest(brandingPreferenceModel);
             responseDTO = BrandingPreferenceServiceHolder.getBrandingPreferenceManager().
                     replaceBrandingPreference(requestDTO);
         } catch (BrandingPreferenceMgtException e) {

--- a/components/org.wso2.carbon.identity.api.server.branding.preference.management/org.wso2.carbon.identity.api.server.branding.preference.management.v1/src/main/java/org/wso2/carbon/identity/api/server/branding/preference/management/v1/core/BrandingPreferenceManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.branding.preference.management/org.wso2.carbon.identity.api.server.branding.preference.management.v1/src/main/java/org/wso2/carbon/identity/api/server/branding/preference/management/v1/core/BrandingPreferenceManagementService.java
@@ -39,6 +39,7 @@ import javax.ws.rs.core.Response;
 import static org.wso2.carbon.identity.api.server.branding.preference.management.common.BrandingPreferenceManagementConstants.BRANDING_PREFERENCE_ALREADY_EXISTS_ERROR_CODE;
 import static org.wso2.carbon.identity.api.server.branding.preference.management.common.BrandingPreferenceManagementConstants.BRANDING_PREFERENCE_ERROR_PREFIX;
 import static org.wso2.carbon.identity.api.server.branding.preference.management.common.BrandingPreferenceManagementConstants.BRANDING_PREFERENCE_MGT_ERROR_CODE_DELIMITER;
+import static org.wso2.carbon.identity.api.server.branding.preference.management.common.BrandingPreferenceManagementConstants.BRANDING_PREFERENCE_NOT_ALLOWED_ERROR_CODE;
 import static org.wso2.carbon.identity.api.server.branding.preference.management.common.BrandingPreferenceManagementConstants.BRANDING_PREFERENCE_NOT_EXISTS_ERROR_CODE;
 import static org.wso2.carbon.identity.api.server.branding.preference.management.common.BrandingPreferenceManagementConstants.DEFAULT_LOCALE;
 import static org.wso2.carbon.identity.api.server.branding.preference.management.common.BrandingPreferenceManagementConstants.ErrorMessage.ERROR_CODE_BRANDING_PREFERENCE_NOT_EXISTS;
@@ -48,6 +49,7 @@ import static org.wso2.carbon.identity.api.server.branding.preference.management
 import static org.wso2.carbon.identity.api.server.branding.preference.management.common.BrandingPreferenceManagementConstants.ErrorMessage.ERROR_CODE_ERROR_GETTING_BRANDING_PREFERENCE;
 import static org.wso2.carbon.identity.api.server.branding.preference.management.common.BrandingPreferenceManagementConstants.ErrorMessage.ERROR_CODE_ERROR_UPDATING_BRANDING_PREFERENCE;
 import static org.wso2.carbon.identity.api.server.branding.preference.management.common.BrandingPreferenceManagementConstants.ErrorMessage.ERROR_CODE_INVALID_BRANDING_PREFERENCE;
+import static org.wso2.carbon.identity.api.server.branding.preference.management.common.BrandingPreferenceManagementConstants.ErrorMessage.ERROR_CODE_NOT_ALLOWED_BRANDING_PREFERENCE_CONFIGURATIONS;
 import static org.wso2.carbon.identity.api.server.branding.preference.management.common.BrandingPreferenceManagementConstants.ORGANIZATION_TYPE;
 import static org.wso2.carbon.identity.api.server.common.ContextLoader.getTenantDomainFromContext;
 
@@ -85,6 +87,14 @@ public class BrandingPreferenceManagementService {
                 }
                 throw handleException(Response.Status.CONFLICT, ERROR_CODE_CONFLICT_BRANDING_PREFERENCE,
                         tenantDomain);
+            }
+            if (BRANDING_PREFERENCE_NOT_ALLOWED_ERROR_CODE.equals(e.getErrorCode())) {
+                if (log.isDebugEnabled()) {
+                    log.debug("Requested branding preference customizations are not allowed to add for tenant: "
+                            + tenantDomain, e);
+                }
+                throw handleExceptionWithMessage(Response.Status.FORBIDDEN,
+                        ERROR_CODE_NOT_ALLOWED_BRANDING_PREFERENCE_CONFIGURATIONS, e.getMessage());
             }
             throw handleBrandingPreferenceMgtException(e, ERROR_CODE_ERROR_ADDING_BRANDING_PREFERENCE, tenantDomain);
         }
@@ -179,6 +189,14 @@ public class BrandingPreferenceManagementService {
                 }
                 throw handleException(Response.Status.NOT_FOUND, ERROR_CODE_BRANDING_PREFERENCE_NOT_EXISTS,
                         tenantDomain);
+            }
+            if (BRANDING_PREFERENCE_NOT_ALLOWED_ERROR_CODE.equals(e.getErrorCode())) {
+                if (log.isDebugEnabled()) {
+                    log.debug("Requested branding preference customizations are not allowed to update for tenant: "
+                            + tenantDomain, e);
+                }
+                throw handleExceptionWithMessage(Response.Status.FORBIDDEN,
+                        ERROR_CODE_NOT_ALLOWED_BRANDING_PREFERENCE_CONFIGURATIONS, e.getMessage());
             }
             throw handleBrandingPreferenceMgtException(e, ERROR_CODE_ERROR_UPDATING_BRANDING_PREFERENCE, tenantDomain);
         }
@@ -332,5 +350,22 @@ public class BrandingPreferenceManagementService {
         } else {
             return error.getDescription();
         }
+    }
+
+    /**
+     * Handle exceptions generated in API with a custom description.
+     *
+     * @param status      HTTP Status.
+     * @param error       Error Message information.
+     * @param description Error Message description.
+     * @return APIError.
+     */
+    private APIError handleExceptionWithMessage(Response.Status status,
+                                                BrandingPreferenceManagementConstants.ErrorMessage error,
+                                                String description) {
+
+        ErrorResponse errorResponse = new ErrorResponse.Builder().withCode(error.getCode())
+                .withMessage(error.getMessage()).withDescription(description).build();
+        return new APIError(status, errorResponse);
     }
 }

--- a/components/org.wso2.carbon.identity.api.server.branding.preference.management/org.wso2.carbon.identity.api.server.branding.preference.management.v1/src/main/java/org/wso2/carbon/identity/api/server/branding/preference/management/v1/core/utils/BrandingPreferenceUtils.java
+++ b/components/org.wso2.carbon.identity.api.server.branding.preference.management/org.wso2.carbon.identity.api.server.branding.preference.management.v1/src/main/java/org/wso2/carbon/identity/api/server/branding/preference/management/v1/core/utils/BrandingPreferenceUtils.java
@@ -18,34 +18,14 @@
 
 package org.wso2.carbon.identity.api.server.branding.preference.management.v1.core.utils;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import org.apache.commons.lang.StringUtils;
 import org.json.JSONException;
 import org.json.JSONObject;
-
-import java.io.ByteArrayInputStream;
-import java.io.InputStream;
-import java.io.UnsupportedEncodingException;
-import java.nio.charset.StandardCharsets;
 
 /**
  * Util class for branding preference management.
  */
 public class BrandingPreferenceUtils {
-
-    /**
-     * Generate Branding Preference input stream.
-     *
-     * @param preferencesJSON JSON string of preferences.
-     * @return Input stream of the preferences JSON string.
-     * @throws JsonProcessingException      JSON Processing Exception.
-     * @throws UnsupportedEncodingException Unsupported Encoding Exception.
-     */
-    public static InputStream generatePreferenceInputStream(String preferencesJSON)
-            throws JsonProcessingException, UnsupportedEncodingException {
-
-        return new ByteArrayInputStream(preferencesJSON.getBytes(StandardCharsets.UTF_8.name()));
-    }
 
     /**
      * Check whether the given string is a valid JSON or not.

--- a/components/org.wso2.carbon.identity.api.server.branding.preference.management/org.wso2.carbon.identity.api.server.branding.preference.management.v1/src/main/java/org/wso2/carbon/identity/api/server/branding/preference/management/v1/impl/BrandingPreferenceApiServiceImpl.java
+++ b/components/org.wso2.carbon.identity.api.server.branding.preference.management/org.wso2.carbon.identity.api.server.branding.preference.management.v1/src/main/java/org/wso2/carbon/identity/api/server/branding/preference/management/v1/impl/BrandingPreferenceApiServiceImpl.java
@@ -92,11 +92,15 @@ public class BrandingPreferenceApiServiceImpl implements BrandingPreferenceApiSe
             if (!ORGANIZATION_TYPE.equals(type)) {
                 return Response.status(Response.Status.NOT_FOUND).build();
             }
+        } else {
+            type = ORGANIZATION_TYPE;
         }
         if (locale != null) {
             if (!DEFAULT_LOCALE.equals(locale)) {
                 return Response.status(Response.Status.NOT_FOUND).build();
             }
+        } else {
+            locale = DEFAULT_LOCALE;
         }
 
         brandingPreferenceManagementService.deleteBrandingPreference(type, name, locale);

--- a/components/org.wso2.carbon.identity.api.server.branding.preference.management/org.wso2.carbon.identity.api.server.branding.preference.management.v1/src/main/resources/META-INF/cxf/branding-preference-server-v1-cxf.xml
+++ b/components/org.wso2.carbon.identity.api.server.branding.preference.management/org.wso2.carbon.identity.api.server.branding.preference.management.v1/src/main/resources/META-INF/cxf/branding-preference-server-v1-cxf.xml
@@ -20,8 +20,8 @@
        xsi:schemaLocation="http://www.springframework.org/schema/beans  http://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
     <bean class="org.wso2.carbon.identity.api.server.branding.preference.management.v1.core.BrandingPreferenceManagementService"/>
     <bean class="org.wso2.carbon.identity.api.server.branding.preference.management.v1.impl.BrandingPreferenceApiServiceImpl"/>
-    <bean id="configurationManagerFactoryBean" class="org.wso2.carbon.identity.api.server.branding.preference.management.common.factory.ConfigurationMgtOSGiServiceFactory"/>
+    <bean id="brandingPreferenceManagerFactoryBean" class="org.wso2.carbon.identity.api.server.branding.preference.management.common.factory.BrandingPreferenceMgtOSGiServiceFactory"/>
     <bean id="brandingPreferenceServiceImplDataHolderBean" class="org.wso2.carbon.identity.api.server.branding.preference.management.common.BrandingPreferenceServiceHolder">
-        <property name="brandingPreferenceConfigManager" ref="configurationManagerFactoryBean"/>
+        <property name="brandingPreferenceManager" ref="brandingPreferenceManagerFactoryBean"/>
     </bean>
 </beans>

--- a/pom.xml
+++ b/pom.xml
@@ -429,6 +429,12 @@
                 <artifactId>org.wso2.carbon.identity.tenant.resource.manager</artifactId>
                 <version>${tenant.resource.manager.version}</version>
             </dependency>
+            <dependency>
+                <groupId>org.wso2.carbon.identity.branding.preference.management</groupId>
+                <artifactId>org.wso2.carbon.identity.branding.preference.management.core</artifactId>
+                <version>${identity.branding.preference.management.version}</version>
+                <scope>provided</scope>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -517,6 +523,7 @@
         <carbon.multitenancy.version>4.9.10</carbon.multitenancy.version>
         <org.wso2.carbon.identity.remotefetch.version>0.7.12</org.wso2.carbon.identity.remotefetch.version>
         <org.wso2.carbon.event.publisher.version>5.2.15</org.wso2.carbon.event.publisher.version>
+        <identity.branding.preference.management.version>1.0.0</identity.branding.preference.management.version>
         <!--<maven.checkstyleplugin.excludes>**/gen/**/*</maven.checkstyleplugin.excludes>-->
 
         <tenant.resource.manager.version>1.5.55</tenant.resource.manager.version>

--- a/pom.xml
+++ b/pom.xml
@@ -523,7 +523,7 @@
         <carbon.multitenancy.version>4.9.10</carbon.multitenancy.version>
         <org.wso2.carbon.identity.remotefetch.version>0.7.12</org.wso2.carbon.identity.remotefetch.version>
         <org.wso2.carbon.event.publisher.version>5.2.15</org.wso2.carbon.event.publisher.version>
-        <identity.branding.preference.management.version>1.0.0</identity.branding.preference.management.version>
+        <identity.branding.preference.management.version>1.0.1</identity.branding.preference.management.version>
         <!--<maven.checkstyleplugin.excludes>**/gen/**/*</maven.checkstyleplugin.excludes>-->
 
         <tenant.resource.manager.version>1.5.55</tenant.resource.manager.version>


### PR DESCRIPTION
## Purpose
>Improve branding preferences API to invoke new branding-preference management feature.
 - https://github.com/wso2-extensions/identity-branding-preference-management

## Approach
> Previously Branding API invokes configuration-mgt directly. Instead of that with this change now the Branding API will invoke branding preference management feature and this module will invoke configuration-mgt for access database tables

### Prerequisites
Before merged this PR following PRs need to be merge.
- [ ] https://github.com/wso2-extensions/identity-branding-preference-management/pull/1
- [ ] https://github.com/wso2/product-is/pull/13034

### TODO
- [ ] Bump branding preference management version to the latest version after merging above PRs

