### PR TITLE
change permission name

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.permission.management/org.wso2.carbon.identity.api.server.permission.management.v1/src/main/resources/permission-management.yaml
+++ b/components/org.wso2.carbon.identity.api.server.permission.management/org.wso2.carbon.identity.api.server.permission.management.v1/src/main/resources/permission-management.yaml
@@ -103,7 +103,7 @@ components:
           resourcePath: "/permission/admin/monitor/metrics"
         - displayName: Monitor BPEL
           resourcePath: "/permission/admin/monitor/bpel"
-        - displayName: Monitor BPEL
+        - displayName: Monitor Attachment
           resourcePath: "/permission/admin/monitor/attachment"
         - displayName: Configure
           resourcePath: "/permission/admin/configure"


### PR DESCRIPTION
## Purpose
> The permission display name `Monitor BPEL` has been duplicated twice for two different resource paths i.e. `/permission/admin/monitor/bpel` and `/permission/admin/monitor/attachment`. Considering these two paths, the display name for `/permission/admin/monitor/attachment` has been renamed to `Monitor Attachment` in the relevant component. The example permission tree listed in permission-management.yaml file is updated according to the relevant change.

## Related Issues
> Issue https://github.com/wso2/product-is/issues/14009

## Related PRs
> PR https://github.com/wso2/carbon-business-process/pull/675