### PR TITLE
Switch for slf4j

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.common/src/main/java/org/wso2/carbon/identity/api/server/common/Util.java
+++ b/components/org.wso2.carbon.identity.api.server.common/src/main/java/org/wso2/carbon/identity/api/server/common/Util.java
@@ -16,7 +16,7 @@
 
 package org.wso2.carbon.identity.api.server.common;
 
-import org.apache.log4j.MDC;
+import org.slf4j.MDC;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.identity.recovery.ChallengeQuestionManager;
 
@@ -55,7 +55,7 @@ public class Util {
     public static String getCorrelation() {
         String ref;
         if (isCorrelationIDPresent()) {
-            ref = MDC.get(Constants.CORRELATION_ID_MDC).toString();
+            ref = MDC.get(Constants.CORRELATION_ID_MDC);
         } else {
             ref = UUID.randomUUID().toString();
 

--- a/components/org.wso2.carbon.identity.api.server.secret.management/org.wso2.carbon.identity.api.server.secret.management.common/src/main/java/org/wso2/carbon/identity/api/server/secret/management/common/Utils.java
+++ b/components/org.wso2.carbon.identity.api.server.secret.management/org.wso2.carbon.identity.api.server.secret.management.common/src/main/java/org/wso2/carbon/identity/api/server/secret/management/common/Utils.java
@@ -18,7 +18,7 @@
 
 package org.wso2.carbon.identity.api.server.secret.management.common;
 
-import org.apache.logging.log4j.ThreadContext;
+import org.slf4j.MDC;
 
 import java.util.UUID;
 
@@ -38,7 +38,7 @@ public class Utils {
 
         if (isCorrelationIDPresent()) {
 
-            return ThreadContext.get(CORRELATION_ID_MDC);
+            return MDC.get(CORRELATION_ID_MDC);
         }
         return UUID.randomUUID().toString();
     }
@@ -50,6 +50,6 @@ public class Utils {
      */
     public static boolean isCorrelationIDPresent() {
 
-        return ThreadContext.get(CORRELATION_ID_MDC) != null;
+        return MDC.get(CORRELATION_ID_MDC) != null;
     }
 }


### PR DESCRIPTION
## Purpose
Switch for logging facade instead of concrete implementations like log4j2. Then it would be easy to switch between logging frameworks based on necessity without any code changes.