### PR TITLE
Fixing InboundConfiguration property export structure

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/pom.xml
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/pom.xml
@@ -153,6 +153,11 @@
             <artifactId>cxf-rt-rs-extension-search</artifactId>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.dataformat</groupId>
+            <artifactId>jackson-dataformat-xml</artifactId>
+            <version>2.13.2</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/pom.xml
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/pom.xml
@@ -153,11 +153,6 @@
             <artifactId>cxf-rt-rs-extension-search</artifactId>
             <scope>provided</scope>
         </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.dataformat</groupId>
-            <artifactId>jackson-dataformat-xml</artifactId>
-            <version>2.13.2</version>
-        </dependency>
     </dependencies>
 
     <build>

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/CustomRepresenter.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/CustomRepresenter.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.application.management.v1.core;
+
+import org.yaml.snakeyaml.introspector.Property;
+import org.yaml.snakeyaml.representer.Representer;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * The CustomRepresenter class for YAML serialization.
+ */
+public class CustomRepresenter extends Representer {
+    @Override
+    protected Set<Property> getProperties(Class<? extends Object> type) {
+        Set<Property> properties = super.getProperties(type);
+
+        // Remove the property inboundConfiguration.
+        properties = properties.stream()
+                .filter(property -> !property.getName().equals("inboundConfiguration"))
+                .collect(Collectors.toSet());
+        return properties;
+    }
+}

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/CustomRepresenter.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/CustomRepresenter.java
@@ -30,7 +30,8 @@ import java.util.stream.Collectors;
  */
 public class CustomRepresenter extends Representer {
 
-    private static final String[] PROPERTIES_TO_REMOVE = {"inboundConfiguration"};
+    private static final String[] PROPERTIES_TO_REMOVE = {"inboundConfiguration", "applicationID", "owner",
+            "tenantDomain", "id", "idpProperties", "resourceId", "spProperties", "applicationResourceId"};
 
     @Override
     protected Set<Property> getProperties(Class<?> type) {

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/CustomRepresenter.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/CustomRepresenter.java
@@ -21,6 +21,7 @@ package org.wso2.carbon.identity.api.server.application.management.v1.core;
 import org.yaml.snakeyaml.introspector.Property;
 import org.yaml.snakeyaml.representer.Representer;
 
+import java.util.Arrays;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -28,14 +29,19 @@ import java.util.stream.Collectors;
  * The CustomRepresenter class for YAML serialization.
  */
 public class CustomRepresenter extends Representer {
+
+    private static final String[] PROPERTIES_TO_REMOVE = {"inboundConfiguration"};
+
     @Override
-    protected Set<Property> getProperties(Class<? extends Object> type) {
+    protected Set<Property> getProperties(Class<?> type) {
+
         Set<Property> properties = super.getProperties(type);
 
-        // Remove the property inboundConfiguration.
+        // Remove the specified properties.
         properties = properties.stream()
-                .filter(property -> !property.getName().equals("inboundConfiguration"))
+                .filter(property -> !Arrays.asList(PROPERTIES_TO_REMOVE).contains(property.getName()))
                 .collect(Collectors.toSet());
+
         return properties;
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -560,13 +560,13 @@
         <maven.buildnumber.plugin.version>1.4</maven.buildnumber.plugin.version>
         <org.apache.felix.annotations.version>1.2.4</org.apache.felix.annotations.version>
         <identity.governance.version>1.8.23</identity.governance.version>
-        <carbon.identity.framework.version>5.25.138</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.25.157</carbon.identity.framework.version>
         <maven.findbugsplugin.version>3.0.5</maven.findbugsplugin.version>
         <identity.workflow.impl.bps.version>5.2.0</identity.workflow.impl.bps.version>
         <maven.checkstyleplugin.excludes>**/gen/**/*</maven.checkstyleplugin.excludes>
         <identity.event.handler.version>1.4.4</identity.event.handler.version>
-        <identity.inbound.oauth2.version>6.8.0</identity.inbound.oauth2.version>
-        <identity.inbound.saml2.version>5.8.44</identity.inbound.saml2.version>
+        <identity.inbound.oauth2.version>6.11.51</identity.inbound.oauth2.version>
+        <identity.inbound.saml2.version>5.11.9</identity.inbound.saml2.version>
         <commons.beanutils.version>1.9.4</commons.beanutils.version>
         <mavan.findbugsplugin.exclude.file>findbugs-exclude-filter.xml</mavan.findbugsplugin.exclude.file>
         <carbon.kernel.version>4.9.0</carbon.kernel.version>


### PR DESCRIPTION
## Purpose
Related to https://github.com/wso2/product-is/issues/15683

This PR resolves the issue of inboundConfiguration property being exported as an XML string instead of being broken down into properties when exporting service providers through the API.

## Goals
When exporting service providers through the API, the "inboundConfiguration" property is exported broken down into individual properties.

## Approach
inboundConfigurationProtocol abstract class property is added and inboundConfiguration is ignored during serialization. samlssoServiceProviderDTO, oAuthAppDO classes are updated to extend the new inboundConfigurationProtocol class.

## Related PRs
https://github.com/wso2/carbon-identity-framework/pull/4505
https://github.com/wso2-extensions/identity-inbound-auth-saml/pull/391
https://github.com/wso2-extensions/identity-inbound-auth-oauth/pull/2047

**Need to bump framework version after merging the following PR:**
https://github.com/wso2/carbon-identity-framework/pull/4505
https://github.com/wso2-extensions/identity-inbound-auth-saml/pull/391
https://github.com/wso2-extensions/identity-inbound-auth-oauth/pull/2047