### PR TITLE
Add sharedApp param to application advanced configurations.

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/application/management/v1/AdvancedApplicationConfiguration.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/application/management/v1/AdvancedApplicationConfiguration.java
@@ -173,15 +173,15 @@ public class AdvancedApplicationConfiguration  {
     }
 
     /**
-     * Decides whether application is a shared application.
-     */
+    * Decides whether application is a shared application.
+    **/
     public AdvancedApplicationConfiguration sharedApp(Boolean sharedApp) {
 
         this.sharedApp = sharedApp;
         return this;
     }
-
-    @ApiModelProperty(example = "true", value = "Decides whether the application is shared application.")
+    
+    @ApiModelProperty(example = "false", value = "Decides whether application is a shared application.")
     @JsonProperty("sharedApp")
     @Valid
     public Boolean getSharedApp() {
@@ -190,6 +190,8 @@ public class AdvancedApplicationConfiguration  {
     public void setSharedApp(Boolean sharedApp) {
         this.sharedApp = sharedApp;
     }
+
+
 
     @Override
     public boolean equals(java.lang.Object o) {
@@ -207,12 +209,13 @@ public class AdvancedApplicationConfiguration  {
             Objects.equals(this.skipLoginConsent, advancedApplicationConfiguration.skipLoginConsent) &&
             Objects.equals(this.skipLogoutConsent, advancedApplicationConfiguration.skipLogoutConsent) &&
             Objects.equals(this.returnAuthenticatedIdpList, advancedApplicationConfiguration.returnAuthenticatedIdpList) &&
-            Objects.equals(this.enableAuthorization, advancedApplicationConfiguration.enableAuthorization);
+            Objects.equals(this.enableAuthorization, advancedApplicationConfiguration.enableAuthorization) &&
+            Objects.equals(this.sharedApp, advancedApplicationConfiguration.sharedApp);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(saas, discoverableByEndUsers, certificate, skipLoginConsent, skipLogoutConsent, returnAuthenticatedIdpList, enableAuthorization);
+        return Objects.hash(saas, discoverableByEndUsers, certificate, skipLoginConsent, skipLogoutConsent, returnAuthenticatedIdpList, enableAuthorization, sharedApp);
     }
 
     @Override
@@ -228,6 +231,7 @@ public class AdvancedApplicationConfiguration  {
         sb.append("    skipLogoutConsent: ").append(toIndentedString(skipLogoutConsent)).append("\n");
         sb.append("    returnAuthenticatedIdpList: ").append(toIndentedString(returnAuthenticatedIdpList)).append("\n");
         sb.append("    enableAuthorization: ").append(toIndentedString(enableAuthorization)).append("\n");
+        sb.append("    sharedApp: ").append(toIndentedString(sharedApp)).append("\n");
         sb.append("}");
         return sb.toString();
     }

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/application/management/v1/AdvancedApplicationConfiguration.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/application/management/v1/AdvancedApplicationConfiguration.java
@@ -38,7 +38,7 @@ public class AdvancedApplicationConfiguration  {
     private Boolean skipLogoutConsent;
     private Boolean returnAuthenticatedIdpList;
     private Boolean enableAuthorization;
-    private Boolean sharedApp;
+    private Boolean fragment;
 
     /**
     * Decides whether the application is accessible across tenants.
@@ -173,22 +173,22 @@ public class AdvancedApplicationConfiguration  {
     }
 
     /**
-    * Decides whether application is a shared application.
+    * Decides whether application is a fragment application.
     **/
-    public AdvancedApplicationConfiguration sharedApp(Boolean sharedApp) {
+    public AdvancedApplicationConfiguration fragment(Boolean fragment) {
 
-        this.sharedApp = sharedApp;
+        this.fragment = fragment;
         return this;
     }
     
-    @ApiModelProperty(example = "false", value = "Decides whether application is a shared application.")
-    @JsonProperty("sharedApp")
+    @ApiModelProperty(example = "false", value = "Decides whether application is a fragment application.")
+    @JsonProperty("fragment")
     @Valid
-    public Boolean getSharedApp() {
-        return sharedApp;
+    public Boolean getFragment() {
+        return fragment;
     }
-    public void setSharedApp(Boolean sharedApp) {
-        this.sharedApp = sharedApp;
+    public void setFragment(Boolean fragment) {
+        this.fragment = fragment;
     }
 
 
@@ -210,12 +210,12 @@ public class AdvancedApplicationConfiguration  {
             Objects.equals(this.skipLogoutConsent, advancedApplicationConfiguration.skipLogoutConsent) &&
             Objects.equals(this.returnAuthenticatedIdpList, advancedApplicationConfiguration.returnAuthenticatedIdpList) &&
             Objects.equals(this.enableAuthorization, advancedApplicationConfiguration.enableAuthorization) &&
-            Objects.equals(this.sharedApp, advancedApplicationConfiguration.sharedApp);
+            Objects.equals(this.fragment, advancedApplicationConfiguration.fragment);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(saas, discoverableByEndUsers, certificate, skipLoginConsent, skipLogoutConsent, returnAuthenticatedIdpList, enableAuthorization, sharedApp);
+        return Objects.hash(saas, discoverableByEndUsers, certificate, skipLoginConsent, skipLogoutConsent, returnAuthenticatedIdpList, enableAuthorization, fragment);
     }
 
     @Override
@@ -231,7 +231,7 @@ public class AdvancedApplicationConfiguration  {
         sb.append("    skipLogoutConsent: ").append(toIndentedString(skipLogoutConsent)).append("\n");
         sb.append("    returnAuthenticatedIdpList: ").append(toIndentedString(returnAuthenticatedIdpList)).append("\n");
         sb.append("    enableAuthorization: ").append(toIndentedString(enableAuthorization)).append("\n");
-        sb.append("    sharedApp: ").append(toIndentedString(sharedApp)).append("\n");
+        sb.append("    fragment: ").append(toIndentedString(fragment)).append("\n");
         sb.append("}");
         return sb.toString();
     }

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/application/management/v1/AdvancedApplicationConfiguration.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/application/management/v1/AdvancedApplicationConfiguration.java
@@ -38,6 +38,7 @@ public class AdvancedApplicationConfiguration  {
     private Boolean skipLogoutConsent;
     private Boolean returnAuthenticatedIdpList;
     private Boolean enableAuthorization;
+    private Boolean sharedApp;
 
     /**
     * Decides whether the application is accessible across tenants.
@@ -171,7 +172,24 @@ public class AdvancedApplicationConfiguration  {
         this.enableAuthorization = enableAuthorization;
     }
 
+    /**
+     * Decides whether application is a shared application.
+     */
+    public AdvancedApplicationConfiguration sharedApp(Boolean sharedApp) {
 
+        this.sharedApp = sharedApp;
+        return this;
+    }
+
+    @ApiModelProperty(example = "true", value = "Decides whether the application is shared application.")
+    @JsonProperty("sharedApp")
+    @Valid
+    public Boolean getSharedApp() {
+        return sharedApp;
+    }
+    public void setSharedApp(Boolean sharedApp) {
+        this.sharedApp = sharedApp;
+    }
 
     @Override
     public boolean equals(java.lang.Object o) {

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/functions/application/ServiceProviderToApiModel.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/functions/application/ServiceProviderToApiModel.java
@@ -367,7 +367,7 @@ public class ServiceProviderToApiModel implements Function<ServiceProvider, Appl
 
         return serviceProvider != null && serviceProvider.getSpProperties() != null &&
                 Arrays.stream(serviceProvider.getSpProperties())
-                        .filter(p -> IS_SHARED_APP.equalsIgnoreCase(p.getName())).findFirst().map(
+                        .filter(p -> IS_SHARED_APP.equals(p.getName())).findFirst().map(
                                 p -> Boolean.valueOf(p.getValue())).orElse(Boolean.FALSE);
     }
 

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/functions/application/ServiceProviderToApiModel.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/functions/application/ServiceProviderToApiModel.java
@@ -71,7 +71,7 @@ public class ServiceProviderToApiModel implements Function<ServiceProvider, Appl
 
     private static final Set<String> systemApplications = ApplicationManagementServiceHolder
             .getApplicationManagementService().getSystemApplications();
-    private static final String IS_SHARED_APP = "isSharedApp";
+    private static final String IS_FRAGMENT_APP = "isFragmentApp";
 
     @Override
     public ApplicationResponseModel apply(ServiceProvider application) {
@@ -349,7 +349,7 @@ public class ServiceProviderToApiModel implements Function<ServiceProvider, Appl
                 .skipLoginConsent(authConfig.isSkipConsent())
                 .skipLogoutConsent(authConfig.isSkipLogoutConsent())
                 .certificate(getCertificate(serviceProvider))
-                .sharedApp(isSharedApp(serviceProvider));
+                .fragment(isFragmentApp(serviceProvider));
     }
 
     private Certificate getCertificate(ServiceProvider serviceProvider) {
@@ -363,11 +363,11 @@ public class ServiceProviderToApiModel implements Function<ServiceProvider, Appl
         return null;
     }
 
-    private boolean isSharedApp(ServiceProvider serviceProvider) {
+    private boolean isFragmentApp(ServiceProvider serviceProvider) {
 
         return serviceProvider != null && serviceProvider.getSpProperties() != null &&
                 Arrays.stream(serviceProvider.getSpProperties())
-                        .filter(p -> IS_SHARED_APP.equals(p.getName())).findFirst().map(
+                        .filter(p -> IS_FRAGMENT_APP.equals(p.getName())).findFirst().map(
                                 p -> Boolean.valueOf(p.getValue())).orElse(Boolean.FALSE);
     }
 

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/resources/applications.yaml
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/resources/applications.yaml
@@ -2445,9 +2445,9 @@ components:
           type: boolean
           description: Decides whether authorization policies needs to be engaged during authentication flows.
           example: true
-        sharedApp:
+        fragment:
           type: boolean
-          description: Decides whether application is a shared application.
+          description: Decides whether application is a fragment application.
           example: false
     Certificate:
       type: object

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/resources/applications.yaml
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/resources/applications.yaml
@@ -2445,6 +2445,10 @@ components:
           type: boolean
           description: Decides whether authorization policies needs to be engaged during authentication flows.
           example: true
+        sharedApp:
+          type: boolean
+          description: Decides whether application is a shared application.
+          example: false
     Certificate:
       type: object
       properties:


### PR DESCRIPTION
## Purpose
Introducing a parameter in advanced configuration in application to denote whether the application is a shared application. Based on this property, frontend application can decide which operations should be allowed to the users.