### PR TITLE
Resolve the issue in adding IDP Issuer Name using a PATCH request.

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/main/java/org/wso2/carbon/identity/api/server/idp/v1/core/ServerIdpManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/main/java/org/wso2/carbon/identity/api/server/idp/v1/core/ServerIdpManagementService.java
@@ -2830,6 +2830,21 @@ public class ServerIdpManagementService {
                     if (ArrayUtils.isNotEmpty(idpToUpdate.getCertificateInfoArray())) {
                         idpToUpdate.setCertificate(null);
                     }
+                } else if (Constants.IDP_ISSUER_NAME_PATH.equals(path)) {
+                    IdentityProviderProperty[] propertyDTOS = idpToUpdate.getIdpProperties();
+                    for (IdentityProviderProperty propertyDTO : propertyDTOS) {
+                        if (Constants.IDP_ISSUER_NAME.equals(propertyDTO.getName())) {
+                            throw handleException(Response.Status.BAD_REQUEST,
+                                    Constants.ErrorMessage.ERROR_CODE_ERROR_UPDATING_IDP,
+                                    "Cannot add Issuer Name as it already exists");
+                        }
+                    }
+                    List<IdentityProviderProperty> idpProperties = new ArrayList<>(Arrays.asList(propertyDTOS));
+                    IdentityProviderProperty issuerNameProperty = new IdentityProviderProperty();
+                    issuerNameProperty.setName(Constants.IDP_ISSUER_NAME);
+                    issuerNameProperty.setValue(value);
+                    idpProperties.add(issuerNameProperty);
+                    idpToUpdate.setIdpProperties(idpProperties.toArray(new IdentityProviderProperty[0]));
                 } else {
                     throw handleException(Response.Status.BAD_REQUEST,
                             Constants.ErrorMessage.ERROR_CODE_INVALID_INPUT, null);


### PR DESCRIPTION
**Purpose**
Fix the issue reported in https://github.com/wso2/product-is/issues/13964 by providing ability to add Issuer Name for IDPs which are not having an Issuer Name using PATCH request with ADD operation.

**Issue description**
When an IDP is created without adding Identity Provider's Issuer Name, then the user cannot edit the Identity Provider's Issuer Name using a PATCH request with ADD or REPLACE operations later.