### PR TITLE
Update ApiModelToOAuthConsumerApp to process a collection of callback urls

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/functions/application/inbound/oauth2/ApiModelToOAuthConsumerApp.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/functions/application/inbound/oauth2/ApiModelToOAuthConsumerApp.java
@@ -47,7 +47,7 @@ public class ApiModelToOAuthConsumerApp implements ApiModelToOAuthConsumerAppFun
         consumerAppDTO.setOauthConsumerKey(oidcModel.getClientId());
         consumerAppDTO.setOauthConsumerSecret(oidcModel.getClientSecret());
 
-        consumerAppDTO.setCallbackUrl(getCallbackUrl(oidcModel.getCallbackURLs()));
+        consumerAppDTO.setCallBackUrls(getCallbackUrl(oidcModel.getCallbackURLs()));
 
         consumerAppDTO.setOAuthVersion(OAuthConstants.OAuthVersions.VERSION_2);
 
@@ -162,15 +162,17 @@ public class ApiModelToOAuthConsumerApp implements ApiModelToOAuthConsumerAppFun
                 .orElse(new String[0]);
     }
 
-    private String getCallbackUrl(List<String> callbackURLs) {
+    private List<String> getCallbackUrl(List<String> callbackURLs) {
 
         if (CollectionUtils.isNotEmpty(callbackURLs)) {
             // We can't support multiple callback URLs at the moment. So we need to send a server error.
             if (callbackURLs.size() > 1) {
-                throw Utils.buildNotImplementedError("Multiple callbacks for OAuth2 are not supported yet. " +
-                        "Please use regex to define multiple callbacks.");
+                return callbackURLs;
+//                throw Utils.buildNotImplementedError("Multiple callbacks for OAuth2 are not supported yet. " +
+//                        "Please use regex to define multiple callbacks.");
             } else if (callbackURLs.size() == 1) {
-                return callbackURLs.get(0);
+//                return callbackURLs.get(0);
+                return callbackURLs;
             } else {
                 return null;
             }

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/functions/application/inbound/oauth2/ApiModelToOAuthConsumerApp.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/functions/application/inbound/oauth2/ApiModelToOAuthConsumerApp.java
@@ -23,7 +23,6 @@ import org.wso2.carbon.identity.api.server.application.management.v1.OAuth2PKCEC
 import org.wso2.carbon.identity.api.server.application.management.v1.OIDCLogoutConfiguration;
 import org.wso2.carbon.identity.api.server.application.management.v1.OpenIDConnectConfiguration;
 import org.wso2.carbon.identity.api.server.application.management.v1.RefreshTokenConfiguration;
-import org.wso2.carbon.identity.api.server.application.management.v1.core.functions.Utils;
 import org.wso2.carbon.identity.oauth.common.OAuthConstants;
 import org.wso2.carbon.identity.oauth.dto.OAuthConsumerAppDTO;
 

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/functions/application/inbound/oauth2/OAuthConsumerAppToApiModel.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/functions/application/inbound/oauth2/OAuthConsumerAppToApiModel.java
@@ -15,6 +15,7 @@
  */
 package org.wso2.carbon.identity.api.server.application.management.v1.core.functions.application.inbound.oauth2;
 
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang.StringUtils;
 import org.wso2.carbon.identity.api.server.application.management.v1.AccessTokenConfiguration;
 import org.wso2.carbon.identity.api.server.application.management.v1.IdTokenConfiguration;
@@ -141,7 +142,9 @@ public class OAuthConsumerAppToApiModel implements Function<OAuthConsumerAppDTO,
     private List<String> getCallbackUrls(OAuthConsumerAppDTO oauthApp) {
 
         List<String> callbackUris = new ArrayList<>();
-        if (StringUtils.isNotBlank(oauthApp.getCallbackUrl())) {
+        if (CollectionUtils.isNotEmpty(oauthApp.getCallBackUrls())) {
+            callbackUris = oauthApp.getCallBackUrls();
+        } else if (StringUtils.isNotBlank(oauthApp.getCallbackUrl())) {
             callbackUris.add(oauthApp.getCallbackUrl());
         }
         return callbackUris;


### PR DESCRIPTION
## Purpose
> Provide 1st Class support for multiple callback URLs in the WSO2 Identity Server.

## Goals
> Facilitate the passage of a collection of callback urls as (separate entities) through the api layer of IS.

## Approach
> Updated ApiModelToOAuthConsumerApp to be able to handle a collection of callback urls.

## Related Issues
https://github.com/wso2/product-is/issues/8983