### PR TITLE
Add content Type to sms publisher configurations

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.notification.sender/org.wso2.carbon.identity.api.server.notification.sender.v1/src/gen/java/org/wso2/carbon/identity/api/server/notification/sender/v1/model/SMSSender.java
+++ b/components/org.wso2.carbon.identity.api.server.notification.sender/org.wso2.carbon.identity.api.server.notification.sender.v1/src/gen/java/org/wso2/carbon/identity/api/server/notification/sender/v1/model/SMSSender.java
@@ -39,6 +39,40 @@ public class SMSSender  {
     private String key;
     private String secret;
     private String sender;
+
+    @XmlType(name="ContentTypeEnum")
+    @XmlEnum(String.class)
+    public enum ContentTypeEnum {
+
+        @XmlEnumValue("JSON") JSON(String.valueOf("JSON")), @XmlEnumValue("FORM") FORM(String.valueOf("FORM"));
+
+
+        private String value;
+
+        ContentTypeEnum(String v) {
+            value = v;
+        }
+
+        public String value() {
+            return value;
+        }
+
+        @Override
+        public String toString() {
+            return String.valueOf(value);
+        }
+
+        public static ContentTypeEnum fromValue(String value) {
+            for (ContentTypeEnum b : ContentTypeEnum.values()) {
+                if (b.value.equals(value)) {
+                    return b;
+                }
+            }
+            throw new IllegalArgumentException("Unexpected value '" + value + "'");
+        }
+    }
+
+    private ContentTypeEnum contentType;
     private List<Properties> properties = null;
 
 
@@ -158,6 +192,26 @@ public class SMSSender  {
 
     /**
     **/
+    public SMSSender contentType(ContentTypeEnum contentType) {
+
+        this.contentType = contentType;
+        return this;
+    }
+
+    @ApiModelProperty(required = true, value = "")
+    @JsonProperty("contentType")
+    @Valid
+    @NotNull(message = "Property contentType cannot be null.")
+
+    public ContentTypeEnum getContentType() {
+        return contentType;
+    }
+    public void setContentType(ContentTypeEnum contentType) {
+        this.contentType = contentType;
+    }
+
+    /**
+    **/
     public SMSSender properties(List<Properties> properties) {
 
         this.properties = properties;
@@ -200,12 +254,13 @@ public class SMSSender  {
             Objects.equals(this.key, smSSender.key) &&
             Objects.equals(this.secret, smSSender.secret) &&
             Objects.equals(this.sender, smSSender.sender) &&
+            Objects.equals(this.contentType, smSSender.contentType) &&
             Objects.equals(this.properties, smSSender.properties);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(name, provider, providerURL, key, secret, sender, properties);
+        return Objects.hash(name, provider, providerURL, key, secret, sender, contentType, properties);
     }
 
     @Override
@@ -220,6 +275,7 @@ public class SMSSender  {
         sb.append("    key: ").append(toIndentedString(key)).append("\n");
         sb.append("    secret: ").append(toIndentedString(secret)).append("\n");
         sb.append("    sender: ").append(toIndentedString(sender)).append("\n");
+        sb.append("    contentType: ").append(toIndentedString(contentType)).append("\n");
         sb.append("    properties: ").append(toIndentedString(properties)).append("\n");
         sb.append("}");
         return sb.toString();

--- a/components/org.wso2.carbon.identity.api.server.notification.sender/org.wso2.carbon.identity.api.server.notification.sender.v1/src/gen/java/org/wso2/carbon/identity/api/server/notification/sender/v1/model/SMSSenderAdd.java
+++ b/components/org.wso2.carbon.identity.api.server.notification.sender/org.wso2.carbon.identity.api.server.notification.sender.v1/src/gen/java/org/wso2/carbon/identity/api/server/notification/sender/v1/model/SMSSenderAdd.java
@@ -39,6 +39,40 @@ public class SMSSenderAdd  {
     private String key;
     private String secret;
     private String sender;
+
+    @XmlType(name="ContentTypeEnum")
+    @XmlEnum(String.class)
+    public enum ContentTypeEnum {
+
+        @XmlEnumValue("JSON") JSON(String.valueOf("JSON")), @XmlEnumValue("FORM") FORM(String.valueOf("FORM"));
+
+
+        private String value;
+
+        ContentTypeEnum(String v) {
+            value = v;
+        }
+
+        public String value() {
+            return value;
+        }
+
+        @Override
+        public String toString() {
+            return String.valueOf(value);
+        }
+
+        public static ContentTypeEnum fromValue(String value) {
+            for (ContentTypeEnum b : ContentTypeEnum.values()) {
+                if (b.value.equals(value)) {
+                    return b;
+                }
+            }
+            throw new IllegalArgumentException("Unexpected value '" + value + "'");
+        }
+    }
+
+    private ContentTypeEnum contentType;
     private List<Properties> properties = null;
 
 
@@ -156,6 +190,26 @@ public class SMSSenderAdd  {
 
     /**
     **/
+    public SMSSenderAdd contentType(ContentTypeEnum contentType) {
+
+        this.contentType = contentType;
+        return this;
+    }
+
+    @ApiModelProperty(required = true, value = "")
+    @JsonProperty("contentType")
+    @Valid
+    @NotNull(message = "Property contentType cannot be null.")
+
+    public ContentTypeEnum getContentType() {
+        return contentType;
+    }
+    public void setContentType(ContentTypeEnum contentType) {
+        this.contentType = contentType;
+    }
+
+    /**
+     **/
     public SMSSenderAdd properties(List<Properties> properties) {
 
         this.properties = properties;
@@ -198,12 +252,13 @@ public class SMSSenderAdd  {
             Objects.equals(this.key, smSSenderAdd.key) &&
             Objects.equals(this.secret, smSSenderAdd.secret) &&
             Objects.equals(this.sender, smSSenderAdd.sender) &&
+            Objects.equals(this.contentType, smSSenderAdd.contentType) &&
             Objects.equals(this.properties, smSSenderAdd.properties);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(name, provider, providerURL, key, secret, sender, properties);
+        return Objects.hash(name, provider, providerURL, key, secret, sender, contentType, properties);
     }
 
     @Override
@@ -218,6 +273,7 @@ public class SMSSenderAdd  {
         sb.append("    key: ").append(toIndentedString(key)).append("\n");
         sb.append("    secret: ").append(toIndentedString(secret)).append("\n");
         sb.append("    sender: ").append(toIndentedString(sender)).append("\n");
+        sb.append("    contentType: ").append(toIndentedString(contentType)).append("\n");
         sb.append("    properties: ").append(toIndentedString(properties)).append("\n");
         sb.append("}");
         return sb.toString();

--- a/components/org.wso2.carbon.identity.api.server.notification.sender/org.wso2.carbon.identity.api.server.notification.sender.v1/src/gen/java/org/wso2/carbon/identity/api/server/notification/sender/v1/model/SMSSenderUpdateRequest.java
+++ b/components/org.wso2.carbon.identity.api.server.notification.sender/org.wso2.carbon.identity.api.server.notification.sender.v1/src/gen/java/org/wso2/carbon/identity/api/server/notification/sender/v1/model/SMSSenderUpdateRequest.java
@@ -38,6 +38,40 @@ public class SMSSenderUpdateRequest  {
     private String key;
     private String secret;
     private String sender;
+
+    @XmlType(name="ContentTypeEnum")
+    @XmlEnum(String.class)
+    public enum ContentTypeEnum {
+
+        @XmlEnumValue("JSON") JSON(String.valueOf("JSON")), @XmlEnumValue("FORM") FORM(String.valueOf("FORM"));
+
+
+        private String value;
+
+        ContentTypeEnum(String v) {
+            value = v;
+        }
+
+        public String value() {
+            return value;
+        }
+
+        @Override
+        public String toString() {
+            return String.valueOf(value);
+        }
+
+        public static ContentTypeEnum fromValue(String value) {
+            for (ContentTypeEnum b : ContentTypeEnum.values()) {
+                if (b.value.equals(value)) {
+                    return b;
+                }
+            }
+            throw new IllegalArgumentException("Unexpected value '" + value + "'");
+        }
+    }
+
+    private ContentTypeEnum contentType;
     private List<Properties> properties = null;
 
 
@@ -137,6 +171,26 @@ public class SMSSenderUpdateRequest  {
 
     /**
     **/
+    public SMSSenderUpdateRequest contentType(ContentTypeEnum contentType) {
+
+        this.contentType = contentType;
+        return this;
+    }
+
+    @ApiModelProperty(required = true, value = "")
+    @JsonProperty("contentType")
+    @Valid
+    @NotNull(message = "Property contentType cannot be null.")
+
+    public ContentTypeEnum getContentType() {
+        return contentType;
+    }
+    public void setContentType(ContentTypeEnum contentType) {
+        this.contentType = contentType;
+    }
+
+    /**
+    **/
     public SMSSenderUpdateRequest properties(List<Properties> properties) {
 
         this.properties = properties;
@@ -178,12 +232,13 @@ public class SMSSenderUpdateRequest  {
             Objects.equals(this.key, smSSenderUpdateRequest.key) &&
             Objects.equals(this.secret, smSSenderUpdateRequest.secret) &&
             Objects.equals(this.sender, smSSenderUpdateRequest.sender) &&
+            Objects.equals(this.contentType, smSSenderUpdateRequest.contentType) &&
             Objects.equals(this.properties, smSSenderUpdateRequest.properties);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(provider, providerURL, key, secret, sender, properties);
+        return Objects.hash(provider, providerURL, key, secret, sender, contentType, properties);
     }
 
     @Override
@@ -197,6 +252,7 @@ public class SMSSenderUpdateRequest  {
         sb.append("    key: ").append(toIndentedString(key)).append("\n");
         sb.append("    secret: ").append(toIndentedString(secret)).append("\n");
         sb.append("    sender: ").append(toIndentedString(sender)).append("\n");
+        sb.append("    contentType: ").append(toIndentedString(contentType)).append("\n");
         sb.append("    properties: ").append(toIndentedString(properties)).append("\n");
         sb.append("}");
         return sb.toString();

--- a/components/org.wso2.carbon.identity.api.server.notification.sender/org.wso2.carbon.identity.api.server.notification.sender.v1/src/main/java/org/wso2/carbon/identity/api/server/notification/sender/v1/core/NotificationSenderManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.notification.sender/org.wso2.carbon.identity.api.server.notification.sender.v1/src/main/java/org/wso2/carbon/identity/api/server/notification/sender/v1/core/NotificationSenderManagementService.java
@@ -264,6 +264,7 @@ public class NotificationSenderManagementService {
         dto.setKey(smsSenderAdd.getKey());
         dto.setSecret(smsSenderAdd.getSecret());
         dto.setSender(smsSenderAdd.getSender());
+        dto.setContentType(smsSenderAdd.getContentType().toString());
         List<Properties> properties = smsSenderAdd.getProperties();
         properties.forEach((prop) -> dto.getProperties().put(prop.getKey(), prop.getValue()));
         return dto;
@@ -279,6 +280,7 @@ public class NotificationSenderManagementService {
         dto.setKey(smsSenderUpdateRequest.getKey());
         dto.setSecret(smsSenderUpdateRequest.getSecret());
         dto.setSender(smsSenderUpdateRequest.getSender());
+        dto.setContentType(smsSenderUpdateRequest.getContentType().toString());
         List<Properties> properties = smsSenderUpdateRequest.getProperties();
         properties.forEach((prop) -> dto.getProperties().put(prop.getKey(), prop.getValue()));
         return dto;
@@ -301,6 +303,7 @@ public class NotificationSenderManagementService {
         smsSender.setKey(dto.getKey());
         smsSender.setSecret(dto.getSecret());
         smsSender.setSender(dto.getSender());
+        smsSender.setContentType(SMSSender.ContentTypeEnum.valueOf(dto.getContentType()));
         List<Properties> properties = new ArrayList<>();
         dto.getProperties().forEach((key, value) -> {
             Properties prop = new Properties();

--- a/components/org.wso2.carbon.identity.api.server.notification.sender/org.wso2.carbon.identity.api.server.notification.sender.v1/src/main/resources/notification-sender.yaml
+++ b/components/org.wso2.carbon.identity.api.server.notification.sender/org.wso2.carbon.identity.api.server.notification.sender.v1/src/main/resources/notification-sender.yaml
@@ -378,6 +378,7 @@ paths:
               key: 123**45
               secret: 5tg**ssd
               sender: +94 775563324
+              type : json
               properties:
                 - key: body.scope
                   value: "internal"
@@ -513,6 +514,7 @@ paths:
               key: 123**45
               secret: 5tg**ssd
               sender: +94 775563324
+              type : json
               properties:
                 - key: body.scope
                   value: "internal"
@@ -656,6 +658,7 @@ components:
       required:
         - providerURL
         - provider
+        - contentType
       type: object
       properties:
         name:
@@ -676,6 +679,11 @@ components:
         sender:
           type: string
           example: +94 775563324
+        contentType:
+          type: string
+          enum:
+            - JSON
+            - FORM
         properties:
           type: array
           example:
@@ -719,6 +727,7 @@ components:
         - providerURL
         - name
         - provider
+        - contentType
       type: object
       properties:
         name:
@@ -739,6 +748,11 @@ components:
         sender:
           type: string
           example: +94 775563324
+        contentType:
+          type: string
+          enum:
+            - JSON
+            - FORM
         properties:
           type: array
           example:
@@ -781,6 +795,7 @@ components:
       required:
         - providerURL
         - provider
+        - contentType
       type: object
       properties:
         provider:
@@ -798,6 +813,11 @@ components:
         sender:
           type: string
           example: +94 775563324
+        contentType:
+          type: string
+          enum:
+            - JSON
+            - FORM
         properties:
           type: array
           example:

--- a/pom.xml
+++ b/pom.xml
@@ -520,7 +520,7 @@
         <maven.findbugsplugin.version>3.0.5</maven.findbugsplugin.version>
         <identity.workflow.impl.bps.version>5.2.0</identity.workflow.impl.bps.version>
         <maven.checkstyleplugin.excludes>**/gen/**/*</maven.checkstyleplugin.excludes>
-        <identity.event.handler.version>1.4.3</identity.event.handler.version>
+        <identity.event.handler.version>1.4.4</identity.event.handler.version>
         <identity.inbound.oauth2.version>6.4.60</identity.inbound.oauth2.version>
         <identity.inbound.saml2.version>5.8.44</identity.inbound.saml2.version>
         <commons.beanutils.version>1.9.4</commons.beanutils.version>


### PR DESCRIPTION
## Purpose

The current implementation of sms publisher endpoints only support json payloads. Some sms providers such as Twilio only support x-www-form-urlencoded payloads. So improved the API to add the **contentType** as `JSON` or `FORM`


Merge after - https://github.com/wso2-extensions/identity-event-handler-notification/pull/160