### PR TITLE
Update Dependencies to IPK versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -529,18 +529,18 @@
         <javax.ws.rs-api.version>2.1.1</javax.ws.rs-api.version>
         <maven.buildnumber.plugin.version>1.4</maven.buildnumber.plugin.version>
         <org.apache.felix.annotations.version>1.2.4</org.apache.felix.annotations.version>
-        <identity.governance.version>1.5.25</identity.governance.version>
-        <carbon.identity.framework.version>5.25.14</carbon.identity.framework.version>
+        <identity.governance.version>2.0.0</identity.governance.version>
+        <carbon.identity.framework.version>6.0.0</carbon.identity.framework.version>
         <maven.findbugsplugin.version>3.0.5</maven.findbugsplugin.version>
         <identity.workflow.impl.bps.version>5.2.0</identity.workflow.impl.bps.version>
         <maven.checkstyleplugin.excludes>**/gen/**/*</maven.checkstyleplugin.excludes>
-        <identity.event.handler.version>1.4.4</identity.event.handler.version>
-        <identity.inbound.oauth2.version>6.8.0</identity.inbound.oauth2.version>
-        <identity.inbound.saml2.version>5.8.44</identity.inbound.saml2.version>
+        <identity.event.handler.version>2.0.0</identity.event.handler.version>
+        <identity.inbound.oauth2.version>7.0.0</identity.inbound.oauth2.version>
+        <identity.inbound.saml2.version>6.0.0</identity.inbound.saml2.version>
         <commons.beanutils.version>1.9.4</commons.beanutils.version>
         <mavan.findbugsplugin.exclude.file>findbugs-exclude-filter.xml</mavan.findbugsplugin.exclude.file>
         <carbon.kernel.version>4.7.1</carbon.kernel.version>
-        <carbon.multitenancy.version>4.9.10</carbon.multitenancy.version>
+        <carbon.multitenancy.version>5.0.0</carbon.multitenancy.version>
         <org.wso2.carbon.identity.remotefetch.version>0.7.12</org.wso2.carbon.identity.remotefetch.version>
         <org.wso2.carbon.event.publisher.version>5.2.15</org.wso2.carbon.event.publisher.version>
         <identity.branding.preference.management.version>1.0.1</identity.branding.preference.management.version>


### PR DESCRIPTION
The identity components are bumped to major versions created for IPK.

Related issue: https://github.com/wso2-enterprise/identity-k8s-access-runtime/issues/16