### PR TITLE
log4j1 removal

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.common/src/main/java/org/wso2/carbon/identity/api/server/common/Util.java
+++ b/components/org.wso2.carbon.identity.api.server.common/src/main/java/org/wso2/carbon/identity/api/server/common/Util.java
@@ -16,7 +16,7 @@
 
 package org.wso2.carbon.identity.api.server.common;
 
-import org.apache.log4j.MDC;
+import org.apache.logging.log4j.ThreadContext;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.identity.recovery.ChallengeQuestionManager;
 
@@ -55,7 +55,7 @@ public class Util {
     public static String getCorrelation() {
         String ref;
         if (isCorrelationIDPresent()) {
-            ref = MDC.get(Constants.CORRELATION_ID_MDC).toString();
+            ref = ThreadContext.get(Constants.CORRELATION_ID_MDC);
         } else {
             ref = UUID.randomUUID().toString();
 
@@ -69,7 +69,7 @@ public class Util {
      * @return whether the correlation id is present
      */
     public static boolean isCorrelationIDPresent() {
-        return MDC.get(Constants.CORRELATION_ID_MDC) != null;
+        return ThreadContext.get(Constants.CORRELATION_ID_MDC) != null;
     }
 
     /**


### PR DESCRIPTION
## Purpose
> Switch to ThreadContext in apache logging library instead of MDC in log4j1
