### PR TITLE
[Improvement] Add REST API suppport for configure JWT private key client authentication Connector

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.common/pom.xml
+++ b/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.common/pom.xml
@@ -57,6 +57,11 @@
             <artifactId>spring-web</artifactId>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.extension.identity.oauth.addons</groupId>
+            <artifactId>org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt</artifactId>
+            <scope>compile</scope>
+        </dependency>
     </dependencies>
     
 </project>

--- a/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.common/src/main/java/org/wso2/carbon/identity/api/server/configs/common/Constants.java
+++ b/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.common/src/main/java/org/wso2/carbon/identity/api/server/configs/common/Constants.java
@@ -49,6 +49,11 @@ public class Constants {
     public static final String CORS_CONFIG_MAX_AGE_PATH_REGEX = "^/maxAge$";
 
     /**
+     * PATCH operation path for Private Key JWT Validation configuration.
+     */
+    public static final String PRIVATE_KEY_JWT_VALIDATION_CONFIG_TOKEN_REUSE = "/enableTokenReuse";
+
+    /**
      * Enum for error messages.
      */
     public enum ErrorMessage {
@@ -85,7 +90,22 @@ public class Constants {
                 "Server encountered an error while retrieving the CORS configuration."),
         ERROR_CODE_CORS_CONFIG_UPDATE("65002",
                 "Unable to update CORS configuration.",
-                "Server encountered an error while updating the CORS configuration.");
+                "Server encountered an error while updating the CORS configuration."),
+
+        /**
+         * Private Key JWT Validation errors.
+         */
+        ERROR_CODE_PRIVATE_KEY_JWT_VALIDATOR_CONFIG_RETRIEVE("65006",
+                                                "Unable to retrieve Private Key JWT Validation configuration.",
+                                                "Server encountered an error while retrieving the " +
+                                                        "Private Key JWT Validation configuration."),
+        ERROR_CODE_PRIVATE_KEY_JWT_VALIDATOR_CONFIG_UPDATE("65007",
+                                              "Unable to update Private Key JWT Validation configuration.",
+                                              "Server encountered an error while updating the " +
+                                                      "Private Key JWT Validation configuration."),
+        ERROR_JWT_AUTHENTICATOR_SERVICE_NOT_FOUND("60505",
+                "Private Key JWT Authenticator is not supported.",
+                "Private Key JWT Authenticator service is unavailable at the moment.");
 
         private final String code;
         private final String message;

--- a/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.common/src/main/java/org/wso2/carbon/identity/api/server/configs/common/factory/JWTAuthenticationMgtOGSiServiceFactory.java
+++ b/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.common/src/main/java/org/wso2/carbon/identity/api/server/configs/common/factory/JWTAuthenticationMgtOGSiServiceFactory.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.configs.common.factory;
+
+import org.wso2.carbon.context.PrivilegedCarbonContext;
+import org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.core.JWTClientAuthenticatorMgtService;
+
+/**
+ * Since this factory produces JWTClientAuthenticatorMgtService connector service,  there is a possibility that said
+ * connector not available in the distribution.
+ * So rather than designing as Factory Beans this class designed as Singleton.
+ */
+public class JWTAuthenticationMgtOGSiServiceFactory {
+
+    private static JWTClientAuthenticatorMgtService jwtClientAuthenticatorMgtService = null;
+
+
+    /**
+     * This method return  the instance if the OSGi service exists.
+     * Else throw Null pointer Exception. We handle the exception gracefully.
+     *
+     * @return JWTClientAuthenticatorMgtService
+     */
+    public static JWTClientAuthenticatorMgtService getInstance() {
+
+        if (jwtClientAuthenticatorMgtService == null) {
+            /* Try catch statement is included due to a  NullPointerException which occurs at the server startup and
+            runtime when the JWTClientAuthenticatorMgtService is not available in the product. */
+
+            try {
+                JWTClientAuthenticatorMgtService taskOperationService
+                        = (JWTClientAuthenticatorMgtService) PrivilegedCarbonContext.
+                        getThreadLocalCarbonContext().getOSGiService
+                                (JWTClientAuthenticatorMgtService.class, null);
+                if (taskOperationService != null) {
+                    jwtClientAuthenticatorMgtService = taskOperationService;
+                }
+
+            } catch (NullPointerException e) {
+                /* Catch block without implementation so that the JWTClientAuthenticatorMgtService will be set to null
+                   in-turn helps in validating the rest API requests. */
+            }
+        }
+        return jwtClientAuthenticatorMgtService;
+    }
+}

--- a/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.common/src/main/java/org/wso2/carbon/identity/api/server/configs/common/factory/JWTAuthenticationMgtOGSiServiceFactory.java
+++ b/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.common/src/main/java/org/wso2/carbon/identity/api/server/configs/common/factory/JWTAuthenticationMgtOGSiServiceFactory.java
@@ -18,6 +18,8 @@
 
 package org.wso2.carbon.identity.api.server.configs.common.factory;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.core.JWTClientAuthenticatorMgtService;
 
@@ -29,6 +31,7 @@ import org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.core.JWTClie
 public class JWTAuthenticationMgtOGSiServiceFactory {
 
     private static JWTClientAuthenticatorMgtService jwtClientAuthenticatorMgtService = null;
+    private static final Log log = LogFactory.getLog(JWTAuthenticationMgtOGSiServiceFactory.class);
 
 
     /**
@@ -44,6 +47,10 @@ public class JWTAuthenticationMgtOGSiServiceFactory {
             runtime when the JWTClientAuthenticatorMgtService is not available in the product. */
 
             try {
+                // Call class for name to check the class is available in the run time.
+                // This method will call only once at the first api call.
+                Class.forName("org.wso2.carbon.identity.oauth2.token.handler." +
+                        "clientauth.jwt.core.JWTClientAuthenticatorMgtService");
                 JWTClientAuthenticatorMgtService taskOperationService
                         = (JWTClientAuthenticatorMgtService) PrivilegedCarbonContext.
                         getThreadLocalCarbonContext().getOSGiService
@@ -52,9 +59,13 @@ public class JWTAuthenticationMgtOGSiServiceFactory {
                     jwtClientAuthenticatorMgtService = taskOperationService;
                 }
 
-            } catch (NullPointerException e) {
+            } catch (NullPointerException | ClassNotFoundException  e) {
                 /* Catch block without implementation so that the JWTClientAuthenticatorMgtService will be set to null
                    in-turn helps in validating the rest API requests. */
+                if (log.isDebugEnabled()) {
+                    log.debug("Unable to find the JWTClientAuthenticatorMgtService. " +
+                            "JWTClientAuthenticatorMgtService is not available in the server.");
+                }
             }
         }
         return jwtClientAuthenticatorMgtService;

--- a/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/pom.xml
+++ b/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/pom.xml
@@ -171,6 +171,11 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>org.wso2.carbon.extension.identity.oauth.addons</groupId>
+            <artifactId>org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>commons-beanutils</groupId>
             <artifactId>commons-beanutils</artifactId>
         </dependency>

--- a/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/gen/java/org/wso2/carbon/identity/api/server/configs/v1/ConfigsApi.java
+++ b/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/gen/java/org/wso2/carbon/identity/api/server/configs/v1/ConfigsApi.java
@@ -20,13 +20,14 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.apache.cxf.jaxrs.ext.multipart.Attachment;
 import org.apache.cxf.jaxrs.ext.multipart.Multipart;
 import java.io.InputStream;
-import java.util.List;
 
 import org.wso2.carbon.identity.api.server.configs.v1.model.Authenticator;
 import org.wso2.carbon.identity.api.server.configs.v1.model.AuthenticatorListItem;
 import org.wso2.carbon.identity.api.server.configs.v1.model.CORSConfig;
 import org.wso2.carbon.identity.api.server.configs.v1.model.CORSPatch;
 import org.wso2.carbon.identity.api.server.configs.v1.model.Error;
+import org.wso2.carbon.identity.api.server.configs.v1.model.JWTKeyValidatorPatch;
+import org.wso2.carbon.identity.api.server.configs.v1.model.JWTValidatorConfig;
 import java.util.List;
 import org.wso2.carbon.identity.api.server.configs.v1.model.Patch;
 import org.wso2.carbon.identity.api.server.configs.v1.model.Schema;
@@ -172,6 +173,30 @@ public class ConfigsApi  {
 
     @Valid
     @GET
+    @Path("/jwt-key-validator")
+    
+    @Produces({ "application/json" })
+    @ApiOperation(value = "Retrieve the tenant private key jwt authentication configuration.", notes = "Retrieve the tenant private key jwt authentication configuration.", response = JWTValidatorConfig.class, authorizations = {
+        @Authorization(value = "BasicAuth"),
+        @Authorization(value = "OAuth2", scopes = {
+            
+        })
+    }, tags={ "Private Key JWY validation Authenticators", })
+    @ApiResponses(value = { 
+        @ApiResponse(code = 200, message = "Successful Response", response = JWTValidatorConfig.class),
+        @ApiResponse(code = 400, message = "Bad Request", response = Error.class),
+        @ApiResponse(code = 401, message = "Unauthorized", response = Void.class),
+        @ApiResponse(code = 403, message = "Forbidden", response = Void.class),
+        @ApiResponse(code = 404, message = "Not Found", response = Error.class),
+        @ApiResponse(code = 500, message = "Server Error", response = Error.class)
+    })
+    public Response getPrivatKeyJWTValidationConfiguration() {
+
+        return delegate.getPrivatKeyJWTValidationConfiguration();
+    }
+
+    @Valid
+    @GET
     @Path("/schemas/{schema-id}")
     
     @Produces({ "application/json" })
@@ -289,6 +314,30 @@ public class ConfigsApi  {
     public Response patchConfigs(@ApiParam(value = "" ,required=true) @Valid List<Patch> patch) {
 
         return delegate.patchConfigs(patch );
+    }
+
+    @Valid
+    @PATCH
+    @Path("/jwt-key-validator")
+    @Consumes({ "application/json" })
+    @Produces({ "application/json" })
+    @ApiOperation(value = "Patch the tenant private key jwt authentication configuration.", notes = "Patch the tenant private key jwt authentication configuration.  A JSONPatch as defined by RFC 6902.", response = Void.class, authorizations = {
+        @Authorization(value = "BasicAuth"),
+        @Authorization(value = "OAuth2", scopes = {
+            
+        })
+    }, tags={ "Private Key JWY validation Authenticators", })
+    @ApiResponses(value = { 
+        @ApiResponse(code = 200, message = "Successful Response", response = Void.class),
+        @ApiResponse(code = 400, message = "Bad Request", response = Error.class),
+        @ApiResponse(code = 401, message = "Unauthorized", response = Void.class),
+        @ApiResponse(code = 403, message = "Forbidden", response = Void.class),
+        @ApiResponse(code = 404, message = "Not Found", response = Error.class),
+        @ApiResponse(code = 500, message = "Server Error", response = Error.class)
+    })
+    public Response patchPrivatKeyJWTValidationConfiguration(@ApiParam(value = "" ,required=true) @Valid List<JWTKeyValidatorPatch> jwTKeyValidatorPatch) {
+
+        return delegate.patchPrivatKeyJWTValidationConfiguration(jwTKeyValidatorPatch );
     }
 
     @Valid

--- a/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/gen/java/org/wso2/carbon/identity/api/server/configs/v1/ConfigsApiService.java
+++ b/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/gen/java/org/wso2/carbon/identity/api/server/configs/v1/ConfigsApiService.java
@@ -21,12 +21,13 @@ import org.wso2.carbon.identity.api.server.configs.v1.model.*;
 import org.apache.cxf.jaxrs.ext.multipart.Attachment;
 import org.apache.cxf.jaxrs.ext.multipart.Multipart;
 import java.io.InputStream;
-import java.util.List;
 import org.wso2.carbon.identity.api.server.configs.v1.model.Authenticator;
 import org.wso2.carbon.identity.api.server.configs.v1.model.AuthenticatorListItem;
 import org.wso2.carbon.identity.api.server.configs.v1.model.CORSConfig;
 import org.wso2.carbon.identity.api.server.configs.v1.model.CORSPatch;
 import org.wso2.carbon.identity.api.server.configs.v1.model.Error;
+import org.wso2.carbon.identity.api.server.configs.v1.model.JWTKeyValidatorPatch;
+import org.wso2.carbon.identity.api.server.configs.v1.model.JWTValidatorConfig;
 import java.util.List;
 import org.wso2.carbon.identity.api.server.configs.v1.model.Patch;
 import org.wso2.carbon.identity.api.server.configs.v1.model.Schema;
@@ -48,6 +49,8 @@ public interface ConfigsApiService {
 
       public Response getInboundScimConfigs();
 
+      public Response getPrivatKeyJWTValidationConfiguration();
+
       public Response getSchema(String schemaId);
 
       public Response getSchemas();
@@ -57,6 +60,8 @@ public interface ConfigsApiService {
       public Response patchCORSConfiguration(List<CORSPatch> coRSPatch);
 
       public Response patchConfigs(List<Patch> patch);
+
+      public Response patchPrivatKeyJWTValidationConfiguration(List<JWTKeyValidatorPatch> jwTKeyValidatorPatch);
 
       public Response updateInboundScimConfigs(ScimConfig scimConfig);
 }

--- a/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/gen/java/org/wso2/carbon/identity/api/server/configs/v1/model/JWTKeyValidatorPatch.java
+++ b/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/gen/java/org/wso2/carbon/identity/api/server/configs/v1/model/JWTKeyValidatorPatch.java
@@ -1,18 +1,20 @@
 /*
-* Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-* http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 
 package org.wso2.carbon.identity.api.server.configs.v1.model;
 

--- a/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/gen/java/org/wso2/carbon/identity/api/server/configs/v1/model/JWTKeyValidatorPatch.java
+++ b/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/gen/java/org/wso2/carbon/identity/api/server/configs/v1/model/JWTKeyValidatorPatch.java
@@ -1,0 +1,180 @@
+/*
+* Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package org.wso2.carbon.identity.api.server.configs.v1.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import javax.validation.constraints.*;
+
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+import javax.validation.Valid;
+import javax.xml.bind.annotation.*;
+
+public class JWTKeyValidatorPatch  {
+  
+
+@XmlType(name="OperationEnum")
+@XmlEnum(String.class)
+public enum OperationEnum {
+
+    @XmlEnumValue("ADD") ADD(String.valueOf("ADD")), @XmlEnumValue("REMOVE") REMOVE(String.valueOf("REMOVE")), @XmlEnumValue("REPLACE") REPLACE(String.valueOf("REPLACE"));
+
+
+    private String value;
+
+    OperationEnum(String v) {
+        value = v;
+    }
+
+    public String value() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    public static OperationEnum fromValue(String value) {
+        for (OperationEnum b : OperationEnum.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
+}
+
+    private OperationEnum operation;
+    private String path;
+    private Boolean value;
+
+    /**
+    * The operation to be performed.
+    **/
+    public JWTKeyValidatorPatch operation(OperationEnum operation) {
+
+        this.operation = operation;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "ADD", required = true, value = "The operation to be performed.")
+    @JsonProperty("operation")
+    @Valid
+    @NotNull(message = "Property operation cannot be null.")
+
+    public OperationEnum getOperation() {
+        return operation;
+    }
+    public void setOperation(OperationEnum operation) {
+        this.operation = operation;
+    }
+
+    /**
+    * A JSON-Pointer
+    **/
+    public JWTKeyValidatorPatch path(String path) {
+
+        this.path = path;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "/enableTokenReuse", required = true, value = "A JSON-Pointer")
+    @JsonProperty("path")
+    @Valid
+    @NotNull(message = "Property path cannot be null.")
+
+    public String getPath() {
+        return path;
+    }
+    public void setPath(String path) {
+        this.path = path;
+    }
+
+    /**
+    * The value to be used within the operations.
+    **/
+    public JWTKeyValidatorPatch value(Boolean value) {
+
+        this.value = value;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "false", required = true, value = "The value to be used within the operations.")
+    @JsonProperty("value")
+    @Valid
+    @NotNull(message = "Property value cannot be null.")
+
+    public Boolean getValue() {
+        return value;
+    }
+    public void setValue(Boolean value) {
+        this.value = value;
+    }
+
+
+
+    @Override
+    public boolean equals(java.lang.Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        JWTKeyValidatorPatch jwTKeyValidatorPatch = (JWTKeyValidatorPatch) o;
+        return Objects.equals(this.operation, jwTKeyValidatorPatch.operation) &&
+            Objects.equals(this.path, jwTKeyValidatorPatch.path) &&
+            Objects.equals(this.value, jwTKeyValidatorPatch.value);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(operation, path, value);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class JWTKeyValidatorPatch {\n");
+        
+        sb.append("    operation: ").append(toIndentedString(operation)).append("\n");
+        sb.append("    path: ").append(toIndentedString(path)).append("\n");
+        sb.append("    value: ").append(toIndentedString(value)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+    * Convert the given object to string with each line indented by 4 spaces
+    * (except the first line).
+    */
+    private String toIndentedString(java.lang.Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}
+

--- a/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/gen/java/org/wso2/carbon/identity/api/server/configs/v1/model/JWTValidatorConfig.java
+++ b/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/gen/java/org/wso2/carbon/identity/api/server/configs/v1/model/JWTValidatorConfig.java
@@ -1,0 +1,97 @@
+/*
+* Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package org.wso2.carbon.identity.api.server.configs.v1.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import javax.validation.constraints.*;
+
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+import javax.validation.Valid;
+import javax.xml.bind.annotation.*;
+
+public class JWTValidatorConfig  {
+  
+    private Boolean enableTokenReuse;
+
+    /**
+    * If true, the JTI in the JWT will be unique per the request if the previously used JWT is not already expired. JTI (JWT ID) is a claim that provides a unique identifier for the JWT.
+    **/
+    public JWTValidatorConfig enableTokenReuse(Boolean enableTokenReuse) {
+
+        this.enableTokenReuse = enableTokenReuse;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "true", value = "If true, the JTI in the JWT will be unique per the request if the previously used JWT is not already expired. JTI (JWT ID) is a claim that provides a unique identifier for the JWT.")
+    @JsonProperty("enableTokenReuse")
+    @Valid
+    public Boolean getEnableTokenReuse() {
+        return enableTokenReuse;
+    }
+    public void setEnableTokenReuse(Boolean enableTokenReuse) {
+        this.enableTokenReuse = enableTokenReuse;
+    }
+
+
+
+    @Override
+    public boolean equals(java.lang.Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        JWTValidatorConfig jwTValidatorConfig = (JWTValidatorConfig) o;
+        return Objects.equals(this.enableTokenReuse, jwTValidatorConfig.enableTokenReuse);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(enableTokenReuse);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class JWTValidatorConfig {\n");
+        
+        sb.append("    enableTokenReuse: ").append(toIndentedString(enableTokenReuse)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+    * Convert the given object to string with each line indented by 4 spaces
+    * (except the first line).
+    */
+    private String toIndentedString(java.lang.Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}
+

--- a/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/gen/java/org/wso2/carbon/identity/api/server/configs/v1/model/JWTValidatorConfig.java
+++ b/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/gen/java/org/wso2/carbon/identity/api/server/configs/v1/model/JWTValidatorConfig.java
@@ -1,18 +1,20 @@
 /*
-* Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-* http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 
 package org.wso2.carbon.identity.api.server.configs.v1.model;
 

--- a/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/main/java/org/wso2/carbon/identity/api/server/configs/v1/core/ServerConfigManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/main/java/org/wso2/carbon/identity/api/server/configs/v1/core/ServerConfigManagementService.java
@@ -909,6 +909,11 @@ public class ServerConfigManagementService {
         return message;
     }
 
+    /**
+     * Get the private key JWT validator configuration.
+     *
+     * @return JWTValidatorConfig  JWTValidatorConfig.
+     */
     public JWTValidatorConfig getPrivateKeyJWTValidatorConfiguration() {
 
         String tenantDomain = ContextLoader.getTenantDomainFromContext();
@@ -918,12 +923,12 @@ public class ServerConfigManagementService {
                 return new JWTValidatorConfig()
                         .enableTokenReuse(JWTAuthenticationMgtOGSiServiceFactory.getInstance()
                                 .getPrivateKeyJWTClientAuthenticatorConfiguration(tenantDomain).isEnableTokenReuse());
-            } else {
-                throw new JWTClientAuthenticatorException(ERROR_JWT_AUTHENTICATOR_SERVICE_NOT_FOUND.message(),
-                        ERROR_JWT_AUTHENTICATOR_SERVICE_NOT_FOUND.code());
             }
+            throw new JWTClientAuthenticatorException(ERROR_JWT_AUTHENTICATOR_SERVICE_NOT_FOUND.message(),
+                    ERROR_JWT_AUTHENTICATOR_SERVICE_NOT_FOUND.code());
+
         } catch (Exception e) {
-            if (e.getMessage().equals(ERROR_JWT_AUTHENTICATOR_SERVICE_NOT_FOUND.message())) {
+            if (ERROR_JWT_AUTHENTICATOR_SERVICE_NOT_FOUND.message().equals(e.getMessage())) {
                 throw handleNotFoundError();
             } else {
                 throw JWTConnectorUtil.handlePrivateKeyJWTValidationException(e,
@@ -1001,8 +1006,8 @@ public class ServerConfigManagementService {
                                         tenantDomain);
             }
         } catch (Exception e) {
-                throw JWTConnectorUtil.handlePrivateKeyJWTValidationException(e,
-                        Constants.ErrorMessage.ERROR_CODE_PRIVATE_KEY_JWT_VALIDATOR_CONFIG_UPDATE, null);
+            throw JWTConnectorUtil.handlePrivateKeyJWTValidationException(e,
+                    Constants.ErrorMessage.ERROR_CODE_PRIVATE_KEY_JWT_VALIDATOR_CONFIG_UPDATE, null);
         }
     }
 

--- a/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/main/java/org/wso2/carbon/identity/api/server/configs/v1/exception/JWTClientAuthenticatorClientException.java
+++ b/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/main/java/org/wso2/carbon/identity/api/server/configs/v1/exception/JWTClientAuthenticatorClientException.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.configs.v1.exception;
+
+/**
+ * Client exception class for the JWT Authentication Service.
+ */
+public class JWTClientAuthenticatorClientException extends JWTClientAuthenticatorException {
+
+    /**
+     * The default constructor.
+     */
+    public JWTClientAuthenticatorClientException() {
+
+    }
+
+    /**
+     * Constructor with {@code message} and {@code errorCode} parameters.
+     *
+     * @param message   Message to be included in the exception.
+     * @param errorCode Error code of the exception.
+     */
+    public JWTClientAuthenticatorClientException(String message, String errorCode) {
+
+        super(message, errorCode);
+    }
+
+    /**
+     * Constructor with {@code message}, {@code errorCode} and {@code cause} parameters.
+     *
+     * @param message   Message to be included in the exception.
+     * @param errorCode Error code of the exception.
+     * @param cause     Exception to be wrapped.
+     */
+    public JWTClientAuthenticatorClientException(String message, String errorCode, Throwable cause) {
+
+        super(message, errorCode, cause);
+    }
+
+    /**
+     * Constructor with {@code cause} parameter.
+     *
+     * @param cause Exception to be wrapped.
+     */
+    public JWTClientAuthenticatorClientException(Throwable cause) {
+
+        super(cause);
+    }
+}

--- a/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/main/java/org/wso2/carbon/identity/api/server/configs/v1/exception/JWTClientAuthenticatorException.java
+++ b/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/main/java/org/wso2/carbon/identity/api/server/configs/v1/exception/JWTClientAuthenticatorException.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.configs.v1.exception;
+
+/**
+ * Base exception class for the JWT Authentication Service.
+ */
+public class JWTClientAuthenticatorException extends Exception {
+
+    /**
+     * The error code.
+     */
+    private String errorCode;
+
+    /**
+     * The default constructor.
+     */
+    public JWTClientAuthenticatorException() {
+
+        super();
+    }
+
+    /**
+     * Constructor with {@code message} and {@code errorCode} parameters.
+     *
+     * @param message   Message to be included in the exception.
+     * @param errorCode Error code of the exception.
+     */
+    public JWTClientAuthenticatorException(String message, String errorCode) {
+
+        super(message);
+        this.errorCode = errorCode;
+    }
+
+    /**
+     * Constructor with {@code message}, {@code errorCode} and {@code cause} parameters.
+     *
+     * @param message   Message to be included in the exception.
+     * @param errorCode Error code of the exception.
+     * @param cause     Exception to be wrapped.
+     */
+    public JWTClientAuthenticatorException(String message, String errorCode, Throwable cause) {
+
+        super(message, cause);
+        this.errorCode = errorCode;
+    }
+
+    /**
+     * Constructor with {@code cause} parameter.
+     *
+     * @param cause Exception to be wrapped.
+     */
+    public JWTClientAuthenticatorException(Throwable cause) {
+
+        super(cause);
+    }
+
+    /**
+     * Get the {@code errorCode}.
+     *
+     * @return Returns the {@code errorCode}.
+     */
+    public String getErrorCode() {
+
+        return errorCode;
+    }
+
+    /**
+     * Set the {@code errorCode}.
+     *
+     * @param errorCode The value to be set as the {@code errorCode}.
+     */
+    protected void setErrorCode(String errorCode) {
+
+        this.errorCode = errorCode;
+    }
+}

--- a/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/main/java/org/wso2/carbon/identity/api/server/configs/v1/exception/JWTClientAuthenticatorServerException.java
+++ b/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/main/java/org/wso2/carbon/identity/api/server/configs/v1/exception/JWTClientAuthenticatorServerException.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.configs.v1.exception;
+
+/**
+ * Server exception class for the JWT Authenticator Service.
+ */
+public class JWTClientAuthenticatorServerException extends JWTClientAuthenticatorException {
+
+    /**
+     * The default constructor.
+     */
+    public JWTClientAuthenticatorServerException() {
+
+    }
+
+    /**
+     * Constructor with {@code message} and {@code errorCode} parameters.
+     *
+     * @param message   Message to be included in the exception.
+     * @param errorCode Error code of the exception.
+     */
+    public JWTClientAuthenticatorServerException(String message, String errorCode) {
+
+        super(message, errorCode);
+    }
+
+    /**
+     * Constructor with {@code message}, {@code errorCode} and {@code cause} parameters.
+     *
+     * @param message   Message to be included in the exception.
+     * @param errorCode Error code of the exception.
+     * @param cause     Exception to be wrapped.
+     */
+    public JWTClientAuthenticatorServerException(String message, String errorCode, Throwable cause) {
+
+        super(message, errorCode, cause);
+    }
+
+    /**
+     * Constructor with {@code cause} parameter.
+     *
+     * @param cause Exception to be wrapped.
+     */
+    public JWTClientAuthenticatorServerException(Throwable cause) {
+
+        super(cause);
+    }
+}

--- a/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/main/java/org/wso2/carbon/identity/api/server/configs/v1/function/JWTConnectorUtil.java
+++ b/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/main/java/org/wso2/carbon/identity/api/server/configs/v1/function/JWTConnectorUtil.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.configs.v1.function;
+
+import org.apache.commons.lang.StringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.identity.api.server.common.error.APIError;
+import org.wso2.carbon.identity.api.server.common.error.ErrorResponse;
+import org.wso2.carbon.identity.api.server.configs.common.Constants;
+import org.wso2.carbon.identity.api.server.configs.common.factory.JWTAuthenticationMgtOGSiServiceFactory;
+import org.wso2.carbon.identity.api.server.configs.v1.model.JWTValidatorConfig;
+import org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.core.exception.JWTClientAuthenticatorServiceClientException;
+import org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.core.exception.JWTClientAuthenticatorServiceServerException;
+import org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.core.model.JWTClientAuthenticatorConfig;
+
+import javax.ws.rs.core.Response;
+
+/**
+ * Util class for JWT Connector.
+ * These methods are used to convert JWTValidatorConfig to JWTClientAuthenticatorConfig and vice versa.
+ * These methods are used to handle exceptions.
+ * These objects are from JWTClientAuthenticatorService connector.
+ */
+public class JWTConnectorUtil {
+
+    private static final Log log = LogFactory.getLog(JWTConnectorUtil.class);
+
+
+    /**
+     * Get the JWTValidatorConfig from the JWTClientAuthenticatorConfig for said tenant domain.
+     *
+     * @param tenantDomain Tenant domain.
+     * @return JWTValidatorConfig.
+     * @throws Exception Exception.
+     */
+    public static JWTValidatorConfig getJWTValidatorConfig(String tenantDomain) throws Exception {
+
+
+        return new JWTValidatorConfig().enableTokenReuse(JWTAuthenticationMgtOGSiServiceFactory.getInstance().
+                getPrivateKeyJWTClientAuthenticatorConfiguration(tenantDomain).isEnableTokenReuse());
+    }
+
+    /**
+     * Get the JWTClientAuthenticatorConfig from the JWTValidatorConfig.
+     *
+     * @param jwtValidatorConfig JWTValidatorConfig.
+     * @return  JWTClientAuthenticatorConfig.
+     */
+    public static JWTClientAuthenticatorConfig getJWTDaoConfig(JWTValidatorConfig jwtValidatorConfig) {
+
+        JWTClientAuthenticatorConfig jwtClientAuthenticatorConfig = new JWTClientAuthenticatorConfig();
+        jwtClientAuthenticatorConfig.setEnableTokenReuse(jwtValidatorConfig.getEnableTokenReuse());
+        return jwtClientAuthenticatorConfig;
+    }
+
+    /**
+     * Handle exceptions for JWT Rest API.
+     *
+     * @param e Exception.
+     * @param errorEnum Error Message information.
+     * @param data Context data.
+     * @return APIError.
+     */
+    public static APIError handlePrivateKeyJWTValidationException(Exception e,
+                                                                  Constants.ErrorMessage errorEnum, String data) {
+
+        ErrorResponse errorResponse;
+
+        Response.Status status;
+
+        if (e instanceof JWTClientAuthenticatorServiceClientException) {
+            JWTClientAuthenticatorServiceClientException exception = (JWTClientAuthenticatorServiceClientException) e;
+            errorResponse = getErrorBuilder(errorEnum, data).build(log, exception.getMessage());
+            if (exception.getErrorCode() != null) {
+                String errorCode = exception.getErrorCode();
+                errorCode =
+                        errorCode.contains
+                                (org.wso2.carbon.identity.api.server.common.Constants.ERROR_CODE_DELIMITER) ?
+                                errorCode : Constants.CONFIG_ERROR_PREFIX + errorCode;
+                errorResponse.setCode(errorCode);
+            }
+            errorResponse.setDescription(exception.getMessage());
+            status = Response.Status.BAD_REQUEST;
+        } else if (e instanceof JWTClientAuthenticatorServiceServerException) {
+            JWTClientAuthenticatorServiceServerException exception = (JWTClientAuthenticatorServiceServerException) e;
+            errorResponse = getErrorBuilder(errorEnum, data).build(log, exception, errorEnum.description());
+            if (exception.getErrorCode() != null) {
+                String errorCode = exception.getErrorCode();
+                errorCode =
+                        errorCode.contains
+                                (org.wso2.carbon.identity.api.server.common.Constants.ERROR_CODE_DELIMITER) ?
+                                errorCode : Constants.CONFIG_ERROR_PREFIX + errorCode;
+                errorResponse.setCode(errorCode);
+            }
+            errorResponse.setDescription(exception.getMessage());
+            status = Response.Status.INTERNAL_SERVER_ERROR;
+        } else {
+            errorResponse = getErrorBuilder(errorEnum, data).build(log, e, errorEnum.description());
+            status = Response.Status.INTERNAL_SERVER_ERROR;
+        }
+        return new APIError(status, errorResponse);
+    }
+
+    /**
+     * Return error builder.
+     *
+     * @param errorMsg Error Message information.
+     * @return ErrorResponse.Builder.
+     */
+    private static ErrorResponse.Builder getErrorBuilder(Constants.ErrorMessage errorMsg, String data) {
+
+        return new ErrorResponse.Builder().withCode(errorMsg.code()).withMessage(errorMsg.message())
+                .withDescription(includeData(errorMsg, data));
+    }
+
+    /**
+     * Include context data to error message.
+     *
+     * @param error Constant.ErrorMessage.
+     * @param data  Context data.
+     * @return Formatted error message.
+     */
+    private static String includeData(Constants.ErrorMessage error, String data) {
+
+        String message;
+        if (StringUtils.isNotBlank(data)) {
+            message = String.format(error.description(), data);
+        } else {
+            message = error.description();
+        }
+        return message;
+    }
+}

--- a/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/main/java/org/wso2/carbon/identity/api/server/configs/v1/impl/ConfigsApiServiceImpl.java
+++ b/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/main/java/org/wso2/carbon/identity/api/server/configs/v1/impl/ConfigsApiServiceImpl.java
@@ -1,18 +1,20 @@
 /*
-* Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-* http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 
 package org.wso2.carbon.identity.api.server.configs.v1.impl;
 
@@ -20,6 +22,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.wso2.carbon.identity.api.server.configs.v1.ConfigsApiService;
 import org.wso2.carbon.identity.api.server.configs.v1.core.ServerConfigManagementService;
 import org.wso2.carbon.identity.api.server.configs.v1.model.CORSPatch;
+import org.wso2.carbon.identity.api.server.configs.v1.model.JWTKeyValidatorPatch;
 import org.wso2.carbon.identity.api.server.configs.v1.model.Patch;
 import org.wso2.carbon.identity.api.server.configs.v1.model.ScimConfig;
 
@@ -34,6 +37,7 @@ public class ConfigsApiServiceImpl implements ConfigsApiService {
 
     @Autowired
     private ServerConfigManagementService configManagementService;
+
 
     @Override
     public Response getAuthenticator(String authenticatorId) {
@@ -68,6 +72,21 @@ public class ConfigsApiServiceImpl implements ConfigsApiService {
     public Response getSchema(String schemaId) {
 
         return Response.ok().entity(configManagementService.getSchema(schemaId)).build();
+    }
+
+    @Override
+    public Response getPrivatKeyJWTValidationConfiguration() {
+
+        // do some magic!
+        return Response.ok().entity(configManagementService.getPrivateKeyJWTValidatorConfiguration()).build();
+
+    }
+
+    @Override
+    public Response patchPrivatKeyJWTValidationConfiguration(List<JWTKeyValidatorPatch> jwTKeyValidatorPatch) {
+
+        configManagementService.patchPrivateKeyJWTValidatorSConfig(jwTKeyValidatorPatch);
+        return Response.ok().build();
     }
 
     @Override

--- a/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/main/java/org/wso2/carbon/identity/api/server/configs/v1/impl/ConfigsApiServiceImpl.java
+++ b/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/main/java/org/wso2/carbon/identity/api/server/configs/v1/impl/ConfigsApiServiceImpl.java
@@ -77,7 +77,6 @@ public class ConfigsApiServiceImpl implements ConfigsApiService {
     @Override
     public Response getPrivatKeyJWTValidationConfiguration() {
 
-        // do some magic!
         return Response.ok().entity(configManagementService.getPrivateKeyJWTValidatorConfiguration()).build();
 
     }

--- a/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/main/resources/configs.yaml
+++ b/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/main/resources/configs.yaml
@@ -326,6 +326,79 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
+  /configs/jwt-key-validator:
+    get:
+      tags:
+        - Private Key JWY validation Authenticators
+      summary: Retrieve the tenant private key jwt authentication configuration.
+      operationId: getPrivatKeyJWTValidationConfiguration
+      description: Retrieve the tenant private key jwt authentication configuration.
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/JWTValidatorConfig'
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '500':
+          description: Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+    patch:
+      tags:
+        - Private Key JWY validation Authenticators
+      summary: Patch the tenant private key jwt authentication configuration.
+      operationId: patchPrivatKeyJWTValidationConfiguration
+      description: Patch the tenant private key jwt authentication configuration.  A JSONPatch as defined by RFC 6902.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/JWTKeyValidatorPatchRequest'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '500':
+          description: Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
   /configs/home-realm-identifiers:
     get:
       tags:
@@ -708,6 +781,13 @@ components:
           type: number
           description: Indicates how long the results of a preflight request can be cached by the web client, in seconds. If -1 then unspecified.
           example: 3600
+    JWTValidatorConfig:
+      type: object
+      properties:
+        enableTokenReuse:
+          type: boolean
+          description: If true, the JTI in the JWT will be unique per the request if the previously used JWT is not already expired. JTI (JWT ID) is a claim that provides a unique identifier for the JWT.
+          example: true
     CORSPatchRequest:
       type: array
       items:
@@ -735,6 +815,33 @@ components:
           type: string
           description: The value to be used within the operations.
           example: '30'
+    JWTKeyValidatorPatchRequest:
+      type: array
+      items:
+        $ref: '#/components/schemas/JWTKeyValidatorPatch'
+    JWTKeyValidatorPatch:
+      type: object
+      required:
+        - operation
+        - path
+        - value
+      properties:
+        operation:
+          type: string
+          description: The operation to be performed.
+          enum:
+            - ADD
+            - REMOVE
+            - REPLACE
+          example: ADD
+        path:
+          type: string
+          description: A JSON-Pointer
+          example: '/enableTokenReuse'
+        value:
+          type: boolean
+          description: The value to be used within the operations.
+          example: false
     HomeRealmIdentifiers:
       type: array
       description: The list of home realm identifiers.

--- a/pom.xml
+++ b/pom.xml
@@ -566,7 +566,7 @@
         <carbon.kernel.version>4.9.0</carbon.kernel.version>
         <carbon.multitenancy.version>4.9.10</carbon.multitenancy.version>
         <org.wso2.carbon.identity.remotefetch.version>0.7.12</org.wso2.carbon.identity.remotefetch.version>
-        <org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.version>2.4.20</org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.version>
+        <org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.version>2.4.21</org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.version>
         <org.wso2.carbon.event.publisher.version>5.2.15</org.wso2.carbon.event.publisher.version>
         <identity.branding.preference.management.version>1.0.4</identity.branding.preference.management.version>
         <!--<maven.checkstyleplugin.excludes>**/gen/**/*</maven.checkstyleplugin.excludes>-->

--- a/pom.xml
+++ b/pom.xml
@@ -389,6 +389,12 @@
                 <scope>provided</scope>
             </dependency>
             <dependency>
+                <groupId>org.wso2.carbon.extension.identity.oauth.addons</groupId>
+                <artifactId>org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt</artifactId>
+                <version>${org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.version}</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
                 <groupId>org.wso2.carbon.identity.fetch.remote</groupId>
                 <artifactId>org.wso2.carbon.identity.remotefetch.core</artifactId>
                 <version>${org.wso2.carbon.identity.remotefetch.version}</version>
@@ -560,6 +566,7 @@
         <carbon.kernel.version>4.9.0</carbon.kernel.version>
         <carbon.multitenancy.version>4.9.10</carbon.multitenancy.version>
         <org.wso2.carbon.identity.remotefetch.version>0.7.12</org.wso2.carbon.identity.remotefetch.version>
+        <org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.version>2.4.20-SNAPSHOT</org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.version>
         <org.wso2.carbon.event.publisher.version>5.2.15</org.wso2.carbon.event.publisher.version>
         <identity.branding.preference.management.version>1.0.4</identity.branding.preference.management.version>
         <!--<maven.checkstyleplugin.excludes>**/gen/**/*</maven.checkstyleplugin.excludes>-->

--- a/pom.xml
+++ b/pom.xml
@@ -566,7 +566,7 @@
         <carbon.kernel.version>4.9.0</carbon.kernel.version>
         <carbon.multitenancy.version>4.9.10</carbon.multitenancy.version>
         <org.wso2.carbon.identity.remotefetch.version>0.7.12</org.wso2.carbon.identity.remotefetch.version>
-        <org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.version>2.4.20-SNAPSHOT</org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.version>
+        <org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.version>2.4.20</org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.version>
         <org.wso2.carbon.event.publisher.version>5.2.15</org.wso2.carbon.event.publisher.version>
         <identity.branding.preference.management.version>1.0.4</identity.branding.preference.management.version>
         <!--<maven.checkstyleplugin.excludes>**/gen/**/*</maven.checkstyleplugin.excludes>-->


### PR DESCRIPTION
## Purpose
$sub

**GET**:  api/server/v1/configs/jwt-key-validator - Retrieve the tenant private key jwt authentication configuration.
**PATCH**:  api/server/v1/configs/jwt-key-validator - Patch the tenant private key jwt authentication configuration.

Prerequisites:

- [x] Merge Backend Support https://github.com/wso2-extensions/identity-oauth-addons/pull/100 
- [x] Bump pom.xml version