### PR TITLE
Add PUT API for field to get/update validation configs

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.input.validation/org.wso2.carbon.identity.api.server.input.validation.common/src/main/java/org/wso2/carbon/identity/api/server/input/validation/common/util/ValidationManagementConstants.java
+++ b/components/org.wso2.carbon.identity.api.server.input.validation/org.wso2.carbon.identity.api.server.input.validation.common/src/main/java/org/wso2/carbon/identity/api/server/input/validation/common/util/ValidationManagementConstants.java
@@ -36,6 +36,9 @@ public class ValidationManagementConstants {
         ERROR_CODE_INPUT_VALIDATION_NOT_EXISTS("60001",
                 "Validation configurations are not configured.",
                 "Validation configurations are not configured for organization: %s."),
+        ERROR_CODE_FIELD_NOT_EXISTS("60002",
+                "Field is not found.",
+                "Invalid or unsupported field %s is provided."),
         // Server errors 650xx.
         ERROR_CODE_ERROR_GETTING_VALIDATION_CONFIG("65001",
                 "Error while getting input validation configurations.",

--- a/components/org.wso2.carbon.identity.api.server.input.validation/org.wso2.carbon.identity.api.server.input.validation.v1/src/gen/java/org/wso2/carbon/identity/api/server/input/validation/v1/ValidationRulesApi.java
+++ b/components/org.wso2.carbon.identity.api.server.input.validation/org.wso2.carbon.identity.api.server.input.validation.v1/src/gen/java/org/wso2/carbon/identity/api/server/input/validation/v1/ValidationRulesApi.java
@@ -27,6 +27,7 @@ import java.util.List;
 import org.wso2.carbon.identity.api.server.input.validation.v1.models.Error;
 import java.util.List;
 import org.wso2.carbon.identity.api.server.input.validation.v1.models.ValidationConfigModel;
+import org.wso2.carbon.identity.api.server.input.validation.v1.models.ValidationConfigModelForField;
 import org.wso2.carbon.identity.api.server.input.validation.v1.models.ValidatorModel;
 import org.wso2.carbon.identity.api.server.input.validation.v1.ValidationRulesApiService;
 
@@ -65,6 +66,25 @@ public class ValidationRulesApi  {
 
     @Valid
     @GET
+    @Path("/{field}")
+    
+    @Produces({ "application/json" })
+    @ApiOperation(value = "", notes = "Get validation rules for user inputs", response = ValidationConfigModel.class, tags={ "Get Validation Rules for a field", })
+    @ApiResponses(value = { 
+        @ApiResponse(code = 200, message = "Configurations successfully updated for the field.", response = ValidationConfigModel.class),
+        @ApiResponse(code = 400, message = "Invalid Input Request", response = Error.class),
+        @ApiResponse(code = 401, message = "Unauthorized", response = Void.class),
+        @ApiResponse(code = 403, message = "Resource Forbidden", response = Void.class),
+        @ApiResponse(code = 404, message = "Field not found", response = Void.class),
+        @ApiResponse(code = 500, message = "Internal Server Error", response = Error.class)
+    })
+    public Response getValidationRulesForField(@ApiParam(value = "name of the field",required=true) @PathParam("field") String field) {
+
+        return delegate.getValidationRulesForField(field );
+    }
+
+    @Valid
+    @GET
     @Path("/validators")
     
     @Produces({ "application/json" })
@@ -97,6 +117,25 @@ public class ValidationRulesApi  {
     public Response updateValidationRules(@ApiParam(value = "Represents the password validation criteria." ,required=true) @Valid List<ValidationConfigModel> validationConfigModel) {
 
         return delegate.updateValidationRules(validationConfigModel );
+    }
+
+    @Valid
+    @PUT
+    @Path("/{field}")
+    @Consumes({ "application/json" })
+    @Produces({ "application/json" })
+    @ApiOperation(value = "", notes = "Update validation rules for user inputs for a field", response = ValidationConfigModel.class, tags={ "Update Validation Rules for a field" })
+    @ApiResponses(value = { 
+        @ApiResponse(code = 200, message = "Configurations successfully updated for the field.", response = ValidationConfigModel.class),
+        @ApiResponse(code = 400, message = "Invalid Input Request", response = Error.class),
+        @ApiResponse(code = 401, message = "Unauthorized", response = Void.class),
+        @ApiResponse(code = 403, message = "Resource Forbidden", response = Void.class),
+        @ApiResponse(code = 404, message = "Field not found", response = Void.class),
+        @ApiResponse(code = 500, message = "Internal Server Error", response = Error.class)
+    })
+    public Response updateValidationRulesForField(@ApiParam(value = "name of the field",required=true) @PathParam("field") String field, @ApiParam(value = "Represents the password validation criteria." ,required=true) @Valid ValidationConfigModelForField validationConfigModelForField) {
+
+        return delegate.updateValidationRulesForField(field,  validationConfigModelForField );
     }
 
 }

--- a/components/org.wso2.carbon.identity.api.server.input.validation/org.wso2.carbon.identity.api.server.input.validation.v1/src/gen/java/org/wso2/carbon/identity/api/server/input/validation/v1/ValidationRulesApiService.java
+++ b/components/org.wso2.carbon.identity.api.server.input.validation/org.wso2.carbon.identity.api.server.input.validation.v1/src/gen/java/org/wso2/carbon/identity/api/server/input/validation/v1/ValidationRulesApiService.java
@@ -27,6 +27,7 @@ import java.util.List;
 import org.wso2.carbon.identity.api.server.input.validation.v1.models.Error;
 import java.util.List;
 import org.wso2.carbon.identity.api.server.input.validation.v1.models.ValidationConfigModel;
+import org.wso2.carbon.identity.api.server.input.validation.v1.models.ValidationConfigModelForField;
 import org.wso2.carbon.identity.api.server.input.validation.v1.models.ValidatorModel;
 import javax.ws.rs.core.Response;
 
@@ -39,6 +40,14 @@ public interface ValidationRulesApiService {
        * @return  List of configured validation rules.
        */
       public Response getValidationRules();
+
+      /**
+       * Method to get configured validation rules for a field.
+       *
+       * @param field   Field that validation configurations need to be retrieved.
+       * @return  List of configured validation rules for the field.
+       */
+      public Response getValidationRulesForField(String field);
 
       /**
        * Method to get available validator configurations.
@@ -54,4 +63,14 @@ public interface ValidationRulesApiService {
        * @return  Updated validation rules.
        */
       public Response updateValidationRules(List<ValidationConfigModel> validationConfigModel);
+
+      /**
+       * Method to update validation rules for a field.
+       *
+       * @param field                             Field that validations need to be updated.
+       * @param validationConfigModelForField     List of validation rules to be updated for the field.
+       * @return  Updated validation rules for the field.
+       */
+      public Response updateValidationRulesForField(String field,
+                                                    ValidationConfigModelForField validationConfigModelForField);
 }

--- a/components/org.wso2.carbon.identity.api.server.input.validation/org.wso2.carbon.identity.api.server.input.validation.v1/src/gen/java/org/wso2/carbon/identity/api/server/input/validation/v1/models/ValidationConfigModelForField.java
+++ b/components/org.wso2.carbon.identity.api.server.input.validation/org.wso2.carbon.identity.api.server.input.validation.v1/src/gen/java/org/wso2/carbon/identity/api/server/input/validation/v1/models/ValidationConfigModelForField.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.input.validation.v1.models;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import java.util.ArrayList;
+import java.util.List;
+import org.wso2.carbon.identity.api.server.input.validation.v1.models.RuleModel;
+import javax.validation.constraints.*;
+
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+import javax.validation.Valid;
+import javax.xml.bind.annotation.*;
+
+public class ValidationConfigModelForField  {
+  
+    private List<RuleModel> rules = null;
+
+    private List<RuleModel> regEx = null;
+
+
+    /**
+    **/
+    public ValidationConfigModelForField rules(List<RuleModel> rules) {
+
+        this.rules = rules;
+        return this;
+    }
+    
+    @ApiModelProperty(value = "")
+    @JsonProperty("rules")
+    @Valid
+    public List<RuleModel> getRules() {
+        return rules;
+    }
+    public void setRules(List<RuleModel> rules) {
+        this.rules = rules;
+    }
+
+    public ValidationConfigModelForField addRulesItem(RuleModel rulesItem) {
+        if (this.rules == null) {
+            this.rules = new ArrayList<>();
+        }
+        this.rules.add(rulesItem);
+        return this;
+    }
+
+        /**
+    **/
+    public ValidationConfigModelForField regEx(List<RuleModel> regEx) {
+
+        this.regEx = regEx;
+        return this;
+    }
+    
+    @ApiModelProperty(value = "")
+    @JsonProperty("regEx")
+    @Valid
+    public List<RuleModel> getRegEx() {
+        return regEx;
+    }
+    public void setRegEx(List<RuleModel> regEx) {
+        this.regEx = regEx;
+    }
+
+    public ValidationConfigModelForField addRegExItem(RuleModel regExItem) {
+        if (this.regEx == null) {
+            this.regEx = new ArrayList<>();
+        }
+        this.regEx.add(regExItem);
+        return this;
+    }
+
+    
+
+    @Override
+    public boolean equals(java.lang.Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ValidationConfigModelForField validationConfigModelForField = (ValidationConfigModelForField) o;
+        return Objects.equals(this.rules, validationConfigModelForField.rules) &&
+            Objects.equals(this.regEx, validationConfigModelForField.regEx);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(rules, regEx);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class ValidationConfigModelForField {\n");
+        
+        sb.append("    rules: ").append(toIndentedString(rules)).append("\n");
+        sb.append("    regEx: ").append(toIndentedString(regEx)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+    * Convert the given object to string with each line indented by 4 spaces
+    * (except the first line).
+    */
+    private String toIndentedString(java.lang.Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}
+

--- a/components/org.wso2.carbon.identity.api.server.input.validation/org.wso2.carbon.identity.api.server.input.validation.v1/src/main/java/org/wso2/carbon/identity/api/server/input/validation/v1/core/ValidationRulesManagementApiService.java
+++ b/components/org.wso2.carbon.identity.api.server.input.validation/org.wso2.carbon.identity.api.server.input.validation.v1/src/main/java/org/wso2/carbon/identity/api/server/input/validation/v1/core/ValidationRulesManagementApiService.java
@@ -51,6 +51,7 @@ import static org.wso2.carbon.identity.api.server.input.validation.common.util.U
 import static org.wso2.carbon.identity.api.server.input.validation.common.util.ValidationManagementConstants.ErrorMessage.ERROR_CODE_ERROR_GETTING_VALIDATION_CONFIG;
 import static org.wso2.carbon.identity.api.server.input.validation.common.util.ValidationManagementConstants.ErrorMessage.ERROR_CODE_ERROR_GETTING_VALIDATORS;
 import static org.wso2.carbon.identity.api.server.input.validation.common.util.ValidationManagementConstants.ErrorMessage.ERROR_CODE_ERROR_UPDATING_VALIDATION_CONFIG;
+import static org.wso2.carbon.identity.api.server.input.validation.common.util.ValidationManagementConstants.ErrorMessage.ERROR_CODE_FIELD_NOT_EXISTS;
 import static org.wso2.carbon.identity.api.server.input.validation.common.util.ValidationManagementConstants.ErrorMessage.ERROR_CODE_INPUT_VALIDATION_NOT_EXISTS;
 import static org.wso2.carbon.identity.api.server.input.validation.common.util.ValidationManagementConstants.INPUT_VALIDATION_ERROR_PREFIX;
 import static org.wso2.carbon.identity.api.server.input.validation.common.util.ValidationManagementConstants.INPUT_VALIDATION_MGT_ERROR_CODE_DELIMITER;
@@ -85,6 +86,24 @@ public class ValidationRulesManagementApiService {
     }
 
     /**
+     * Method to get input validation configuration.
+     *
+     * @param tenantDomain  Tenant Domain.
+     * @return ValidationConfigModal.
+     */
+    public ValidationConfigModel getValidationConfigurationForField(String tenantDomain, String field) {
+
+        try {
+            isFieldFound(field);
+            ValidationConfiguration configuration = InputValidationServiceHolder.getInputValidationMgtService()
+                    .getInputValidationConfigurationForField(tenantDomain, field);
+            return buildResponse(configuration);
+        } catch (InputValidationMgtException e) {
+            throw handleInputValidationMgtException(e, ERROR_CODE_ERROR_GETTING_VALIDATION_CONFIG, tenantDomain);
+        }
+    }
+
+    /**
      * Method to update input validation configuration.
      *
      * @param validationConfigModel Validation Configuration Model.
@@ -98,6 +117,33 @@ public class ValidationRulesManagementApiService {
             validateProperties(requestDTO, tenantDomain);
             List<ValidationConfiguration> configurations = InputValidationServiceHolder.getInputValidationMgtService()
                     .updateInputValidationConfiguration(requestDTO, tenantDomain);
+            return buildResponse(configurations);
+        } catch (InputValidationMgtException e) {
+            if (LOGGER.isDebugEnabled()) {
+                LOGGER.debug("Unable to update validation configuration for tenant: " + tenantDomain, e);
+            }
+            throw handleInputValidationMgtException(e, ERROR_CODE_ERROR_UPDATING_VALIDATION_CONFIG, tenantDomain);
+        }
+    }
+
+    /**
+     * Method to update input validation configuration.
+     *
+     * @param validationConfigModel Validation Configuration Model.
+     * @param tenantDomain          Tenant domain name.
+     * @return ValidationConfigModel for the field.
+     */
+    public ValidationConfigModel updateInputValidationConfigurationForField(
+            ValidationConfigModel validationConfigModel, String tenantDomain) {
+
+        try {
+            isFieldFound(validationConfigModel.getField());
+            List<ValidationConfigModel> configModels = new ArrayList<>();
+            configModels.add(validationConfigModel);
+            List<ValidationConfiguration> requestDTO = buildRequestDTOFromValidationRequest(configModels);
+            validateProperties(requestDTO, tenantDomain);
+            ValidationConfiguration configurations = InputValidationServiceHolder.getInputValidationMgtService()
+                    .updateValidationConfiguration(requestDTO.get(0), tenantDomain);
             return buildResponse(configurations);
         } catch (InputValidationMgtException e) {
             if (LOGGER.isDebugEnabled()) {
@@ -218,18 +264,30 @@ public class ValidationRulesManagementApiService {
         List<ValidationConfigModel> response = new ArrayList<>();
 
         for (ValidationConfiguration configuration: configurations) {
-            ValidationConfigModel configModel = new ValidationConfigModel();
-            configModel.setField(configuration.getField());
-
-            if (configuration.getRules() != null) {
-                configModel.setRules(buildRulesModel(configuration.getRules()));
-            }
-            if (configModel.getRegEx() != null) {
-                configModel.setRules(buildRulesModel(configuration.getRegEx()));
-            }
-            response.add(configModel);
+            response.add(buildResponse(configuration));
         }
         return response;
+    }
+
+    /**
+     * Method to build response for single field.
+     *
+     * @param configuration    Configuration of the field.
+     * @return ValidationConfigModal of the field.
+     */
+    private ValidationConfigModel buildResponse(ValidationConfiguration configuration) {
+
+        ValidationConfigModel configModel = new ValidationConfigModel();
+        configModel.setField(configuration.getField());
+
+        if (configuration.getRules() != null) {
+            configModel.setRules(buildRulesModel(configuration.getRules()));
+        }
+        if (configModel.getRegEx() != null) {
+            configModel.setRules(buildRulesModel(configuration.getRegEx()));
+        }
+
+        return configModel;
     }
 
     /**
@@ -370,7 +428,8 @@ public class ValidationRulesManagementApiService {
                 errorResponse.setMessage(exception.getMessage());
                 errorResponse.setDescription(exception.getDescription());
             }
-            if (ERROR_CODE_INPUT_VALIDATION_NOT_EXISTS.getCode().contains(exception.getErrorCode())) {
+            if (ERROR_CODE_INPUT_VALIDATION_NOT_EXISTS.getCode().contains(exception.getErrorCode()) ||
+                    ERROR_CODE_FIELD_NOT_EXISTS.getCode().contains(exception.getErrorCode())) {
                 status = Response.Status.NOT_FOUND;
             } else {
                 status = Response.Status.BAD_REQUEST;
@@ -421,5 +480,21 @@ public class ValidationRulesManagementApiService {
         } else {
             return error.getDescription();
         }
+    }
+
+    /**
+     * Check whether field is supported for validation configurations.
+     *
+     * @param field     Field name.
+     * @return True if given field is supported.
+     * @throws InputValidationMgtClientException if field is not supported or invalid.
+     */
+    private boolean isFieldFound(String field) throws InputValidationMgtClientException {
+
+        if (SUPPORTED_PARAMS.contains(field)) {
+            return true;
+        }
+        throw new InputValidationMgtClientException(ERROR_CODE_FIELD_NOT_EXISTS.getCode(), ERROR_CODE_FIELD_NOT_EXISTS
+                .getMessage(), String.format(ERROR_CODE_FIELD_NOT_EXISTS.getDescription(), field));
     }
 }

--- a/components/org.wso2.carbon.identity.api.server.input.validation/org.wso2.carbon.identity.api.server.input.validation.v1/src/main/java/org/wso2/carbon/identity/api/server/input/validation/v1/core/ValidationRulesManagementApiService.java
+++ b/components/org.wso2.carbon.identity.api.server.input.validation/org.wso2.carbon.identity.api.server.input.validation.v1/src/main/java/org/wso2/carbon/identity/api/server/input/validation/v1/core/ValidationRulesManagementApiService.java
@@ -89,12 +89,12 @@ public class ValidationRulesManagementApiService {
      * Method to get input validation configuration.
      *
      * @param tenantDomain  Tenant Domain.
-     * @return ValidationConfigModal.
+     * @return ValidationConfigModel.
      */
     public ValidationConfigModel getValidationConfigurationForField(String tenantDomain, String field) {
 
         try {
-            isFieldFound(field);
+            isFieldSupported(field);
             ValidationConfiguration configuration = InputValidationServiceHolder.getInputValidationMgtService()
                     .getInputValidationConfigurationForField(tenantDomain, field);
             return buildResponse(configuration);
@@ -119,9 +119,6 @@ public class ValidationRulesManagementApiService {
                     .updateInputValidationConfiguration(requestDTO, tenantDomain);
             return buildResponse(configurations);
         } catch (InputValidationMgtException e) {
-            if (LOGGER.isDebugEnabled()) {
-                LOGGER.debug("Unable to update validation configuration for tenant: " + tenantDomain, e);
-            }
             throw handleInputValidationMgtException(e, ERROR_CODE_ERROR_UPDATING_VALIDATION_CONFIG, tenantDomain);
         }
     }
@@ -137,7 +134,7 @@ public class ValidationRulesManagementApiService {
             ValidationConfigModel validationConfigModel, String tenantDomain) {
 
         try {
-            isFieldFound(validationConfigModel.getField());
+            isFieldSupported(validationConfigModel.getField());
             List<ValidationConfigModel> configModels = new ArrayList<>();
             configModels.add(validationConfigModel);
             List<ValidationConfiguration> requestDTO = buildRequestDTOFromValidationRequest(configModels);
@@ -146,9 +143,6 @@ public class ValidationRulesManagementApiService {
                     .updateValidationConfiguration(requestDTO.get(0), tenantDomain);
             return buildResponse(configurations);
         } catch (InputValidationMgtException e) {
-            if (LOGGER.isDebugEnabled()) {
-                LOGGER.debug("Unable to update validation configuration for tenant: " + tenantDomain, e);
-            }
             throw handleInputValidationMgtException(e, ERROR_CODE_ERROR_UPDATING_VALIDATION_CONFIG, tenantDomain);
         }
     }
@@ -489,7 +483,7 @@ public class ValidationRulesManagementApiService {
      * @return True if given field is supported.
      * @throws InputValidationMgtClientException if field is not supported or invalid.
      */
-    private boolean isFieldFound(String field) throws InputValidationMgtClientException {
+    private boolean isFieldSupported(String field) throws InputValidationMgtClientException {
 
         if (SUPPORTED_PARAMS.contains(field)) {
             return true;

--- a/components/org.wso2.carbon.identity.api.server.input.validation/org.wso2.carbon.identity.api.server.input.validation.v1/src/main/java/org/wso2/carbon/identity/api/server/input/validation/v1/impl/ValidationRulesApiServiceImpl.java
+++ b/components/org.wso2.carbon.identity.api.server.input.validation/org.wso2.carbon.identity.api.server.input.validation.v1/src/main/java/org/wso2/carbon/identity/api/server/input/validation/v1/impl/ValidationRulesApiServiceImpl.java
@@ -20,6 +20,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.wso2.carbon.identity.api.server.input.validation.v1.ValidationRulesApiService;
 import org.wso2.carbon.identity.api.server.input.validation.v1.core.ValidationRulesManagementApiService;
 import org.wso2.carbon.identity.api.server.input.validation.v1.models.ValidationConfigModel;
+import org.wso2.carbon.identity.api.server.input.validation.v1.models.ValidationConfigModelForField;
 
 import static org.wso2.carbon.identity.api.server.common.ContextLoader.getTenantDomainFromContext;
 
@@ -42,6 +43,20 @@ public class ValidationRulesApiServiceImpl implements ValidationRulesApiService 
                 .getValidationConfiguration(tenantDomain)).build();
     }
 
+    /**
+     * Method to get configured validation rules for a field.
+     *
+     * @param field   Field that validation configurations need to be retrieved.
+     * @return  List of configured validation rules for the field.
+     */
+    @Override
+    public Response getValidationRulesForField(String field) {
+
+        String tenantDomain = getTenantDomainFromContext();
+        return Response.ok().entity(validationRulesManagementApiService
+                .getValidationConfigurationForField(tenantDomain, field)).build();
+    }
+
     @Override
     public Response getValidators() {
 
@@ -56,5 +71,25 @@ public class ValidationRulesApiServiceImpl implements ValidationRulesApiService 
         String tenantDomain = getTenantDomainFromContext();
         return Response.ok().entity(validationRulesManagementApiService
                 .updateInputValidationConfiguration(validationConfigModels, tenantDomain)).build();
+    }
+
+    /**
+     * Method to update validation rules for a field.
+     *
+     * @param field                             Field that validations need to be updated.
+     * @param validationConfigModelForField     List of validation rules to be updated for the field.
+     * @return  Updated validation rules for the field.
+     */
+    @Override
+    public Response updateValidationRulesForField(String field, ValidationConfigModelForField
+            validationConfigModelForField) {
+
+        String tenantDomain = getTenantDomainFromContext();
+        ValidationConfigModel validationConfigModel = new ValidationConfigModel();
+        validationConfigModel.setField(field);
+        validationConfigModel.setRules(validationConfigModelForField.getRules());
+        validationConfigModel.setRegEx(validationConfigModelForField.getRegEx());
+        return Response.ok().entity(validationRulesManagementApiService
+                .updateInputValidationConfigurationForField(validationConfigModel, tenantDomain)).build();
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>identity-api-server</artifactId>
     <packaging>pom</packaging>
-    <version>1.2.27-SNAPSHOT</version>
+    <version>1.2.24</version>
     <name>WSO2 Identity Server - Server API Module</name>
     <description>
 
@@ -542,7 +542,7 @@
         <maven.buildnumber.plugin.version>1.4</maven.buildnumber.plugin.version>
         <org.apache.felix.annotations.version>1.2.4</org.apache.felix.annotations.version>
         <identity.governance.version>1.5.25</identity.governance.version>
-        <carbon.identity.framework.version>5.25.101</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.25.104</carbon.identity.framework.version>
         <maven.findbugsplugin.version>3.0.5</maven.findbugsplugin.version>
         <identity.workflow.impl.bps.version>5.2.0</identity.workflow.impl.bps.version>
         <maven.checkstyleplugin.excludes>**/gen/**/*</maven.checkstyleplugin.excludes>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>identity-api-server</artifactId>
     <packaging>pom</packaging>
-    <version>1.2.24</version>
+    <version>1.2.27-SNAPSHOT</version>
     <name>WSO2 Identity Server - Server API Module</name>
     <description>
 


### PR DESCRIPTION
The current API support for PUT and GET for all field at once. With PUT we cannot update validation configs for only one field. Therefore need to have PUT and GET for a single field.

yaml file PR:
- https://github.com/wso2/identity-api-server/pull/421