### PR TITLE
update maven-compiler-plugin version and set parameters to true

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -472,6 +472,7 @@
                         <encoding>UTF-8</encoding>
                         <source>1.8</source>
                         <target>1.8</target>
+                        <parameters>true</parameters>
                     </configuration>
                 </plugin>
                 <plugin>
@@ -503,7 +504,7 @@
 
     <properties>
         <!--Maven Plugin Version-->
-        <maven.compiler.plugin.version>2.3.1</maven.compiler.plugin.version>
+        <maven.compiler.plugin.version>3.10.1</maven.compiler.plugin.version>
         <maven.bundle.plugin.version>2.4.0</maven.bundle.plugin.version>
         <jackson-jaxrs-json-provider.version>2.13.2</jackson-jaxrs-json-provider.version>
         <jackson-databind.version>2.13.2.2</jackson-databind.version>


### PR DESCRIPTION
## Purpose
This PR will
- update the `maven-compiler-plugin` version to the latest (3.10.1)
- Set the `<parameters>` configuration of `maven-compiler-plugin` to true

## Related Issues
As explained in [issue](https://github.com/wso2/product-is/issues/14129) following WARN logs were observed in JDK 17.
```
[2022-07-06 16:02:50,713] [7ba2674a-0b6c-4f93-a52c-820a3493730d]  WARN {org.hibernate.validator.internal.properties.javabean.JavaBeanExecutable} - HV000254: Missing parameter metadata for TypeEnum(String, int, String), which declares implicit or synthetic parameters. Automatic resolution of generic type information for method parameters may yield incorrect results if multiple parameters have the same erasure. To solve this, compile your code with the '-parameters' flag.
```
This is due to `enum` not been compiled with `-parameters`.

As explained in [[1]](https://stackoverflow.com/questions/64699000/javabeanexecutable-hv000254-missing-parameter-metadata-for-java-enum) and [[2]](https://github.com/quarkusio/quarkus/issues/10669) we have to add <parameters>true</parameters> configuration to the maven-compiler-plugin. As this configuration is only supported from 3.6.2 we have to bump our dependency to a later version than that.

[1] https://stackoverflow.com/questions/64699000/javabeanexecutable-hv000254-missing-parameter-metadata-for-java-enum
[2] https://github.com/quarkusio/quarkus/issues/10669
