### PR TITLE
Allow users to filter applications by SAML issuer

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.common/src/main/java/org/wso2/carbon/identity/api/server/application/management/common/ApplicationManagementConstants.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.common/src/main/java/org/wso2/carbon/identity/api/server/application/management/common/ApplicationManagementConstants.java
@@ -62,15 +62,14 @@ public class ApplicationManagementConstants {
         UNSUPPORTED_FILTER_ATTRIBUTE("60004",
                 "Filtering using the attempted attribute is not supported.",
                 "Filtering cannot be done with the '%s' attribute. " +
-                        "Filtering is only supported with the 'name', and the 'clientId' attributes."),
+                        "Filtering is only supported with 'name', 'clientId', and 'issuer' attributes."),
         INVALID_FILTER_FORMAT("60004",
-                "Invalid format user for filtering.",
+                "Invalid filter query format.",
                 "Filter needs to be in the format <attribute>+<operation>+<value>. Eg: name+eq+john"),
         INVALID_FILTER_OPERATION("60004",
                 "Attempted filtering operation is invalid.",
-                "Attempted filtering operation '%s' is invalid. " +
-                        "Please use one of the supported filtering operations such as 'eq', 'co', 'sw', 'ew', 'and' " +
-                        "or 'or'."),
+                "Attempted filtering operation '%s' is invalid. Please use one of the supported " +
+                        "filtering operations such as 'eq', 'co', 'sw', 'ew', 'and', 'or'."),
         APPLICATION_NOT_FOUND("60006",
                 "Application not found.",
                 "Application cannot be found for the provided id: %s in the tenantDomain: %s."),

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.common/src/main/java/org/wso2/carbon/identity/api/server/application/management/common/ApplicationManagementConstants.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.common/src/main/java/org/wso2/carbon/identity/api/server/application/management/common/ApplicationManagementConstants.java
@@ -48,6 +48,7 @@ public class ApplicationManagementConstants {
     public static final String DEFAULT_CERTIFICATE_ALIAS = "wso2carbon";
     public static final String ADVANCED_CONFIGURATIONS = "advancedConfigurations";
     public static final String TEMPLATE_ID = "templateId";
+    public static final String NAME = "name";
     public static final String CLIENT_ID = "clientId";
     public static final String ISSUER = "issuer";
 

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/ServerApplicationManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/ServerApplicationManagementService.java
@@ -289,9 +289,7 @@ public class ServerApplicationManagementService {
             return Stream.of(validateFilterTree(leftNode), validateFilterTree(rightNode))
                     .flatMap(Collection::stream)
                     .collect(Collectors.toList());
-        } else {
-            throw buildClientError(ErrorMessage.INVALID_FILTER_FORMAT);
-        }
+        throw buildClientError(ErrorMessage.INVALID_FILTER_FORMAT);
     }
 
     private void validateRequiredAttributes(List<String> requestedAttributeList) {

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/ServerApplicationManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/ServerApplicationManagementService.java
@@ -114,14 +114,15 @@ import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static org.wso2.carbon.identity.api.server.application.management.common.ApplicationManagementConstants.ADVANCED_CONFIGURATIONS;
 import static org.wso2.carbon.identity.api.server.application.management.common.ApplicationManagementConstants.APPLICATION_MANAGEMENT_PATH_COMPONENT;
@@ -157,15 +158,9 @@ public class ServerApplicationManagementService {
     private static final Log log = LogFactory.getLog(ServerApplicationManagementService.class);
 
     // Allowed filter attributes mapped to real field names.
-    private static final Map<String, String> SEARCH_SUPPORTED_FIELD_MAP = new HashMap<>();
+    private static final Set<String> SUPPORTED_FILTER_ATTRIBUTES = new HashSet<>();
     private static final List<String> SUPPORTED_REQUIRED_ATTRIBUTES = new ArrayList<>();
     private static final int DEFAULT_OFFSET = 0;
-
-    // Filter related constants.
-    private static final String FILTER_STARTS_WITH = "sw";
-    private static final String FILTER_ENDS_WITH = "ew";
-    private static final String FILTER_EQUALS = "eq";
-    private static final String FILTER_CONTAINS = "co";
 
     // WS-Trust related constants.
     private static final String WS_TRUST_TEMPLATE_ID = "061a3de4-8c08-4878-84a6-24245f11bf0e";
@@ -173,16 +168,15 @@ public class ServerApplicationManagementService {
             "not be found since the WS-Trust connector has not been configured.";
 
     static {
-        SEARCH_SUPPORTED_FIELD_MAP.put("name", "SP_APP.APP_NAME");
-        SEARCH_SUPPORTED_FIELD_MAP.put("clientId", "SP_INBOUND_AUTH.INBOUND_AUTH_KEY");
+        SUPPORTED_FILTER_ATTRIBUTES.add("name");
+        SUPPORTED_FILTER_ATTRIBUTES.add(CLIENT_ID);
+        SUPPORTED_FILTER_ATTRIBUTES.add(ISSUER);
 
         SUPPORTED_REQUIRED_ATTRIBUTES.add(ADVANCED_CONFIGURATIONS);
         SUPPORTED_REQUIRED_ATTRIBUTES.add(CLIENT_ID);
         SUPPORTED_REQUIRED_ATTRIBUTES.add(TEMPLATE_ID);
         SUPPORTED_REQUIRED_ATTRIBUTES.add(ISSUER);
     }
-
-    private static final Set<String> SEARCH_SUPPORTED_ATTRIBUTES = SEARCH_SUPPORTED_FIELD_MAP.keySet();
 
     @Autowired
     private ServerApplicationMetadataService applicationMetadataService;
@@ -196,56 +190,15 @@ public class ServerApplicationManagementService {
         limit = validateAndGetLimit(limit);
         offset = validateAndGetOffset(offset);
 
-        boolean isFilterContainsClientIdAttribute = false;
+        List<String> submittedFilterAttributes = new ArrayList<>();
 
         // Get the filter tree and validate it before sending the filter to the backend.
         if (StringUtils.isNotBlank(filter)) {
             try {
                 FilterTreeBuilder filterTreeBuilder = new FilterTreeBuilder(filter);
                 Node rootNode = filterTreeBuilder.buildTree();
-                if (rootNode instanceof ExpressionNode) {
-                    ExpressionNode expressionNode = (ExpressionNode) rootNode;
-                    if (!SEARCH_SUPPORTED_ATTRIBUTES.contains(expressionNode.getAttributeValue())) {
-                        throw buildClientError(ErrorMessage.UNSUPPORTED_FILTER_ATTRIBUTE, expressionNode
-                                .getAttributeValue());
-                    }
 
-                    if (expressionNode.getAttributeValue().equals(CLIENT_ID)) {
-                        isFilterContainsClientIdAttribute = true;
-                    }
-                } else if (rootNode instanceof OperationNode) {
-                    // Currently, supports only filters with one AND/OR operation.
-                    // Have to recursively traverse the filter tree to support more than one operation.
-                    OperationNode operationNode = (OperationNode) rootNode;
-                    Node leftNode = rootNode.getLeftNode();
-                    Node rightNode = rootNode.getRightNode();
-
-                    if (operationNode.getOperation().equals("not")) {
-                        throw buildClientError(ErrorMessage.INVALID_FILTER_FORMAT);
-                    }
-
-                    if (leftNode instanceof ExpressionNode && rightNode instanceof ExpressionNode) {
-                        ExpressionNode expressionLeftNode = (ExpressionNode) leftNode;
-                        ExpressionNode expressionRightNode = (ExpressionNode) rightNode;
-                        if (!SEARCH_SUPPORTED_ATTRIBUTES.contains(expressionLeftNode.getAttributeValue())) {
-                            throw buildClientError(ErrorMessage.UNSUPPORTED_FILTER_ATTRIBUTE, expressionLeftNode
-                                    .getAttributeValue());
-                        }
-                        if (!SEARCH_SUPPORTED_ATTRIBUTES.contains(expressionRightNode.getAttributeValue())) {
-                            throw buildClientError(ErrorMessage.UNSUPPORTED_FILTER_ATTRIBUTE, expressionRightNode
-                                    .getAttributeValue());
-                        }
-
-                        if (expressionLeftNode.getAttributeValue().equals(CLIENT_ID) ||
-                                expressionRightNode.getAttributeValue().equals(CLIENT_ID)) {
-                            isFilterContainsClientIdAttribute = true;
-                        }
-                    } else {
-                        throw buildClientError(ErrorMessage.INVALID_FILTER_FORMAT);
-                    }
-                } else {
-                    throw buildClientError(ErrorMessage.INVALID_FILTER_FORMAT);
-                }
+                submittedFilterAttributes = validateFilterTree(rootNode);
             } catch (IOException | IdentityException e) {
                 throw buildClientError(ErrorMessage.INVALID_FILTER_FORMAT);
             }
@@ -267,9 +220,12 @@ public class ServerApplicationManagementService {
             }
 
             // Add clientId as a required attribute when there's clientId as a filter param.
-            if (!requestedAttributeList.contains(CLIENT_ID) && !StringUtils.isBlank(filter) &&
-                    !filter.equals("*") && isFilterContainsClientIdAttribute) {
+            if (!requestedAttributeList.contains(CLIENT_ID) && submittedFilterAttributes.contains(CLIENT_ID)) {
                 requestedAttributeList.add(CLIENT_ID);
+            }
+            // Add issuer as a required attribute when there's issuer as a filter param.
+            if (!requestedAttributeList.contains(ISSUER) && submittedFilterAttributes.contains(ISSUER)) {
+                requestedAttributeList.add(ISSUER);
             }
 
             if (CollectionUtils.isNotEmpty(requestedAttributeList)) {
@@ -304,6 +260,36 @@ public class ServerApplicationManagementService {
         } catch (IdentityApplicationManagementException e) {
             String msg = "Error listing applications of tenantDomain: " + tenantDomain;
             throw handleIdentityApplicationManagementException(e, msg);
+        }
+    }
+
+    private List<String> validateFilterTree(Node rootNode) {
+
+        List<String> submittedFilterAttributes = new ArrayList<>();
+
+        if (rootNode instanceof ExpressionNode) {
+            ExpressionNode expressionNode = (ExpressionNode) rootNode;
+            if (!SUPPORTED_FILTER_ATTRIBUTES.contains(expressionNode.getAttributeValue())) {
+                throw buildClientError(ErrorMessage.UNSUPPORTED_FILTER_ATTRIBUTE, expressionNode
+                        .getAttributeValue());
+            }
+
+            submittedFilterAttributes.add(expressionNode.getAttributeValue());
+            return submittedFilterAttributes;
+        } else if (rootNode instanceof OperationNode) {
+            OperationNode operationNode = (OperationNode) rootNode;
+            Node leftNode = rootNode.getLeftNode();
+            Node rightNode = rootNode.getRightNode();
+
+            if (operationNode.getOperation().equals("not")) {
+                throw buildClientError(ErrorMessage.INVALID_FILTER_OPERATION);
+            }
+
+            return Stream.of(validateFilterTree(leftNode), validateFilterTree(rightNode))
+                    .flatMap(Collection::stream)
+                    .collect(Collectors.toList());
+        } else {
+            throw buildClientError(ErrorMessage.INVALID_FILTER_FORMAT);
         }
     }
 

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/ServerApplicationManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/ServerApplicationManagementService.java
@@ -289,6 +289,7 @@ public class ServerApplicationManagementService {
             return Stream.of(validateFilterTree(leftNode), validateFilterTree(rightNode))
                     .flatMap(Collection::stream)
                     .collect(Collectors.toList());
+        }
         throw buildClientError(ErrorMessage.INVALID_FILTER_FORMAT);
     }
 

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/ServerApplicationManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/ServerApplicationManagementService.java
@@ -132,6 +132,7 @@ import static org.wso2.carbon.identity.api.server.application.management.common.
 import static org.wso2.carbon.identity.api.server.application.management.common.ApplicationManagementConstants.ErrorMessage.ERROR_PROCESSING_REQUEST;
 import static org.wso2.carbon.identity.api.server.application.management.common.ApplicationManagementConstants.ErrorMessage.INBOUND_NOT_CONFIGURED;
 import static org.wso2.carbon.identity.api.server.application.management.common.ApplicationManagementConstants.ISSUER;
+import static org.wso2.carbon.identity.api.server.application.management.common.ApplicationManagementConstants.NAME;
 import static org.wso2.carbon.identity.api.server.application.management.common.ApplicationManagementConstants.TEMPLATE_ID;
 import static org.wso2.carbon.identity.api.server.application.management.v1.core.functions.Utils.buildBadRequestError;
 import static org.wso2.carbon.identity.api.server.application.management.v1.core.functions.Utils.buildNotImplementedError;
@@ -168,7 +169,7 @@ public class ServerApplicationManagementService {
             "not be found since the WS-Trust connector has not been configured.";
 
     static {
-        SUPPORTED_FILTER_ATTRIBUTES.add("name");
+        SUPPORTED_FILTER_ATTRIBUTES.add(NAME);
         SUPPORTED_FILTER_ATTRIBUTES.add(CLIENT_ID);
         SUPPORTED_FILTER_ATTRIBUTES.add(ISSUER);
 

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/resources/applications.yaml
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/resources/applications.yaml
@@ -2121,8 +2121,9 @@ components:
       name: filter
       required: false
       description: |
-        Condition to filter the retrieval of records. Supports 'sw', 'co', 'ew' and 'eq' operations.
-        Currently supports only filtering based on the 'name' and the 'clientId' attribute.
+        Condition to filter the retrieval of records.
+        Supports 'sw', 'co', 'ew', and 'eq' operations with 'and', 'or' logical operations.
+        Currently supports only filtering based on the 'name', the 'clientId', and the 'issuer' attributes.
 
         /applications?filter=name+eq+user_portal
         /applications?filter=name+co+prod+or+clientId+co+123

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/resources/applications.yaml
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/resources/applications.yaml
@@ -2122,10 +2122,13 @@ components:
       required: false
       description: |
         Condition to filter the retrieval of records.
-        Supports 'sw', 'co', 'ew', and 'eq' operations with 'and', 'or' logical operations.
+        Supports 'sw', 'co', 'ew', and 'eq' operations with 'and', 'or' logical operators.
+        Please note that 'and' and 'or' operators in filters follow the general precedence of logical operators
+        ex: A and B or C and D = (A and B) or (C and D)).
         Currently supports only filtering based on the 'name', the 'clientId', and the 'issuer' attributes.
 
         /applications?filter=name+eq+user_portal
+        <br>
         /applications?filter=name+co+prod+or+clientId+co+123
       schema:
         type: string

--- a/pom.xml
+++ b/pom.xml
@@ -523,7 +523,7 @@
         <maven.buildnumber.plugin.version>1.4</maven.buildnumber.plugin.version>
         <org.apache.felix.annotations.version>1.2.4</org.apache.felix.annotations.version>
         <identity.governance.version>1.5.25</identity.governance.version>
-        <carbon.identity.framework.version>5.23.26</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.23.39</carbon.identity.framework.version>
         <maven.findbugsplugin.version>3.0.5</maven.findbugsplugin.version>
         <identity.workflow.impl.bps.version>5.2.0</identity.workflow.impl.bps.version>
         <maven.checkstyleplugin.excludes>**/gen/**/*</maven.checkstyleplugin.excludes>


### PR DESCRIPTION
### Proposed changes in this pull request
- Allow filter query to contain any number of 'and', 'or' operations.
- Added SAML issuer as an application filter attribute.

## Approach
> Recursively traverse the filter tree to validate the filter query accepting any number of logical operations.

### Related Issues
Fixes [asgardeo-product/#11894](https://github.com/wso2-enterprise/asgardeo-product/issues/11894)

## User stories
> As an Asgardedo user, I want to search a particular SAML application by its issuer as similar to searching an OAuth application by its clientID.

## Related PRs
Merge after merging [carbon-identity-framework/#4240](https://github.com/wso2/carbon-identity-framework/pull/4240)