### PR TITLE
Update user store REST API to test connection for both JDBC and LDAP types

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.userstore/org.wso2.carbon.identity.api.server.userstore.common/src/main/java/org/wso2/carbon/identity/api/server/userstore/common/UserStoreConstants.java
+++ b/components/org.wso2.carbon.identity.api.server.userstore/org.wso2.carbon.identity.api.server.userstore.common/src/main/java/org/wso2/carbon/identity/api/server/userstore/common/UserStoreConstants.java
@@ -30,6 +30,15 @@ public class UserStoreConstants {
     public static final String USER_STORE_PROPERTIES = "/properties/";
     public static final String USER_STORE_PROPERTY_MASK = "************";
     public static final String CLAIM_MANAGEMENT_PREFIX = "CMT-";
+    public static final String URL = "url";
+    public static final String DRIVER_NAME = "driverName";
+    public static final String USER_NAME = "userName";
+    public static final String PASSWORD = "password";
+    public static final String JDBC_USER_STORE_TYPE_ID = "SkRCQ1VzZXJTdG9yZU1hbmFnZXI=";
+    public static final String CONNECTION_URL = "ConnectionURL";
+    public static final String CONNECTION_NAME = "ConnectionName";
+    public static final String CONNECTION_PASSWORD = "ConnectionPassword";
+
 
     /**
      * Enum for user store related errors in the format of
@@ -118,8 +127,10 @@ public class UserStoreConstants {
         ERROR_CODE_EMPTY_ATTRIBUTE_MAPPINGS("60014", "Attribute mapping not specified.",
                 "Attribute mapping cannot be empty."),
         ERROR_CODE_INVALID_USERSTORE_TYPE("60015", "UserStore type is not allowed",
-                "Requested UserStore type is not allowed", Response.Status.BAD_REQUEST);
-
+                "Requested UserStore type is not allowed", Response.Status.BAD_REQUEST),
+        ERROR_CODE_INVALID_USER_STORE_TYPE("60016", "Invalid user store type",
+                "Incorrect user store type.",
+                Response.Status.BAD_REQUEST);
         private final String code;
         private final String message;
         private final String description;

--- a/components/org.wso2.carbon.identity.api.server.userstore/org.wso2.carbon.identity.api.server.userstore.v1/src/gen/java/org/wso2/carbon/identity/api/server/userstore/v1/UserstoresApi.java
+++ b/components/org.wso2.carbon.identity.api.server.userstore/org.wso2.carbon.identity.api.server.userstore.v1/src/gen/java/org/wso2/carbon/identity/api/server/userstore/v1/UserstoresApi.java
@@ -29,9 +29,9 @@ import org.wso2.carbon.identity.api.server.userstore.v1.model.Error;
 import java.util.List;
 import org.wso2.carbon.identity.api.server.userstore.v1.model.MetaUserStoreType;
 import org.wso2.carbon.identity.api.server.userstore.v1.model.PatchDocument;
-import org.wso2.carbon.identity.api.server.userstore.v1.model.RDBMSConnectionReq;
 import org.wso2.carbon.identity.api.server.userstore.v1.model.UserStoreAttributeMappingResponse;
 import org.wso2.carbon.identity.api.server.userstore.v1.model.UserStoreConfigurationsRes;
+import org.wso2.carbon.identity.api.server.userstore.v1.model.UserStoreConnectionReq;
 import org.wso2.carbon.identity.api.server.userstore.v1.model.UserStoreListResponse;
 import org.wso2.carbon.identity.api.server.userstore.v1.model.UserStoreReq;
 import org.wso2.carbon.identity.api.server.userstore.v1.model.UserStoreResponse;
@@ -263,7 +263,7 @@ public class UserstoresApi  {
     @Path("/test-connection")
     @Consumes({ "application/json" })
     @Produces({ "application/json" })
-    @ApiOperation(value = "Test the connection to the datasource used by a JDBC user store manager.", notes = "This API provides the capability to test the connection to the datasource used by a JDBC user store manager.    <b>Permission required:</b>   *_/permission/admin ", response = ConnectionEstablishedResponse.class, authorizations = {
+    @ApiOperation(value = "Test the connection to the datasource used by a user store manager.", notes = "This API provides the capability to test the connection to the datasource used by a user store manager.    <b>Permission required:</b>   *_/permission/admin ", response = ConnectionEstablishedResponse.class, authorizations = {
         @Authorization(value = "BasicAuth"),
         @Authorization(value = "OAuth2", scopes = {
             
@@ -275,9 +275,9 @@ public class UserstoresApi  {
         @ApiResponse(code = 401, message = "Unauthorized.", response = Void.class),
         @ApiResponse(code = 500, message = "Internal Server Error.", response = Error.class)
     })
-    public Response testRDBMSConnection(@ApiParam(value = "RDBMS connection properties used to connect to the datasource used by a JDBC user store manager." ) @Valid RDBMSConnectionReq rdBMSConnectionReq) {
+    public Response testUserStoreConnection(@ApiParam(value = "RDBMS connection properties used to connect to the datasource used by a JDBC user store manager." ) @Valid UserStoreConnectionReq userStoreConnectionReq) {
 
-        return delegate.testRDBMSConnection(rdBMSConnectionReq );
+        return delegate.testUserStoreConnection(userStoreConnectionReq );
     }
 
     @Valid

--- a/components/org.wso2.carbon.identity.api.server.userstore/org.wso2.carbon.identity.api.server.userstore.v1/src/gen/java/org/wso2/carbon/identity/api/server/userstore/v1/UserstoresApiService.java
+++ b/components/org.wso2.carbon.identity.api.server.userstore/org.wso2.carbon.identity.api.server.userstore.v1/src/gen/java/org/wso2/carbon/identity/api/server/userstore/v1/UserstoresApiService.java
@@ -29,9 +29,9 @@ import org.wso2.carbon.identity.api.server.userstore.v1.model.Error;
 import java.util.List;
 import org.wso2.carbon.identity.api.server.userstore.v1.model.MetaUserStoreType;
 import org.wso2.carbon.identity.api.server.userstore.v1.model.PatchDocument;
-import org.wso2.carbon.identity.api.server.userstore.v1.model.RDBMSConnectionReq;
 import org.wso2.carbon.identity.api.server.userstore.v1.model.UserStoreAttributeMappingResponse;
 import org.wso2.carbon.identity.api.server.userstore.v1.model.UserStoreConfigurationsRes;
+import org.wso2.carbon.identity.api.server.userstore.v1.model.UserStoreConnectionReq;
 import org.wso2.carbon.identity.api.server.userstore.v1.model.UserStoreListResponse;
 import org.wso2.carbon.identity.api.server.userstore.v1.model.UserStoreReq;
 import org.wso2.carbon.identity.api.server.userstore.v1.model.UserStoreResponse;
@@ -58,7 +58,7 @@ public interface UserstoresApiService {
 
       public Response patchUserStore(String userstoreDomainId, List<PatchDocument> patchDocument);
 
-      public Response testRDBMSConnection(RDBMSConnectionReq rdBMSConnectionReq);
+      public Response testUserStoreConnection(UserStoreConnectionReq userStoreConnectionReq);
 
       public Response updateAttributeMappings(String userstoreDomainId, List<ClaimAttributeMapping> claimAttributeMapping);
 

--- a/components/org.wso2.carbon.identity.api.server.userstore/org.wso2.carbon.identity.api.server.userstore.v1/src/gen/java/org/wso2/carbon/identity/api/server/userstore/v1/model/UserStoreConnectionReq.java
+++ b/components/org.wso2.carbon.identity.api.server.userstore/org.wso2.carbon.identity.api.server.userstore.v1/src/gen/java/org/wso2/carbon/identity/api/server/userstore/v1/model/UserStoreConnectionReq.java
@@ -1,0 +1,244 @@
+/*
+* Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package org.wso2.carbon.identity.api.server.userstore.v1.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import java.util.ArrayList;
+import java.util.List;
+import org.wso2.carbon.identity.api.server.userstore.v1.model.Property;
+import javax.validation.constraints.*;
+
+/**
+ * User Store Connection Request.
+ **/
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+import javax.validation.Valid;
+import javax.xml.bind.annotation.*;
+@ApiModel(description = "User Store Connection Request.")
+public class UserStoreConnectionReq  {
+  
+    private String typeId;
+    private String domain;
+    private String driverName;
+    private String connectionURL;
+    private String username;
+    private String connectionPassword;
+    private List<Property> properties = null;
+
+
+    /**
+    * The id of the user store manager class type.
+    **/
+    public UserStoreConnectionReq typeId(String typeId) {
+
+        this.typeId = typeId;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "VW5pcXVlSURKREJDVXNlclN0b3JlTWFuYWdlcg", value = "The id of the user store manager class type.")
+    @JsonProperty("typeId")
+    @Valid
+    public String getTypeId() {
+        return typeId;
+    }
+    public void setTypeId(String typeId) {
+        this.typeId = typeId;
+    }
+
+    /**
+    * User store domain name.
+    **/
+    public UserStoreConnectionReq domain(String domain) {
+
+        this.domain = domain;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "PRIMARY", value = "User store domain name.")
+    @JsonProperty("domain")
+    @Valid
+    public String getDomain() {
+        return domain;
+    }
+    public void setDomain(String domain) {
+        this.domain = domain;
+    }
+
+    /**
+    * Driver Name.
+    **/
+    public UserStoreConnectionReq driverName(String driverName) {
+
+        this.driverName = driverName;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "com.mysql.jdbc.Driver", value = "Driver Name.")
+    @JsonProperty("driverName")
+    @Valid
+    public String getDriverName() {
+        return driverName;
+    }
+    public void setDriverName(String driverName) {
+        this.driverName = driverName;
+    }
+
+    /**
+    * The Connection URL.
+    **/
+    public UserStoreConnectionReq connectionURL(String connectionURL) {
+
+        this.connectionURL = connectionURL;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "jdbc:mysql://192.168.48.154:3306/test", value = "The Connection URL.")
+    @JsonProperty("connectionURL")
+    @Valid
+    public String getConnectionURL() {
+        return connectionURL;
+    }
+    public void setConnectionURL(String connectionURL) {
+        this.connectionURL = connectionURL;
+    }
+
+    /**
+    * The username.
+    **/
+    public UserStoreConnectionReq username(String username) {
+
+        this.username = username;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "root", value = "The username.")
+    @JsonProperty("username")
+    @Valid
+    public String getUsername() {
+        return username;
+    }
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    /**
+    * The password.
+    **/
+    public UserStoreConnectionReq connectionPassword(String connectionPassword) {
+
+        this.connectionPassword = connectionPassword;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "root", value = "The password.")
+    @JsonProperty("connectionPassword")
+    @Valid
+    public String getConnectionPassword() {
+        return connectionPassword;
+    }
+    public void setConnectionPassword(String connectionPassword) {
+        this.connectionPassword = connectionPassword;
+    }
+
+    /**
+    * Properties related to the user store.
+    **/
+    public UserStoreConnectionReq properties(List<Property> properties) {
+
+        this.properties = properties;
+        return this;
+    }
+    
+    @ApiModelProperty(value = "Properties related to the user store.")
+    @JsonProperty("properties")
+    @Valid
+    public List<Property> getProperties() {
+        return properties;
+    }
+    public void setProperties(List<Property> properties) {
+        this.properties = properties;
+    }
+
+    public UserStoreConnectionReq addPropertiesItem(Property propertiesItem) {
+        if (this.properties == null) {
+            this.properties = new ArrayList<>();
+        }
+        this.properties.add(propertiesItem);
+        return this;
+    }
+
+    
+
+    @Override
+    public boolean equals(java.lang.Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        UserStoreConnectionReq userStoreConnectionReq = (UserStoreConnectionReq) o;
+        return Objects.equals(this.typeId, userStoreConnectionReq.typeId) &&
+            Objects.equals(this.domain, userStoreConnectionReq.domain) &&
+            Objects.equals(this.driverName, userStoreConnectionReq.driverName) &&
+            Objects.equals(this.connectionURL, userStoreConnectionReq.connectionURL) &&
+            Objects.equals(this.username, userStoreConnectionReq.username) &&
+            Objects.equals(this.connectionPassword, userStoreConnectionReq.connectionPassword) &&
+            Objects.equals(this.properties, userStoreConnectionReq.properties);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(typeId, domain, driverName, connectionURL, username, connectionPassword, properties);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class UserStoreConnectionReq {\n");
+        
+        sb.append("    typeId: ").append(toIndentedString(typeId)).append("\n");
+        sb.append("    domain: ").append(toIndentedString(domain)).append("\n");
+        sb.append("    driverName: ").append(toIndentedString(driverName)).append("\n");
+        sb.append("    connectionURL: ").append(toIndentedString(connectionURL)).append("\n");
+        sb.append("    username: ").append(toIndentedString(username)).append("\n");
+        sb.append("    connectionPassword: ").append(toIndentedString(connectionPassword)).append("\n");
+        sb.append("    properties: ").append(toIndentedString(properties)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+    * Convert the given object to string with each line indented by 4 spaces
+    * (except the first line).
+    */
+    private String toIndentedString(java.lang.Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}
+

--- a/components/org.wso2.carbon.identity.api.server.userstore/org.wso2.carbon.identity.api.server.userstore.v1/src/main/java/org/wso2/carbon/identity/api/server/userstore/v1/impl/UserstoresApiServiceImpl.java
+++ b/components/org.wso2.carbon.identity.api.server.userstore/org.wso2.carbon.identity.api.server.userstore.v1/src/main/java/org/wso2/carbon/identity/api/server/userstore/v1/impl/UserstoresApiServiceImpl.java
@@ -1,18 +1,18 @@
 /*
- * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+* Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
 
 package org.wso2.carbon.identity.api.server.userstore.v1.impl;
 
@@ -21,7 +21,7 @@ import org.wso2.carbon.identity.api.server.userstore.v1.UserstoresApiService;
 import org.wso2.carbon.identity.api.server.userstore.v1.core.ServerUserStoreService;
 import org.wso2.carbon.identity.api.server.userstore.v1.model.ClaimAttributeMapping;
 import org.wso2.carbon.identity.api.server.userstore.v1.model.PatchDocument;
-import org.wso2.carbon.identity.api.server.userstore.v1.model.RDBMSConnectionReq;
+import org.wso2.carbon.identity.api.server.userstore.v1.model.UserStoreConnectionReq;
 import org.wso2.carbon.identity.api.server.userstore.v1.model.UserStoreReq;
 import org.wso2.carbon.identity.api.server.userstore.v1.model.UserStoreResponse;
 
@@ -115,9 +115,10 @@ public class UserstoresApiServiceImpl implements UserstoresApiService {
     }
 
     @Override
-    public Response testRDBMSConnection(RDBMSConnectionReq rdBMSConnectionReq) {
+    public Response testUserStoreConnection(UserStoreConnectionReq userStoreConnectionReq) {
 
-        return Response.ok().entity(serverUserStoreService.testRDBMSConnection(rdBMSConnectionReq)).build();
+        // do some magic!
+        return Response.ok().entity(serverUserStoreService.testUserStoreConnection(userStoreConnectionReq)).build();
     }
 
     @Override

--- a/components/org.wso2.carbon.identity.api.server.userstore/org.wso2.carbon.identity.api.server.userstore.v1/src/main/resources/userstore.yaml
+++ b/components/org.wso2.carbon.identity.api.server.userstore/org.wso2.carbon.identity.api.server.userstore.v1/src/main/resources/userstore.yaml
@@ -383,7 +383,7 @@ paths:
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
-            $ref: '#/components/responses/Forbidden'
+          $ref: '#/components/responses/Forbidden'
         '404':
           $ref: '#/components/responses/NotFound'
         '500':
@@ -392,11 +392,11 @@ paths:
     post:
       tags:
         - User Store
-      summary: Test the connection to the datasource used by a JDBC user store manager.
-      operationId: testRDBMSConnection
+      summary: Test the connection to the datasource used by a user store manager.
+      operationId: testUserStoreConnection
       description: >
         This API provides the capability to test the connection to the
-        datasource used by a JDBC user store manager.
+        datasource used by a user store manager.
 
           <b>Permission required:</b>
           */permission/admin
@@ -417,7 +417,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/RDBMSConnectionReq'
+              $ref: '#/components/schemas/UserStoreConnectionReq'
         description: >-
           RDBMS connection properties used to connect to the datasource used by a
           JDBC user store manager.
@@ -634,6 +634,38 @@ components:
           type: string
           description: The password.
           example: root
+    UserStoreConnectionReq:
+      description: User Store Connection Request.
+      properties:
+        typeId:
+          type: string
+          description: The id of the user store manager class type.
+          example: VW5pcXVlSURKREJDVXNlclN0b3JlTWFuYWdlcg
+        domain:
+          type: string
+          description: User store domain name.
+          example: PRIMARY
+        driverName:
+          type: string
+          description: Driver Name.
+          example: com.mysql.jdbc.Driver
+        connectionURL:
+          type: string
+          description: The Connection URL.
+          example: 'jdbc:mysql://192.168.48.154:3306/test'
+        username:
+          type: string
+          description: The username.
+          example: root
+        connectionPassword:
+          type: string
+          description: The password.
+          example: root
+        properties:
+          type: array
+          description: Properties related to the user store.
+          items:
+            $ref: '#/components/schemas/Property'
     ClaimAttributeMapping:
       type: object
       required:

--- a/pom.xml
+++ b/pom.xml
@@ -523,7 +523,7 @@
         <maven.buildnumber.plugin.version>1.4</maven.buildnumber.plugin.version>
         <org.apache.felix.annotations.version>1.2.4</org.apache.felix.annotations.version>
         <identity.governance.version>1.5.25</identity.governance.version>
-        <carbon.identity.framework.version>5.23.26</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.23.45</carbon.identity.framework.version>
         <maven.findbugsplugin.version>3.0.5</maven.findbugsplugin.version>
         <identity.workflow.impl.bps.version>5.2.0</identity.workflow.impl.bps.version>
         <maven.checkstyleplugin.excludes>**/gen/**/*</maven.checkstyleplugin.excludes>


### PR DESCRIPTION
## Purpose
- Update test-connection user store REST API to support LDAP user store types.

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

## Approach
> Updated the yaml to accept a general request object for both JDBC and LDAP user store types. Updated the model keeping the previous variables to maintain backward compatibility.
Now test-connection API accepts a request body as below as well in addition to the previous request body.
```
{
    "typeId": "VW5pcXVlSURSZWFkT25seUxEQVBVc2VyU3RvcmVNYW5hZ2Vy",
    "properties": [
        {
            "name": "ConnectionURL",
            "value": "ldap://localhost:10390"
        },
        {
            "name": "ConnectionName",
            "value": "uid=admin,ou=system"
        },
        {
            "name": "ConnectionPassword",
            "value": "admin"
        }
    ]
}
```

## Related PRs
> Depends on the wso2/carbon-identity-framework#4230
> Fixes wso2/product-is#1528
