### PR TITLE
Logs the server errors at the notification senders API.

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.notification.sender/org.wso2.carbon.identity.api.server.notification.sender.v1/src/main/java/org/wso2/carbon/identity/api/server/notification/sender/v1/core/NotificationSenderManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.notification.sender/org.wso2.carbon.identity.api.server.notification.sender.v1/src/main/java/org/wso2/carbon/identity/api/server/notification/sender/v1/core/NotificationSenderManagementService.java
@@ -326,7 +326,7 @@ public class NotificationSenderManagementService {
                 .withCode(errorCode)
                 .withMessage(e.getMessage())
                 .withDescription(e.getDescription())
-                .build(log, e.getMessage());
+                .build(log, e, e.getMessage());
 
         Response.Status status = Response.Status.INTERNAL_SERVER_ERROR;
         return new APIError(status, errorResponse);


### PR DESCRIPTION
## Purpose
> Notification senders API wasn't logging the server errors from the down stream, this change is to log the server errors occurred in notification API.
