### PR TITLE
Add tenant name to get the configured authenticators

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/ServerApplicationManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/ServerApplicationManagementService.java
@@ -367,10 +367,11 @@ public class ServerApplicationManagementService {
      */
     public ArrayList<ConfiguredAuthenticatorsModal> getConfiguredAuthenticators(String applicationId) {
 
+        String tenantDomain = ContextLoader.getTenantDomainFromContext();
         ArrayList<ConfiguredAuthenticatorsModal> response = new ArrayList<>();
         try {
             AuthenticationStep[] authenticationSteps = getApplicationManagementService()
-                    .getConfiguredAuthenticators(applicationId);
+                    .getConfiguredAuthenticators(applicationId, tenantDomain);
 
             if (authenticationSteps == null) {
                 throw buildClientError(ErrorMessage.APPLICATION_NOT_FOUND, applicationId);

--- a/pom.xml
+++ b/pom.xml
@@ -554,7 +554,7 @@
         <maven.buildnumber.plugin.version>1.4</maven.buildnumber.plugin.version>
         <org.apache.felix.annotations.version>1.2.4</org.apache.felix.annotations.version>
         <identity.governance.version>1.8.23</identity.governance.version>
-        <carbon.identity.framework.version>5.25.105</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.25.130</carbon.identity.framework.version>
         <maven.findbugsplugin.version>3.0.5</maven.findbugsplugin.version>
         <identity.workflow.impl.bps.version>5.2.0</identity.workflow.impl.bps.version>
         <maven.checkstyleplugin.excludes>**/gen/**/*</maven.checkstyleplugin.excludes>


### PR DESCRIPTION
## Purpose
> Support caching when retrieving configured authenticators for an application

**Related PR**
https://github.com/wso2/carbon-identity-framework/pull/4470