### PR TITLE
Validate if OIDC Scopes are configured in both Scopes and Query Params in OpenID Connect Authenticator

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.common/src/main/java/org/wso2/carbon/identity/api/server/idp/common/Constants.java
+++ b/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.common/src/main/java/org/wso2/carbon/identity/api/server/idp/common/Constants.java
@@ -139,6 +139,8 @@ public class Constants {
         ERROR_CODE_DUPLICATE_OIDC_SCOPES("60037", "Duplicate OIDC Scopes.",
                 "Cannot set scopes in both Scopes and Additional Query Parameters." +
                         " Please use Scopes field to set scopes."),
+        ERROR_CODE_INVALID_OIDC_SCOPES("60038", "Invalid OIDC Scopes.",
+                "Scopes must contain 'openid'."),
 
         // Server Error starting from 650xx.
         ERROR_CODE_ERROR_ADDING_IDP("65002",

--- a/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.common/src/main/java/org/wso2/carbon/identity/api/server/idp/common/Constants.java
+++ b/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.common/src/main/java/org/wso2/carbon/identity/api/server/idp/common/Constants.java
@@ -138,7 +138,7 @@ public class Constants {
                 "One or more IDP certificate formats are invalid"),
         ERROR_CODE_DUPLICATE_OIDC_SCOPES("60037", "Duplicate OIDC Scopes.",
                 "Cannot set scopes in both Scopes and Additional Query Parameters." +
-                        " Please use Scopes field to set scopes."),
+                        " Recommend to use Scopes field."),
         ERROR_CODE_INVALID_OIDC_SCOPES("60038", "Invalid OIDC Scopes.",
                 "Scopes must contain 'openid'."),
 

--- a/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.common/src/main/java/org/wso2/carbon/identity/api/server/idp/common/Constants.java
+++ b/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.common/src/main/java/org/wso2/carbon/identity/api/server/idp/common/Constants.java
@@ -36,6 +36,8 @@ public class Constants {
     public static final String SELECT_MODE = "SelectMode";
     public static final String SELECT_MODE_METADATA = "Metadata File Configuration";
     public static final String TEMPLATE_MGT_ERROR_CODE_DELIMITER = "_";
+    public static final String SCOPES_OIDC = "Scopes";
+    public static final Stirng QUERY_PARAMS = "commonAuthQueryParams";
 
     // IdP property keys.
     public static final String PROP_DISPLAY_NAME = "DisplayName";
@@ -134,6 +136,8 @@ public class Constants {
                 "Maximum number of allowed identity providers have been reached."),
         ERROR_CODE_INVALID_CERTIFICATE_FORMAT("60036", "Invalid IDP certificate format.",
                 "One or more IDP certificate formats are invalid"),
+        ERROR_CODE_INVALID_OIDC_SCOPES("60037", "Duplicate OIDC Scopes.",
+                "Cannot set scopes in both Scopes and Additional Query Parameters."),
 
         // Server Error starting from 650xx.
         ERROR_CODE_ERROR_ADDING_IDP("65002",

--- a/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.common/src/main/java/org/wso2/carbon/identity/api/server/idp/common/Constants.java
+++ b/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.common/src/main/java/org/wso2/carbon/identity/api/server/idp/common/Constants.java
@@ -136,7 +136,7 @@ public class Constants {
                 "Maximum number of allowed identity providers have been reached."),
         ERROR_CODE_INVALID_CERTIFICATE_FORMAT("60036", "Invalid IDP certificate format.",
                 "One or more IDP certificate formats are invalid"),
-        ERROR_CODE_INVALID_OIDC_SCOPES("60037", "Duplicate OIDC Scopes.",
+        ERROR_CODE_DUPLICATE_OIDC_SCOPES("60037", "Duplicate OIDC Scopes.",
                 "Cannot set scopes in both Scopes and Additional Query Parameters." +
                         " Please use Scopes field to set scopes."),
 

--- a/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.common/src/main/java/org/wso2/carbon/identity/api/server/idp/common/Constants.java
+++ b/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.common/src/main/java/org/wso2/carbon/identity/api/server/idp/common/Constants.java
@@ -137,7 +137,8 @@ public class Constants {
         ERROR_CODE_INVALID_CERTIFICATE_FORMAT("60036", "Invalid IDP certificate format.",
                 "One or more IDP certificate formats are invalid"),
         ERROR_CODE_INVALID_OIDC_SCOPES("60037", "Duplicate OIDC Scopes.",
-                "Cannot set scopes in both Scopes and Additional Query Parameters."),
+                "Cannot set scopes in both Scopes and Additional Query Parameters." +
+                        " Please use Scopes field to set scopes."),
 
         // Server Error starting from 650xx.
         ERROR_CODE_ERROR_ADDING_IDP("65002",

--- a/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.common/src/main/java/org/wso2/carbon/identity/api/server/idp/common/Constants.java
+++ b/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.common/src/main/java/org/wso2/carbon/identity/api/server/idp/common/Constants.java
@@ -37,7 +37,7 @@ public class Constants {
     public static final String SELECT_MODE_METADATA = "Metadata File Configuration";
     public static final String TEMPLATE_MGT_ERROR_CODE_DELIMITER = "_";
     public static final String SCOPES_OIDC = "Scopes";
-    public static final Stirng QUERY_PARAMS = "commonAuthQueryParams";
+    public static final String QUERY_PARAMS = "commonAuthQueryParams";
 
     // IdP property keys.
     public static final String PROP_DISPLAY_NAME = "DisplayName";

--- a/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.common/src/main/java/org/wso2/carbon/identity/api/server/idp/common/Constants.java
+++ b/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.common/src/main/java/org/wso2/carbon/identity/api/server/idp/common/Constants.java
@@ -36,8 +36,6 @@ public class Constants {
     public static final String SELECT_MODE = "SelectMode";
     public static final String SELECT_MODE_METADATA = "Metadata File Configuration";
     public static final String TEMPLATE_MGT_ERROR_CODE_DELIMITER = "_";
-    public static final String SCOPES_OIDC = "Scopes";
-    public static final String QUERY_PARAMS = "commonAuthQueryParams";
 
     // IdP property keys.
     public static final String PROP_DISPLAY_NAME = "DisplayName";

--- a/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/gen/java/org/wso2/carbon/identity/api/server/idp/v1/IdentityProvidersApi.java
+++ b/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/gen/java/org/wso2/carbon/identity/api/server/idp/v1/IdentityProvidersApi.java
@@ -637,7 +637,6 @@ public class IdentityProvidersApi  {
         @ApiResponse(code = 401, message = "Unauthorized", response = Void.class),
         @ApiResponse(code = 403, message = "Forbidden", response = Void.class),
         @ApiResponse(code = 404, message = "Not Found", response = Error.class),
-        @ApiResponse(code = 409, message = "Conflict", response = Error.class),
         @ApiResponse(code = 500, message = "Server Error", response = Error.class)
     })
     public Response updateFederatedAuthenticator(@ApiParam(value = "ID of the identity provider.",required=true) @PathParam("identity-provider-id") String identityProviderId, @ApiParam(value = "ID of the federated authenticator.",required=true) @PathParam("federated-authenticator-id") String federatedAuthenticatorId, @ApiParam(value = "This represents the federated authenticator to be updated" ,required=true) @Valid FederatedAuthenticatorPUTRequest federatedAuthenticatorPUTRequest) {

--- a/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/gen/java/org/wso2/carbon/identity/api/server/idp/v1/IdentityProvidersApi.java
+++ b/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/gen/java/org/wso2/carbon/identity/api/server/idp/v1/IdentityProvidersApi.java
@@ -637,6 +637,7 @@ public class IdentityProvidersApi  {
         @ApiResponse(code = 401, message = "Unauthorized", response = Void.class),
         @ApiResponse(code = 403, message = "Forbidden", response = Void.class),
         @ApiResponse(code = 404, message = "Not Found", response = Error.class),
+        @ApiResponse(code = 409, message = "Conflict", response = Error.class),
         @ApiResponse(code = 500, message = "Server Error", response = Error.class)
     })
     public Response updateFederatedAuthenticator(@ApiParam(value = "ID of the identity provider.",required=true) @PathParam("identity-provider-id") String identityProviderId, @ApiParam(value = "ID of the federated authenticator.",required=true) @PathParam("federated-authenticator-id") String federatedAuthenticatorId, @ApiParam(value = "This represents the federated authenticator to be updated" ,required=true) @Valid FederatedAuthenticatorPUTRequest federatedAuthenticatorPUTRequest) {

--- a/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/main/java/org/wso2/carbon/identity/api/server/idp/v1/core/ServerIdpManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/main/java/org/wso2/carbon/identity/api/server/idp/v1/core/ServerIdpManagementService.java
@@ -2488,7 +2488,7 @@ public class ServerIdpManagementService {
         if (IdentityApplicationConstants.Authenticator.SAML2SSO.FED_AUTH_NAME.equals(authenticatorName)) {
             validateSamlMetadata(authProperties);
         }
-        if ("OpenIDConnectAuthenticator".equals(authenticatorName)) {
+        if (IdentityApplicationConstants.Authenticator.OIDC.FED_AUTH_NAME.equals(authenticatorName)) {
             validateDuplicateOpenIDConnectScopes(authProperties);
             validateDefaultOpenIDConnectScopes(authProperties);
         }
@@ -2510,12 +2510,12 @@ public class ServerIdpManagementService {
             boolean queryParamsScopesFilled = false;
             for (org.wso2.carbon.identity.api.server.idp.v1
                     .model.Property oidcAuthenticatorProperty : oidcAuthenticatorProperties) {
-                if (Constants.SCOPES_OIDC.equals(oidcAuthenticatorProperty.getKey()) &&
+                if (IdentityApplicationConstants.Authenticator.OIDC.SCOPES.equals(oidcAuthenticatorProperty.getKey()) &&
                         StringUtils.isNotBlank(oidcAuthenticatorProperty.getValue())) {
                     scopesFieldFilled = true;
                 }
-                if (Constants.QUERY_PARAMS.equals(oidcAuthenticatorProperty.getKey()) &&
-                        oidcAuthenticatorProperty.getValue().contains("scope=")) {
+                if (IdentityApplicationConstants.Authenticator.QUERY_PARAMS.equals(oidcAuthenticatorProperty.getKey())
+                        && oidcAuthenticatorProperty.getValue().contains("scope=")) {
                     queryParamsScopesFilled = true;
                 }
             }
@@ -2537,7 +2537,7 @@ public class ServerIdpManagementService {
         if (oidcAuthenticatorProperties != null) {
             for (org.wso2.carbon.identity.api.server.idp.v1
                     .model.Property oidcAuthenticatorProperty : oidcAuthenticatorProperties) {
-                if (Constants.SCOPES_OIDC.equals(oidcAuthenticatorProperty.getKey())) {
+                if (IdentityApplicationConstants.Authenticator.OIDC.SCOPES.equals(oidcAuthenticatorProperty.getKey())) {
                     String scopes = oidcAuthenticatorProperty.getValue();
                     if (StringUtils.isNotBlank(scopes) && !scopes.contains("openid")) {
                         throw handleException(Response.Status.BAD_REQUEST, Constants.ErrorMessage

--- a/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/main/java/org/wso2/carbon/identity/api/server/idp/v1/core/ServerIdpManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/main/java/org/wso2/carbon/identity/api/server/idp/v1/core/ServerIdpManagementService.java
@@ -2519,7 +2519,7 @@ public class ServerIdpManagementService {
             }
             if (scopesFieldFilled && queryParamsScopesFilled) {
                 throw handleException(Response.Status.BAD_REQUEST, Constants.ErrorMessage
-                        .ERROR_CODE_INVALID_OIDC_SCOPES, null);
+                        .ERROR_CODE_DUPLICATE_OIDC_SCOPES, null);
             }
         }
     }

--- a/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/main/java/org/wso2/carbon/identity/api/server/idp/v1/core/ServerIdpManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/main/java/org/wso2/carbon/identity/api/server/idp/v1/core/ServerIdpManagementService.java
@@ -2514,7 +2514,7 @@ public class ServerIdpManagementService {
                         StringUtils.isNotBlank(oidcAuthenticatorProperty.getValue())) {
                     scopesFieldFilled = true;
                 }
-                if (IdentityApplicationConstants.Authenticator.QUERY_PARAMS.equals(oidcAuthenticatorProperty.getKey())
+                if (IdentityApplicationConstants.Authenticator.OIDC.QUERY_PARAMS.equals(oidcAuthenticatorProperty.getKey())
                         && oidcAuthenticatorProperty.getValue().contains("scope=")) {
                     queryParamsScopesFilled = true;
                 }

--- a/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/main/java/org/wso2/carbon/identity/api/server/idp/v1/core/ServerIdpManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/main/java/org/wso2/carbon/identity/api/server/idp/v1/core/ServerIdpManagementService.java
@@ -2518,7 +2518,7 @@ public class ServerIdpManagementService {
                 }
             }
             if (scopesFieldFilled && queryParamsScopesFilled) {
-                throw handleException(Response.Status.CONFLICT, Constants.ErrorMessage
+                throw handleException(Response.Status.BAD_REQUEST, Constants.ErrorMessage
                         .ERROR_CODE_INVALID_OIDC_SCOPES, null);
             }
         }

--- a/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/main/java/org/wso2/carbon/identity/api/server/idp/v1/core/ServerIdpManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/main/java/org/wso2/carbon/identity/api/server/idp/v1/core/ServerIdpManagementService.java
@@ -2514,7 +2514,8 @@ public class ServerIdpManagementService {
                         StringUtils.isNotBlank(oidcAuthenticatorProperty.getValue())) {
                     scopesFieldFilled = true;
                 }
-                if (IdentityApplicationConstants.Authenticator.OIDC.QUERY_PARAMS.equals(oidcAuthenticatorProperty.getKey())
+                if (IdentityApplicationConstants.Authenticator.OIDC.QUERY_PARAMS.equals
+                        (oidcAuthenticatorProperty.getKey())
                         && oidcAuthenticatorProperty.getValue().contains("scope=")) {
                     queryParamsScopesFilled = true;
                 }

--- a/pom.xml
+++ b/pom.xml
@@ -523,7 +523,7 @@
         <maven.buildnumber.plugin.version>1.4</maven.buildnumber.plugin.version>
         <org.apache.felix.annotations.version>1.2.4</org.apache.felix.annotations.version>
         <identity.governance.version>1.5.25</identity.governance.version>
-        <carbon.identity.framework.version>5.23.44</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.25.5</carbon.identity.framework.version>
         <maven.findbugsplugin.version>3.0.5</maven.findbugsplugin.version>
         <identity.workflow.impl.bps.version>5.2.0</identity.workflow.impl.bps.version>
         <maven.checkstyleplugin.excludes>**/gen/**/*</maven.checkstyleplugin.excludes>


### PR DESCRIPTION
## Purpose
For an OIDC external IdP, OIDC scope configuration controls which attributes are requested from the configured external IdP. Since requesting Scopes is an important task for the developer, PR [[1]](https://github.com/wso2-extensions/identity-outbound-auth-oidc/pull/124) and [[2]](https://github.com/wso2/carbon-identity-framework/pull/4237) introduces the Scopes field as a first-class attribute. 

With this improvement, scopes can be configured in both the newly introduced Scopes field as well as previous Additional Query Parameters field. An exception needs to be thrown if scopes have been configured in both places. This PR checks if scopes have been configured in both Scopes field and Additional Query Parameters field and raises HTTP 400 error if so. 

Also, it is mandatory to have the `openid` scope in OIDC scopes. This PR also introduces changes to raise an HTTP 400 error if the Scopes field value does not contain `openid`.


## Related Issues
- Issue https://github.com/wso2/product-is/issues/14845

## Related PRs
- PR https://github.com/wso2-extensions/identity-outbound-auth-oidc/pull/124
- PR https://github.com/wso2/carbon-identity-framework/pull/4237