### PR TITLE
Check the consent url is empty before validating the external consent page url

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/functions/application/UpdateAdvancedConfigurations.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/functions/application/UpdateAdvancedConfigurations.java
@@ -89,7 +89,9 @@ public class UpdateAdvancedConfigurations implements UpdateFunction<ServiceProvi
 
         ExternalizedConsentPageConfig externalConsentManagementConfig = getExternalizedConsentPageConfig(config);
         if (externalizedConsentPageApiModel != null) {
-            validateConsentPageUrl(externalizedConsentPageApiModel.getConsentPageUrl());
+            if (!externalizedConsentPageApiModel.getConsentPageUrl().isEmpty()) {
+                validateConsentPageUrl(externalizedConsentPageApiModel.getConsentPageUrl());
+            }
             setIfNotNull(externalizedConsentPageApiModel.getEnabled(), externalConsentManagementConfig::setEnabled);
             setIfNotNull(externalizedConsentPageApiModel.getConsentPageUrl(),
                     externalConsentManagementConfig::setConsentPageUrl);


### PR DESCRIPTION
## Purpose
-  $subject

## Changes from the PR
- Currently is shows a wrong error message when the external consent page url is empty.
- Check the external consent page url value is empty or not before validating the url  (From the validating method we are checking that the configured url is a valid url )
