### PR TITLE
Fix response body building issue.

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.input.validation/org.wso2.carbon.identity.api.server.input.validation.v1/src/main/java/org/wso2/carbon/identity/api/server/input/validation/v1/core/ValidationRulesManagementApiService.java
+++ b/components/org.wso2.carbon.identity.api.server.input.validation/org.wso2.carbon.identity.api.server.input.validation.v1/src/main/java/org/wso2/carbon/identity/api/server/input/validation/v1/core/ValidationRulesManagementApiService.java
@@ -277,8 +277,8 @@ public class ValidationRulesManagementApiService {
         if (configuration.getRules() != null) {
             configModel.setRules(buildRulesModel(configuration.getRules()));
         }
-        if (configModel.getRegEx() != null) {
-            configModel.setRules(buildRulesModel(configuration.getRegEx()));
+        if (configuration.getRegEx() != null) {
+            configModel.setRegEx(buildRulesModel(configuration.getRegEx()));
         }
 
         return configModel;


### PR DESCRIPTION
Fix the following issue:
If the validation of a field is configured as regex validator, the response body of GET and PUT APIs do not have the configured regex values. 