### PR TITLE
Add trusted token issuers API

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.common/src/main/java/org/wso2/carbon/identity/api/server/idp/common/Constants.java
+++ b/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.common/src/main/java/org/wso2/carbon/identity/api/server/idp/common/Constants.java
@@ -27,6 +27,8 @@ public class Constants {
 
     public static final String IDP_MANAGEMENT_PREFIX = "IDP-";
     public static final String IDP_PATH_COMPONENT = "/identity-providers";
+    public static final String TRUSTED_TOKEN_ISSUER_PATH_COMPONENT = "/trusted-token-issuers";
+
     public static final String IDP_TEMPLATE_PATH_COMPONENT = "/templates";
     public static final String PATH_SEPERATOR = "/";
     public static final String JWKS_URI = "jwksUri";
@@ -140,6 +142,9 @@ public class Constants {
                         " Recommend to use Scopes field."),
         ERROR_CODE_INVALID_OIDC_SCOPES("60038", "Invalid OIDC Scopes.",
                 "Scopes must contain 'openid'."),
+        ERROR_CODE_ERROR_LISTING_TRUSTED_TOKEN_ISSUERS("60021",
+                "Unable to list existing trusted token issuers.",
+                "Server encountered an error while listing the trusted token issuers."),
 
         // Server Error starting from 650xx.
         ERROR_CODE_ERROR_ADDING_IDP("65002",

--- a/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/gen/java/org/wso2/carbon/identity/api/server/idp/v1/TrustedTokenIssuersApi.java
+++ b/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/gen/java/org/wso2/carbon/identity/api/server/idp/v1/TrustedTokenIssuersApi.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.idp.v1;
+
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.List;
+
+import org.wso2.carbon.identity.api.server.idp.v1.model.Error;
+import org.wso2.carbon.identity.api.server.idp.v1.model.IdentityProviderListResponse;
+import java.util.List;
+import org.wso2.carbon.identity.api.server.idp.v1.model.Patch;
+import org.wso2.carbon.identity.api.server.idp.v1.model.TrustedTokenIssuerPOSTRequest;
+import org.wso2.carbon.identity.api.server.idp.v1.model.TrustedTokenIssuerResponse;
+import org.wso2.carbon.identity.api.server.idp.v1.TrustedTokenIssuersApiService;
+
+import javax.validation.Valid;
+import javax.ws.rs.*;
+import javax.ws.rs.core.Response;
+import io.swagger.annotations.*;
+import org.wso2.carbon.identity.api.server.idp.v1.model.Error;
+
+@Path("/trusted-token-issuers")
+@Api(description = "The trusted-token-issuers API")
+
+public class TrustedTokenIssuersApi  {
+
+    @Autowired
+    private TrustedTokenIssuersApiService delegate;
+
+    @Valid
+    @POST
+    
+    @Consumes({ "application/json" })
+    @Produces({ "application/json", "application/xml" })
+    @ApiOperation(value = "Add a new trusted token issuer ", notes = "This API provides the capability to create a token issuer. <br> <b>Permission required:</b> <br>     * /permission/admin/manage/identity/idpmgt/create <br> <b>Scope required:</b> <br>     * internal_idp_create ", response = TrustedTokenIssuerResponse.class, authorizations = {
+        @Authorization(value = "BasicAuth"),
+        @Authorization(value = "OAuth2", scopes = {
+            
+        })
+    }, tags={ "Trusted Token Issuers", })
+    @ApiResponses(value = { 
+        @ApiResponse(code = 201, message = "Successful response", response = TrustedTokenIssuerResponse.class),
+        @ApiResponse(code = 400, message = "Bad Request", response = Error.class),
+        @ApiResponse(code = 401, message = "Unauthorized", response = Void.class),
+        @ApiResponse(code = 403, message = "Forbidden", response = Void.class),
+        @ApiResponse(code = 409, message = "Conflict", response = Error.class),
+        @ApiResponse(code = 500, message = "Server Error", response = Error.class)
+    })
+    public Response addTrustedTokenIssuer(@ApiParam(value = "This represents the trusted Token issuer to be created." ,required=true) @Valid TrustedTokenIssuerPOSTRequest trustedTokenIssuerPOSTRequest) {
+
+        return delegate.addTrustedTokenIssuer(trustedTokenIssuerPOSTRequest );
+    }
+
+    @Valid
+    @DELETE
+    @Path("/{trusted-token-issuer-id}")
+    
+    @Produces({ "application/json" })
+    @ApiOperation(value = "Delete a trusted Token issuer by using the trusted token issuer's ID. ", notes = "This API provides the capability to delete a trusted Token issuer by giving its ID. <br> <b>Permission required:</b> <br>     * /permission/admin/manage/identity/idpmgt/delete <br> <b>Scope required:</b> <br>     * internal_idp_delete ", response = Void.class, authorizations = {
+        @Authorization(value = "BasicAuth"),
+        @Authorization(value = "OAuth2", scopes = {
+            
+        })
+    }, tags={ "Trusted Token Issuers", })
+    @ApiResponses(value = { 
+        @ApiResponse(code = 204, message = "Successfully Deleted", response = Void.class),
+        @ApiResponse(code = 400, message = "Bad Request", response = Error.class),
+        @ApiResponse(code = 401, message = "Unauthorized", response = Void.class),
+        @ApiResponse(code = 403, message = "Forbidden", response = Void.class),
+        @ApiResponse(code = 404, message = "Not Found", response = Error.class),
+        @ApiResponse(code = 500, message = "Server Error", response = Error.class)
+    })
+    public Response deleteTrustedTokenIssuer(@ApiParam(value = "ID of the trusted Token issuer",required=true) @PathParam("trusted-token-issuer-id") String trustedTokenIssuerId,     @Valid@ApiParam(value = "Enforces the forceful deletion of an identity provider, federated authenticator or an outbound provisioning connector even though it is referred by a service provider. ", defaultValue="false") @DefaultValue("false")  @QueryParam("force") Boolean force) {
+
+        return delegate.deleteTrustedTokenIssuer(trustedTokenIssuerId,  force );
+    }
+
+    @Valid
+    @GET
+    @Path("/{trusted-token-issuer-id}")
+    
+    @Produces({ "application/json", "application/xml" })
+    @ApiOperation(value = "Retrieve identity provider by trusted token issuer's ID ", notes = "This API provides the capability to retrieve the trusted Token issuer details by using its ID.<br> <b>Permission required:</b> <br>     * /permission/admin/manage/identity/idpmgt/view <br> <b>Scope required:</b> <br>     * internal_idp_view ", response = TrustedTokenIssuerResponse.class, authorizations = {
+        @Authorization(value = "BasicAuth"),
+        @Authorization(value = "OAuth2", scopes = {
+            
+        })
+    }, tags={ "Trusted Token Issuers", })
+    @ApiResponses(value = { 
+        @ApiResponse(code = 200, message = "Successful response", response = TrustedTokenIssuerResponse.class),
+        @ApiResponse(code = 400, message = "Bad Request", response = Error.class),
+        @ApiResponse(code = 401, message = "Unauthorized", response = Void.class),
+        @ApiResponse(code = 403, message = "Forbidden", response = Void.class),
+        @ApiResponse(code = 404, message = "Not Found", response = Error.class),
+        @ApiResponse(code = 500, message = "Server Error", response = Error.class)
+    })
+    public Response getTrustedTokenIssuer(@ApiParam(value = "ID of the trusted Token issuer.",required=true) @PathParam("trusted-token-issuer-id") String trustedTokenIssuerId) {
+
+        return delegate.getTrustedTokenIssuer(trustedTokenIssuerId );
+    }
+
+    @Valid
+    @GET
+    
+    
+    @Produces({ "application/json" })
+    @ApiOperation(value = "List Trusted Token issuers ", notes = "This API provides the capability to retrieve the list of token issuers.<br> <b>Permission required:</b> <br>     * /permission/admin/manage/identity/idpmgt/view <br> <b>Scope required:</b> <br>     * internal_idp_view ", response = IdentityProviderListResponse.class, authorizations = {
+        @Authorization(value = "BasicAuth"),
+        @Authorization(value = "OAuth2", scopes = {
+            
+        })
+    }, tags={ "Trusted Token Issuers", })
+    @ApiResponses(value = { 
+        @ApiResponse(code = 200, message = "Successful Response", response = IdentityProviderListResponse.class),
+        @ApiResponse(code = 400, message = "Bad Request", response = Error.class),
+        @ApiResponse(code = 401, message = "Unauthorized", response = Void.class),
+        @ApiResponse(code = 403, message = "Forbidden", response = Void.class),
+        @ApiResponse(code = 404, message = "Not Found", response = Void.class),
+        @ApiResponse(code = 500, message = "Server Error", response = Error.class)
+    })
+    public Response getTrustedTokenIssuers(    @Valid@ApiParam(value = "Maximum number of records to return. ")  @QueryParam("limit") Integer limit,     @Valid@ApiParam(value = "Number of records to skip for pagination. ")  @QueryParam("offset") Integer offset,     @Valid@ApiParam(value = "Condition to filter the retrieval of records. Supports 'sw', 'co', 'ew' and 'eq' operations and also complex queries with 'and' operations. E.g. /identity-providers?filter=name+sw+\"google\"+and+isEnabled+eq+\"true\" ")  @QueryParam("filter") String filter,     @Valid@ApiParam(value = "Attribute by which the retrieved records should be sorted. Currently sorting through _<b>domainName<b>_ only supported.")  @QueryParam("sortBy") String sortBy,     @Valid@ApiParam(value = "Define the order in which the retrieved tenants should be sorted.", allowableValues="asc, desc")  @QueryParam("sortOrder") String sortOrder,     @Valid@ApiParam(value = "Specifies the required parameters in the response. ")  @QueryParam("requiredAttributes") String requiredAttributes) {
+
+        return delegate.getTrustedTokenIssuers(limit,  offset,  filter,  sortBy,  sortOrder,  requiredAttributes );
+    }
+
+    @Valid
+    @PATCH
+    @Path("/{trusted-token-issuer-id}")
+    @Consumes({ "application/json" })
+    @Produces({ "application/json" })
+    @ApiOperation(value = "Patch a trusted Token issuer property by ID. Patch is supported only for key-value pairs ", notes = "This API provides the capability to update a trusted Token issuer property using patch request. Trusted Token issuer patch is supported only for key-value pairs. <br> <b>Permission required:</b> <br>     * /permission/admin/manage/identity/idpmgt/update <br> <b>Scope required:</b> <br>     * internal_idp_update ", response = TrustedTokenIssuerResponse.class, authorizations = {
+        @Authorization(value = "BasicAuth"),
+        @Authorization(value = "OAuth2", scopes = {
+            
+        })
+    }, tags={ "Trusted Token Issuers" })
+    @ApiResponses(value = { 
+        @ApiResponse(code = 200, message = "Successful response", response = TrustedTokenIssuerResponse.class),
+        @ApiResponse(code = 400, message = "Bad Request", response = Error.class),
+        @ApiResponse(code = 401, message = "Unauthorized", response = Void.class),
+        @ApiResponse(code = 403, message = "Forbidden", response = Void.class),
+        @ApiResponse(code = 404, message = "Not Found", response = Error.class),
+        @ApiResponse(code = 500, message = "Server Error", response = Error.class)
+    })
+    public Response patchTrustedTokenIssuer(@ApiParam(value = "ID of the trusted Token issuer.",required=true) @PathParam("trusted-token-issuer-id") String trustedTokenIssuerId, @ApiParam(value = "" ,required=true) @Valid List<Patch> patch) {
+
+        return delegate.patchTrustedTokenIssuer(trustedTokenIssuerId,  patch );
+    }
+
+}

--- a/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/gen/java/org/wso2/carbon/identity/api/server/idp/v1/TrustedTokenIssuersApiService.java
+++ b/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/gen/java/org/wso2/carbon/identity/api/server/idp/v1/TrustedTokenIssuersApiService.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.idp.v1;
+
+import java.util.List;
+
+import org.wso2.carbon.identity.api.server.idp.v1.model.Patch;
+import org.wso2.carbon.identity.api.server.idp.v1.model.TrustedTokenIssuerPOSTRequest;
+
+import javax.ws.rs.core.Response;
+
+
+public interface TrustedTokenIssuersApiService {
+
+      public Response addTrustedTokenIssuer(TrustedTokenIssuerPOSTRequest trustedTokenIssuerPOSTRequest);
+
+      public Response deleteTrustedTokenIssuer(String trustedTokenIssuerId, Boolean force);
+
+      public Response getTrustedTokenIssuer(String trustedTokenIssuerId);
+
+      public Response getTrustedTokenIssuers(Integer limit, Integer offset, String filter, String sortBy, String sortOrder, String requiredAttributes);
+
+      public Response patchTrustedTokenIssuer(String trustedTokenIssuerId, List<Patch> patch);
+}

--- a/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/gen/java/org/wso2/carbon/identity/api/server/idp/v1/factories/TrustedTokenIssuersApiServiceFactory.java
+++ b/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/gen/java/org/wso2/carbon/identity/api/server/idp/v1/factories/TrustedTokenIssuersApiServiceFactory.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.idp.v1.factories;
+
+import org.wso2.carbon.identity.api.server.idp.v1.TrustedTokenIssuersApiService;
+import org.wso2.carbon.identity.api.server.idp.v1.impl.TrustedTokenIssuersApiServiceImpl;
+
+public class TrustedTokenIssuersApiServiceFactory {
+
+   private final static TrustedTokenIssuersApiService service = new TrustedTokenIssuersApiServiceImpl();
+
+   public static TrustedTokenIssuersApiService getTrustedTokenIssuersApi()
+   {
+      return service;
+   }
+}

--- a/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/gen/java/org/wso2/carbon/identity/api/server/idp/v1/model/TrustedTokenIssuerListItem.java
+++ b/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/gen/java/org/wso2/carbon/identity/api/server/idp/v1/model/TrustedTokenIssuerListItem.java
@@ -1,0 +1,431 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.idp.v1.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import java.util.ArrayList;
+import java.util.List;
+import org.wso2.carbon.identity.api.server.idp.v1.model.Certificate;
+import org.wso2.carbon.identity.api.server.idp.v1.model.Claims;
+import org.wso2.carbon.identity.api.server.idp.v1.model.FederatedAuthenticatorListResponse;
+import org.wso2.carbon.identity.api.server.idp.v1.model.IdPGroup;
+import org.wso2.carbon.identity.api.server.idp.v1.model.ProvisioningResponse;
+import org.wso2.carbon.identity.api.server.idp.v1.model.Roles;
+import javax.validation.constraints.*;
+
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+import javax.validation.Valid;
+import javax.xml.bind.annotation.*;
+
+public class TrustedTokenIssuerListItem  {
+  
+    private String id;
+    private String name;
+    private String description;
+    private Boolean isEnabled = true;
+    private String image;
+    private Boolean isPrimary;
+    private Boolean isFederationHub;
+    private String homeRealmIdentifier;
+    private Certificate certificate;
+    private String alias;
+    private Claims claims;
+    private Roles roles;
+    private List<IdPGroup> groups = null;
+
+    private FederatedAuthenticatorListResponse federatedAuthenticators;
+    private ProvisioningResponse provisioning;
+    private String self;
+
+    /**
+    **/
+    public TrustedTokenIssuerListItem id(String id) {
+
+        this.id = id;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "123e4567-e89b-12d3-a456-556642440000", value = "")
+    @JsonProperty("id")
+    @Valid
+    public String getId() {
+        return id;
+    }
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    /**
+    **/
+    public TrustedTokenIssuerListItem name(String name) {
+
+        this.name = name;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "google", value = "")
+    @JsonProperty("name")
+    @Valid
+    public String getName() {
+        return name;
+    }
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    /**
+    **/
+    public TrustedTokenIssuerListItem description(String description) {
+
+        this.description = description;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "trusted token issuer for google idp", value = "")
+    @JsonProperty("description")
+    @Valid
+    public String getDescription() {
+        return description;
+    }
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    /**
+    **/
+    public TrustedTokenIssuerListItem isEnabled(Boolean isEnabled) {
+
+        this.isEnabled = isEnabled;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "true", value = "")
+    @JsonProperty("isEnabled")
+    @Valid
+    public Boolean getIsEnabled() {
+        return isEnabled;
+    }
+    public void setIsEnabled(Boolean isEnabled) {
+        this.isEnabled = isEnabled;
+    }
+
+    /**
+    **/
+    public TrustedTokenIssuerListItem image(String image) {
+
+        this.image = image;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "google-logo-url", value = "")
+    @JsonProperty("image")
+    @Valid
+    public String getImage() {
+        return image;
+    }
+    public void setImage(String image) {
+        this.image = image;
+    }
+
+    /**
+    **/
+    public TrustedTokenIssuerListItem isPrimary(Boolean isPrimary) {
+
+        this.isPrimary = isPrimary;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "false", value = "")
+    @JsonProperty("isPrimary")
+    @Valid
+    public Boolean getIsPrimary() {
+        return isPrimary;
+    }
+    public void setIsPrimary(Boolean isPrimary) {
+        this.isPrimary = isPrimary;
+    }
+
+    /**
+    **/
+    public TrustedTokenIssuerListItem isFederationHub(Boolean isFederationHub) {
+
+        this.isFederationHub = isFederationHub;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "false", value = "")
+    @JsonProperty("isFederationHub")
+    @Valid
+    public Boolean getIsFederationHub() {
+        return isFederationHub;
+    }
+    public void setIsFederationHub(Boolean isFederationHub) {
+        this.isFederationHub = isFederationHub;
+    }
+
+    /**
+    **/
+    public TrustedTokenIssuerListItem homeRealmIdentifier(String homeRealmIdentifier) {
+
+        this.homeRealmIdentifier = homeRealmIdentifier;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "localhost", value = "")
+    @JsonProperty("homeRealmIdentifier")
+    @Valid
+    public String getHomeRealmIdentifier() {
+        return homeRealmIdentifier;
+    }
+    public void setHomeRealmIdentifier(String homeRealmIdentifier) {
+        this.homeRealmIdentifier = homeRealmIdentifier;
+    }
+
+    /**
+    **/
+    public TrustedTokenIssuerListItem certificate(Certificate certificate) {
+
+        this.certificate = certificate;
+        return this;
+    }
+    
+    @ApiModelProperty(value = "")
+    @JsonProperty("certificate")
+    @Valid
+    public Certificate getCertificate() {
+        return certificate;
+    }
+    public void setCertificate(Certificate certificate) {
+        this.certificate = certificate;
+    }
+
+    /**
+    **/
+    public TrustedTokenIssuerListItem alias(String alias) {
+
+        this.alias = alias;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "https://localhost:9444/oauth2/token", value = "")
+    @JsonProperty("alias")
+    @Valid
+    public String getAlias() {
+        return alias;
+    }
+    public void setAlias(String alias) {
+        this.alias = alias;
+    }
+
+    /**
+    **/
+    public TrustedTokenIssuerListItem claims(Claims claims) {
+
+        this.claims = claims;
+        return this;
+    }
+    
+    @ApiModelProperty(value = "")
+    @JsonProperty("claims")
+    @Valid
+    public Claims getClaims() {
+        return claims;
+    }
+    public void setClaims(Claims claims) {
+        this.claims = claims;
+    }
+
+    /**
+    **/
+    public TrustedTokenIssuerListItem roles(Roles roles) {
+
+        this.roles = roles;
+        return this;
+    }
+    
+    @ApiModelProperty(value = "")
+    @JsonProperty("roles")
+    @Valid
+    public Roles getRoles() {
+        return roles;
+    }
+    public void setRoles(Roles roles) {
+        this.roles = roles;
+    }
+
+    /**
+    * IdP groups supported by the IdP.
+    **/
+    public TrustedTokenIssuerListItem groups(List<IdPGroup> groups) {
+
+        this.groups = groups;
+        return this;
+    }
+    
+    @ApiModelProperty(value = "IdP groups supported by the IdP.")
+    @JsonProperty("groups")
+    @Valid @Size(min=0)
+    public List<IdPGroup> getGroups() {
+        return groups;
+    }
+    public void setGroups(List<IdPGroup> groups) {
+        this.groups = groups;
+    }
+
+    public TrustedTokenIssuerListItem addGroupsItem(IdPGroup groupsItem) {
+        if (this.groups == null) {
+            this.groups = new ArrayList<>();
+        }
+        this.groups.add(groupsItem);
+        return this;
+    }
+
+        /**
+    **/
+    public TrustedTokenIssuerListItem federatedAuthenticators(FederatedAuthenticatorListResponse federatedAuthenticators) {
+
+        this.federatedAuthenticators = federatedAuthenticators;
+        return this;
+    }
+    
+    @ApiModelProperty(value = "")
+    @JsonProperty("federatedAuthenticators")
+    @Valid
+    public FederatedAuthenticatorListResponse getFederatedAuthenticators() {
+        return federatedAuthenticators;
+    }
+    public void setFederatedAuthenticators(FederatedAuthenticatorListResponse federatedAuthenticators) {
+        this.federatedAuthenticators = federatedAuthenticators;
+    }
+
+    /**
+    **/
+    public TrustedTokenIssuerListItem provisioning(ProvisioningResponse provisioning) {
+
+        this.provisioning = provisioning;
+        return this;
+    }
+    
+    @ApiModelProperty(value = "")
+    @JsonProperty("provisioning")
+    @Valid
+    public ProvisioningResponse getProvisioning() {
+        return provisioning;
+    }
+    public void setProvisioning(ProvisioningResponse provisioning) {
+        this.provisioning = provisioning;
+    }
+
+    /**
+    **/
+    public TrustedTokenIssuerListItem self(String self) {
+
+        this.self = self;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "/t/carbon.super/api/server/v1/trusted-token-issuers/123e4567-e89b-12d3-a456-556642440000", value = "")
+    @JsonProperty("self")
+    @Valid
+    public String getSelf() {
+        return self;
+    }
+    public void setSelf(String self) {
+        this.self = self;
+    }
+
+
+
+    @Override
+    public boolean equals(java.lang.Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        TrustedTokenIssuerListItem trustedTokenIssuerListItem = (TrustedTokenIssuerListItem) o;
+        return Objects.equals(this.id, trustedTokenIssuerListItem.id) &&
+            Objects.equals(this.name, trustedTokenIssuerListItem.name) &&
+            Objects.equals(this.description, trustedTokenIssuerListItem.description) &&
+            Objects.equals(this.isEnabled, trustedTokenIssuerListItem.isEnabled) &&
+            Objects.equals(this.image, trustedTokenIssuerListItem.image) &&
+            Objects.equals(this.isPrimary, trustedTokenIssuerListItem.isPrimary) &&
+            Objects.equals(this.isFederationHub, trustedTokenIssuerListItem.isFederationHub) &&
+            Objects.equals(this.homeRealmIdentifier, trustedTokenIssuerListItem.homeRealmIdentifier) &&
+            Objects.equals(this.certificate, trustedTokenIssuerListItem.certificate) &&
+            Objects.equals(this.alias, trustedTokenIssuerListItem.alias) &&
+            Objects.equals(this.claims, trustedTokenIssuerListItem.claims) &&
+            Objects.equals(this.roles, trustedTokenIssuerListItem.roles) &&
+            Objects.equals(this.groups, trustedTokenIssuerListItem.groups) &&
+            Objects.equals(this.federatedAuthenticators, trustedTokenIssuerListItem.federatedAuthenticators) &&
+            Objects.equals(this.provisioning, trustedTokenIssuerListItem.provisioning) &&
+            Objects.equals(this.self, trustedTokenIssuerListItem.self);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, name, description, isEnabled, image, isPrimary, isFederationHub, homeRealmIdentifier, certificate, alias, claims, roles, groups, federatedAuthenticators, provisioning, self);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class TrustedTokenIssuerListItem {\n");
+        
+        sb.append("    id: ").append(toIndentedString(id)).append("\n");
+        sb.append("    name: ").append(toIndentedString(name)).append("\n");
+        sb.append("    description: ").append(toIndentedString(description)).append("\n");
+        sb.append("    isEnabled: ").append(toIndentedString(isEnabled)).append("\n");
+        sb.append("    image: ").append(toIndentedString(image)).append("\n");
+        sb.append("    isPrimary: ").append(toIndentedString(isPrimary)).append("\n");
+        sb.append("    isFederationHub: ").append(toIndentedString(isFederationHub)).append("\n");
+        sb.append("    homeRealmIdentifier: ").append(toIndentedString(homeRealmIdentifier)).append("\n");
+        sb.append("    certificate: ").append(toIndentedString(certificate)).append("\n");
+        sb.append("    alias: ").append(toIndentedString(alias)).append("\n");
+        sb.append("    claims: ").append(toIndentedString(claims)).append("\n");
+        sb.append("    roles: ").append(toIndentedString(roles)).append("\n");
+        sb.append("    groups: ").append(toIndentedString(groups)).append("\n");
+        sb.append("    federatedAuthenticators: ").append(toIndentedString(federatedAuthenticators)).append("\n");
+        sb.append("    provisioning: ").append(toIndentedString(provisioning)).append("\n");
+        sb.append("    self: ").append(toIndentedString(self)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+    * Convert the given object to string with each line indented by 4 spaces
+    * (except the first line).
+    */
+    private String toIndentedString(java.lang.Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}
+

--- a/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/gen/java/org/wso2/carbon/identity/api/server/idp/v1/model/TrustedTokenIssuerListResponse.java
+++ b/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/gen/java/org/wso2/carbon/identity/api/server/idp/v1/model/TrustedTokenIssuerListResponse.java
@@ -1,0 +1,204 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.idp.v1.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import java.util.ArrayList;
+import java.util.List;
+import org.wso2.carbon.identity.api.server.idp.v1.model.Link;
+import org.wso2.carbon.identity.api.server.idp.v1.model.TrustedTokenIssuerListItem;
+import javax.validation.constraints.*;
+
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+import javax.validation.Valid;
+import javax.xml.bind.annotation.*;
+
+public class TrustedTokenIssuerListResponse  {
+  
+    private Integer totalResults;
+    private Integer startIndex;
+    private Integer count;
+    private List<Link> links = null;
+
+    private List<TrustedTokenIssuerListItem> identityProviders = null;
+
+
+    /**
+    **/
+    public TrustedTokenIssuerListResponse totalResults(Integer totalResults) {
+
+        this.totalResults = totalResults;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "10", value = "")
+    @JsonProperty("totalResults")
+    @Valid
+    public Integer getTotalResults() {
+        return totalResults;
+    }
+    public void setTotalResults(Integer totalResults) {
+        this.totalResults = totalResults;
+    }
+
+    /**
+    **/
+    public TrustedTokenIssuerListResponse startIndex(Integer startIndex) {
+
+        this.startIndex = startIndex;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "1", value = "")
+    @JsonProperty("startIndex")
+    @Valid
+    public Integer getStartIndex() {
+        return startIndex;
+    }
+    public void setStartIndex(Integer startIndex) {
+        this.startIndex = startIndex;
+    }
+
+    /**
+    **/
+    public TrustedTokenIssuerListResponse count(Integer count) {
+
+        this.count = count;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "10", value = "")
+    @JsonProperty("count")
+    @Valid
+    public Integer getCount() {
+        return count;
+    }
+    public void setCount(Integer count) {
+        this.count = count;
+    }
+
+    /**
+    **/
+    public TrustedTokenIssuerListResponse links(List<Link> links) {
+
+        this.links = links;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "[{\"href\":\"trusted-token-issuers?offset=50&limit=10\",\"rel\":\"next\"},{\"href\":\"trusted-token-issuers?offset=30&limit=10\",\"rel\":\"previous\"}]", value = "")
+    @JsonProperty("links")
+    @Valid
+    public List<Link> getLinks() {
+        return links;
+    }
+    public void setLinks(List<Link> links) {
+        this.links = links;
+    }
+
+    public TrustedTokenIssuerListResponse addLinksItem(Link linksItem) {
+        if (this.links == null) {
+            this.links = new ArrayList<>();
+        }
+        this.links.add(linksItem);
+        return this;
+    }
+
+        /**
+    **/
+    public TrustedTokenIssuerListResponse identityProviders(List<TrustedTokenIssuerListItem> identityProviders) {
+
+        this.identityProviders = identityProviders;
+        return this;
+    }
+    
+    @ApiModelProperty(value = "")
+    @JsonProperty("identityProviders")
+    @Valid
+    public List<TrustedTokenIssuerListItem> getIdentityProviders() {
+        return identityProviders;
+    }
+    public void setIdentityProviders(List<TrustedTokenIssuerListItem> identityProviders) {
+        this.identityProviders = identityProviders;
+    }
+
+    public TrustedTokenIssuerListResponse addIdentityProvidersItem(TrustedTokenIssuerListItem identityProvidersItem) {
+        if (this.identityProviders == null) {
+            this.identityProviders = new ArrayList<>();
+        }
+        this.identityProviders.add(identityProvidersItem);
+        return this;
+    }
+
+    
+
+    @Override
+    public boolean equals(java.lang.Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        TrustedTokenIssuerListResponse trustedTokenIssuerListResponse = (TrustedTokenIssuerListResponse) o;
+        return Objects.equals(this.totalResults, trustedTokenIssuerListResponse.totalResults) &&
+            Objects.equals(this.startIndex, trustedTokenIssuerListResponse.startIndex) &&
+            Objects.equals(this.count, trustedTokenIssuerListResponse.count) &&
+            Objects.equals(this.links, trustedTokenIssuerListResponse.links) &&
+            Objects.equals(this.identityProviders, trustedTokenIssuerListResponse.identityProviders);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(totalResults, startIndex, count, links, identityProviders);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class TrustedTokenIssuerListResponse {\n");
+        
+        sb.append("    totalResults: ").append(toIndentedString(totalResults)).append("\n");
+        sb.append("    startIndex: ").append(toIndentedString(startIndex)).append("\n");
+        sb.append("    count: ").append(toIndentedString(count)).append("\n");
+        sb.append("    links: ").append(toIndentedString(links)).append("\n");
+        sb.append("    identityProviders: ").append(toIndentedString(identityProviders)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+    * Convert the given object to string with each line indented by 4 spaces
+    * (except the first line).
+    */
+    private String toIndentedString(java.lang.Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}
+

--- a/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/gen/java/org/wso2/carbon/identity/api/server/idp/v1/model/TrustedTokenIssuerPOSTRequest.java
+++ b/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/gen/java/org/wso2/carbon/identity/api/server/idp/v1/model/TrustedTokenIssuerPOSTRequest.java
@@ -1,0 +1,253 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.idp.v1.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import org.wso2.carbon.identity.api.server.idp.v1.model.Certificate;
+import org.wso2.carbon.identity.api.server.idp.v1.model.Claims;
+import javax.validation.constraints.*;
+
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+import javax.validation.Valid;
+import javax.xml.bind.annotation.*;
+
+public class TrustedTokenIssuerPOSTRequest  {
+  
+    private String name;
+    private String description;
+    private String image;
+    private String templateId;
+    private Certificate certificate;
+    private String alias;
+    private String issuer;
+    private Claims claims;
+
+    /**
+    **/
+    public TrustedTokenIssuerPOSTRequest name(String name) {
+
+        this.name = name;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "google", required = true, value = "")
+    @JsonProperty("name")
+    @Valid
+    @NotNull(message = "Property name cannot be null.")
+
+    public String getName() {
+        return name;
+    }
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    /**
+    **/
+    public TrustedTokenIssuerPOSTRequest description(String description) {
+
+        this.description = description;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "Trusted Token Issuer", value = "")
+    @JsonProperty("description")
+    @Valid
+    public String getDescription() {
+        return description;
+    }
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    /**
+    **/
+    public TrustedTokenIssuerPOSTRequest image(String image) {
+
+        this.image = image;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "issuer-logo-url", value = "")
+    @JsonProperty("image")
+    @Valid
+    public String getImage() {
+        return image;
+    }
+    public void setImage(String image) {
+        this.image = image;
+    }
+
+    /**
+    **/
+    public TrustedTokenIssuerPOSTRequest templateId(String templateId) {
+
+        this.templateId = templateId;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "8ea23303-49c0-4253-b81f-82c0fe6fb4a0", value = "")
+    @JsonProperty("templateId")
+    @Valid
+    public String getTemplateId() {
+        return templateId;
+    }
+    public void setTemplateId(String templateId) {
+        this.templateId = templateId;
+    }
+
+    /**
+    **/
+    public TrustedTokenIssuerPOSTRequest certificate(Certificate certificate) {
+
+        this.certificate = certificate;
+        return this;
+    }
+    
+    @ApiModelProperty(required = true, value = "")
+    @JsonProperty("certificate")
+    @Valid
+    @NotNull(message = "Property certificate cannot be null.")
+
+    public Certificate getCertificate() {
+        return certificate;
+    }
+    public void setCertificate(Certificate certificate) {
+        this.certificate = certificate;
+    }
+
+    /**
+    **/
+    public TrustedTokenIssuerPOSTRequest alias(String alias) {
+
+        this.alias = alias;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "https://localhost:9444/oauth2/token", value = "")
+    @JsonProperty("alias")
+    @Valid
+    public String getAlias() {
+        return alias;
+    }
+    public void setAlias(String alias) {
+        this.alias = alias;
+    }
+
+    /**
+    **/
+    public TrustedTokenIssuerPOSTRequest issuer(String issuer) {
+
+        this.issuer = issuer;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "https://www.issuer.com", required = true, value = "")
+    @JsonProperty("issuer")
+    @Valid
+    @NotNull(message = "Property issuer cannot be null.")
+
+    public String getIssuer() {
+        return issuer;
+    }
+    public void setIssuer(String issuer) {
+        this.issuer = issuer;
+    }
+
+    /**
+    **/
+    public TrustedTokenIssuerPOSTRequest claims(Claims claims) {
+
+        this.claims = claims;
+        return this;
+    }
+    
+    @ApiModelProperty(value = "")
+    @JsonProperty("claims")
+    @Valid
+    public Claims getClaims() {
+        return claims;
+    }
+    public void setClaims(Claims claims) {
+        this.claims = claims;
+    }
+
+
+
+    @Override
+    public boolean equals(java.lang.Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        TrustedTokenIssuerPOSTRequest trustedTokenIssuerPOSTRequest = (TrustedTokenIssuerPOSTRequest) o;
+        return Objects.equals(this.name, trustedTokenIssuerPOSTRequest.name) &&
+            Objects.equals(this.description, trustedTokenIssuerPOSTRequest.description) &&
+            Objects.equals(this.image, trustedTokenIssuerPOSTRequest.image) &&
+            Objects.equals(this.templateId, trustedTokenIssuerPOSTRequest.templateId) &&
+            Objects.equals(this.certificate, trustedTokenIssuerPOSTRequest.certificate) &&
+            Objects.equals(this.alias, trustedTokenIssuerPOSTRequest.alias) &&
+            Objects.equals(this.issuer, trustedTokenIssuerPOSTRequest.issuer) &&
+            Objects.equals(this.claims, trustedTokenIssuerPOSTRequest.claims);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, description, image, templateId, certificate, alias, issuer, claims);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class TrustedTokenIssuerPOSTRequest {\n");
+        
+        sb.append("    name: ").append(toIndentedString(name)).append("\n");
+        sb.append("    description: ").append(toIndentedString(description)).append("\n");
+        sb.append("    image: ").append(toIndentedString(image)).append("\n");
+        sb.append("    templateId: ").append(toIndentedString(templateId)).append("\n");
+        sb.append("    certificate: ").append(toIndentedString(certificate)).append("\n");
+        sb.append("    alias: ").append(toIndentedString(alias)).append("\n");
+        sb.append("    issuer: ").append(toIndentedString(issuer)).append("\n");
+        sb.append("    claims: ").append(toIndentedString(claims)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+    * Convert the given object to string with each line indented by 4 spaces
+    * (except the first line).
+    */
+    private String toIndentedString(java.lang.Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}
+

--- a/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/gen/java/org/wso2/carbon/identity/api/server/idp/v1/model/TrustedTokenIssuerResponse.java
+++ b/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/gen/java/org/wso2/carbon/identity/api/server/idp/v1/model/TrustedTokenIssuerResponse.java
@@ -1,0 +1,452 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.idp.v1.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import java.util.ArrayList;
+import java.util.List;
+import org.wso2.carbon.identity.api.server.idp.v1.model.Certificate;
+import org.wso2.carbon.identity.api.server.idp.v1.model.Claims;
+import org.wso2.carbon.identity.api.server.idp.v1.model.FederatedAuthenticatorListResponse;
+import org.wso2.carbon.identity.api.server.idp.v1.model.IdPGroup;
+import org.wso2.carbon.identity.api.server.idp.v1.model.ProvisioningResponse;
+import org.wso2.carbon.identity.api.server.idp.v1.model.Roles;
+import javax.validation.constraints.*;
+
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+import javax.validation.Valid;
+import javax.xml.bind.annotation.*;
+
+public class TrustedTokenIssuerResponse  {
+  
+    private String id;
+    private String name;
+    private String description;
+    private String templateId;
+    private Boolean isEnabled = true;
+    private Boolean isPrimary = false;
+    private String image;
+    private Boolean isFederationHub;
+    private String homeRealmIdentifier;
+    private Certificate certificate;
+    private String alias;
+    private String issuer;
+    private Claims claims;
+    private Roles roles;
+    private List<IdPGroup> groups = null;
+
+    private FederatedAuthenticatorListResponse federatedAuthenticators;
+    private ProvisioningResponse provisioning;
+
+    /**
+    **/
+    public TrustedTokenIssuerResponse id(String id) {
+
+        this.id = id;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "123e4567-e89b-12d3-a456-556642440000", value = "")
+    @JsonProperty("id")
+    @Valid
+    public String getId() {
+        return id;
+    }
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    /**
+    **/
+    public TrustedTokenIssuerResponse name(String name) {
+
+        this.name = name;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "google", value = "")
+    @JsonProperty("name")
+    @Valid
+    public String getName() {
+        return name;
+    }
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    /**
+    **/
+    public TrustedTokenIssuerResponse description(String description) {
+
+        this.description = description;
+        return this;
+    }
+    
+    @ApiModelProperty(value = "")
+    @JsonProperty("description")
+    @Valid
+    public String getDescription() {
+        return description;
+    }
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    /**
+    **/
+    public TrustedTokenIssuerResponse templateId(String templateId) {
+
+        this.templateId = templateId;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "8ea23303-49c0-4253-b81f-82c0fe6fb4a0", value = "")
+    @JsonProperty("templateId")
+    @Valid
+    public String getTemplateId() {
+        return templateId;
+    }
+    public void setTemplateId(String templateId) {
+        this.templateId = templateId;
+    }
+
+    /**
+    **/
+    public TrustedTokenIssuerResponse isEnabled(Boolean isEnabled) {
+
+        this.isEnabled = isEnabled;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "true", value = "")
+    @JsonProperty("isEnabled")
+    @Valid
+    public Boolean getIsEnabled() {
+        return isEnabled;
+    }
+    public void setIsEnabled(Boolean isEnabled) {
+        this.isEnabled = isEnabled;
+    }
+
+    /**
+    **/
+    public TrustedTokenIssuerResponse isPrimary(Boolean isPrimary) {
+
+        this.isPrimary = isPrimary;
+        return this;
+    }
+    
+    @ApiModelProperty(value = "")
+    @JsonProperty("isPrimary")
+    @Valid
+    public Boolean getIsPrimary() {
+        return isPrimary;
+    }
+    public void setIsPrimary(Boolean isPrimary) {
+        this.isPrimary = isPrimary;
+    }
+
+    /**
+    **/
+    public TrustedTokenIssuerResponse image(String image) {
+
+        this.image = image;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "google-logo-url", value = "")
+    @JsonProperty("image")
+    @Valid
+    public String getImage() {
+        return image;
+    }
+    public void setImage(String image) {
+        this.image = image;
+    }
+
+    /**
+    **/
+    public TrustedTokenIssuerResponse isFederationHub(Boolean isFederationHub) {
+
+        this.isFederationHub = isFederationHub;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "false", value = "")
+    @JsonProperty("isFederationHub")
+    @Valid
+    public Boolean getIsFederationHub() {
+        return isFederationHub;
+    }
+    public void setIsFederationHub(Boolean isFederationHub) {
+        this.isFederationHub = isFederationHub;
+    }
+
+    /**
+    **/
+    public TrustedTokenIssuerResponse homeRealmIdentifier(String homeRealmIdentifier) {
+
+        this.homeRealmIdentifier = homeRealmIdentifier;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "localhost", value = "")
+    @JsonProperty("homeRealmIdentifier")
+    @Valid
+    public String getHomeRealmIdentifier() {
+        return homeRealmIdentifier;
+    }
+    public void setHomeRealmIdentifier(String homeRealmIdentifier) {
+        this.homeRealmIdentifier = homeRealmIdentifier;
+    }
+
+    /**
+    **/
+    public TrustedTokenIssuerResponse certificate(Certificate certificate) {
+
+        this.certificate = certificate;
+        return this;
+    }
+    
+    @ApiModelProperty(value = "")
+    @JsonProperty("certificate")
+    @Valid
+    public Certificate getCertificate() {
+        return certificate;
+    }
+    public void setCertificate(Certificate certificate) {
+        this.certificate = certificate;
+    }
+
+    /**
+    **/
+    public TrustedTokenIssuerResponse alias(String alias) {
+
+        this.alias = alias;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "https://localhost:9444/oauth2/token", value = "")
+    @JsonProperty("alias")
+    @Valid
+    public String getAlias() {
+        return alias;
+    }
+    public void setAlias(String alias) {
+        this.alias = alias;
+    }
+
+    /**
+    **/
+    public TrustedTokenIssuerResponse issuer(String issuer) {
+
+        this.issuer = issuer;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "https://www.idp.com", value = "")
+    @JsonProperty("issuer")
+    @Valid
+    public String getIssuer() {
+        return issuer;
+    }
+    public void setIssuer(String issuer) {
+        this.issuer = issuer;
+    }
+
+    /**
+    **/
+    public TrustedTokenIssuerResponse claims(Claims claims) {
+
+        this.claims = claims;
+        return this;
+    }
+    
+    @ApiModelProperty(value = "")
+    @JsonProperty("claims")
+    @Valid
+    public Claims getClaims() {
+        return claims;
+    }
+    public void setClaims(Claims claims) {
+        this.claims = claims;
+    }
+
+    /**
+    **/
+    public TrustedTokenIssuerResponse roles(Roles roles) {
+
+        this.roles = roles;
+        return this;
+    }
+    
+    @ApiModelProperty(value = "")
+    @JsonProperty("roles")
+    @Valid
+    public Roles getRoles() {
+        return roles;
+    }
+    public void setRoles(Roles roles) {
+        this.roles = roles;
+    }
+
+    /**
+    * IdP groups supported by the IdP.
+    **/
+    public TrustedTokenIssuerResponse groups(List<IdPGroup> groups) {
+
+        this.groups = groups;
+        return this;
+    }
+    
+    @ApiModelProperty(value = "IdP groups supported by the IdP.")
+    @JsonProperty("groups")
+    @Valid @Size(min=0)
+    public List<IdPGroup> getGroups() {
+        return groups;
+    }
+    public void setGroups(List<IdPGroup> groups) {
+        this.groups = groups;
+    }
+
+    public TrustedTokenIssuerResponse addGroupsItem(IdPGroup groupsItem) {
+        if (this.groups == null) {
+            this.groups = new ArrayList<>();
+        }
+        this.groups.add(groupsItem);
+        return this;
+    }
+
+        /**
+    **/
+    public TrustedTokenIssuerResponse federatedAuthenticators(FederatedAuthenticatorListResponse federatedAuthenticators) {
+
+        this.federatedAuthenticators = federatedAuthenticators;
+        return this;
+    }
+    
+    @ApiModelProperty(value = "")
+    @JsonProperty("federatedAuthenticators")
+    @Valid
+    public FederatedAuthenticatorListResponse getFederatedAuthenticators() {
+        return federatedAuthenticators;
+    }
+    public void setFederatedAuthenticators(FederatedAuthenticatorListResponse federatedAuthenticators) {
+        this.federatedAuthenticators = federatedAuthenticators;
+    }
+
+    /**
+    **/
+    public TrustedTokenIssuerResponse provisioning(ProvisioningResponse provisioning) {
+
+        this.provisioning = provisioning;
+        return this;
+    }
+    
+    @ApiModelProperty(value = "")
+    @JsonProperty("provisioning")
+    @Valid
+    public ProvisioningResponse getProvisioning() {
+        return provisioning;
+    }
+    public void setProvisioning(ProvisioningResponse provisioning) {
+        this.provisioning = provisioning;
+    }
+
+
+
+    @Override
+    public boolean equals(java.lang.Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        TrustedTokenIssuerResponse trustedTokenIssuerResponse = (TrustedTokenIssuerResponse) o;
+        return Objects.equals(this.id, trustedTokenIssuerResponse.id) &&
+            Objects.equals(this.name, trustedTokenIssuerResponse.name) &&
+            Objects.equals(this.description, trustedTokenIssuerResponse.description) &&
+            Objects.equals(this.templateId, trustedTokenIssuerResponse.templateId) &&
+            Objects.equals(this.isEnabled, trustedTokenIssuerResponse.isEnabled) &&
+            Objects.equals(this.isPrimary, trustedTokenIssuerResponse.isPrimary) &&
+            Objects.equals(this.image, trustedTokenIssuerResponse.image) &&
+            Objects.equals(this.isFederationHub, trustedTokenIssuerResponse.isFederationHub) &&
+            Objects.equals(this.homeRealmIdentifier, trustedTokenIssuerResponse.homeRealmIdentifier) &&
+            Objects.equals(this.certificate, trustedTokenIssuerResponse.certificate) &&
+            Objects.equals(this.alias, trustedTokenIssuerResponse.alias) &&
+            Objects.equals(this.issuer, trustedTokenIssuerResponse.issuer) &&
+            Objects.equals(this.claims, trustedTokenIssuerResponse.claims) &&
+            Objects.equals(this.roles, trustedTokenIssuerResponse.roles) &&
+            Objects.equals(this.groups, trustedTokenIssuerResponse.groups) &&
+            Objects.equals(this.federatedAuthenticators, trustedTokenIssuerResponse.federatedAuthenticators) &&
+            Objects.equals(this.provisioning, trustedTokenIssuerResponse.provisioning);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, name, description, templateId, isEnabled, isPrimary, image, isFederationHub, homeRealmIdentifier, certificate, alias, issuer, claims, roles, groups, federatedAuthenticators, provisioning);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class TrustedTokenIssuerResponse {\n");
+        
+        sb.append("    id: ").append(toIndentedString(id)).append("\n");
+        sb.append("    name: ").append(toIndentedString(name)).append("\n");
+        sb.append("    description: ").append(toIndentedString(description)).append("\n");
+        sb.append("    templateId: ").append(toIndentedString(templateId)).append("\n");
+        sb.append("    isEnabled: ").append(toIndentedString(isEnabled)).append("\n");
+        sb.append("    isPrimary: ").append(toIndentedString(isPrimary)).append("\n");
+        sb.append("    image: ").append(toIndentedString(image)).append("\n");
+        sb.append("    isFederationHub: ").append(toIndentedString(isFederationHub)).append("\n");
+        sb.append("    homeRealmIdentifier: ").append(toIndentedString(homeRealmIdentifier)).append("\n");
+        sb.append("    certificate: ").append(toIndentedString(certificate)).append("\n");
+        sb.append("    alias: ").append(toIndentedString(alias)).append("\n");
+        sb.append("    issuer: ").append(toIndentedString(issuer)).append("\n");
+        sb.append("    claims: ").append(toIndentedString(claims)).append("\n");
+        sb.append("    roles: ").append(toIndentedString(roles)).append("\n");
+        sb.append("    groups: ").append(toIndentedString(groups)).append("\n");
+        sb.append("    federatedAuthenticators: ").append(toIndentedString(federatedAuthenticators)).append("\n");
+        sb.append("    provisioning: ").append(toIndentedString(provisioning)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+    * Convert the given object to string with each line indented by 4 spaces
+    * (except the first line).
+    */
+    private String toIndentedString(java.lang.Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}
+

--- a/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/main/java/org/wso2/carbon/identity/api/server/idp/v1/core/ServerIdpManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/main/java/org/wso2/carbon/identity/api/server/idp/v1/core/ServerIdpManagementService.java
@@ -201,6 +201,34 @@ public class ServerIdpManagementService {
     }
 
     /**
+     * Get list of identity providers.
+     *
+     * @param requiredAttributes Required attributes in the IDP list response.
+     * @param limit      Items per page.
+     * @param offset     Offset.
+     * @param filter     Filter string. E.g. filter="name" sw "google" and "isEnabled" eq "true"
+     * @param sortBy     Attribute to sort the IDPs by. E.g. name
+     * @param sortOrder  Order in which IDPs should be sorted. Can be either ASC or DESC.
+     * @return IdentityProviderListResponse.
+     */
+    public IdentityProviderListResponse getTrustedTokenIssuers(String requiredAttributes, Integer limit, Integer offset,
+                                                      String filter, String sortBy, String sortOrder) {
+
+        try {
+            List<String> requestedAttributeList = null;
+            if (StringUtils.isNotBlank(requiredAttributes)) {
+                requestedAttributeList = new ArrayList<>(Arrays.asList(requiredAttributes.split(",")));
+            }
+            return createIDPListResponse(
+                    IdentityProviderServiceHolder.getIdentityProviderManager().getTrustedTokenIssuers(limit, offset,
+                            filter, sortBy, sortOrder, ContextLoader.getTenantDomainFromContext(),
+                            requestedAttributeList), requestedAttributeList);
+        } catch (IdentityProviderManagementException e) {
+            throw handleIdPException(e, Constants.ErrorMessage.ERROR_CODE_ERROR_LISTING_TRUSTED_TOKEN_ISSUERS, null);
+        }
+    }
+
+    /**
      * Add an identity provider.
      *
      * @param identityProviderPOSTRequest identityProviderPOSTRequest.

--- a/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/main/java/org/wso2/carbon/identity/api/server/idp/v1/impl/TrustedTokenIssuersApiServiceImpl.java
+++ b/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/main/java/org/wso2/carbon/identity/api/server/idp/v1/impl/TrustedTokenIssuersApiServiceImpl.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.idp.v1.impl;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.wso2.carbon.identity.api.server.common.ContextLoader;
+import org.wso2.carbon.identity.api.server.idp.v1.TrustedTokenIssuersApiService;
+import org.wso2.carbon.identity.api.server.idp.v1.core.ServerIdpManagementService;
+import org.wso2.carbon.identity.api.server.idp.v1.model.IdentityProviderPOSTRequest;
+import org.wso2.carbon.identity.api.server.idp.v1.model.IdentityProviderResponse;
+import org.wso2.carbon.identity.api.server.idp.v1.model.Patch;
+import org.wso2.carbon.identity.api.server.idp.v1.model.TrustedTokenIssuerPOSTRequest;
+import org.wso2.carbon.identity.api.server.idp.v1.model.TrustedTokenIssuerResponse;
+
+import java.net.URI;
+import java.util.List;
+
+import javax.ws.rs.core.Response;
+
+import static org.wso2.carbon.identity.api.server.common.Constants.V1_API_PATH_COMPONENT;
+import static org.wso2.carbon.identity.api.server.idp.common.Constants.TRUSTED_TOKEN_ISSUER_PATH_COMPONENT;
+
+/**
+ * Implementation of the Trusted Token Issuers REST API.
+ */
+public class TrustedTokenIssuersApiServiceImpl implements TrustedTokenIssuersApiService {
+
+    @Autowired
+    private ServerIdpManagementService idpManagementService;
+
+    @Override
+    public Response addTrustedTokenIssuer(TrustedTokenIssuerPOSTRequest trustedTokenIssuerPOSTRequest) {
+
+        IdentityProviderPOSTRequest identityProviderPOSTRequest =
+                getIdentityProviderPOSTRequest(trustedTokenIssuerPOSTRequest);
+        IdentityProviderResponse idPResponse = idpManagementService.addIDP(identityProviderPOSTRequest);
+        URI location = ContextLoader.buildURIForHeader(V1_API_PATH_COMPONENT +
+                TRUSTED_TOKEN_ISSUER_PATH_COMPONENT + "/" + idPResponse.getId());
+        return Response.created(location).entity(getTrustedTokenIssuerResponse(idPResponse)).build();
+    }
+
+    @Override
+    public Response deleteTrustedTokenIssuer(String trustedTokenIssuerId, Boolean force) {
+
+        if (force) {
+            idpManagementService.forceDeleteIDP(trustedTokenIssuerId);
+        } else {
+            idpManagementService.deleteIDP(trustedTokenIssuerId);
+        }
+        return Response.noContent().build();
+    }
+
+    @Override
+    public Response getTrustedTokenIssuer(String trustedTokenIssuerId) {
+
+        IdentityProviderResponse idPResponse = idpManagementService.getIDP(trustedTokenIssuerId);
+        return Response.ok().entity(getTrustedTokenIssuerResponse(idPResponse)).build();
+    }
+
+    @Override
+    public Response getTrustedTokenIssuers(Integer limit, Integer offset, String filter, String sortBy,
+                                           String sortOrder, String requiredAttributes) {
+
+        return Response.ok().entity(idpManagementService.getTrustedTokenIssuers(requiredAttributes, limit, offset,
+                filter, sortBy, sortOrder)).build();
+    }
+
+    @Override
+    public Response patchTrustedTokenIssuer(String trustedTokenIssuerId, List<Patch> patchRequest) {
+
+        IdentityProviderResponse idPResponse = idpManagementService.patchIDP(trustedTokenIssuerId, patchRequest);
+        return Response.ok().entity(getTrustedTokenIssuerResponse(idPResponse)).build();
+    }
+
+    private IdentityProviderPOSTRequest getIdentityProviderPOSTRequest(TrustedTokenIssuerPOSTRequest
+                                                                               trustedTokenIssuerPOSTRequest) {
+
+        IdentityProviderPOSTRequest identityProviderPOSTRequest = new IdentityProviderPOSTRequest();
+        identityProviderPOSTRequest.setIdpIssuerName(trustedTokenIssuerPOSTRequest.getIssuer());
+        identityProviderPOSTRequest.setAlias(trustedTokenIssuerPOSTRequest.getAlias());
+        identityProviderPOSTRequest.setName(trustedTokenIssuerPOSTRequest.getName());
+        identityProviderPOSTRequest.setCertificate(trustedTokenIssuerPOSTRequest.getCertificate());
+        identityProviderPOSTRequest.setDescription(trustedTokenIssuerPOSTRequest.getDescription());
+        identityProviderPOSTRequest.setImage(trustedTokenIssuerPOSTRequest.getImage());
+        identityProviderPOSTRequest.setTemplateId(trustedTokenIssuerPOSTRequest.getTemplateId());
+        identityProviderPOSTRequest.setClaims(trustedTokenIssuerPOSTRequest.getClaims());
+        return identityProviderPOSTRequest;
+    }
+
+    private TrustedTokenIssuerResponse getTrustedTokenIssuerResponse(IdentityProviderResponse
+                                                                             identityProviderResponse) {
+
+        TrustedTokenIssuerResponse trustedTokenIssuerResponse = new TrustedTokenIssuerResponse();
+        trustedTokenIssuerResponse.setId(identityProviderResponse.getId());
+        trustedTokenIssuerResponse.setName(identityProviderResponse.getName());
+        trustedTokenIssuerResponse.setDescription(identityProviderResponse.getDescription());
+        trustedTokenIssuerResponse.setTemplateId(identityProviderResponse.getTemplateId());
+        trustedTokenIssuerResponse.setIsEnabled(identityProviderResponse.getIsEnabled());
+        trustedTokenIssuerResponse.setIsPrimary(identityProviderResponse.getIsPrimary());
+        trustedTokenIssuerResponse.setImage(identityProviderResponse.getImage());
+        trustedTokenIssuerResponse.setIsFederationHub(identityProviderResponse.getIsFederationHub());
+        trustedTokenIssuerResponse.setHomeRealmIdentifier(identityProviderResponse.getHomeRealmIdentifier());
+        trustedTokenIssuerResponse.setCertificate(identityProviderResponse.getCertificate());
+        trustedTokenIssuerResponse.setAlias(identityProviderResponse.getAlias());
+        trustedTokenIssuerResponse.setIssuer(identityProviderResponse.getIdpIssuerName());
+        trustedTokenIssuerResponse.setClaims(identityProviderResponse.getClaims());
+        trustedTokenIssuerResponse.setRoles(identityProviderResponse.getRoles());
+        trustedTokenIssuerResponse.setGroups(identityProviderResponse.getGroups());
+        trustedTokenIssuerResponse.setFederatedAuthenticators(identityProviderResponse.getFederatedAuthenticators());
+        trustedTokenIssuerResponse.setProvisioning(identityProviderResponse.getProvisioning());
+        return trustedTokenIssuerResponse;
+    }
+}

--- a/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/main/resources/META-INF/cxf/idp-server-v1-cxf.xml
+++ b/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/main/resources/META-INF/cxf/idp-server-v1-cxf.xml
@@ -18,6 +18,7 @@
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:jaxrs="http://cxf.apache.org/jaxrs" xmlns:context="http://www.springframework.org/schema/context" xsi:schemaLocation=" http://www.springframework.org/schema/beans  http://www.springframework.org/schema/beans/spring-beans-3.0.xsd http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.0.xsd http://cxf.apache.org/jaxrs http://cxf.apache.org/schemas/jaxrs.xsd">
     <bean class="org.wso2.carbon.identity.api.server.idp.v1.core.ServerIdpManagementService"/>
     <bean class="org.wso2.carbon.identity.api.server.idp.v1.impl.IdentityProvidersApiServiceImpl"/>
+    <bean class="org.wso2.carbon.identity.api.server.idp.v1.impl.TrustedTokenIssuersApiServiceImpl"/>
     <bean id="identityProviderServiceFactoryBean"
           class="org.wso2.carbon.identity.api.server.idp.common.factory.IdPMgtOSGIServiceFactory"/>
     <bean id="claimMetadataServiceFactoryBean"

--- a/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/main/resources/idp.yaml
+++ b/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/main/resources/idp.yaml
@@ -462,7 +462,7 @@ paths:
       tags:
         - Identity Providers
       summary: |
-        Delete an identity provider by using the identity provider's ID. 
+        Delete an identity provider by using the identity provider's ID.
       description: >
         This API provides the capability to delete an identity provider by
         giving its ID. <br>
@@ -1978,6 +1978,286 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
+
+  '/trusted-token-issuers':
+    get:
+      tags:
+        - Trusted Token Issuers
+      summary: |
+        List Trusted Token issuers
+      description: >
+        This API provides the capability to retrieve the list of token issuers.<br>
+        <b>Permission required:</b> <br>
+            * /permission/admin/manage/identity/idpmgt/view <br>
+        <b>Scope required:</b> <br>
+            * internal_idp_view
+      operationId: getTrustedTokenIssuers
+      parameters:
+        - $ref: '#/components/parameters/limitQueryParam'
+        - $ref: '#/components/parameters/offsetQueryParam'
+        - $ref: '#/components/parameters/filterQueryParam'
+        - $ref: '#/components/parameters/sortByQueryParam'
+        - $ref: '#/components/parameters/sortOrderQueryParam'
+        - $ref: '#/components/parameters/requiredAttributesQueryParam'
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IdentityProviderListResponse'
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+        '500':
+          description: Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+    post:
+      tags:
+        - Trusted Token Issuers
+      summary: |
+        Add a new trusted token issuer
+      description: |
+        This API provides the capability to create a token issuer. <br>
+        <b>Permission required:</b> <br>
+            * /permission/admin/manage/identity/idpmgt/create <br>
+        <b>Scope required:</b> <br>
+            * internal_idp_create
+      operationId: addTrustedTokenIssuer
+      responses:
+        '201':
+          description: Successful response
+          headers:
+            Location:
+              description: Location of the newly created Token issuer.
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TrustedTokenIssuerResponse'
+            application/xml:
+              schema:
+                $ref: '#/components/schemas/TrustedTokenIssuerResponse'
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+            application/xml:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '409':
+          description: Conflict
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+            application/xml:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '500':
+          description: Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+            application/xml:
+              schema:
+                $ref: '#/components/schemas/Error'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TrustedTokenIssuerPOSTRequest'
+        description: This represents the trusted Token issuer to be created.
+        required: true
+
+  '/trusted-token-issuers/{trusted-token-issuer-id}':
+    get:
+      tags:
+        - Trusted Token Issuers
+      summary: |
+        Retrieve identity provider by trusted token issuer's ID
+      description: >
+        This API provides the capability to retrieve the trusted Token issuer details by using its ID.<br>
+        <b>Permission required:</b> <br>
+            * /permission/admin/manage/identity/idpmgt/view <br>
+        <b>Scope required:</b> <br>
+            * internal_idp_view
+      operationId: getTrustedTokenIssuer
+      parameters:
+        - name: trusted-token-issuer-id
+          in: path
+          description: ID of the trusted Token issuer.
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TrustedTokenIssuerResponse'
+            application/xml:
+              schema:
+                $ref: '#/components/schemas/TrustedTokenIssuerResponse'
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+            application/xml:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+            application/xml:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '500':
+          description: Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+            application/xml:
+              schema:
+                $ref: '#/components/schemas/Error'
+    patch:
+      tags:
+        - Trusted Token Issuers
+      summary: >
+        Patch a trusted Token issuer property by ID. Patch is supported only for key-value pairs
+      description: >
+        This API provides the capability to update a trusted Token issuer property
+        using patch request. Trusted Token issuer patch is supported only for key-value pairs. <br>
+        <b>Permission required:</b> <br>
+            * /permission/admin/manage/identity/idpmgt/update <br>
+        <b>Scope required:</b> <br>
+            * internal_idp_update
+      operationId: patchTrustedTokenIssuer
+      parameters:
+        - name: trusted-token-issuer-id
+          in: path
+          description: ID of the trusted Token issuer.
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Successful response
+          headers:
+            Location:
+              description: Location of the updated trusted Token issuer.
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TrustedTokenIssuerResponse'
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '500':
+          description: Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PatchRequest'
+        required: true
+    delete:
+      tags:
+        - Trusted Token Issuers
+      summary: |
+        Delete a trusted Token issuer by using the trusted token issuer's ID.
+      description: >
+        This API provides the capability to delete a trusted Token issuer by
+        giving its ID. <br>
+        <b>Permission required:</b> <br>
+            * /permission/admin/manage/identity/idpmgt/delete <br>
+        <b>Scope required:</b> <br>
+            * internal_idp_delete
+      operationId: deleteTrustedTokenIssuer
+      parameters:
+        - name: trusted-token-issuer-id
+          in: path
+          description: ID of the trusted Token issuer
+          required: true
+          schema:
+            type: string
+        - $ref: '#/components/parameters/forceQueryParam'
+      responses:
+        '204':
+          description: Successfully Deleted
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '500':
+          description: Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
 servers:
   - url: 'https://localhost:9443/t/{tenant-domain}/api/server/v1'
     variables:
@@ -2058,6 +2338,26 @@ components:
           - text/yaml
           - text/xml
           - text/json
+    sortOrderQueryParam:
+      in: query
+      name: sortOrder
+      required: false
+      description: >-
+        Define the order in which the retrieved tenants should be sorted.
+      schema:
+        type: string
+        enum:
+          - asc
+          - desc
+    sortByQueryParam:
+      in: query
+      name: sortBy
+      required: false
+      description: >-
+        Attribute by which the retrieved records should be sorted. Currently sorting through _<b>domainName<b>_ only
+        supported.
+      schema:
+        type: string
   securitySchemes:
     BasicAuth:
       type: http
@@ -2896,6 +3196,84 @@ components:
       required:
         - name
         - idp
+    TrustedTokenIssuerPOSTRequest:
+      type: object
+      required:
+        - name
+        - issuer
+        - certificate
+      properties:
+        name:
+          type: string
+          example: google
+        description:
+          type: string
+          example: "Trusted Token Issuer"
+        image:
+          type: string
+          example: "issuer-logo-url"
+        templateId:
+          type: string
+          example: '8ea23303-49c0-4253-b81f-82c0fe6fb4a0'
+        certificate:
+          $ref: '#/components/schemas/Certificate'
+        alias:
+          type: string
+          example: 'https://localhost:9444/oauth2/token'
+        issuer:
+          type: string
+          example: 'https://www.issuer.com'
+        claims:
+          $ref: '#/components/schemas/Claims'
+    TrustedTokenIssuerResponse:
+      type: object
+      properties:
+        id:
+          type: string
+          example: '123e4567-e89b-12d3-a456-556642440000'
+        name:
+          type: string
+          example: google
+        description:
+          type: string
+        templateId:
+          type: string
+          example: '8ea23303-49c0-4253-b81f-82c0fe6fb4a0'
+        isEnabled:
+          type: boolean
+          default: true
+          example: true
+        isPrimary:
+          type: boolean
+          default: false
+        image:
+          type: string
+          example: "google-logo-url"
+        isFederationHub:
+          type: boolean
+          example: false
+        homeRealmIdentifier:
+          type: string
+          example: localhost
+        certificate:
+          $ref: '#/components/schemas/Certificate'
+        alias:
+          type: string
+          example: 'https://localhost:9444/oauth2/token'
+        issuer:
+          type: string
+          example: 'https://www.idp.com'
+        claims:
+          $ref: '#/components/schemas/Claims'
+        roles:
+          $ref: '#/components/schemas/Roles'
+        groups:
+          $ref: '#/components/schemas/IdPGroupsConfig'
+        federatedAuthenticators:
+          $ref: '#/components/schemas/FederatedAuthenticatorListResponse'
+        provisioning:
+          $ref: '#/components/schemas/ProvisioningResponse'
+
     Service:
       type: string
       example: 'Authentication'

--- a/pom.xml
+++ b/pom.xml
@@ -572,7 +572,7 @@
         <maven.buildnumber.plugin.version>1.4</maven.buildnumber.plugin.version>
         <org.apache.felix.annotations.version>1.2.4</org.apache.felix.annotations.version>
         <identity.governance.version>1.8.23</identity.governance.version>
-        <carbon.identity.framework.version>5.25.186</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.25.198</carbon.identity.framework.version>
         <maven.findbugsplugin.version>3.0.5</maven.findbugsplugin.version>
         <identity.workflow.impl.bps.version>5.2.0</identity.workflow.impl.bps.version>
         <maven.checkstyleplugin.excludes>**/gen/**/*</maven.checkstyleplugin.excludes>


### PR DESCRIPTION
## Purpose
- Add `/trusted-token-issuers` API to support adding and fetching trusted token issuers. 
- Trusted token issuers API will use the identity provider management OSGi service to add and fetch the trusted token issuers.
- Adding trusted token issuers will require a simpler payload than the identity provider API.

## Git Issue
https://github.com/wso2/product-is/issues/15897