### PR TITLE
Add Jwt issuers API implementation

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/gen/java/org/wso2/carbon/identity/api/server/idp/v1/model/JWTIssuerPOSTRequest.java
+++ b/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/gen/java/org/wso2/carbon/identity/api/server/idp/v1/model/JWTIssuerPOSTRequest.java
@@ -1,0 +1,231 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.com).
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.idp.v1.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import org.wso2.carbon.identity.api.server.idp.v1.model.Certificate;
+import javax.validation.constraints.*;
+
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+import javax.validation.Valid;
+import javax.xml.bind.annotation.*;
+
+public class JWTIssuerPOSTRequest  {
+  
+    private String name;
+    private String description;
+    private String image;
+    private String templateId;
+    private Certificate certificate;
+    private String alias;
+    private String idpIssuerName;
+
+    /**
+    **/
+    public JWTIssuerPOSTRequest name(String name) {
+
+        this.name = name;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "google", required = true, value = "")
+    @JsonProperty("name")
+    @Valid
+    @NotNull(message = "Property name cannot be null.")
+
+    public String getName() {
+        return name;
+    }
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    /**
+    **/
+    public JWTIssuerPOSTRequest description(String description) {
+
+        this.description = description;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "JWT Issuer", value = "")
+    @JsonProperty("description")
+    @Valid
+    public String getDescription() {
+        return description;
+    }
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    /**
+    **/
+    public JWTIssuerPOSTRequest image(String image) {
+
+        this.image = image;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "issuer-logo-url", value = "")
+    @JsonProperty("image")
+    @Valid
+    public String getImage() {
+        return image;
+    }
+    public void setImage(String image) {
+        this.image = image;
+    }
+
+    /**
+    **/
+    public JWTIssuerPOSTRequest templateId(String templateId) {
+
+        this.templateId = templateId;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "8ea23303-49c0-4253-b81f-82c0fe6fb4a0", value = "")
+    @JsonProperty("templateId")
+    @Valid
+    public String getTemplateId() {
+        return templateId;
+    }
+    public void setTemplateId(String templateId) {
+        this.templateId = templateId;
+    }
+
+    /**
+    **/
+    public JWTIssuerPOSTRequest certificate(Certificate certificate) {
+
+        this.certificate = certificate;
+        return this;
+    }
+    
+    @ApiModelProperty(required = true, value = "")
+    @JsonProperty("certificate")
+    @Valid
+    @NotNull(message = "Property certificate cannot be null.")
+
+    public Certificate getCertificate() {
+        return certificate;
+    }
+    public void setCertificate(Certificate certificate) {
+        this.certificate = certificate;
+    }
+
+    /**
+    **/
+    public JWTIssuerPOSTRequest alias(String alias) {
+
+        this.alias = alias;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "https://localhost:9444/oauth2/token", value = "")
+    @JsonProperty("alias")
+    @Valid
+    public String getAlias() {
+        return alias;
+    }
+    public void setAlias(String alias) {
+        this.alias = alias;
+    }
+
+    /**
+    **/
+    public JWTIssuerPOSTRequest idpIssuerName(String idpIssuerName) {
+
+        this.idpIssuerName = idpIssuerName;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "https://www.issuer.com", required = true, value = "")
+    @JsonProperty("idpIssuerName")
+    @Valid
+    @NotNull(message = "Property idpIssuerName cannot be null.")
+
+    public String getIdpIssuerName() {
+        return idpIssuerName;
+    }
+    public void setIdpIssuerName(String idpIssuerName) {
+        this.idpIssuerName = idpIssuerName;
+    }
+
+
+
+    @Override
+    public boolean equals(java.lang.Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        JWTIssuerPOSTRequest jwTIssuerPOSTRequest = (JWTIssuerPOSTRequest) o;
+        return Objects.equals(this.name, jwTIssuerPOSTRequest.name) &&
+            Objects.equals(this.description, jwTIssuerPOSTRequest.description) &&
+            Objects.equals(this.image, jwTIssuerPOSTRequest.image) &&
+            Objects.equals(this.templateId, jwTIssuerPOSTRequest.templateId) &&
+            Objects.equals(this.certificate, jwTIssuerPOSTRequest.certificate) &&
+            Objects.equals(this.alias, jwTIssuerPOSTRequest.alias) &&
+            Objects.equals(this.idpIssuerName, jwTIssuerPOSTRequest.idpIssuerName);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, description, image, templateId, certificate, alias, idpIssuerName);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class JWTIssuerPOSTRequest {\n");
+        
+        sb.append("    name: ").append(toIndentedString(name)).append("\n");
+        sb.append("    description: ").append(toIndentedString(description)).append("\n");
+        sb.append("    image: ").append(toIndentedString(image)).append("\n");
+        sb.append("    templateId: ").append(toIndentedString(templateId)).append("\n");
+        sb.append("    certificate: ").append(toIndentedString(certificate)).append("\n");
+        sb.append("    alias: ").append(toIndentedString(alias)).append("\n");
+        sb.append("    idpIssuerName: ").append(toIndentedString(idpIssuerName)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+    * Convert the given object to string with each line indented by 4 spaces
+    * (except the first line).
+    */
+    private String toIndentedString(java.lang.Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}
+

--- a/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/gen/java/org/wso2/carbon/identity/api/server/idp/v1/model/JwtIssuersApi.java
+++ b/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/gen/java/org/wso2/carbon/identity/api/server/idp/v1/model/JwtIssuersApi.java
@@ -1,0 +1,4 @@
+package org.wso2.carbon.identity.api.server.idp.v1.model;
+
+public class JwtIssuersApi {
+}

--- a/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/main/java/org/wso2/carbon/identity/api/server/idp/v1/core/ServerIdpManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/main/java/org/wso2/carbon/identity/api/server/idp/v1/core/ServerIdpManagementService.java
@@ -201,6 +201,34 @@ public class ServerIdpManagementService {
     }
 
     /**
+     * Get list of identity providers.
+     *
+     * @param requiredAttributes Required attributes in the IDP list response.
+     * @param limit      Items per page.
+     * @param offset     Offset.
+     * @param filter     Filter string. E.g. filter="name" sw "google" and "isEnabled" eq "true"
+     * @param sortBy     Attribute to sort the IDPs by. E.g. name
+     * @param sortOrder  Order in which IDPs should be sorted. Can be either ASC or DESC.
+     * @return IdentityProviderListResponse.
+     */
+    public IdentityProviderListResponse getJwtIssuers(String requiredAttributes, Integer limit, Integer offset,
+                                                      String filter, String sortBy, String sortOrder) {
+
+        try {
+            List<String> requestedAttributeList = null;
+            if (StringUtils.isNotBlank(requiredAttributes)) {
+                requestedAttributeList = new ArrayList<>(Arrays.asList(requiredAttributes.split(",")));
+            }
+            return createIDPListResponse(
+                    IdentityProviderServiceHolder.getIdentityProviderManager().getJWTIssuers(limit, offset, filter,
+                            sortBy, sortOrder, ContextLoader.getTenantDomainFromContext(), requestedAttributeList),
+                    requestedAttributeList);
+        } catch (IdentityProviderManagementException e) {
+            throw handleIdPException(e, Constants.ErrorMessage.ERROR_CODE_ERROR_LISTING_IDPS, null);
+        }
+    }
+
+    /**
      * Add an identity provider.
      *
      * @param identityProviderPOSTRequest identityProviderPOSTRequest.

--- a/components/org.wso2.carbon.identity.api.server.jwt.issuers/org.wso2.carbon.identity.api.server.jwt.issuers.common/pom.xml
+++ b/components/org.wso2.carbon.identity.api.server.jwt.issuers/org.wso2.carbon.identity.api.server.jwt.issuers.common/pom.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2023, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+  ~
+  ~ WSO2 Inc. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>org.wso2.carbon.identity.api.server.jwt.issuers</artifactId>
+        <groupId>org.wso2.carbon.identity.server.api</groupId>
+        <relativePath>../pom.xml</relativePath>
+        <version>1.2.54</version>
+    </parent>
+
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>org.wso2.carbon.identity.api.server.jwt.issuers.common</artifactId>
+    <packaging>jar</packaging>
+
+    <properties>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+    <dependencies>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.idp.mgt</artifactId>
+            <version>5.25.186</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-beans</artifactId>
+            <version>5.3.25</version>
+            <scope>compile</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/components/org.wso2.carbon.identity.api.server.jwt.issuers/org.wso2.carbon.identity.api.server.jwt.issuers.common/src/main/java/org/wso2/carbon/identity/api/server/jwt/issuers/common/Constants.java
+++ b/components/org.wso2.carbon.identity.api.server.jwt.issuers/org.wso2.carbon.identity.api.server.jwt.issuers.common/src/main/java/org/wso2/carbon/identity/api/server/jwt/issuers/common/Constants.java
@@ -1,0 +1,7 @@
+package org.wso2.carbon.identity.api.server.jwt.issuers.common;
+
+/**
+ * Constants for JWT Issuers API.
+ */
+public class Constants {
+}

--- a/components/org.wso2.carbon.identity.api.server.jwt.issuers/org.wso2.carbon.identity.api.server.jwt.issuers.common/src/main/java/org/wso2/carbon/identity/api/server/jwt/issuers/common/JWTIssuerServiceHolder.java
+++ b/components/org.wso2.carbon.identity.api.server.jwt.issuers/org.wso2.carbon.identity.api.server.jwt.issuers.common/src/main/java/org/wso2/carbon/identity/api/server/jwt/issuers/common/JWTIssuerServiceHolder.java
@@ -1,0 +1,31 @@
+package org.wso2.carbon.identity.api.server.jwt.issuers.common;
+
+import org.wso2.carbon.idp.mgt.IdentityProviderManager;
+
+/**
+ * Service holder class for JWT Issuer.
+ */
+public class JWTIssuerServiceHolder {
+
+    private static IdentityProviderManager identityProviderManager;
+
+    /**
+     * Get IdentityProviderManager osgi service.
+     *
+     * @return IdentityProviderManager
+     */
+    public static IdentityProviderManager getIdentityProviderManager() {
+
+        return identityProviderManager;
+    }
+
+    /**
+     * Set IdentityProviderManager osgi service.
+     *
+     * @param identityProviderManager IdentityProviderManager.
+     */
+    public static void setIdentityProviderManager(IdentityProviderManager identityProviderManager) {
+
+        JWTIssuerServiceHolder.identityProviderManager = identityProviderManager;
+    }
+}

--- a/components/org.wso2.carbon.identity.api.server.jwt.issuers/org.wso2.carbon.identity.api.server.jwt.issuers.common/src/main/java/org/wso2/carbon/identity/api/server/jwt/issuers/common/factory/IdPMgtOSGIServiceFactory.java
+++ b/components/org.wso2.carbon.identity.api.server.jwt.issuers/org.wso2.carbon.identity.api.server.jwt.issuers.common/src/main/java/org/wso2/carbon/identity/api/server/jwt/issuers/common/factory/IdPMgtOSGIServiceFactory.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *                                                                         
+ * Licensed under the Apache License, Version 2.0 (the "License");         
+ * you may not use this file except in compliance with the License.        
+ * You may obtain a copy of the License at                                 
+ *                                                                         
+ * http://www.apache.org/licenses/LICENSE-2.0                              
+ *                                                                         
+ * Unless required by applicable law or agreed to in writing, software     
+ * distributed under the License is distributed on an "AS IS" BASIS,       
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and     
+ * limitations under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.jwt.issuers.common.factory;
+
+import org.springframework.beans.factory.config.AbstractFactoryBean;
+import org.wso2.carbon.context.PrivilegedCarbonContext;
+import org.wso2.carbon.idp.mgt.IdpManager;
+
+/**
+ * Factory Beans serves as a factory for creating other beans within the IOC container. This factory bean is used to
+ * instantiate the IdentityProviderManager type of object inside the container.
+ */
+public class IdPMgtOSGIServiceFactory extends AbstractFactoryBean<IdpManager> {
+
+    private IdpManager identityProviderManager;
+
+    @Override
+    public Class<?> getObjectType() {
+
+        return Object.class;
+    }
+
+    @Override
+    protected IdpManager createInstance() throws Exception {
+
+        if (this.identityProviderManager == null) {
+            IdpManager taskOperationService = (IdpManager) PrivilegedCarbonContext.
+                    getThreadLocalCarbonContext().getOSGiService(IdpManager.class, null);
+            if (taskOperationService != null) {
+                this.identityProviderManager = taskOperationService;
+            } else {
+                throw new Exception("Unable to retrieve identityProviderManager service.");
+            }
+        }
+        return this.identityProviderManager;
+    }
+}

--- a/components/org.wso2.carbon.identity.api.server.jwt.issuers/org.wso2.carbon.identity.api.server.jwt.issuers.v1/pom.xml
+++ b/components/org.wso2.carbon.identity.api.server.jwt.issuers/org.wso2.carbon.identity.api.server.jwt.issuers.v1/pom.xml
@@ -1,0 +1,126 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2023, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+  ~
+  ~ WSO2 Inc. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <parent>
+        <groupId>org.wso2.carbon.identity.server.api</groupId>
+        <artifactId>org.wso2.carbon.identity.api.server.jwt.issuers</artifactId>
+        <relativePath>../pom.xml</relativePath>
+        <version>1.2.54</version>
+    </parent>
+
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>org.wso2.carbon.identity.api.server.jwt.issuers.v1</artifactId>
+    <packaging>jar</packaging>
+
+    <build>
+        <plugins>
+<!--            <plugin>-->
+<!--            <groupId>org.openapitools</groupId>-->
+<!--            <artifactId>openapi-generator-maven-plugin</artifactId>-->
+<!--            <version>4.1.2</version>-->
+<!--            <executions>-->
+<!--            <execution>-->
+<!--            <goals>-->
+<!--            <goal>generate</goal>-->
+<!--            </goals>-->
+<!--            <configuration>-->
+<!--            <inputSpec>${project.basedir}/src/main/resources/jwt-issuers.yaml</inputSpec>-->
+<!--            <generatorName>org.wso2.carbon.codegen.CxfWso2Generator</generatorName>-->
+<!--            <configOptions>-->
+<!--            <sourceFolder>src/gen/java</sourceFolder>-->
+<!--            <apiPackage>org.wso2.carbon.identity.api.server.jwt.issuers.v1</apiPackage>-->
+<!--            <modelPackage>org.wso2.carbon.identity.api.server.jwt.issuers.v1.model</modelPackage>-->
+<!--            <packageName>org.wso2.carbon.identity.api.server.jwt.issuers.v1</packageName>-->
+<!--            <dateLibrary>java8</dateLibrary>-->
+<!--            <hideGenerationTimestamp>true</hideGenerationTimestamp>-->
+<!--            <ignoreFileOverride>${project.basedir}/.openapi-generator-ignore</ignoreFileOverride>-->
+<!--            </configOptions>-->
+<!--            <output>.</output>-->
+<!--            <skipOverwrite>true</skipOverwrite>-->
+<!--            </configuration>-->
+<!--            </execution>-->
+<!--            </executions>-->
+<!--            <dependencies>-->
+<!--            <dependency>-->
+<!--            <groupId>org.openapitools</groupId>-->
+<!--            <artifactId>cxf-wso2-openapi-generator</artifactId>-->
+<!--            <version>1.0.0</version>-->
+<!--            </dependency>-->
+<!--            </dependencies>-->
+<!--            </plugin>-->
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <version>1.8</version>
+                <executions>
+                    <execution>
+                        <id>add-source</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>add-source</goal>
+                        </goals>
+                        <configuration>
+                            <sources>
+                                <source>src/gen/java</source>
+                            </sources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.10.1</version>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.server.api</groupId>
+            <artifactId>org.wso2.carbon.identity.api.server.idp.v1</artifactId>
+            <version>1.2.54</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.server.api</groupId>
+            <artifactId>org.wso2.carbon.identity.api.server.jwt.issuers.common</artifactId>
+            <version>1.2.54</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.server.api</groupId>
+            <artifactId>org.wso2.carbon.identity.api.server.common</artifactId>
+            <version>1.2.54</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.cxf</groupId>
+            <artifactId>cxf-rt-frontend-jaxrs</artifactId>
+            <version>3.5.0</version>
+            <scope>compile</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/components/org.wso2.carbon.identity.api.server.jwt.issuers/org.wso2.carbon.identity.api.server.jwt.issuers.v1/src/gen/java/org/wso2/carbon/identity/api/server/jwt/issuers/v1/JwtIssuersApi.java
+++ b/components/org.wso2.carbon.identity.api.server.jwt.issuers/org.wso2.carbon.identity.api.server.jwt.issuers.v1/src/gen/java/org/wso2/carbon/identity/api/server/jwt/issuers/v1/JwtIssuersApi.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.com).
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.jwt.issuers.v1;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.apache.cxf.jaxrs.ext.multipart.Attachment;
+import org.apache.cxf.jaxrs.ext.multipart.Multipart;
+import java.io.InputStream;
+import java.util.List;
+
+import org.wso2.carbon.identity.api.server.jwt.issuers.v1.model.Error;
+import org.wso2.carbon.identity.api.server.jwt.issuers.v1.model.IdentityProviderListResponse;
+import org.wso2.carbon.identity.api.server.jwt.issuers.v1.model.IdentityProviderResponse;
+import org.wso2.carbon.identity.api.server.jwt.issuers.v1.model.JWTIssuerPOSTRequest;
+import org.wso2.carbon.identity.api.server.jwt.issuers.v1.JwtIssuersApiService;
+
+import javax.validation.Valid;
+import javax.ws.rs.*;
+import javax.ws.rs.core.Response;
+import io.swagger.annotations.*;
+
+import javax.validation.constraints.*;
+
+@Path("/jwt-issuers")
+@Api(description = "The jwt-issuers API")
+
+public class JwtIssuersApi  {
+
+    @Autowired
+    private JwtIssuersApiService delegate;
+
+    @Valid
+    @POST
+    
+    @Consumes({ "application/json", "application/xml" })
+    @Produces({ "application/json", "application/xml" })
+    @ApiOperation(value = "Add a new jwt issuer ", notes = "This API provides the capability to create a jwt issuer. <br> <b>Permission required:</b> <br>     * /permission/admin/manage/identity/idpmgt/create <br> <b>Scope required:</b> <br>     * internal_idp_create ", response = IdentityProviderResponse.class, authorizations = {
+        @Authorization(value = "BasicAuth"),
+        @Authorization(value = "OAuth2", scopes = {
+            
+        })
+    }, tags={ "JWT Issuers", })
+    @ApiResponses(value = { 
+        @ApiResponse(code = 201, message = "Successful response", response = IdentityProviderResponse.class),
+        @ApiResponse(code = 400, message = "Bad Request", response = Error.class),
+        @ApiResponse(code = 401, message = "Unauthorized", response = Void.class),
+        @ApiResponse(code = 403, message = "Forbidden", response = Void.class),
+        @ApiResponse(code = 409, message = "Conflict", response = Error.class),
+        @ApiResponse(code = 500, message = "Server Error", response = Error.class)
+    })
+    public Response addJWTIssuer(@ApiParam(value = "This represents the JWT issuer to be created." ,required=true) @Valid JWTIssuerPOSTRequest jwTIssuerPOSTRequest) {
+
+        return delegate.addJWTIssuer(jwTIssuerPOSTRequest );
+    }
+
+    @Valid
+    @GET
+    
+    
+    @Produces({ "application/json" })
+    @ApiOperation(value = "List JWT issuers ", notes = "This API provides the capability to retrieve the list of jwt issuers.<br> <b>Permission required:</b> <br>     * /permission/admin/manage/identity/idpmgt/view <br> <b>Scope required:</b> <br>     * internal_idp_view ", response = IdentityProviderListResponse.class, authorizations = {
+        @Authorization(value = "BasicAuth"),
+        @Authorization(value = "OAuth2", scopes = {
+            
+        })
+    }, tags={ "JWT Issuers" })
+    @ApiResponses(value = { 
+        @ApiResponse(code = 200, message = "Successful Response", response = IdentityProviderListResponse.class),
+        @ApiResponse(code = 400, message = "Bad Request", response = Error.class),
+        @ApiResponse(code = 401, message = "Unauthorized", response = Void.class),
+        @ApiResponse(code = 403, message = "Forbidden", response = Void.class),
+        @ApiResponse(code = 404, message = "Not Found", response = Error.class),
+        @ApiResponse(code = 500, message = "Server Error", response = Error.class),
+        @ApiResponse(code = 501, message = "Not Implemented", response = Error.class)
+    })
+    public Response getJwtIssuers(    @Valid@ApiParam(value = "Maximum number of records to return. ")  @QueryParam("limit") Integer limit,     @Valid@ApiParam(value = "Number of records to skip for pagination. ")  @QueryParam("offset") Integer offset,     @Valid@ApiParam(value = "Condition to filter the retrieval of records. Supports 'sw', 'co', 'ew' and 'eq' operations and also complex queries with 'and' operations. E.g. /identity-providers?filter=name+sw+\"google\"+and+isEnabled+eq+\"true\" ")  @QueryParam("filter") String filter,     @Valid@ApiParam(value = "Attribute by which the retrieved records should be sorted. Currently sorting through _<b>domainName<b>_ only supported.")  @QueryParam("sortBy") String sortBy,     @Valid@ApiParam(value = "Define the order in which the retrieved tenants should be sorted.", allowableValues="asc, desc")  @QueryParam("sortOrder") String sortOrder,     @Valid@ApiParam(value = "Specifies the required parameters in the response. ")  @QueryParam("requiredAttributes") String requiredAttributes) {
+
+        return delegate.getJwtIssuers(limit,  offset,  filter,  sortBy,  sortOrder,  requiredAttributes );
+    }
+
+}

--- a/components/org.wso2.carbon.identity.api.server.jwt.issuers/org.wso2.carbon.identity.api.server.jwt.issuers.v1/src/gen/java/org/wso2/carbon/identity/api/server/jwt/issuers/v1/JwtIssuersApiService.java
+++ b/components/org.wso2.carbon.identity.api.server.jwt.issuers/org.wso2.carbon.identity.api.server.jwt.issuers.v1/src/gen/java/org/wso2/carbon/identity/api/server/jwt/issuers/v1/JwtIssuersApiService.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.com).
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.jwt.issuers.v1;
+
+import org.wso2.carbon.identity.api.server.jwt.issuers.v1.*;
+import org.wso2.carbon.identity.api.server.jwt.issuers.v1.model.*;
+import org.apache.cxf.jaxrs.ext.multipart.Attachment;
+import org.apache.cxf.jaxrs.ext.multipart.Multipart;
+import java.io.InputStream;
+import java.util.List;
+import org.wso2.carbon.identity.api.server.jwt.issuers.v1.model.Error;
+import org.wso2.carbon.identity.api.server.jwt.issuers.v1.model.IdentityProviderListResponse;
+import org.wso2.carbon.identity.api.server.jwt.issuers.v1.model.IdentityProviderResponse;
+import org.wso2.carbon.identity.api.server.jwt.issuers.v1.model.JWTIssuerPOSTRequest;
+import javax.ws.rs.core.Response;
+
+
+public interface JwtIssuersApiService {
+
+      public Response addJWTIssuer(JWTIssuerPOSTRequest jwTIssuerPOSTRequest);
+
+      public Response getJwtIssuers(Integer limit, Integer offset, String filter, String sortBy, String sortOrder, String requiredAttributes);
+}

--- a/components/org.wso2.carbon.identity.api.server.jwt.issuers/org.wso2.carbon.identity.api.server.jwt.issuers.v1/src/gen/java/org/wso2/carbon/identity/api/server/jwt/issuers/v1/factories/JwtIssuersApiServiceFactory.java
+++ b/components/org.wso2.carbon.identity.api.server.jwt.issuers/org.wso2.carbon.identity.api.server.jwt.issuers.v1/src/gen/java/org/wso2/carbon/identity/api/server/jwt/issuers/v1/factories/JwtIssuersApiServiceFactory.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.com).
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.jwt.issuers.v1.factories;
+
+import org.wso2.carbon.identity.api.server.jwt.issuers.v1.JwtIssuersApiService;
+import org.wso2.carbon.identity.api.server.jwt.issuers.v1.impl.JwtIssuersApiServiceImpl;
+
+public class JwtIssuersApiServiceFactory {
+
+   private final static JwtIssuersApiService service = new JwtIssuersApiServiceImpl();
+
+   public static JwtIssuersApiService getJwtIssuersApi()
+   {
+      return service;
+   }
+}

