### PR TITLE
Add a Method to Check if the Provided File Type contains a Valid Media Type

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/ServerApplicationManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/ServerApplicationManagementService.java
@@ -606,17 +606,27 @@ public class ServerApplicationManagementService {
                     spFileContent.getFileName(), tenantDomain));
         }
 
-        if (Arrays.asList(VALID_MEDIA_TYPES_XML).contains(fileType)) {
+        if (containsValidMediaType(fileType, VALID_MEDIA_TYPES_XML)) {
             return parseServiceProviderFromXml(spFileContent, tenantDomain);
-        } else if (Arrays.asList(VALID_MEDIA_TYPES_YAML).contains(fileType)) {
+        } else if (containsValidMediaType(fileType, VALID_MEDIA_TYPES_YAML)) {
             return parseServiceProviderFromYaml(spFileContent, tenantDomain);
-        } else if (Arrays.asList(VALID_MEDIA_TYPES_JSON).contains(fileType)) {
+        } else if (containsValidMediaType(fileType, VALID_MEDIA_TYPES_JSON)) {
             return parseServiceProviderFromJson(spFileContent, tenantDomain);
         } else {
             log.warn("Unsupported file type " + fileType + " for file " + spFileContent.getFileName() + " . " +
                     "Defaulting to XML parsing");
             return parseServiceProviderFromXml(spFileContent, tenantDomain);
         }
+    }
+
+    private boolean containsValidMediaType(String fileType, String[] mediaTypes) {
+
+        for (String mediaType : mediaTypes) {
+            if (fileType.contains(mediaType)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private ServiceProvider parseServiceProviderFromXml(SpFileContent spFileContent, String tenantDomain)


### PR DESCRIPTION
With the current implementation, if the file-type extracted from the Content-type header is not an exact match to one of the valid media types, the behaviour will default to xml file type. Since additional parameters such as charset can be appended to the file type at the Content-type header, the logic should be changed to check if the file-type should contain one of the valid media types instead of direct comparison.

This PR adds a new method to check if the file type received through the Content-type header contains one of the provided valid media types and uses it to check the file type before parsing the SP.