--- a/components/org.wso2.carbon.identity.api.server.jwt.issuers/org.wso2.carbon.identity.api.server.jwt.issuers.v1/src/gen/java/org/wso2/carbon/identity/api/server/jwt/issuers/v1/model/Certificate.java
+++ b/components/org.wso2.carbon.identity.api.server.jwt.issuers/org.wso2.carbon.identity.api.server.jwt.issuers.v1/src/gen/java/org/wso2/carbon/identity/api/server/jwt/issuers/v1/model/Certificate.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.com).
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.jwt.issuers.v1.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import java.util.ArrayList;
+import java.util.List;
+import javax.validation.constraints.*;
+
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+import javax.validation.Valid;
+import javax.xml.bind.annotation.*;
+
+public class Certificate  {
+  
+    private List<String> certificates = null;
+
+    private String jwksUri;
+
+    /**
+    **/
+    public Certificate certificates(List<String> certificates) {
+
+        this.certificates = certificates;
+        return this;
+    }
+    
+    @ApiModelProperty(value = "")
+    @JsonProperty("certificates")
+    @Valid
+    public List<String> getCertificates() {
+        return certificates;
+    }
+    public void setCertificates(List<String> certificates) {
+        this.certificates = certificates;
+    }
+
+    public Certificate addCertificatesItem(String certificatesItem) {
+        if (this.certificates == null) {
+            this.certificates = new ArrayList<>();
+        }
+        this.certificates.add(certificatesItem);
+        return this;
+    }
+
+        /**
+    **/
+    public Certificate jwksUri(String jwksUri) {
+
+        this.jwksUri = jwksUri;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "https://localhost:9444/oauth2/jwks", value = "")
+    @JsonProperty("jwksUri")
+    @Valid
+    public String getJwksUri() {
+        return jwksUri;
+    }
+    public void setJwksUri(String jwksUri) {
+        this.jwksUri = jwksUri;
+    }
+
+
+
+    @Override
+    public boolean equals(java.lang.Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Certificate certificate = (Certificate) o;
+        return Objects.equals(this.certificates, certificate.certificates) &&
+            Objects.equals(this.jwksUri, certificate.jwksUri);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(certificates, jwksUri);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class Certificate {\n");
+        
+        sb.append("    certificates: ").append(toIndentedString(certificates)).append("\n");
+        sb.append("    jwksUri: ").append(toIndentedString(jwksUri)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+    * Convert the given object to string with each line indented by 4 spaces
+    * (except the first line).
+    */
+    private String toIndentedString(java.lang.Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}
+

--- a/components/org.wso2.carbon.identity.api.server.jwt.issuers/org.wso2.carbon.identity.api.server.jwt.issuers.v1/src/gen/java/org/wso2/carbon/identity/api/server/jwt/issuers/v1/model/Claim.java
+++ b/components/org.wso2.carbon.identity.api.server.jwt.issuers/org.wso2.carbon.identity.api.server.jwt.issuers.v1/src/gen/java/org/wso2/carbon/identity/api/server/jwt/issuers/v1/model/Claim.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.com).
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.jwt.issuers.v1.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import javax.validation.constraints.*;
+
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+import javax.validation.Valid;
+import javax.xml.bind.annotation.*;
+
+public class Claim  {
+  
+    private String id;
+    private String uri;
+    private String displayName;
+
+    /**
+    **/
+    public Claim id(String id) {
+
+        this.id = id;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "aHR0cDovL3dzbzIub3JnL2NsYWltcy91c2VybmFtZQ", value = "")
+    @JsonProperty("id")
+    @Valid
+    public String getId() {
+        return id;
+    }
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    /**
+    **/
+    public Claim uri(String uri) {
+
+        this.uri = uri;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "http://wso2.org/claims/username", required = true, value = "")
+    @JsonProperty("uri")
+    @Valid
+    @NotNull(message = "Property uri cannot be null.")
+
+    public String getUri() {
+        return uri;
+    }
+    public void setUri(String uri) {
+        this.uri = uri;
+    }
+
+    /**
+    **/
+    public Claim displayName(String displayName) {
+
+        this.displayName = displayName;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "Username", value = "")
+    @JsonProperty("displayName")
+    @Valid
+    public String getDisplayName() {
+        return displayName;
+    }
+    public void setDisplayName(String displayName) {
+        this.displayName = displayName;
+    }
+
+
+
+    @Override
+    public boolean equals(java.lang.Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Claim claim = (Claim) o;
+        return Objects.equals(this.id, claim.id) &&
+            Objects.equals(this.uri, claim.uri) &&
+            Objects.equals(this.displayName, claim.displayName);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, uri, displayName);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class Claim {\n");
+        
+        sb.append("    id: ").append(toIndentedString(id)).append("\n");
+        sb.append("    uri: ").append(toIndentedString(uri)).append("\n");
+        sb.append("    displayName: ").append(toIndentedString(displayName)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+    * Convert the given object to string with each line indented by 4 spaces
+    * (except the first line).
+    */
+    private String toIndentedString(java.lang.Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}
+

--- a/components/org.wso2.carbon.identity.api.server.jwt.issuers/org.wso2.carbon.identity.api.server.jwt.issuers.v1/src/gen/java/org/wso2/carbon/identity/api/server/jwt/issuers/v1/model/ClaimMapping.java
+++ b/components/org.wso2.carbon.identity.api.server.jwt.issuers/org.wso2.carbon.identity.api.server.jwt.issuers.v1/src/gen/java/org/wso2/carbon/identity/api/server/jwt/issuers/v1/model/ClaimMapping.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.com).
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.jwt.issuers.v1.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import org.wso2.carbon.identity.api.server.jwt.issuers.v1.model.Claim;
+import javax.validation.constraints.*;
+
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+import javax.validation.Valid;
+import javax.xml.bind.annotation.*;
+
+public class ClaimMapping  {
+  
+    private String idpClaim;
+    private Claim localClaim;
+
+    /**
+    **/
+    public ClaimMapping idpClaim(String idpClaim) {
+
+        this.idpClaim = idpClaim;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "country", value = "")
+    @JsonProperty("idpClaim")
+    @Valid
+    public String getIdpClaim() {
+        return idpClaim;
+    }
+    public void setIdpClaim(String idpClaim) {
+        this.idpClaim = idpClaim;
+    }
+
+    /**
+    **/
+    public ClaimMapping localClaim(Claim localClaim) {
+
+        this.localClaim = localClaim;
+        return this;
+    }
+    
+    @ApiModelProperty(value = "")
+    @JsonProperty("localClaim")
+    @Valid
+    public Claim getLocalClaim() {
+        return localClaim;
+    }
+    public void setLocalClaim(Claim localClaim) {
+        this.localClaim = localClaim;
+    }
+
+
+
+    @Override
+    public boolean equals(java.lang.Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ClaimMapping claimMapping = (ClaimMapping) o;
+        return Objects.equals(this.idpClaim, claimMapping.idpClaim) &&
+            Objects.equals(this.localClaim, claimMapping.localClaim);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(idpClaim, localClaim);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class ClaimMapping {\n");
+        
+        sb.append("    idpClaim: ").append(toIndentedString(idpClaim)).append("\n");
+        sb.append("    localClaim: ").append(toIndentedString(localClaim)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+    * Convert the given object to string with each line indented by 4 spaces
+    * (except the first line).
+    */
+    private String toIndentedString(java.lang.Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}
+

--- a/components/org.wso2.carbon.identity.api.server.jwt.issuers/org.wso2.carbon.identity.api.server.jwt.issuers.v1/src/gen/java/org/wso2/carbon/identity/api/server/jwt/issuers/v1/model/Claims.java
+++ b/components/org.wso2.carbon.identity.api.server.jwt.issuers/org.wso2.carbon.identity.api.server.jwt.issuers.v1/src/gen/java/org/wso2/carbon/identity/api/server/jwt/issuers/v1/model/Claims.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.com).
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.jwt.issuers.v1.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import java.util.ArrayList;
+import java.util.List;
+import org.wso2.carbon.identity.api.server.jwt.issuers.v1.model.Claim;
+import org.wso2.carbon.identity.api.server.jwt.issuers.v1.model.ClaimMapping;
+import org.wso2.carbon.identity.api.server.jwt.issuers.v1.model.ProvisioningClaim;
+import javax.validation.constraints.*;
+
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+import javax.validation.Valid;
+import javax.xml.bind.annotation.*;
+
+public class Claims  {
+  
+    private Claim userIdClaim;
+    private Claim roleClaim;
+    private List<ClaimMapping> mappings = null;
+
+    private List<ProvisioningClaim> provisioningClaims = null;
+
+
+    /**
+    **/
+    public Claims userIdClaim(Claim userIdClaim) {
+
+        this.userIdClaim = userIdClaim;
+        return this;
+    }
+    
+    @ApiModelProperty(value = "")
+    @JsonProperty("userIdClaim")
+    @Valid
+    public Claim getUserIdClaim() {
+        return userIdClaim;
+    }
+    public void setUserIdClaim(Claim userIdClaim) {
+        this.userIdClaim = userIdClaim;
+    }
+
+    /**
+    **/
+    public Claims roleClaim(Claim roleClaim) {
+
+        this.roleClaim = roleClaim;
+        return this;
+    }
+    
+    @ApiModelProperty(value = "")
+    @JsonProperty("roleClaim")
+    @Valid
+    public Claim getRoleClaim() {
+        return roleClaim;
+    }
+    public void setRoleClaim(Claim roleClaim) {
+        this.roleClaim = roleClaim;
+    }
+
+    /**
+    **/
+    public Claims mappings(List<ClaimMapping> mappings) {
+
+        this.mappings = mappings;
+        return this;
+    }
+    
+    @ApiModelProperty(value = "")
+    @JsonProperty("mappings")
+    @Valid
+    public List<ClaimMapping> getMappings() {
+        return mappings;
+    }
+    public void setMappings(List<ClaimMapping> mappings) {
+        this.mappings = mappings;
+    }
+
+    public Claims addMappingsItem(ClaimMapping mappingsItem) {
+        if (this.mappings == null) {
+            this.mappings = new ArrayList<>();
+        }
+        this.mappings.add(mappingsItem);
+        return this;
+    }
+
+        /**
+    **/
+    public Claims provisioningClaims(List<ProvisioningClaim> provisioningClaims) {
+
+        this.provisioningClaims = provisioningClaims;
+        return this;
+    }
+    
+    @ApiModelProperty(value = "")
+    @JsonProperty("provisioningClaims")
+    @Valid
+    public List<ProvisioningClaim> getProvisioningClaims() {
+        return provisioningClaims;
+    }
+    public void setProvisioningClaims(List<ProvisioningClaim> provisioningClaims) {
+        this.provisioningClaims = provisioningClaims;
+    }
+
+    public Claims addProvisioningClaimsItem(ProvisioningClaim provisioningClaimsItem) {
+        if (this.provisioningClaims == null) {
+            this.provisioningClaims = new ArrayList<>();
+        }
+        this.provisioningClaims.add(provisioningClaimsItem);
+        return this;
+    }
+
+    
+
+    @Override
+    public boolean equals(java.lang.Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Claims claims = (Claims) o;
+        return Objects.equals(this.userIdClaim, claims.userIdClaim) &&
+            Objects.equals(this.roleClaim, claims.roleClaim) &&
+            Objects.equals(this.mappings, claims.mappings) &&
+            Objects.equals(this.provisioningClaims, claims.provisioningClaims);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(userIdClaim, roleClaim, mappings, provisioningClaims);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class Claims {\n");
+        
+        sb.append("    userIdClaim: ").append(toIndentedString(userIdClaim)).append("\n");
+        sb.append("    roleClaim: ").append(toIndentedString(roleClaim)).append("\n");
+        sb.append("    mappings: ").append(toIndentedString(mappings)).append("\n");
+        sb.append("    provisioningClaims: ").append(toIndentedString(provisioningClaims)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+    * Convert the given object to string with each line indented by 4 spaces
+    * (except the first line).
+    */
+    private String toIndentedString(java.lang.Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}
+

--- a/components/org.wso2.carbon.identity.api.server.jwt.issuers/org.wso2.carbon.identity.api.server.jwt.issuers.v1/src/gen/java/org/wso2/carbon/identity/api/server/jwt/issuers/v1/model/Error.java
+++ b/components/org.wso2.carbon.identity.api.server.jwt.issuers/org.wso2.carbon.identity.api.server.jwt.issuers.v1/src/gen/java/org/wso2/carbon/identity/api/server/jwt/issuers/v1/model/Error.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.com).
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.jwt.issuers.v1.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import javax.validation.constraints.*;
+
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+import javax.validation.Valid;
+import javax.xml.bind.annotation.*;
+
+public class Error  {
+  
+    private String code;
+    private String message;
+    private String description;
+    private String traceId;
+
+    /**
+    **/
+    public Error code(String code) {
+
+        this.code = code;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "AAA-00000", value = "")
+    @JsonProperty("code")
+    @Valid
+    public String getCode() {
+        return code;
+    }
+    public void setCode(String code) {
+        this.code = code;
+    }
+
+    /**
+    **/
+    public Error message(String message) {
+
+        this.message = message;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "Some Error Message", value = "")
+    @JsonProperty("message")
+    @Valid
+    public String getMessage() {
+        return message;
+    }
+    public void setMessage(String message) {
+        this.message = message;
+    }
+
+    /**
+    **/
+    public Error description(String description) {
+
+        this.description = description;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "Some Error Description", value = "")
+    @JsonProperty("description")
+    @Valid
+    public String getDescription() {
+        return description;
+    }
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    /**
+    **/
+    public Error traceId(String traceId) {
+
+        this.traceId = traceId;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "e0fbcfeb-3617-43c4-8dd0-7b7d38e13047", value = "")
+    @JsonProperty("traceId")
+    @Valid
+    public String getTraceId() {
+        return traceId;
+    }
+    public void setTraceId(String traceId) {
+        this.traceId = traceId;
+    }
+
+
+
+    @Override
+    public boolean equals(java.lang.Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Error error = (Error) o;
+        return Objects.equals(this.code, error.code) &&
+            Objects.equals(this.message, error.message) &&
+            Objects.equals(this.description, error.description) &&
+            Objects.equals(this.traceId, error.traceId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(code, message, description, traceId);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class Error {\n");
+        
+        sb.append("    code: ").append(toIndentedString(code)).append("\n");
+        sb.append("    message: ").append(toIndentedString(message)).append("\n");
+        sb.append("    description: ").append(toIndentedString(description)).append("\n");
+        sb.append("    traceId: ").append(toIndentedString(traceId)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+    * Convert the given object to string with each line indented by 4 spaces
+    * (except the first line).
+    */
+    private String toIndentedString(java.lang.Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}
+

--- a/components/org.wso2.carbon.identity.api.server.jwt.issuers/org.wso2.carbon.identity.api.server.jwt.issuers.v1/src/gen/java/org/wso2/carbon/identity/api/server/jwt/issuers/v1/model/FederatedAuthenticatorListItem.java
+++ b/components/org.wso2.carbon.identity.api.server.jwt.issuers/org.wso2.carbon.identity.api.server.jwt.issuers.v1/src/gen/java/org/wso2/carbon/identity/api/server/jwt/issuers/v1/model/FederatedAuthenticatorListItem.java
@@ -1,0 +1,193 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.com).
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.jwt.issuers.v1.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import java.util.ArrayList;
+import java.util.List;
+import javax.validation.constraints.*;
+
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+import javax.validation.Valid;
+import javax.xml.bind.annotation.*;
+
+public class FederatedAuthenticatorListItem  {
+  
+    private String authenticatorId;
+    private String name;
+    private Boolean isEnabled = false;
+    private List<String> tags = null;
+
+    private String self;
+
+    /**
+    **/
+    public FederatedAuthenticatorListItem authenticatorId(String authenticatorId) {
+
+        this.authenticatorId = authenticatorId;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "U0FNTDJBdXRoZW50aWNhdG9y", value = "")
+    @JsonProperty("authenticatorId")
+    @Valid
+    public String getAuthenticatorId() {
+        return authenticatorId;
+    }
+    public void setAuthenticatorId(String authenticatorId) {
+        this.authenticatorId = authenticatorId;
+    }
+
+    /**
+    **/
+    public FederatedAuthenticatorListItem name(String name) {
+
+        this.name = name;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "SAML2Authenticator", value = "")
+    @JsonProperty("name")
+    @Valid
+    public String getName() {
+        return name;
+    }
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    /**
+    **/
+    public FederatedAuthenticatorListItem isEnabled(Boolean isEnabled) {
+
+        this.isEnabled = isEnabled;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "true", value = "")
+    @JsonProperty("isEnabled")
+    @Valid
+    public Boolean getIsEnabled() {
+        return isEnabled;
+    }
+    public void setIsEnabled(Boolean isEnabled) {
+        this.isEnabled = isEnabled;
+    }
+
+    /**
+    **/
+    public FederatedAuthenticatorListItem tags(List<String> tags) {
+
+        this.tags = tags;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "[\"Social Login\",\"OIDC\"]", value = "")
+    @JsonProperty("tags")
+    @Valid
+    public List<String> getTags() {
+        return tags;
+    }
+    public void setTags(List<String> tags) {
+        this.tags = tags;
+    }
+
+    public FederatedAuthenticatorListItem addTagsItem(String tagsItem) {
+        if (this.tags == null) {
+            this.tags = new ArrayList<>();
+        }
+        this.tags.add(tagsItem);
+        return this;
+    }
+
+        /**
+    **/
+    public FederatedAuthenticatorListItem self(String self) {
+
+        this.self = self;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "/t/carbon.super/api/server/v1/identity-providers/123e4567-e89b-12d3-a456-556642440000/federated-authenticators/U0FNTDJBdXRoZW50aWNhdG9y", value = "")
+    @JsonProperty("self")
+    @Valid
+    public String getSelf() {
+        return self;
+    }
+    public void setSelf(String self) {
+        this.self = self;
+    }
+
+
+
+    @Override
+    public boolean equals(java.lang.Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        FederatedAuthenticatorListItem federatedAuthenticatorListItem = (FederatedAuthenticatorListItem) o;
+        return Objects.equals(this.authenticatorId, federatedAuthenticatorListItem.authenticatorId) &&
+            Objects.equals(this.name, federatedAuthenticatorListItem.name) &&
+            Objects.equals(this.isEnabled, federatedAuthenticatorListItem.isEnabled) &&
+            Objects.equals(this.tags, federatedAuthenticatorListItem.tags) &&
+            Objects.equals(this.self, federatedAuthenticatorListItem.self);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(authenticatorId, name, isEnabled, tags, self);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class FederatedAuthenticatorListItem {\n");
+        
+        sb.append("    authenticatorId: ").append(toIndentedString(authenticatorId)).append("\n");
+        sb.append("    name: ").append(toIndentedString(name)).append("\n");
+        sb.append("    isEnabled: ").append(toIndentedString(isEnabled)).append("\n");
+        sb.append("    tags: ").append(toIndentedString(tags)).append("\n");
+        sb.append("    self: ").append(toIndentedString(self)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+    * Convert the given object to string with each line indented by 4 spaces
+    * (except the first line).
+    */
+    private String toIndentedString(java.lang.Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}
+

--- a/components/org.wso2.carbon.identity.api.server.jwt.issuers/org.wso2.carbon.identity.api.server.jwt.issuers.v1/src/gen/java/org/wso2/carbon/identity/api/server/jwt/issuers/v1/model/FederatedAuthenticatorListResponse.java
+++ b/components/org.wso2.carbon.identity.api.server.jwt.issuers/org.wso2.carbon.identity.api.server.jwt.issuers.v1/src/gen/java/org/wso2/carbon/identity/api/server/jwt/issuers/v1/model/FederatedAuthenticatorListResponse.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.com).
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.jwt.issuers.v1.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import java.util.ArrayList;
+import java.util.List;
+import org.wso2.carbon.identity.api.server.jwt.issuers.v1.model.FederatedAuthenticatorListItem;
+import javax.validation.constraints.*;
+
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+import javax.validation.Valid;
+import javax.xml.bind.annotation.*;
+
+public class FederatedAuthenticatorListResponse  {
+  
+    private String defaultAuthenticatorId;
+    private List<FederatedAuthenticatorListItem> authenticators = null;
+
+
+    /**
+    **/
+    public FederatedAuthenticatorListResponse defaultAuthenticatorId(String defaultAuthenticatorId) {
+
+        this.defaultAuthenticatorId = defaultAuthenticatorId;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "U0FNTDJBdXRoZW50aWNhdG9y", value = "")
+    @JsonProperty("defaultAuthenticatorId")
+    @Valid
+    public String getDefaultAuthenticatorId() {
+        return defaultAuthenticatorId;
+    }
+    public void setDefaultAuthenticatorId(String defaultAuthenticatorId) {
+        this.defaultAuthenticatorId = defaultAuthenticatorId;
+    }
+
+    /**
+    **/
+    public FederatedAuthenticatorListResponse authenticators(List<FederatedAuthenticatorListItem> authenticators) {
+
+        this.authenticators = authenticators;
+        return this;
+    }
+    
+    @ApiModelProperty(value = "")
+    @JsonProperty("authenticators")
+    @Valid
+    public List<FederatedAuthenticatorListItem> getAuthenticators() {
+        return authenticators;
+    }
+    public void setAuthenticators(List<FederatedAuthenticatorListItem> authenticators) {
+        this.authenticators = authenticators;
+    }
+
+    public FederatedAuthenticatorListResponse addAuthenticatorsItem(FederatedAuthenticatorListItem authenticatorsItem) {
+        if (this.authenticators == null) {
+            this.authenticators = new ArrayList<>();
+        }
+        this.authenticators.add(authenticatorsItem);
+        return this;
+    }
+
+    
+
+    @Override
+    public boolean equals(java.lang.Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        FederatedAuthenticatorListResponse federatedAuthenticatorListResponse = (FederatedAuthenticatorListResponse) o;
+        return Objects.equals(this.defaultAuthenticatorId, federatedAuthenticatorListResponse.defaultAuthenticatorId) &&
+            Objects.equals(this.authenticators, federatedAuthenticatorListResponse.authenticators);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(defaultAuthenticatorId, authenticators);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class FederatedAuthenticatorListResponse {\n");
+        
+        sb.append("    defaultAuthenticatorId: ").append(toIndentedString(defaultAuthenticatorId)).append("\n");
+        sb.append("    authenticators: ").append(toIndentedString(authenticators)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+    * Convert the given object to string with each line indented by 4 spaces
+    * (except the first line).
+    */
+    private String toIndentedString(java.lang.Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}
+

--- a/components/org.wso2.carbon.identity.api.server.jwt.issuers/org.wso2.carbon.identity.api.server.jwt.issuers.v1/src/gen/java/org/wso2/carbon/identity/api/server/jwt/issuers/v1/model/IdPGroup.java
+++ b/components/org.wso2.carbon.identity.api.server.jwt.issuers/org.wso2.carbon.identity.api.server.jwt.issuers.v1/src/gen/java/org/wso2/carbon/identity/api/server/jwt/issuers/v1/model/IdPGroup.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.com).
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.jwt.issuers.v1.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import javax.validation.constraints.*;
+
+/**
+ * Represents an IdP group supported by an Identity Provider.
+ **/
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+import javax.validation.Valid;
+import javax.xml.bind.annotation.*;
+@ApiModel(description = "Represents an IdP group supported by an Identity Provider.")
+public class IdPGroup  {
+  
+    private String name;
+    private String id;
+
+    /**
+    * Name of the IdP group
+    **/
+    public IdPGroup name(String name) {
+
+        this.name = name;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "google-admin", required = true, value = "Name of the IdP group")
+    @JsonProperty("name")
+    @Valid
+    @NotNull(message = "Property name cannot be null.")
+
+    public String getName() {
+        return name;
+    }
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    /**
+    * UUID of the IdP group
+    **/
+    public IdPGroup id(String id) {
+
+        this.id = id;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "6b1f8513-3de0-4f28-9cad-b7400dbc94ae", value = "UUID of the IdP group")
+    @JsonProperty("id")
+    @Valid
+    public String getId() {
+        return id;
+    }
+    public void setId(String id) {
+        this.id = id;
+    }
+
+
+
+    @Override
+    public boolean equals(java.lang.Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        IdPGroup idPGroup = (IdPGroup) o;
+        return Objects.equals(this.name, idPGroup.name) &&
+            Objects.equals(this.id, idPGroup.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, id);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class IdPGroup {\n");
+        
+        sb.append("    name: ").append(toIndentedString(name)).append("\n");
+        sb.append("    id: ").append(toIndentedString(id)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+    * Convert the given object to string with each line indented by 4 spaces
+    * (except the first line).
+    */
+    private String toIndentedString(java.lang.Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}
+

--- a/components/org.wso2.carbon.identity.api.server.jwt.issuers/org.wso2.carbon.identity.api.server.jwt.issuers.v1/src/gen/java/org/wso2/carbon/identity/api/server/jwt/issuers/v1/model/IdentityProviderListItem.java
+++ b/components/org.wso2.carbon.identity.api.server.jwt.issuers/org.wso2.carbon.identity.api.server.jwt.issuers.v1/src/gen/java/org/wso2/carbon/identity/api/server/jwt/issuers/v1/model/IdentityProviderListItem.java
@@ -1,0 +1,431 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.com).
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.jwt.issuers.v1.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import java.util.ArrayList;
+import java.util.List;
+import org.wso2.carbon.identity.api.server.jwt.issuers.v1.model.Certificate;
+import org.wso2.carbon.identity.api.server.jwt.issuers.v1.model.Claims;
+import org.wso2.carbon.identity.api.server.jwt.issuers.v1.model.FederatedAuthenticatorListResponse;
+import org.wso2.carbon.identity.api.server.jwt.issuers.v1.model.IdPGroup;
+import org.wso2.carbon.identity.api.server.jwt.issuers.v1.model.ProvisioningResponse;
+import org.wso2.carbon.identity.api.server.jwt.issuers.v1.model.Roles;
+import javax.validation.constraints.*;
+
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+import javax.validation.Valid;
+import javax.xml.bind.annotation.*;
+
+public class IdentityProviderListItem  {
+  
+    private String id;
+    private String name;
+    private String description;
+    private Boolean isEnabled = true;
+    private String image;
+    private Boolean isPrimary;
+    private Boolean isFederationHub;
+    private String homeRealmIdentifier;
+    private Certificate certificate;
+    private String alias;
+    private Claims claims;
+    private Roles roles;
+    private List<IdPGroup> groups = null;
+
+    private FederatedAuthenticatorListResponse federatedAuthenticators;
+    private ProvisioningResponse provisioning;
+    private String self;
+
+    /**
+    **/
+    public IdentityProviderListItem id(String id) {
+
+        this.id = id;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "123e4567-e89b-12d3-a456-556642440000", value = "")
+    @JsonProperty("id")
+    @Valid
+    public String getId() {
+        return id;
+    }
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    /**
+    **/
+    public IdentityProviderListItem name(String name) {
+
+        this.name = name;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "google", value = "")
+    @JsonProperty("name")
+    @Valid
+    public String getName() {
+        return name;
+    }
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    /**
+    **/
+    public IdentityProviderListItem description(String description) {
+
+        this.description = description;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "identity provider for google federation", value = "")
+    @JsonProperty("description")
+    @Valid
+    public String getDescription() {
+        return description;
+    }
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    /**
+    **/
+    public IdentityProviderListItem isEnabled(Boolean isEnabled) {
+
+        this.isEnabled = isEnabled;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "true", value = "")
+    @JsonProperty("isEnabled")
+    @Valid
+    public Boolean getIsEnabled() {
+        return isEnabled;
+    }
+    public void setIsEnabled(Boolean isEnabled) {
+        this.isEnabled = isEnabled;
+    }
+
+    /**
+    **/
+    public IdentityProviderListItem image(String image) {
+
+        this.image = image;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "google-logo-url", value = "")
+    @JsonProperty("image")
+    @Valid
+    public String getImage() {
+        return image;
+    }
+    public void setImage(String image) {
+        this.image = image;
+    }
+
+    /**
+    **/
+    public IdentityProviderListItem isPrimary(Boolean isPrimary) {
+
+        this.isPrimary = isPrimary;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "false", value = "")
+    @JsonProperty("isPrimary")
+    @Valid
+    public Boolean getIsPrimary() {
+        return isPrimary;
+    }
+    public void setIsPrimary(Boolean isPrimary) {
+        this.isPrimary = isPrimary;
+    }
+
+    /**
+    **/
+    public IdentityProviderListItem isFederationHub(Boolean isFederationHub) {
+
+        this.isFederationHub = isFederationHub;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "false", value = "")
+    @JsonProperty("isFederationHub")
+    @Valid
+    public Boolean getIsFederationHub() {
+        return isFederationHub;
+    }
+    public void setIsFederationHub(Boolean isFederationHub) {
+        this.isFederationHub = isFederationHub;
+    }
+
+    /**
+    **/
+    public IdentityProviderListItem homeRealmIdentifier(String homeRealmIdentifier) {
+
+        this.homeRealmIdentifier = homeRealmIdentifier;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "localhost", value = "")
+    @JsonProperty("homeRealmIdentifier")
+    @Valid
+    public String getHomeRealmIdentifier() {
+        return homeRealmIdentifier;
+    }
+    public void setHomeRealmIdentifier(String homeRealmIdentifier) {
+        this.homeRealmIdentifier = homeRealmIdentifier;
+    }
+
+    /**
+    **/
+    public IdentityProviderListItem certificate(Certificate certificate) {
+
+        this.certificate = certificate;
+        return this;
+    }
+    
+    @ApiModelProperty(value = "")
+    @JsonProperty("certificate")
+    @Valid
+    public Certificate getCertificate() {
+        return certificate;
+    }
+    public void setCertificate(Certificate certificate) {
+        this.certificate = certificate;
+    }
+
+    /**
+    **/
+    public IdentityProviderListItem alias(String alias) {
+
+        this.alias = alias;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "https://localhost:9444/oauth2/token", value = "")
+    @JsonProperty("alias")
+    @Valid
+    public String getAlias() {
+        return alias;
+    }
+    public void setAlias(String alias) {
+        this.alias = alias;
+    }
+
+    /**
+    **/
+    public IdentityProviderListItem claims(Claims claims) {
+
+        this.claims = claims;
+        return this;
+    }
+    
+    @ApiModelProperty(value = "")
+    @JsonProperty("claims")
+    @Valid
+    public Claims getClaims() {
+        return claims;
+    }
+    public void setClaims(Claims claims) {
+        this.claims = claims;
+    }
+
+    /**
+    **/
+    public IdentityProviderListItem roles(Roles roles) {
+
+        this.roles = roles;
+        return this;
+    }
+    
+    @ApiModelProperty(value = "")
+    @JsonProperty("roles")
+    @Valid
+    public Roles getRoles() {
+        return roles;
+    }
+    public void setRoles(Roles roles) {
+        this.roles = roles;
+    }
+
+    /**
+    * IdP groups supported by the IdP.
+    **/
+    public IdentityProviderListItem groups(List<IdPGroup> groups) {
+
+        this.groups = groups;
+        return this;
+    }
+    
+    @ApiModelProperty(value = "IdP groups supported by the IdP.")
+    @JsonProperty("groups")
+    @Valid @Size(min=0)
+    public List<IdPGroup> getGroups() {
+        return groups;
+    }
+    public void setGroups(List<IdPGroup> groups) {
+        this.groups = groups;
+    }
+
+    public IdentityProviderListItem addGroupsItem(IdPGroup groupsItem) {
+        if (this.groups == null) {
+            this.groups = new ArrayList<>();
+        }
+        this.groups.add(groupsItem);
+        return this;
+    }
+
+        /**
+    **/
+    public IdentityProviderListItem federatedAuthenticators(FederatedAuthenticatorListResponse federatedAuthenticators) {
+
+        this.federatedAuthenticators = federatedAuthenticators;
+        return this;
+    }
+    
+    @ApiModelProperty(value = "")
+    @JsonProperty("federatedAuthenticators")
+    @Valid
+    public FederatedAuthenticatorListResponse getFederatedAuthenticators() {
+        return federatedAuthenticators;
+    }
+    public void setFederatedAuthenticators(FederatedAuthenticatorListResponse federatedAuthenticators) {
+        this.federatedAuthenticators = federatedAuthenticators;
+    }
+
+    /**
+    **/
+    public IdentityProviderListItem provisioning(ProvisioningResponse provisioning) {
+
+        this.provisioning = provisioning;
+        return this;
+    }
+    
+    @ApiModelProperty(value = "")
+    @JsonProperty("provisioning")
+    @Valid
+    public ProvisioningResponse getProvisioning() {
+        return provisioning;
+    }
+    public void setProvisioning(ProvisioningResponse provisioning) {
+        this.provisioning = provisioning;
+    }
+
+    /**
+    **/
+    public IdentityProviderListItem self(String self) {
+
+        this.self = self;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "/t/carbon.super/api/server/v1/identity-providers/123e4567-e89b-12d3-a456-556642440000", value = "")
+    @JsonProperty("self")
+    @Valid
+    public String getSelf() {
+        return self;
+    }
+    public void setSelf(String self) {
+        this.self = self;
+    }
+
+
+
+    @Override
+    public boolean equals(java.lang.Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        IdentityProviderListItem identityProviderListItem = (IdentityProviderListItem) o;
+        return Objects.equals(this.id, identityProviderListItem.id) &&
+            Objects.equals(this.name, identityProviderListItem.name) &&
+            Objects.equals(this.description, identityProviderListItem.description) &&
+            Objects.equals(this.isEnabled, identityProviderListItem.isEnabled) &&
+            Objects.equals(this.image, identityProviderListItem.image) &&
+            Objects.equals(this.isPrimary, identityProviderListItem.isPrimary) &&
+            Objects.equals(this.isFederationHub, identityProviderListItem.isFederationHub) &&
+            Objects.equals(this.homeRealmIdentifier, identityProviderListItem.homeRealmIdentifier) &&
+            Objects.equals(this.certificate, identityProviderListItem.certificate) &&
+            Objects.equals(this.alias, identityProviderListItem.alias) &&
+            Objects.equals(this.claims, identityProviderListItem.claims) &&
+            Objects.equals(this.roles, identityProviderListItem.roles) &&
+            Objects.equals(this.groups, identityProviderListItem.groups) &&
+            Objects.equals(this.federatedAuthenticators, identityProviderListItem.federatedAuthenticators) &&
+            Objects.equals(this.provisioning, identityProviderListItem.provisioning) &&
+            Objects.equals(this.self, identityProviderListItem.self);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, name, description, isEnabled, image, isPrimary, isFederationHub, homeRealmIdentifier, certificate, alias, claims, roles, groups, federatedAuthenticators, provisioning, self);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class IdentityProviderListItem {\n");
+        
+        sb.append("    id: ").append(toIndentedString(id)).append("\n");
+        sb.append("    name: ").append(toIndentedString(name)).append("\n");
+        sb.append("    description: ").append(toIndentedString(description)).append("\n");
+        sb.append("    isEnabled: ").append(toIndentedString(isEnabled)).append("\n");
+        sb.append("    image: ").append(toIndentedString(image)).append("\n");
+        sb.append("    isPrimary: ").append(toIndentedString(isPrimary)).append("\n");
+        sb.append("    isFederationHub: ").append(toIndentedString(isFederationHub)).append("\n");
+        sb.append("    homeRealmIdentifier: ").append(toIndentedString(homeRealmIdentifier)).append("\n");
+        sb.append("    certificate: ").append(toIndentedString(certificate)).append("\n");
+        sb.append("    alias: ").append(toIndentedString(alias)).append("\n");
+        sb.append("    claims: ").append(toIndentedString(claims)).append("\n");
+        sb.append("    roles: ").append(toIndentedString(roles)).append("\n");
+        sb.append("    groups: ").append(toIndentedString(groups)).append("\n");
+        sb.append("    federatedAuthenticators: ").append(toIndentedString(federatedAuthenticators)).append("\n");
+        sb.append("    provisioning: ").append(toIndentedString(provisioning)).append("\n");
+        sb.append("    self: ").append(toIndentedString(self)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+    * Convert the given object to string with each line indented by 4 spaces
+    * (except the first line).
+    */
+    private String toIndentedString(java.lang.Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}
+

--- a/components/org.wso2.carbon.identity.api.server.jwt.issuers/org.wso2.carbon.identity.api.server.jwt.issuers.v1/src/gen/java/org/wso2/carbon/identity/api/server/jwt/issuers/v1/model/IdentityProviderListResponse.java
+++ b/components/org.wso2.carbon.identity.api.server.jwt.issuers/org.wso2.carbon.identity.api.server.jwt.issuers.v1/src/gen/java/org/wso2/carbon/identity/api/server/jwt/issuers/v1/model/IdentityProviderListResponse.java
@@ -1,0 +1,204 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.com).
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.jwt.issuers.v1.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import java.util.ArrayList;
+import java.util.List;
+import org.wso2.carbon.identity.api.server.jwt.issuers.v1.model.IdentityProviderListItem;
+import org.wso2.carbon.identity.api.server.jwt.issuers.v1.model.Link;
+import javax.validation.constraints.*;
+
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+import javax.validation.Valid;
+import javax.xml.bind.annotation.*;
+
+public class IdentityProviderListResponse  {
+  
+    private Integer totalResults;
+    private Integer startIndex;
+    private Integer count;
+    private List<Link> links = null;
+
+    private List<IdentityProviderListItem> identityProviders = null;
+
+
+    /**
+    **/
+    public IdentityProviderListResponse totalResults(Integer totalResults) {
+
+        this.totalResults = totalResults;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "10", value = "")
+    @JsonProperty("totalResults")
+    @Valid
+    public Integer getTotalResults() {
+        return totalResults;
+    }
+    public void setTotalResults(Integer totalResults) {
+        this.totalResults = totalResults;
+    }
+
+    /**
+    **/
+    public IdentityProviderListResponse startIndex(Integer startIndex) {
+
+        this.startIndex = startIndex;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "1", value = "")
+    @JsonProperty("startIndex")
+    @Valid
+    public Integer getStartIndex() {
+        return startIndex;
+    }
+    public void setStartIndex(Integer startIndex) {
+        this.startIndex = startIndex;
+    }
+
+    /**
+    **/
+    public IdentityProviderListResponse count(Integer count) {
+
+        this.count = count;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "10", value = "")
+    @JsonProperty("count")
+    @Valid
+    public Integer getCount() {
+        return count;
+    }
+    public void setCount(Integer count) {
+        this.count = count;
+    }
+
+    /**
+    **/
+    public IdentityProviderListResponse links(List<Link> links) {
+
+        this.links = links;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "[{\"href\":\"identity-provider?offset=50&limit=10\",\"rel\":\"next\"},{\"href\":\"identity-provider?offset=30&limit=10\",\"rel\":\"previous\"}]", value = "")
+    @JsonProperty("links")
+    @Valid
+    public List<Link> getLinks() {
+        return links;
+    }
+    public void setLinks(List<Link> links) {
+        this.links = links;
+    }
+
+    public IdentityProviderListResponse addLinksItem(Link linksItem) {
+        if (this.links == null) {
+            this.links = new ArrayList<>();
+        }
+        this.links.add(linksItem);
+        return this;
+    }
+
+        /**
+    **/
+    public IdentityProviderListResponse identityProviders(List<IdentityProviderListItem> identityProviders) {
+
+        this.identityProviders = identityProviders;
+        return this;
+    }
+    
+    @ApiModelProperty(value = "")
+    @JsonProperty("identityProviders")
+    @Valid
+    public List<IdentityProviderListItem> getIdentityProviders() {
+        return identityProviders;
+    }
+    public void setIdentityProviders(List<IdentityProviderListItem> identityProviders) {
+        this.identityProviders = identityProviders;
+    }
+
+    public IdentityProviderListResponse addIdentityProvidersItem(IdentityProviderListItem identityProvidersItem) {
+        if (this.identityProviders == null) {
+            this.identityProviders = new ArrayList<>();
+        }
+        this.identityProviders.add(identityProvidersItem);
+        return this;
+    }
+
+    
+
+    @Override
+    public boolean equals(java.lang.Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        IdentityProviderListResponse identityProviderListResponse = (IdentityProviderListResponse) o;
+        return Objects.equals(this.totalResults, identityProviderListResponse.totalResults) &&
+            Objects.equals(this.startIndex, identityProviderListResponse.startIndex) &&
+            Objects.equals(this.count, identityProviderListResponse.count) &&
+            Objects.equals(this.links, identityProviderListResponse.links) &&
+            Objects.equals(this.identityProviders, identityProviderListResponse.identityProviders);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(totalResults, startIndex, count, links, identityProviders);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class IdentityProviderListResponse {\n");
+        
+        sb.append("    totalResults: ").append(toIndentedString(totalResults)).append("\n");
+        sb.append("    startIndex: ").append(toIndentedString(startIndex)).append("\n");
+        sb.append("    count: ").append(toIndentedString(count)).append("\n");
+        sb.append("    links: ").append(toIndentedString(links)).append("\n");
+        sb.append("    identityProviders: ").append(toIndentedString(identityProviders)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+    * Convert the given object to string with each line indented by 4 spaces
+    * (except the first line).
+    */
+    private String toIndentedString(java.lang.Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}
+

--- a/components/org.wso2.carbon.identity.api.server.jwt.issuers/org.wso2.carbon.identity.api.server.jwt.issuers.v1/src/gen/java/org/wso2/carbon/identity/api/server/jwt/issuers/v1/model/IdentityProviderResponse.java
+++ b/components/org.wso2.carbon.identity.api.server.jwt.issuers/org.wso2.carbon.identity.api.server.jwt.issuers.v1/src/gen/java/org/wso2/carbon/identity/api/server/jwt/issuers/v1/model/IdentityProviderResponse.java
@@ -1,0 +1,452 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.com).
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.jwt.issuers.v1.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import java.util.ArrayList;
+import java.util.List;
+import org.wso2.carbon.identity.api.server.jwt.issuers.v1.model.Certificate;
+import org.wso2.carbon.identity.api.server.jwt.issuers.v1.model.Claims;
+import org.wso2.carbon.identity.api.server.jwt.issuers.v1.model.FederatedAuthenticatorListResponse;
+import org.wso2.carbon.identity.api.server.jwt.issuers.v1.model.IdPGroup;
+import org.wso2.carbon.identity.api.server.jwt.issuers.v1.model.ProvisioningResponse;
+import org.wso2.carbon.identity.api.server.jwt.issuers.v1.model.Roles;
+import javax.validation.constraints.*;
+
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+import javax.validation.Valid;
+import javax.xml.bind.annotation.*;
+
+public class IdentityProviderResponse  {
+  
+    private String id;
+    private String name;
+    private String description;
+    private String templateId;
+    private Boolean isEnabled = true;
+    private Boolean isPrimary = false;
+    private String image;
+    private Boolean isFederationHub;
+    private String homeRealmIdentifier;
+    private Certificate certificate;
+    private String alias;
+    private String idpIssuerName;
+    private Claims claims;
+    private Roles roles;
+    private List<IdPGroup> groups = null;
+
+    private FederatedAuthenticatorListResponse federatedAuthenticators;
+    private ProvisioningResponse provisioning;
+
+    /**
+    **/
+    public IdentityProviderResponse id(String id) {
+
+        this.id = id;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "123e4567-e89b-12d3-a456-556642440000", value = "")
+    @JsonProperty("id")
+    @Valid
+    public String getId() {
+        return id;
+    }
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    /**
+    **/
+    public IdentityProviderResponse name(String name) {
+
+        this.name = name;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "google", value = "")
+    @JsonProperty("name")
+    @Valid
+    public String getName() {
+        return name;
+    }
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    /**
+    **/
+    public IdentityProviderResponse description(String description) {
+
+        this.description = description;
+        return this;
+    }
+    
+    @ApiModelProperty(value = "")
+    @JsonProperty("description")
+    @Valid
+    public String getDescription() {
+        return description;
+    }
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    /**
+    **/
+    public IdentityProviderResponse templateId(String templateId) {
+
+        this.templateId = templateId;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "8ea23303-49c0-4253-b81f-82c0fe6fb4a0", value = "")
+    @JsonProperty("templateId")
+    @Valid
+    public String getTemplateId() {
+        return templateId;
+    }
+    public void setTemplateId(String templateId) {
+        this.templateId = templateId;
+    }
+
+    /**
+    **/
+    public IdentityProviderResponse isEnabled(Boolean isEnabled) {
+
+        this.isEnabled = isEnabled;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "true", value = "")
+    @JsonProperty("isEnabled")
+    @Valid
+    public Boolean getIsEnabled() {
+        return isEnabled;
+    }
+    public void setIsEnabled(Boolean isEnabled) {
+        this.isEnabled = isEnabled;
+    }
+
+    /**
+    **/
+    public IdentityProviderResponse isPrimary(Boolean isPrimary) {
+
+        this.isPrimary = isPrimary;
+        return this;
+    }
+    
+    @ApiModelProperty(value = "")
+    @JsonProperty("isPrimary")
+    @Valid
+    public Boolean getIsPrimary() {
+        return isPrimary;
+    }
+    public void setIsPrimary(Boolean isPrimary) {
+        this.isPrimary = isPrimary;
+    }
+
+    /**
+    **/
+    public IdentityProviderResponse image(String image) {
+
+        this.image = image;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "google-logo-url", value = "")
+    @JsonProperty("image")
+    @Valid
+    public String getImage() {
+        return image;
+    }
+    public void setImage(String image) {
+        this.image = image;
+    }
+
+    /**
+    **/
+    public IdentityProviderResponse isFederationHub(Boolean isFederationHub) {
+
+        this.isFederationHub = isFederationHub;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "false", value = "")
+    @JsonProperty("isFederationHub")
+    @Valid
+    public Boolean getIsFederationHub() {
+        return isFederationHub;
+    }
+    public void setIsFederationHub(Boolean isFederationHub) {
+        this.isFederationHub = isFederationHub;
+    }
+
+    /**
+    **/
+    public IdentityProviderResponse homeRealmIdentifier(String homeRealmIdentifier) {
+
+        this.homeRealmIdentifier = homeRealmIdentifier;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "localhost", value = "")
+    @JsonProperty("homeRealmIdentifier")
+    @Valid
+    public String getHomeRealmIdentifier() {
+        return homeRealmIdentifier;
+    }
+    public void setHomeRealmIdentifier(String homeRealmIdentifier) {
+        this.homeRealmIdentifier = homeRealmIdentifier;
+    }
+
+    /**
+    **/
+    public IdentityProviderResponse certificate(Certificate certificate) {
+
+        this.certificate = certificate;
+        return this;
+    }
+    
+    @ApiModelProperty(value = "")
+    @JsonProperty("certificate")
+    @Valid
+    public Certificate getCertificate() {
+        return certificate;
+    }
+    public void setCertificate(Certificate certificate) {
+        this.certificate = certificate;
+    }
+
+    /**
+    **/
+    public IdentityProviderResponse alias(String alias) {
+
+        this.alias = alias;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "https://localhost:9444/oauth2/token", value = "")
+    @JsonProperty("alias")
+    @Valid
+    public String getAlias() {
+        return alias;
+    }
+    public void setAlias(String alias) {
+        this.alias = alias;
+    }
+
+    /**
+    **/
+    public IdentityProviderResponse idpIssuerName(String idpIssuerName) {
+
+        this.idpIssuerName = idpIssuerName;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "https://www.idp.com", value = "")
+    @JsonProperty("idpIssuerName")
+    @Valid
+    public String getIdpIssuerName() {
+        return idpIssuerName;
+    }
+    public void setIdpIssuerName(String idpIssuerName) {
+        this.idpIssuerName = idpIssuerName;
+    }
+
+    /**
+    **/
+    public IdentityProviderResponse claims(Claims claims) {
+
+        this.claims = claims;
+        return this;
+    }
+    
+    @ApiModelProperty(value = "")
+    @JsonProperty("claims")
+    @Valid
+    public Claims getClaims() {
+        return claims;
+    }
+    public void setClaims(Claims claims) {
+        this.claims = claims;
+    }
+
+    /**
+    **/
+    public IdentityProviderResponse roles(Roles roles) {
+
+        this.roles = roles;
+        return this;
+    }
+    
+    @ApiModelProperty(value = "")
+    @JsonProperty("roles")
+    @Valid
+    public Roles getRoles() {
+        return roles;
+    }
+    public void setRoles(Roles roles) {
+        this.roles = roles;
+    }
+
+    /**
+    * IdP groups supported by the IdP.
+    **/
+    public IdentityProviderResponse groups(List<IdPGroup> groups) {
+
+        this.groups = groups;
+        return this;
+    }
+    
+    @ApiModelProperty(value = "IdP groups supported by the IdP.")
+    @JsonProperty("groups")
+    @Valid @Size(min=0)
+    public List<IdPGroup> getGroups() {
+        return groups;
+    }
+    public void setGroups(List<IdPGroup> groups) {
+        this.groups = groups;
+    }
+
+    public IdentityProviderResponse addGroupsItem(IdPGroup groupsItem) {
+        if (this.groups == null) {
+            this.groups = new ArrayList<>();
+        }
+        this.groups.add(groupsItem);
+        return this;
+    }
+
+        /**
+    **/
+    public IdentityProviderResponse federatedAuthenticators(FederatedAuthenticatorListResponse federatedAuthenticators) {
+
+        this.federatedAuthenticators = federatedAuthenticators;
+        return this;
+    }
+    
+    @ApiModelProperty(value = "")
+    @JsonProperty("federatedAuthenticators")
+    @Valid
+    public FederatedAuthenticatorListResponse getFederatedAuthenticators() {
+        return federatedAuthenticators;
+    }
+    public void setFederatedAuthenticators(FederatedAuthenticatorListResponse federatedAuthenticators) {
+        this.federatedAuthenticators = federatedAuthenticators;
+    }
+
+    /**
+    **/
+    public IdentityProviderResponse provisioning(ProvisioningResponse provisioning) {
+
+        this.provisioning = provisioning;
+        return this;
+    }
+    
+    @ApiModelProperty(value = "")
+    @JsonProperty("provisioning")
+    @Valid
+    public ProvisioningResponse getProvisioning() {
+        return provisioning;
+    }
+    public void setProvisioning(ProvisioningResponse provisioning) {
+        this.provisioning = provisioning;
+    }
+
+
+
+    @Override
+    public boolean equals(java.lang.Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        IdentityProviderResponse identityProviderResponse = (IdentityProviderResponse) o;
+        return Objects.equals(this.id, identityProviderResponse.id) &&
+            Objects.equals(this.name, identityProviderResponse.name) &&
+            Objects.equals(this.description, identityProviderResponse.description) &&
+            Objects.equals(this.templateId, identityProviderResponse.templateId) &&
+            Objects.equals(this.isEnabled, identityProviderResponse.isEnabled) &&
+            Objects.equals(this.isPrimary, identityProviderResponse.isPrimary) &&
+            Objects.equals(this.image, identityProviderResponse.image) &&
+            Objects.equals(this.isFederationHub, identityProviderResponse.isFederationHub) &&
+            Objects.equals(this.homeRealmIdentifier, identityProviderResponse.homeRealmIdentifier) &&
+            Objects.equals(this.certificate, identityProviderResponse.certificate) &&
+            Objects.equals(this.alias, identityProviderResponse.alias) &&
+            Objects.equals(this.idpIssuerName, identityProviderResponse.idpIssuerName) &&
+            Objects.equals(this.claims, identityProviderResponse.claims) &&
+            Objects.equals(this.roles, identityProviderResponse.roles) &&
+            Objects.equals(this.groups, identityProviderResponse.groups) &&
+            Objects.equals(this.federatedAuthenticators, identityProviderResponse.federatedAuthenticators) &&
+            Objects.equals(this.provisioning, identityProviderResponse.provisioning);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, name, description, templateId, isEnabled, isPrimary, image, isFederationHub, homeRealmIdentifier, certificate, alias, idpIssuerName, claims, roles, groups, federatedAuthenticators, provisioning);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class IdentityProviderResponse {\n");
+        
+        sb.append("    id: ").append(toIndentedString(id)).append("\n");
+        sb.append("    name: ").append(toIndentedString(name)).append("\n");
+        sb.append("    description: ").append(toIndentedString(description)).append("\n");
+        sb.append("    templateId: ").append(toIndentedString(templateId)).append("\n");
+        sb.append("    isEnabled: ").append(toIndentedString(isEnabled)).append("\n");
+        sb.append("    isPrimary: ").append(toIndentedString(isPrimary)).append("\n");
+        sb.append("    image: ").append(toIndentedString(image)).append("\n");
+        sb.append("    isFederationHub: ").append(toIndentedString(isFederationHub)).append("\n");
+        sb.append("    homeRealmIdentifier: ").append(toIndentedString(homeRealmIdentifier)).append("\n");
+        sb.append("    certificate: ").append(toIndentedString(certificate)).append("\n");
+        sb.append("    alias: ").append(toIndentedString(alias)).append("\n");
+        sb.append("    idpIssuerName: ").append(toIndentedString(idpIssuerName)).append("\n");
+        sb.append("    claims: ").append(toIndentedString(claims)).append("\n");
+        sb.append("    roles: ").append(toIndentedString(roles)).append("\n");
+        sb.append("    groups: ").append(toIndentedString(groups)).append("\n");
+        sb.append("    federatedAuthenticators: ").append(toIndentedString(federatedAuthenticators)).append("\n");
+        sb.append("    provisioning: ").append(toIndentedString(provisioning)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+    * Convert the given object to string with each line indented by 4 spaces
+    * (except the first line).
+    */
+    private String toIndentedString(java.lang.Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}
+

--- a/components/org.wso2.carbon.identity.api.server.jwt.issuers/org.wso2.carbon.identity.api.server.jwt.issuers.v1/src/gen/java/org/wso2/carbon/identity/api/server/jwt/issuers/v1/model/JWTIssuerPOSTRequest.java
+++ b/components/org.wso2.carbon.identity.api.server.jwt.issuers/org.wso2.carbon.identity.api.server.jwt.issuers.v1/src/gen/java/org/wso2/carbon/identity/api/server/jwt/issuers/v1/model/JWTIssuerPOSTRequest.java
@@ -1,0 +1,231 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.com).
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.jwt.issuers.v1.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import org.wso2.carbon.identity.api.server.jwt.issuers.v1.model.Certificate;
+import javax.validation.constraints.*;
+
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+import javax.validation.Valid;
+import javax.xml.bind.annotation.*;
+
+public class JWTIssuerPOSTRequest  {
+  
+    private String name;
+    private String description;
+    private String image;
+    private String templateId;
+    private Certificate certificate;
+    private String alias;
+    private String idpIssuerName;
+
+    /**
+    **/
+    public JWTIssuerPOSTRequest name(String name) {
+
+        this.name = name;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "google", required = true, value = "")
+    @JsonProperty("name")
+    @Valid
+    @NotNull(message = "Property name cannot be null.")
+
+    public String getName() {
+        return name;
+    }
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    /**
+    **/
+    public JWTIssuerPOSTRequest description(String description) {
+
+        this.description = description;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "JWT Issuer", value = "")
+    @JsonProperty("description")
+    @Valid
+    public String getDescription() {
+        return description;
+    }
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    /**
+    **/
+    public JWTIssuerPOSTRequest image(String image) {
+
+        this.image = image;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "issuer-logo-url", value = "")
+    @JsonProperty("image")
+    @Valid
+    public String getImage() {
+        return image;
+    }
+    public void setImage(String image) {
+        this.image = image;
+    }
+
+    /**
+    **/
+    public JWTIssuerPOSTRequest templateId(String templateId) {
+
+        this.templateId = templateId;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "8ea23303-49c0-4253-b81f-82c0fe6fb4a0", value = "")
+    @JsonProperty("templateId")
+    @Valid
+    public String getTemplateId() {
+        return templateId;
+    }
+    public void setTemplateId(String templateId) {
+        this.templateId = templateId;
+    }
+
+    /**
+    **/
+    public JWTIssuerPOSTRequest certificate(Certificate certificate) {
+
+        this.certificate = certificate;
+        return this;
+    }
+    
+    @ApiModelProperty(required = true, value = "")
+    @JsonProperty("certificate")
+    @Valid
+    @NotNull(message = "Property certificate cannot be null.")
+
+    public Certificate getCertificate() {
+        return certificate;
+    }
+    public void setCertificate(Certificate certificate) {
+        this.certificate = certificate;
+    }
+
+    /**
+    **/
+    public JWTIssuerPOSTRequest alias(String alias) {
+
+        this.alias = alias;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "https://localhost:9444/oauth2/token", value = "")
+    @JsonProperty("alias")
+    @Valid
+    public String getAlias() {
+        return alias;
+    }
+    public void setAlias(String alias) {
+        this.alias = alias;
+    }
+
+    /**
+    **/
+    public JWTIssuerPOSTRequest idpIssuerName(String idpIssuerName) {
+
+        this.idpIssuerName = idpIssuerName;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "https://www.issuer.com", required = true, value = "")
+    @JsonProperty("idpIssuerName")
+    @Valid
+    @NotNull(message = "Property idpIssuerName cannot be null.")
+
+    public String getIdpIssuerName() {
+        return idpIssuerName;
+    }
+    public void setIdpIssuerName(String idpIssuerName) {
+        this.idpIssuerName = idpIssuerName;
+    }
+
+
+
+    @Override
+    public boolean equals(java.lang.Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        JWTIssuerPOSTRequest jwTIssuerPOSTRequest = (JWTIssuerPOSTRequest) o;
+        return Objects.equals(this.name, jwTIssuerPOSTRequest.name) &&
+            Objects.equals(this.description, jwTIssuerPOSTRequest.description) &&
+            Objects.equals(this.image, jwTIssuerPOSTRequest.image) &&
+            Objects.equals(this.templateId, jwTIssuerPOSTRequest.templateId) &&
+            Objects.equals(this.certificate, jwTIssuerPOSTRequest.certificate) &&
+            Objects.equals(this.alias, jwTIssuerPOSTRequest.alias) &&
+            Objects.equals(this.idpIssuerName, jwTIssuerPOSTRequest.idpIssuerName);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, description, image, templateId, certificate, alias, idpIssuerName);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class JWTIssuerPOSTRequest {\n");
+        
+        sb.append("    name: ").append(toIndentedString(name)).append("\n");
+        sb.append("    description: ").append(toIndentedString(description)).append("\n");
+        sb.append("    image: ").append(toIndentedString(image)).append("\n");
+        sb.append("    templateId: ").append(toIndentedString(templateId)).append("\n");
+        sb.append("    certificate: ").append(toIndentedString(certificate)).append("\n");
+        sb.append("    alias: ").append(toIndentedString(alias)).append("\n");
+        sb.append("    idpIssuerName: ").append(toIndentedString(idpIssuerName)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+    * Convert the given object to string with each line indented by 4 spaces
+    * (except the first line).
+    */
+    private String toIndentedString(java.lang.Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}
+

--- a/components/org.wso2.carbon.identity.api.server.jwt.issuers/org.wso2.carbon.identity.api.server.jwt.issuers.v1/src/gen/java/org/wso2/carbon/identity/api/server/jwt/issuers/v1/model/JustInTimeProvisioning.java
+++ b/components/org.wso2.carbon.identity.api.server.jwt.issuers/org.wso2.carbon.identity.api.server.jwt.issuers.v1/src/gen/java/org/wso2/carbon/identity/api/server/jwt/issuers/v1/model/JustInTimeProvisioning.java
@@ -1,0 +1,250 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.com).
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.jwt.issuers.v1.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import javax.validation.constraints.*;
+
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+import javax.validation.Valid;
+import javax.xml.bind.annotation.*;
+
+public class JustInTimeProvisioning  {
+  
+    private Boolean isEnabled = false;
+
+@XmlType(name="SchemeEnum")
+@XmlEnum(String.class)
+public enum SchemeEnum {
+
+    @XmlEnumValue("PROMPT_USERNAME_PASSWORD_CONSENT") PROMPT_USERNAME_PASSWORD_CONSENT(String.valueOf("PROMPT_USERNAME_PASSWORD_CONSENT")), @XmlEnumValue("PROMPT_PASSWORD_CONSENT") PROMPT_PASSWORD_CONSENT(String.valueOf("PROMPT_PASSWORD_CONSENT")), @XmlEnumValue("PROMPT_CONSENT") PROMPT_CONSENT(String.valueOf("PROMPT_CONSENT")), @XmlEnumValue("PROVISION_SILENTLY") PROVISION_SILENTLY(String.valueOf("PROVISION_SILENTLY"));
+
+
+    private String value;
+
+    SchemeEnum(String v) {
+        value = v;
+    }
+
+    public String value() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    public static SchemeEnum fromValue(String value) {
+        for (SchemeEnum b : SchemeEnum.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
+}
+
+    private SchemeEnum scheme = SchemeEnum.PROVISION_SILENTLY;
+    private String userstore = "PRIMARY";
+    private Boolean associateLocalUser = false;
+
+@XmlType(name="AttributeSyncMethodEnum")
+@XmlEnum(String.class)
+public enum AttributeSyncMethodEnum {
+
+    @XmlEnumValue("OVERRIDE_ALL") OVERRIDE_ALL(String.valueOf("OVERRIDE_ALL")), @XmlEnumValue("NONE") NONE(String.valueOf("NONE")), @XmlEnumValue("PRESERVE_LOCAL") PRESERVE_LOCAL(String.valueOf("PRESERVE_LOCAL"));
+
+
+    private String value;
+
+    AttributeSyncMethodEnum(String v) {
+        value = v;
+    }
+
+    public String value() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    public static AttributeSyncMethodEnum fromValue(String value) {
+        for (AttributeSyncMethodEnum b : AttributeSyncMethodEnum.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
+}
+
+    private AttributeSyncMethodEnum attributeSyncMethod = AttributeSyncMethodEnum.OVERRIDE_ALL;
+
+    /**
+    **/
+    public JustInTimeProvisioning isEnabled(Boolean isEnabled) {
+
+        this.isEnabled = isEnabled;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "true", required = true, value = "")
+    @JsonProperty("isEnabled")
+    @Valid
+    @NotNull(message = "Property isEnabled cannot be null.")
+
+    public Boolean getIsEnabled() {
+        return isEnabled;
+    }
+    public void setIsEnabled(Boolean isEnabled) {
+        this.isEnabled = isEnabled;
+    }
+
+    /**
+    **/
+    public JustInTimeProvisioning scheme(SchemeEnum scheme) {
+
+        this.scheme = scheme;
+        return this;
+    }
+    
+    @ApiModelProperty(value = "")
+    @JsonProperty("scheme")
+    @Valid
+    public SchemeEnum getScheme() {
+        return scheme;
+    }
+    public void setScheme(SchemeEnum scheme) {
+        this.scheme = scheme;
+    }
+
+    /**
+    **/
+    public JustInTimeProvisioning userstore(String userstore) {
+
+        this.userstore = userstore;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "PRIMARY", value = "")
+    @JsonProperty("userstore")
+    @Valid
+    public String getUserstore() {
+        return userstore;
+    }
+    public void setUserstore(String userstore) {
+        this.userstore = userstore;
+    }
+
+    /**
+    **/
+    public JustInTimeProvisioning associateLocalUser(Boolean associateLocalUser) {
+
+        this.associateLocalUser = associateLocalUser;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "true", value = "")
+    @JsonProperty("associateLocalUser")
+    @Valid
+    public Boolean getAssociateLocalUser() {
+        return associateLocalUser;
+    }
+    public void setAssociateLocalUser(Boolean associateLocalUser) {
+        this.associateLocalUser = associateLocalUser;
+    }
+
+    /**
+    **/
+    public JustInTimeProvisioning attributeSyncMethod(AttributeSyncMethodEnum attributeSyncMethod) {
+
+        this.attributeSyncMethod = attributeSyncMethod;
+        return this;
+    }
+    
+    @ApiModelProperty(value = "")
+    @JsonProperty("attributeSyncMethod")
+    @Valid
+    public AttributeSyncMethodEnum getAttributeSyncMethod() {
+        return attributeSyncMethod;
+    }
+    public void setAttributeSyncMethod(AttributeSyncMethodEnum attributeSyncMethod) {
+        this.attributeSyncMethod = attributeSyncMethod;
+    }
+
+
+
+    @Override
+    public boolean equals(java.lang.Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        JustInTimeProvisioning justInTimeProvisioning = (JustInTimeProvisioning) o;
+        return Objects.equals(this.isEnabled, justInTimeProvisioning.isEnabled) &&
+            Objects.equals(this.scheme, justInTimeProvisioning.scheme) &&
+            Objects.equals(this.userstore, justInTimeProvisioning.userstore) &&
+            Objects.equals(this.associateLocalUser, justInTimeProvisioning.associateLocalUser) &&
+            Objects.equals(this.attributeSyncMethod, justInTimeProvisioning.attributeSyncMethod);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(isEnabled, scheme, userstore, associateLocalUser, attributeSyncMethod);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class JustInTimeProvisioning {\n");
+        
+        sb.append("    isEnabled: ").append(toIndentedString(isEnabled)).append("\n");
+        sb.append("    scheme: ").append(toIndentedString(scheme)).append("\n");
+        sb.append("    userstore: ").append(toIndentedString(userstore)).append("\n");
+        sb.append("    associateLocalUser: ").append(toIndentedString(associateLocalUser)).append("\n");
+        sb.append("    attributeSyncMethod: ").append(toIndentedString(attributeSyncMethod)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+    * Convert the given object to string with each line indented by 4 spaces
+    * (except the first line).
+    */
+    private String toIndentedString(java.lang.Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}
+

--- a/components/org.wso2.carbon.identity.api.server.jwt.issuers/org.wso2.carbon.identity.api.server.jwt.issuers.v1/src/gen/java/org/wso2/carbon/identity/api/server/jwt/issuers/v1/model/Link.java
+++ b/components/org.wso2.carbon.identity.api.server.jwt.issuers/org.wso2.carbon.identity.api.server.jwt.issuers.v1/src/gen/java/org/wso2/carbon/identity/api/server/jwt/issuers/v1/model/Link.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.com).
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.jwt.issuers.v1.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import javax.validation.constraints.*;
+
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+import javax.validation.Valid;
+import javax.xml.bind.annotation.*;
+
+public class Link  {
+  
+    private String href;
+    private String rel;
+
+    /**
+    * Path to the target resource.
+    **/
+    public Link href(String href) {
+
+        this.href = href;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "'/t/carbon.super/api/server/v1/identity-providers/394b8adcce24c64a8a09a8d80abf8c337bd253de'", value = "Path to the target resource.")
+    @JsonProperty("href")
+    @Valid
+    public String getHref() {
+        return href;
+    }
+    public void setHref(String href) {
+        this.href = href;
+    }
+
+    /**
+    * Describes how the current context is related to the target resource.
+    **/
+    public Link rel(String rel) {
+
+        this.rel = rel;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "identity-providers", value = "Describes how the current context is related to the target resource.")
+    @JsonProperty("rel")
+    @Valid
+    public String getRel() {
+        return rel;
+    }
+    public void setRel(String rel) {
+        this.rel = rel;
+    }
+
+
+
+    @Override
+    public boolean equals(java.lang.Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Link link = (Link) o;
+        return Objects.equals(this.href, link.href) &&
+            Objects.equals(this.rel, link.rel);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(href, rel);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class Link {\n");
+        
+        sb.append("    href: ").append(toIndentedString(href)).append("\n");
+        sb.append("    rel: ").append(toIndentedString(rel)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+    * Convert the given object to string with each line indented by 4 spaces
+    * (except the first line).
+    */
+    private String toIndentedString(java.lang.Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}
+

--- a/components/org.wso2.carbon.identity.api.server.jwt.issuers/org.wso2.carbon.identity.api.server.jwt.issuers.v1/src/gen/java/org/wso2/carbon/identity/api/server/jwt/issuers/v1/model/MetaProperty.java
+++ b/components/org.wso2.carbon.identity.api.server.jwt.issuers/org.wso2.carbon.identity.api.server.jwt.issuers.v1/src/gen/java/org/wso2/carbon/identity/api/server/jwt/issuers/v1/model/MetaProperty.java
@@ -1,0 +1,363 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.com).
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.jwt.issuers.v1.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import java.util.ArrayList;
+import java.util.List;
+import javax.validation.constraints.*;
+
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+import javax.validation.Valid;
+import javax.xml.bind.annotation.*;
+
+public class MetaProperty  {
+  
+    private String key;
+    private String displayName;
+    private String description;
+
+@XmlType(name="TypeEnum")
+@XmlEnum(String.class)
+public enum TypeEnum {
+
+    @XmlEnumValue("STRING") STRING(String.valueOf("STRING")), @XmlEnumValue("BOOLEAN") BOOLEAN(String.valueOf("BOOLEAN")), @XmlEnumValue("INTEGER") INTEGER(String.valueOf("INTEGER"));
+
+
+    private String value;
+
+    TypeEnum(String v) {
+        value = v;
+    }
+
+    public String value() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    public static TypeEnum fromValue(String value) {
+        for (TypeEnum b : TypeEnum.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
+}
+
+    private TypeEnum type;
+    private Integer displayOrder;
+    private String regex;
+    private Boolean isMandatory = false;
+    private Boolean isConfidential = false;
+    private List<String> options = null;
+
+    private String defaultValue;
+    private List<MetaProperty> subProperties = null;
+
+
+    /**
+    **/
+    public MetaProperty key(String key) {
+
+        this.key = key;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "httpBinding", required = true, value = "")
+    @JsonProperty("key")
+    @Valid
+    @NotNull(message = "Property key cannot be null.")
+
+    public String getKey() {
+        return key;
+    }
+    public void setKey(String key) {
+        this.key = key;
+    }
+
+    /**
+    **/
+    public MetaProperty displayName(String displayName) {
+
+        this.displayName = displayName;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "HTTP Binding", value = "")
+    @JsonProperty("displayName")
+    @Valid
+    public String getDisplayName() {
+        return displayName;
+    }
+    public void setDisplayName(String displayName) {
+        this.displayName = displayName;
+    }
+
+    /**
+    **/
+    public MetaProperty description(String description) {
+
+        this.description = description;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "Choose the HTTP Binding or decide from incoming request", value = "")
+    @JsonProperty("description")
+    @Valid
+    public String getDescription() {
+        return description;
+    }
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    /**
+    **/
+    public MetaProperty type(TypeEnum type) {
+
+        this.type = type;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "STRING", value = "")
+    @JsonProperty("type")
+    @Valid
+    public TypeEnum getType() {
+        return type;
+    }
+    public void setType(TypeEnum type) {
+        this.type = type;
+    }
+
+    /**
+    **/
+    public MetaProperty displayOrder(Integer displayOrder) {
+
+        this.displayOrder = displayOrder;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "10", value = "")
+    @JsonProperty("displayOrder")
+    @Valid
+    public Integer getDisplayOrder() {
+        return displayOrder;
+    }
+    public void setDisplayOrder(Integer displayOrder) {
+        this.displayOrder = displayOrder;
+    }
+
+    /**
+    **/
+    public MetaProperty regex(String regex) {
+
+        this.regex = regex;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "[a-zA-Z]{3,30}", value = "")
+    @JsonProperty("regex")
+    @Valid
+    public String getRegex() {
+        return regex;
+    }
+    public void setRegex(String regex) {
+        this.regex = regex;
+    }
+
+    /**
+    **/
+    public MetaProperty isMandatory(Boolean isMandatory) {
+
+        this.isMandatory = isMandatory;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "false", value = "")
+    @JsonProperty("isMandatory")
+    @Valid
+    public Boolean getIsMandatory() {
+        return isMandatory;
+    }
+    public void setIsMandatory(Boolean isMandatory) {
+        this.isMandatory = isMandatory;
+    }
+
+    /**
+    **/
+    public MetaProperty isConfidential(Boolean isConfidential) {
+
+        this.isConfidential = isConfidential;
+        return this;
+    }
+    
+    @ApiModelProperty(value = "")
+    @JsonProperty("isConfidential")
+    @Valid
+    public Boolean getIsConfidential() {
+        return isConfidential;
+    }
+    public void setIsConfidential(Boolean isConfidential) {
+        this.isConfidential = isConfidential;
+    }
+
+    /**
+    **/
+    public MetaProperty options(List<String> options) {
+
+        this.options = options;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "[\"HTTP-Redirect\",\"HTTP-POST\",\"As Per Request\"]", value = "")
+    @JsonProperty("options")
+    @Valid
+    public List<String> getOptions() {
+        return options;
+    }
+    public void setOptions(List<String> options) {
+        this.options = options;
+    }
+
+    public MetaProperty addOptionsItem(String optionsItem) {
+        if (this.options == null) {
+            this.options = new ArrayList<>();
+        }
+        this.options.add(optionsItem);
+        return this;
+    }
+
+        /**
+    **/
+    public MetaProperty defaultValue(String defaultValue) {
+
+        this.defaultValue = defaultValue;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "HTTP-Redirect", value = "")
+    @JsonProperty("defaultValue")
+    @Valid
+    public String getDefaultValue() {
+        return defaultValue;
+    }
+    public void setDefaultValue(String defaultValue) {
+        this.defaultValue = defaultValue;
+    }
+
+    /**
+    **/
+    public MetaProperty subProperties(List<MetaProperty> subProperties) {
+
+        this.subProperties = subProperties;
+        return this;
+    }
+    
+    @ApiModelProperty(value = "")
+    @JsonProperty("subProperties")
+    @Valid
+    public List<MetaProperty> getSubProperties() {
+        return subProperties;
+    }
+    public void setSubProperties(List<MetaProperty> subProperties) {
+        this.subProperties = subProperties;
+    }
+
+    public MetaProperty addSubPropertiesItem(MetaProperty subPropertiesItem) {
+        if (this.subProperties == null) {
+            this.subProperties = new ArrayList<>();
+        }
+        this.subProperties.add(subPropertiesItem);
+        return this;
+    }
+
+    
+
+    @Override
+    public boolean equals(java.lang.Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        MetaProperty metaProperty = (MetaProperty) o;
+        return Objects.equals(this.key, metaProperty.key) &&
+            Objects.equals(this.displayName, metaProperty.displayName) &&
+            Objects.equals(this.description, metaProperty.description) &&
+            Objects.equals(this.type, metaProperty.type) &&
+            Objects.equals(this.displayOrder, metaProperty.displayOrder) &&
+            Objects.equals(this.regex, metaProperty.regex) &&
+            Objects.equals(this.isMandatory, metaProperty.isMandatory) &&
+            Objects.equals(this.isConfidential, metaProperty.isConfidential) &&
+            Objects.equals(this.options, metaProperty.options) &&
+            Objects.equals(this.defaultValue, metaProperty.defaultValue) &&
+            Objects.equals(this.subProperties, metaProperty.subProperties);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(key, displayName, description, type, displayOrder, regex, isMandatory, isConfidential, options, defaultValue, subProperties);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class MetaProperty {\n");
+        
+        sb.append("    key: ").append(toIndentedString(key)).append("\n");
+        sb.append("    displayName: ").append(toIndentedString(displayName)).append("\n");
+        sb.append("    description: ").append(toIndentedString(description)).append("\n");
+        sb.append("    type: ").append(toIndentedString(type)).append("\n");
+        sb.append("    displayOrder: ").append(toIndentedString(displayOrder)).append("\n");
+        sb.append("    regex: ").append(toIndentedString(regex)).append("\n");
+        sb.append("    isMandatory: ").append(toIndentedString(isMandatory)).append("\n");
+        sb.append("    isConfidential: ").append(toIndentedString(isConfidential)).append("\n");
+        sb.append("    options: ").append(toIndentedString(options)).append("\n");
+        sb.append("    defaultValue: ").append(toIndentedString(defaultValue)).append("\n");
+        sb.append("    subProperties: ").append(toIndentedString(subProperties)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+    * Convert the given object to string with each line indented by 4 spaces
+    * (except the first line).
+    */
+    private String toIndentedString(java.lang.Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}
+

--- a/components/org.wso2.carbon.identity.api.server.jwt.issuers/org.wso2.carbon.identity.api.server.jwt.issuers.v1/src/gen/java/org/wso2/carbon/identity/api/server/jwt/issuers/v1/model/OutboundConnectorListItem.java
+++ b/components/org.wso2.carbon.identity.api.server.jwt.issuers/org.wso2.carbon.identity.api.server.jwt.issuers.v1/src/gen/java/org/wso2/carbon/identity/api/server/jwt/issuers/v1/model/OutboundConnectorListItem.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.com).
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.jwt.issuers.v1.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import javax.validation.constraints.*;
+
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+import javax.validation.Valid;
+import javax.xml.bind.annotation.*;
+
+public class OutboundConnectorListItem  {
+  
+    private String connectorId;
+    private String name;
+    private Boolean isEnabled = false;
+    private String self;
+
+    /**
+    **/
+    public OutboundConnectorListItem connectorId(String connectorId) {
+
+        this.connectorId = connectorId;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "U0NJTQ", value = "")
+    @JsonProperty("connectorId")
+    @Valid
+    public String getConnectorId() {
+        return connectorId;
+    }
+    public void setConnectorId(String connectorId) {
+        this.connectorId = connectorId;
+    }
+
+    /**
+    **/
+    public OutboundConnectorListItem name(String name) {
+
+        this.name = name;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "SCIM", value = "")
+    @JsonProperty("name")
+    @Valid
+    public String getName() {
+        return name;
+    }
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    /**
+    **/
+    public OutboundConnectorListItem isEnabled(Boolean isEnabled) {
+
+        this.isEnabled = isEnabled;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "true", value = "")
+    @JsonProperty("isEnabled")
+    @Valid
+    public Boolean getIsEnabled() {
+        return isEnabled;
+    }
+    public void setIsEnabled(Boolean isEnabled) {
+        this.isEnabled = isEnabled;
+    }
+
+    /**
+    **/
+    public OutboundConnectorListItem self(String self) {
+
+        this.self = self;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "/t/carbon.super/api/server/v1/identity-providers/123e4567-e89b-12d3-a456-556642440000/provisioning/outbound-connectors/U0NJTQ", value = "")
+    @JsonProperty("self")
+    @Valid
+    public String getSelf() {
+        return self;
+    }
+    public void setSelf(String self) {
+        this.self = self;
+    }
+
+
+
+    @Override
+    public boolean equals(java.lang.Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OutboundConnectorListItem outboundConnectorListItem = (OutboundConnectorListItem) o;
+        return Objects.equals(this.connectorId, outboundConnectorListItem.connectorId) &&
+            Objects.equals(this.name, outboundConnectorListItem.name) &&
+            Objects.equals(this.isEnabled, outboundConnectorListItem.isEnabled) &&
+            Objects.equals(this.self, outboundConnectorListItem.self);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(connectorId, name, isEnabled, self);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OutboundConnectorListItem {\n");
+        
+        sb.append("    connectorId: ").append(toIndentedString(connectorId)).append("\n");
+        sb.append("    name: ").append(toIndentedString(name)).append("\n");
+        sb.append("    isEnabled: ").append(toIndentedString(isEnabled)).append("\n");
+        sb.append("    self: ").append(toIndentedString(self)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+    * Convert the given object to string with each line indented by 4 spaces
+    * (except the first line).
+    */
+    private String toIndentedString(java.lang.Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}
+

--- a/components/org.wso2.carbon.identity.api.server.jwt.issuers/org.wso2.carbon.identity.api.server.jwt.issuers.v1/src/gen/java/org/wso2/carbon/identity/api/server/jwt/issuers/v1/model/OutboundConnectorListResponse.java
+++ b/components/org.wso2.carbon.identity.api.server.jwt.issuers/org.wso2.carbon.identity.api.server.jwt.issuers.v1/src/gen/java/org/wso2/carbon/identity/api/server/jwt/issuers/v1/model/OutboundConnectorListResponse.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.com).
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.jwt.issuers.v1.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import java.util.ArrayList;
+import java.util.List;
+import org.wso2.carbon.identity.api.server.jwt.issuers.v1.model.OutboundConnectorListItem;
+import javax.validation.constraints.*;
+
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+import javax.validation.Valid;
+import javax.xml.bind.annotation.*;
+
+public class OutboundConnectorListResponse  {
+  
+    private String defaultConnectorId;
+    private List<OutboundConnectorListItem> connectors = null;
+
+
+    /**
+    **/
+    public OutboundConnectorListResponse defaultConnectorId(String defaultConnectorId) {
+
+        this.defaultConnectorId = defaultConnectorId;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "U0NJTQ", value = "")
+    @JsonProperty("defaultConnectorId")
+    @Valid
+    public String getDefaultConnectorId() {
+        return defaultConnectorId;
+    }
+    public void setDefaultConnectorId(String defaultConnectorId) {
+        this.defaultConnectorId = defaultConnectorId;
+    }
+
+    /**
+    **/
+    public OutboundConnectorListResponse connectors(List<OutboundConnectorListItem> connectors) {
+
+        this.connectors = connectors;
+        return this;
+    }
+    
+    @ApiModelProperty(value = "")
+    @JsonProperty("connectors")
+    @Valid
+    public List<OutboundConnectorListItem> getConnectors() {
+        return connectors;
+    }
+    public void setConnectors(List<OutboundConnectorListItem> connectors) {
+        this.connectors = connectors;
+    }
+
+    public OutboundConnectorListResponse addConnectorsItem(OutboundConnectorListItem connectorsItem) {
+        if (this.connectors == null) {
+            this.connectors = new ArrayList<>();
+        }
+        this.connectors.add(connectorsItem);
+        return this;
+    }
+
+    
+
+    @Override
+    public boolean equals(java.lang.Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OutboundConnectorListResponse outboundConnectorListResponse = (OutboundConnectorListResponse) o;
+        return Objects.equals(this.defaultConnectorId, outboundConnectorListResponse.defaultConnectorId) &&
+            Objects.equals(this.connectors, outboundConnectorListResponse.connectors);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(defaultConnectorId, connectors);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OutboundConnectorListResponse {\n");
+        
+        sb.append("    defaultConnectorId: ").append(toIndentedString(defaultConnectorId)).append("\n");
+        sb.append("    connectors: ").append(toIndentedString(connectors)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+    * Convert the given object to string with each line indented by 4 spaces
+    * (except the first line).
+    */
+    private String toIndentedString(java.lang.Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}
+

--- a/components/org.wso2.carbon.identity.api.server.jwt.issuers/org.wso2.carbon.identity.api.server.jwt.issuers.v1/src/gen/java/org/wso2/carbon/identity/api/server/jwt/issuers/v1/model/ProvisioningClaim.java
+++ b/components/org.wso2.carbon.identity.api.server.jwt.issuers/org.wso2.carbon.identity.api.server.jwt.issuers.v1/src/gen/java/org/wso2/carbon/identity/api/server/jwt/issuers/v1/model/ProvisioningClaim.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.com).
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.jwt.issuers.v1.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import org.wso2.carbon.identity.api.server.jwt.issuers.v1.model.Claim;
+import javax.validation.constraints.*;
+
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+import javax.validation.Valid;
+import javax.xml.bind.annotation.*;
+
+public class ProvisioningClaim  {
+  
+    private Claim claim;
+    private String defaultValue;
+
+    /**
+    **/
+    public ProvisioningClaim claim(Claim claim) {
+
+        this.claim = claim;
+        return this;
+    }
+    
+    @ApiModelProperty(value = "")
+    @JsonProperty("claim")
+    @Valid
+    public Claim getClaim() {
+        return claim;
+    }
+    public void setClaim(Claim claim) {
+        this.claim = claim;
+    }
+
+    /**
+    **/
+    public ProvisioningClaim defaultValue(String defaultValue) {
+
+        this.defaultValue = defaultValue;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "sathya", value = "")
+    @JsonProperty("defaultValue")
+    @Valid
+    public String getDefaultValue() {
+        return defaultValue;
+    }
+    public void setDefaultValue(String defaultValue) {
+        this.defaultValue = defaultValue;
+    }
+
+
+
+    @Override
+    public boolean equals(java.lang.Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ProvisioningClaim provisioningClaim = (ProvisioningClaim) o;
+        return Objects.equals(this.claim, provisioningClaim.claim) &&
+            Objects.equals(this.defaultValue, provisioningClaim.defaultValue);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(claim, defaultValue);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class ProvisioningClaim {\n");
+        
+        sb.append("    claim: ").append(toIndentedString(claim)).append("\n");
+        sb.append("    defaultValue: ").append(toIndentedString(defaultValue)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+    * Convert the given object to string with each line indented by 4 spaces
+    * (except the first line).
+    */
+    private String toIndentedString(java.lang.Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}
+

--- a/components/org.wso2.carbon.identity.api.server.jwt.issuers/org.wso2.carbon.identity.api.server.jwt.issuers.v1/src/gen/java/org/wso2/carbon/identity/api/server/jwt/issuers/v1/model/ProvisioningResponse.java
+++ b/components/org.wso2.carbon.identity.api.server.jwt.issuers/org.wso2.carbon.identity.api.server.jwt.issuers.v1/src/gen/java/org/wso2/carbon/identity/api/server/jwt/issuers/v1/model/ProvisioningResponse.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.com).
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.jwt.issuers.v1.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import org.wso2.carbon.identity.api.server.jwt.issuers.v1.model.JustInTimeProvisioning;
+import org.wso2.carbon.identity.api.server.jwt.issuers.v1.model.OutboundConnectorListResponse;
+import javax.validation.constraints.*;
+
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+import javax.validation.Valid;
+import javax.xml.bind.annotation.*;
+
+public class ProvisioningResponse  {
+  
+    private JustInTimeProvisioning jit;
+    private OutboundConnectorListResponse outboundConnectors;
+
+    /**
+    **/
+    public ProvisioningResponse jit(JustInTimeProvisioning jit) {
+
+        this.jit = jit;
+        return this;
+    }
+    
+    @ApiModelProperty(value = "")
+    @JsonProperty("jit")
+    @Valid
+    public JustInTimeProvisioning getJit() {
+        return jit;
+    }
+    public void setJit(JustInTimeProvisioning jit) {
+        this.jit = jit;
+    }
+
+    /**
+    **/
+    public ProvisioningResponse outboundConnectors(OutboundConnectorListResponse outboundConnectors) {
+
+        this.outboundConnectors = outboundConnectors;
+        return this;
+    }
+    
+    @ApiModelProperty(value = "")
+    @JsonProperty("outboundConnectors")
+    @Valid
+    public OutboundConnectorListResponse getOutboundConnectors() {
+        return outboundConnectors;
+    }
+    public void setOutboundConnectors(OutboundConnectorListResponse outboundConnectors) {
+        this.outboundConnectors = outboundConnectors;
+    }
+
+
+
+    @Override
+    public boolean equals(java.lang.Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ProvisioningResponse provisioningResponse = (ProvisioningResponse) o;
+        return Objects.equals(this.jit, provisioningResponse.jit) &&
+            Objects.equals(this.outboundConnectors, provisioningResponse.outboundConnectors);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(jit, outboundConnectors);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class ProvisioningResponse {\n");
+        
+        sb.append("    jit: ").append(toIndentedString(jit)).append("\n");
+        sb.append("    outboundConnectors: ").append(toIndentedString(outboundConnectors)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+    * Convert the given object to string with each line indented by 4 spaces
+    * (except the first line).
+    */
+    private String toIndentedString(java.lang.Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}
+

--- a/components/org.wso2.carbon.identity.api.server.jwt.issuers/org.wso2.carbon.identity.api.server.jwt.issuers.v1/src/gen/java/org/wso2/carbon/identity/api/server/jwt/issuers/v1/model/RoleMapping.java
+++ b/components/org.wso2.carbon.identity.api.server.jwt.issuers/org.wso2.carbon.identity.api.server.jwt.issuers.v1/src/gen/java/org/wso2/carbon/identity/api/server/jwt/issuers/v1/model/RoleMapping.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.com).
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.jwt.issuers.v1.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import javax.validation.constraints.*;
+
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+import javax.validation.Valid;
+import javax.xml.bind.annotation.*;
+
+public class RoleMapping  {
+  
+    private String idpRole;
+    private String localRole;
+
+    /**
+    **/
+    public RoleMapping idpRole(String idpRole) {
+
+        this.idpRole = idpRole;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "google-manager", value = "")
+    @JsonProperty("idpRole")
+    @Valid
+    public String getIdpRole() {
+        return idpRole;
+    }
+    public void setIdpRole(String idpRole) {
+        this.idpRole = idpRole;
+    }
+
+    /**
+    **/
+    public RoleMapping localRole(String localRole) {
+
+        this.localRole = localRole;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "manager", value = "")
+    @JsonProperty("localRole")
+    @Valid
+    public String getLocalRole() {
+        return localRole;
+    }
+    public void setLocalRole(String localRole) {
+        this.localRole = localRole;
+    }
+
+
+
+    @Override
+    public boolean equals(java.lang.Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        RoleMapping roleMapping = (RoleMapping) o;
+        return Objects.equals(this.idpRole, roleMapping.idpRole) &&
+            Objects.equals(this.localRole, roleMapping.localRole);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(idpRole, localRole);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class RoleMapping {\n");
+        
+        sb.append("    idpRole: ").append(toIndentedString(idpRole)).append("\n");
+        sb.append("    localRole: ").append(toIndentedString(localRole)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+    * Convert the given object to string with each line indented by 4 spaces
+    * (except the first line).
+    */
+    private String toIndentedString(java.lang.Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}
+

--- a/components/org.wso2.carbon.identity.api.server.jwt.issuers/org.wso2.carbon.identity.api.server.jwt.issuers.v1/src/gen/java/org/wso2/carbon/identity/api/server/jwt/issuers/v1/model/Roles.java
+++ b/components/org.wso2.carbon.identity.api.server.jwt.issuers/org.wso2.carbon.identity.api.server.jwt.issuers.v1/src/gen/java/org/wso2/carbon/identity/api/server/jwt/issuers/v1/model/Roles.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.com).
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.jwt.issuers.v1.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import java.util.ArrayList;
+import java.util.List;
+import org.wso2.carbon.identity.api.server.jwt.issuers.v1.model.RoleMapping;
+import javax.validation.constraints.*;
+
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+import javax.validation.Valid;
+import javax.xml.bind.annotation.*;
+
+public class Roles  {
+  
+    private List<RoleMapping> mappings = null;
+
+    private List<String> outboundProvisioningRoles = null;
+
+
+    /**
+    **/
+    public Roles mappings(List<RoleMapping> mappings) {
+
+        this.mappings = mappings;
+        return this;
+    }
+    
+    @ApiModelProperty(value = "")
+    @JsonProperty("mappings")
+    @Valid
+    public List<RoleMapping> getMappings() {
+        return mappings;
+    }
+    public void setMappings(List<RoleMapping> mappings) {
+        this.mappings = mappings;
+    }
+
+    public Roles addMappingsItem(RoleMapping mappingsItem) {
+        if (this.mappings == null) {
+            this.mappings = new ArrayList<>();
+        }
+        this.mappings.add(mappingsItem);
+        return this;
+    }
+
+        /**
+    **/
+    public Roles outboundProvisioningRoles(List<String> outboundProvisioningRoles) {
+
+        this.outboundProvisioningRoles = outboundProvisioningRoles;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "[\"manager\",\"hr-admin\"]", value = "")
+    @JsonProperty("outboundProvisioningRoles")
+    @Valid
+    public List<String> getOutboundProvisioningRoles() {
+        return outboundProvisioningRoles;
+    }
+    public void setOutboundProvisioningRoles(List<String> outboundProvisioningRoles) {
+        this.outboundProvisioningRoles = outboundProvisioningRoles;
+    }
+
+    public Roles addOutboundProvisioningRolesItem(String outboundProvisioningRolesItem) {
+        if (this.outboundProvisioningRoles == null) {
+            this.outboundProvisioningRoles = new ArrayList<>();
+        }
+        this.outboundProvisioningRoles.add(outboundProvisioningRolesItem);
+        return this;
+    }
+
+    
+
+    @Override
+    public boolean equals(java.lang.Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Roles roles = (Roles) o;
+        return Objects.equals(this.mappings, roles.mappings) &&
+            Objects.equals(this.outboundProvisioningRoles, roles.outboundProvisioningRoles);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(mappings, outboundProvisioningRoles);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class Roles {\n");
+        
+        sb.append("    mappings: ").append(toIndentedString(mappings)).append("\n");
+        sb.append("    outboundProvisioningRoles: ").append(toIndentedString(outboundProvisioningRoles)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+    * Convert the given object to string with each line indented by 4 spaces
+    * (except the first line).
+    */
+    private String toIndentedString(java.lang.Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}
+

--- a/components/org.wso2.carbon.identity.api.server.jwt.issuers/org.wso2.carbon.identity.api.server.jwt.issuers.v1/src/main/java/org/wso2/carbon/identity/api/server/jwt/issuers/v1/impl/JwtIssuersApiServiceImpl.java
+++ b/components/org.wso2.carbon.identity.api.server.jwt.issuers/org.wso2.carbon.identity.api.server.jwt.issuers.v1/src/main/java/org/wso2/carbon/identity/api/server/jwt/issuers/v1/impl/JwtIssuersApiServiceImpl.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.com).
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.jwt.issuers.v1.impl;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.wso2.carbon.identity.api.server.common.ContextLoader;
+import org.wso2.carbon.identity.api.server.idp.v1.core.ServerIdpManagementService;
+import org.wso2.carbon.identity.api.server.idp.v1.model.IdentityProviderPOSTRequest;
+import org.wso2.carbon.identity.api.server.idp.v1.model.IdentityProviderResponse;
+import org.wso2.carbon.identity.api.server.jwt.issuers.v1.JwtIssuersApiService;
+import org.wso2.carbon.identity.api.server.jwt.issuers.v1.model.Certificate;
+import org.wso2.carbon.identity.api.server.jwt.issuers.v1.model.JWTIssuerPOSTRequest;
+
+import java.net.URI;
+import javax.ws.rs.core.Response;
+
+import static org.wso2.carbon.identity.api.server.common.Constants.V1_API_PATH_COMPONENT;
+
+/**
+ * Implementation of the JWT Issuers REST API.
+ */
+public class JwtIssuersApiServiceImpl implements JwtIssuersApiService {
+
+    private static final String IDP_PATH_COMPONENT = "";
+    @Autowired
+    private ServerIdpManagementService serverIdpManagementService;
+
+    @Override
+    public Response addJWTIssuer(JWTIssuerPOSTRequest jwTIssuerPOSTRequest) {
+        IdentityProviderPOSTRequest identityProviderPOSTRequest = new IdentityProviderPOSTRequest();
+        //set name
+        identityProviderPOSTRequest.setIdpIssuerName(jwTIssuerPOSTRequest.getIdpIssuerName());
+        identityProviderPOSTRequest.setAlias(jwTIssuerPOSTRequest.getAlias());
+        identityProviderPOSTRequest.setName(jwTIssuerPOSTRequest.getName());
+        Certificate certificate = jwTIssuerPOSTRequest.getCertificate();
+        if (certificate != null) {
+            org.wso2.carbon.identity.api.server.idp.v1.model.Certificate certificate1 = new
+                    org.wso2.carbon.identity.api.server.idp.v1.model.Certificate();
+            certificate1.setJwksUri(certificate.getJwksUri());
+            certificate1.setCertificates(certificate.getCertificates());
+            identityProviderPOSTRequest.setCertificate(certificate1);
+        }
+        identityProviderPOSTRequest.setDescription(jwTIssuerPOSTRequest.getDescription());
+        identityProviderPOSTRequest.setImage(jwTIssuerPOSTRequest.getImage());
+        identityProviderPOSTRequest.setTemplateId(jwTIssuerPOSTRequest.getTemplateId());
+        IdentityProviderResponse idPResponse = serverIdpManagementService.addIDP(identityProviderPOSTRequest);
+        URI location = ContextLoader.buildURIForHeader(V1_API_PATH_COMPONENT + IDP_PATH_COMPONENT + "/" +
+                idPResponse.getId());
+        return Response.created(location).entity(idPResponse).build();
+    }
+
+    @Override
+    public Response getJwtIssuers(Integer limit, Integer offset, String filter, String sortBy, String sortOrder,
+                                  String requiredAttributes) {
+
+        return Response.ok().entity(serverIdpManagementService.getJwtIssuers(requiredAttributes, limit, offset, filter,
+                sortBy, sortOrder)).build();
+    }
+}

--- a/components/org.wso2.carbon.identity.api.server.jwt.issuers/org.wso2.carbon.identity.api.server.jwt.issuers.v1/src/main/resources/META-INF/cxf/jwt-issuer-server-v1-cxf.xml
+++ b/components/org.wso2.carbon.identity.api.server.jwt.issuers/org.wso2.carbon.identity.api.server.jwt.issuers.v1/src/main/resources/META-INF/cxf/jwt-issuer-server-v1-cxf.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:jaxrs="http://cxf.apache.org/jaxrs" xmlns:context="http://www.springframework.org/schema/context" xsi:schemaLocation=" http://www.springframework.org/schema/beans  http://www.springframework.org/schema/beans/spring-beans-3.0.xsd http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.0.xsd http://cxf.apache.org/jaxrs http://cxf.apache.org/schemas/jaxrs.xsd">
+    <bean class="org.wso2.carbon.identity.api.server.jwt.issuers.v1.impl.JwtIssuersApiServiceImpl"/>
+    <bean id="identityProviderServiceFactoryBean"
+          class="org.wso2.carbon.identity.api.server.idp.common.factory.IdPMgtOSGIServiceFactory"/>
+    <bean id="jwtIssuerServiceHolderBean"
+          class="org.wso2.carbon.identity.api.server.jwt.issuers.common.JWTIssuerServiceHolder">
+        <property name="identityProviderManager" ref="identityProviderServiceFactoryBean"/>
+    </bean>
+</beans>

--- a/components/org.wso2.carbon.identity.api.server.jwt.issuers/org.wso2.carbon.identity.api.server.jwt.issuers.v1/src/main/resources/jwt-issuers.yaml
+++ b/components/org.wso2.carbon.identity.api.server.jwt.issuers/org.wso2.carbon.identity.api.server.jwt.issuers.v1/src/main/resources/jwt-issuers.yaml
@@ -1,0 +1,680 @@
+openapi: 3.0.0
+info:
+  description: >
+    This document specifies an **JWT Issuer Management RESTful API** for
+    **WSO2 Identity Server**. This supports Restful APIs for identity provider management.
+    The APIs provide the capability to add/update/delete/patch identity providers in the identity server.
+    In addition, APIs are available to retrieve metadata about federated authenticators and outbound provisioning
+    connectors that can be configured for any given identity provider.
+  version: "v1"
+  title: WSO2 Identity Server - JWT Issuer Management API definition
+  termsOfService: 'http://swagger.io/terms/'
+  contact:
+    name: WSO2
+    url: 'http://wso2.com/products/identity-server/'
+    email: architecture@wso2.org
+  license:
+    name: Apache 2.0
+    url: 'http://www.apache.org/licenses/LICENSE-2.0.html'
+security:
+  - OAuth2: []
+  - BasicAuth: []
+paths:
+  '/jwt-issuers':
+    get:
+      tags:
+        - JWT Issuers
+      summary: |
+        List JWT issuers
+      description: >
+        This API provides the capability to retrieve the list of jwt issuers.<br>
+        <b>Permission required:</b> <br>
+            * /permission/admin/manage/identity/idpmgt/view <br>
+        <b>Scope required:</b> <br>
+            * internal_idp_view
+      operationId: getJwtIssuers
+      parameters:
+        - $ref: '#/components/parameters/limitQueryParam'
+        - $ref: '#/components/parameters/offsetQueryParam'
+        - $ref: '#/components/parameters/filterQueryParam'
+        - $ref: '#/components/parameters/sortByQueryParam'
+        - $ref: '#/components/parameters/sortOrderQueryParam'
+        - $ref: '#/components/parameters/requiredAttributesQueryParam'
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IdentityProviderListResponse'
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '500':
+          description: Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '501':
+          description: Not Implemented
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+    post:
+      tags:
+        - JWT Issuers
+      summary: |
+        Add a new jwt issuer
+      description: |
+        This API provides the capability to create a jwt issuer. <br>
+        <b>Permission required:</b> <br>
+            * /permission/admin/manage/identity/idpmgt/create <br>
+        <b>Scope required:</b> <br>
+            * internal_idp_create
+      operationId: addJWTIssuer
+      responses:
+        '201':
+          description: Successful response
+          headers:
+            Location:
+              description: Location of the newly created JWT issuer.
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IdentityProviderResponse'
+            application/xml:
+              schema:
+                $ref: '#/components/schemas/IdentityProviderResponse'
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+            application/xml:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '409':
+          description: Conflict
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+            application/xml:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '500':
+          description: Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+            application/xml:
+              schema:
+                $ref: '#/components/schemas/Error'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/JWTIssuerPOSTRequest'
+          application/xml:
+            schema:
+              $ref: '#/components/schemas/JWTIssuerPOSTRequest'
+        description: This represents the JWT issuer to be created.
+        required: true
+servers:
+  - url: 'https://localhost:9443/t/{tenant-domain}/api/server/v1'
+    variables:
+      tenant-domain:
+        default: carbon.super
+components:
+  parameters:
+    limitQueryParam:
+      in: query
+      name: limit
+      required: false
+      description: |
+        Maximum number of records to return.
+      schema:
+        type: integer
+        format: int32
+    offsetQueryParam:
+      in: query
+      name: offset
+      required: false
+      description: |
+        Number of records to skip for pagination.
+      schema:
+        type: integer
+        format: int32
+    filterQueryParam:
+      in: query
+      name: filter
+      required: false
+      description: >
+        Condition to filter the retrieval of records. Supports 'sw', 'co', 'ew'
+        and 'eq' operations and also complex queries with 'and' operations. E.g.
+        /identity-providers?filter=name+sw+"google"+and+isEnabled+eq+"true"
+      schema:
+        type: string
+    requiredAttributesQueryParam:
+      in: query
+      name: requiredAttributes
+      required: false
+      description: |
+        Specifies the required parameters in the response.
+      schema:
+        type: string
+    forceQueryParam:
+      in: query
+      name: force
+      required: false
+      description: >
+        Enforces the forceful deletion of an identity provider,
+        federated authenticator or an outbound provisioning connector even though
+        it is referred by a service provider.
+      schema:
+        type: boolean
+        default: false
+    excludeSecretsQueryParam:
+      in: query
+      name: excludeSecrets
+      required: false
+      description: |
+        Specifies whether to exclude secrets when exporting an identity provider.
+      schema:
+        type: boolean
+        default: true
+    fileTypeHeaderParam:
+      in: header
+      name: Accept
+      required: false
+      description: |
+        Content type of the file.
+      schema:
+        type: string
+        default: application/yaml
+        enum:
+          - application/json
+          - application/xml
+          - application/yaml
+          - application/x-yaml
+          - text/yaml
+          - text/xml
+          - text/json
+    sortOrderQueryParam:
+      in: query
+      name: sortOrder
+      required: false
+      description: >-
+        Define the order in which the retrieved tenants should be sorted.
+      schema:
+        type: string
+        enum:
+          - asc
+          - desc
+    sortByQueryParam:
+      in: query
+      name: sortBy
+      required: false
+      description: >-
+        Attribute by which the retrieved records should be sorted. Currently sorting through _<b>domainName<b>_ only
+        supported.
+      schema:
+        type: string
+  securitySchemes:
+    BasicAuth:
+      type: http
+      scheme: basic
+    OAuth2:
+      type: oauth2
+      flows:
+        authorizationCode:
+          authorizationUrl: 'https://localhost:9443/oauth2/authorize'
+          tokenUrl: 'https://localhost:9443/oauth2/token'
+          scopes: {}
+  schemas:
+    Error:
+      type: object
+      properties:
+        code:
+          type: string
+          example: AAA-00000
+        message:
+          type: string
+          example: Some Error Message
+        description:
+          type: string
+          example: Some Error Description
+        traceId:
+          type: string
+          example: e0fbcfeb-3617-43c4-8dd0-7b7d38e13047
+    MetaProperty:
+      type: object
+      required:
+        - key
+      properties:
+        key:
+          type: string
+          example: 'httpBinding'
+        displayName:
+          type: string
+          example: 'HTTP Binding'
+        description:
+          type: string
+          example: 'Choose the HTTP Binding or decide from incoming request'
+        type:
+          type: string
+          enum:
+            - STRING
+            - BOOLEAN
+            - INTEGER
+          example: STRING
+        displayOrder:
+          type: integer
+          example: 10
+        regex:
+          type: string
+          example: '[a-zA-Z]{3,30}'
+        isMandatory:
+          type: boolean
+          default: false
+          example: false
+        isConfidential:
+          type: boolean
+          default: false
+        options:
+          type: array
+          items:
+            type: string
+          example: ['HTTP-Redirect', 'HTTP-POST', 'As Per Request']
+        defaultValue:
+          type: string
+          example: HTTP-Redirect
+        subProperties:
+          type: array
+          items:
+            $ref: '#/components/schemas/MetaProperty'
+    Link:
+      type: object
+      properties:
+        href:
+          type: string
+          description: Path to the target resource.
+          example: >-
+            '/t/carbon.super/api/server/v1/identity-providers/394b8adcce24c64a8a09a8d80abf8c337bd253de'
+        rel:
+          type: string
+          description: Describes how the current context is related to the target resource.
+          example: identity-providers
+      readOnly: true
+    Certificate:
+      type: object
+      properties:
+        certificates:
+          type: array
+          items:
+            type: string
+        jwksUri:
+          type: string
+          example: "https://localhost:9444/oauth2/jwks"
+    IdentityProviderResponse:
+      type: object
+      properties:
+        id:
+          type: string
+          example: '123e4567-e89b-12d3-a456-556642440000'
+        name:
+          type: string
+          example: google
+        description:
+          type: string
+        templateId:
+          type: string
+          example: '8ea23303-49c0-4253-b81f-82c0fe6fb4a0'
+        isEnabled:
+          type: boolean
+          default: true
+          example: true
+        isPrimary:
+          type: boolean
+          default: false
+        image:
+          type: string
+          example: "google-logo-url"
+        isFederationHub:
+          type: boolean
+          example: false
+        homeRealmIdentifier:
+          type: string
+          example: localhost
+        certificate:
+          $ref: '#/components/schemas/Certificate'
+        alias:
+          type: string
+          example: 'https://localhost:9444/oauth2/token'
+        idpIssuerName:
+          type: string
+          example: 'https://www.idp.com'
+        claims:
+          $ref: '#/components/schemas/Claims'
+        roles:
+          $ref: '#/components/schemas/Roles'
+        groups:
+          $ref: '#/components/schemas/IdPGroupsConfig'
+        federatedAuthenticators:
+          $ref: '#/components/schemas/FederatedAuthenticatorListResponse'
+        provisioning:
+          $ref: '#/components/schemas/ProvisioningResponse'
+    IdentityProviderListResponse:
+      type: object
+      properties:
+        totalResults:
+          type: integer
+          example: 10
+        startIndex:
+          type: integer
+          example: 1
+        count:
+          type: integer
+          example: 10
+        links:
+          type: array
+          items:
+            $ref: '#/components/schemas/Link'
+          example:
+            [
+              {
+                "href": "identity-provider?offset=50&limit=10",
+                "rel": "next",
+              },  {
+              "href": "identity-provider?offset=30&limit=10",
+              "rel": "previous",
+            }
+            ]
+        identityProviders:
+          type: array
+          items:
+            $ref: '#/components/schemas/IdentityProviderListItem'
+    IdentityProviderListItem:
+      type: object
+      properties:
+        id:
+          type: string
+          example: 123e4567-e89b-12d3-a456-556642440000
+        name:
+          type: string
+          example: google
+        description:
+          type: string
+          example: identity provider for google federation
+        isEnabled:
+          type: boolean
+          default: true
+          example: true
+        image:
+          type: string
+          example: "google-logo-url"
+        isPrimary:
+          type: boolean
+          example: false
+        isFederationHub:
+          type: boolean
+          example: false
+        homeRealmIdentifier:
+          type: string
+          example: localhost
+        certificate:
+          $ref: '#/components/schemas/Certificate'
+        alias:
+          type: string
+          example: 'https://localhost:9444/oauth2/token'
+        claims:
+          $ref: '#/components/schemas/Claims'
+        roles:
+          $ref: '#/components/schemas/Roles'
+        groups:
+          $ref: '#/components/schemas/IdPGroupsConfig'
+        federatedAuthenticators:
+          $ref: '#/components/schemas/FederatedAuthenticatorListResponse'
+        provisioning:
+          $ref: '#/components/schemas/ProvisioningResponse'
+        self:
+          type: string
+          example: /t/carbon.super/api/server/v1/identity-providers/123e4567-e89b-12d3-a456-556642440000
+    FederatedAuthenticatorListResponse:
+      type: object
+      properties:
+        defaultAuthenticatorId:
+          type: string
+          example: U0FNTDJBdXRoZW50aWNhdG9y
+        authenticators:
+          type: array
+          items:
+            $ref: '#/components/schemas/FederatedAuthenticatorListItem'
+    FederatedAuthenticatorListItem:
+      type: object
+      properties:
+        authenticatorId:
+          type: string
+          example: U0FNTDJBdXRoZW50aWNhdG9y
+        name:
+          type: string
+          example: SAML2Authenticator
+        isEnabled:
+          type: boolean
+          default: false
+          example: true
+        tags:
+          type: array
+          items:
+            type: string
+          example: [Social Login,OIDC]
+          readOnly: true
+        self:
+          type: string
+          example: /t/carbon.super/api/server/v1/identity-providers/123e4567-e89b-12d3-a456-556642440000/federated-authenticators/U0FNTDJBdXRoZW50aWNhdG9y
+    ProvisioningResponse:
+      type: object
+      properties:
+        jit:
+          $ref: '#/components/schemas/JustInTimeProvisioning'
+        outboundConnectors:
+          $ref: '#/components/schemas/OutboundConnectorListResponse'
+    OutboundConnectorListResponse:
+      type: object
+      properties:
+        defaultConnectorId:
+          type: string
+          example: U0NJTQ
+        connectors:
+          type: array
+          items:
+            $ref: '#/components/schemas/OutboundConnectorListItem'
+    OutboundConnectorListItem:
+      type: object
+      properties:
+        connectorId:
+          type: string
+          example: U0NJTQ
+        name:
+          type: string
+          example: SCIM
+          readOnly: true
+        isEnabled:
+          type: boolean
+          default: false
+          example: true
+        self:
+          type: string
+          example: /t/carbon.super/api/server/v1/identity-providers/123e4567-e89b-12d3-a456-556642440000/provisioning/outbound-connectors/U0NJTQ
+    Roles:
+      type: object
+      properties:
+        mappings:
+          type: array
+          items:
+            $ref: '#/components/schemas/RoleMapping'
+        outboundProvisioningRoles:
+          type: array
+          items:
+            type: string
+          example:
+            - manager
+            - hr-admin
+    RoleMapping:
+      type: object
+      properties:
+        idpRole:
+          type: string
+          example: google-manager
+        localRole:
+          type: string
+          example: manager
+    IdPGroupsConfig:
+      type: array
+      description: IdP groups supported by the IdP.
+      items:
+        $ref: '#/components/schemas/IdPGroup'
+      minItems: 0
+    IdPGroup:
+      type: object
+      required:
+        - name
+      description: Represents an IdP group supported by an Identity Provider.
+      properties:
+        name:
+          type: string
+          description: Name of the IdP group
+          example: google-admin
+        id:
+          type: string
+          description: UUID of the IdP group
+          example: 6b1f8513-3de0-4f28-9cad-b7400dbc94ae
+    Claims:
+      type: object
+      properties:
+        userIdClaim:
+          $ref: '#/components/schemas/Claim'
+        roleClaim:
+          $ref: '#/components/schemas/Claim'
+        mappings:
+          type: array
+          items:
+            $ref: '#/components/schemas/ClaimMapping'
+        provisioningClaims:
+          type: array
+          items:
+            $ref: '#/components/schemas/ProvisioningClaim'
+    ProvisioningClaim:
+      type: object
+      properties:
+        claim:
+          $ref: '#/components/schemas/Claim'
+        defaultValue:
+          type: string
+          example: sathya
+    ClaimMapping:
+      type: object
+      properties:
+        idpClaim:
+          type: string
+          example: country
+        localClaim:
+          $ref: '#/components/schemas/Claim'
+    Claim:
+      type: object
+      required:
+        - uri
+      properties:
+        id:
+          type: string
+          example: aHR0cDovL3dzbzIub3JnL2NsYWltcy91c2VybmFtZQ
+          readOnly: true
+        uri:
+          type: string
+          example: 'http://wso2.org/claims/username'
+        displayName:
+          type: string
+          example: Username
+          readOnly: true
+    JustInTimeProvisioning:
+      type: object
+      required:
+        - isEnabled
+      properties:
+        isEnabled:
+          type: boolean
+          default: false
+          example: true
+        scheme:
+          type: string
+          enum:
+            - PROMPT_USERNAME_PASSWORD_CONSENT
+            - PROMPT_PASSWORD_CONSENT
+            - PROMPT_CONSENT
+            - PROVISION_SILENTLY
+          default: PROVISION_SILENTLY
+        userstore:
+          type: string
+          default: PRIMARY
+          example: PRIMARY
+        associateLocalUser:
+          type: boolean
+          default: false
+          example: true
+        attributeSyncMethod:
+          type: string
+          enum:
+            - OVERRIDE_ALL
+            - NONE
+            - PRESERVE_LOCAL
+          default: OVERRIDE_ALL
+    JWTIssuerPOSTRequest:
+      type: object
+      required:
+        - name
+        - idpIssuerName
+        - certificate
+      properties:
+        name:
+          type: string
+          example: google
+        description:
+          type: string
+          example: "JWT Issuer"
+        image:
+          type: string
+          example: "issuer-logo-url"
+        templateId:
+          type: string
+          example: '8ea23303-49c0-4253-b81f-82c0fe6fb4a0'
+        certificate:
+          $ref: '#/components/schemas/Certificate'
+        alias:
+          type: string
+          example: 'https://localhost:9444/oauth2/token'
+        idpIssuerName:
+          type: string
+          example: 'https://www.issuer.com'

--- a/components/org.wso2.carbon.identity.api.server.jwt.issuers/pom.xml
+++ b/components/org.wso2.carbon.identity.api.server.jwt.issuers/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>identity-api-server</artifactId>
         <groupId>org.wso2.carbon.identity.server.api</groupId>
-        <version>1.2.54</version>
+        <version>1.2.55-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.api.server.jwt.issuers/pom.xml
+++ b/components/org.wso2.carbon.identity.api.server.jwt.issuers/pom.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2023, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+  ~
+  ~ WSO2 Inc. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <parent>
+        <artifactId>identity-api-server</artifactId>
+        <groupId>org.wso2.carbon.identity.server.api</groupId>
+        <version>1.2.54</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>org.wso2.carbon.identity.api.server.jwt.issuers</artifactId>
+    <packaging>pom</packaging>
+
+    <modules>
+        <module>org.wso2.carbon.identity.api.server.jwt.issuers.common</module>
+        <module>org.wso2.carbon.identity.api.server.jwt.issuers.v1</module>
+    </modules>
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -622,6 +622,7 @@
         <module>components/org.wso2.carbon.identity.api.server.branding.preference.management</module>
         <module>components/org.wso2.carbon.identity.api.server.input.validation</module>
         <module>components/org.wso2.carbon.identity.api.server.admin.advisory.management</module>
+        <module>components/org.wso2.carbon.identity.api.server.jwt.issuers</module>
     </modules>
 
 </project>


### PR DESCRIPTION
## Purpose
- Add JWT Issuers API to support adding and fetching trusted JWT issuers. 
- JWT issuers API will use the identity provider management OSGi service to add and fetch the trusted JWT issuers.
- Adding JWT issuers will require a simpler payload than the identity provider API.

## Git Issue
- https://github.com/wso2-enterprise/asgardeo-product/issues/13462