### PR TITLE
Onboard b2b organization and role management APIs

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.common/pom.xml
+++ b/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.common/pom.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2022, WSO2 LLC. (http://www.wso2.com). All Rights Reserved.
+  ~
+  ~ This software is the property of WSO2 LLC. and its suppliers, if any.
+  ~ Dissemination of any information or reproduction of any material contained
+  ~ herein in any form is strictly forbidden, unless permitted by WSO2 expressly.
+  ~ You may not alter or remove any copyright or other notice from copies of this content.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <parent>
+        <groupId>org.wso2.carbon.identity.server.api</groupId>
+        <artifactId>org.wso2.carbon.identity.api.server.organization.management</artifactId>
+        <version>1.2.67-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>org.wso2.carbon.identity.api.server.organization.management.common</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-web</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.organization.management.core</groupId>
+            <artifactId>org.wso2.carbon.identity.organization.management.service</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.organization.management</groupId>
+            <artifactId>org.wso2.carbon.identity.organization.management.application</artifactId>
+        </dependency>
+    </dependencies>
+</project>

--- a/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.common/pom.xml
+++ b/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.common/pom.xml
@@ -1,11 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2022, WSO2 LLC. (http://www.wso2.com). All Rights Reserved.
+  ~ Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
   ~
-  ~ This software is the property of WSO2 LLC. and its suppliers, if any.
-  ~ Dissemination of any information or reproduction of any material contained
-  ~ herein in any form is strictly forbidden, unless permitted by WSO2 expressly.
-  ~ You may not alter or remove any copyright or other notice from copies of this content.
+  ~ WSO2 LLC. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
   -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">

--- a/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.common/src/main/java/org/wso2/carbon/identity/api/server/organization/management/common/OrganizationManagementServiceHolder.java
+++ b/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.common/src/main/java/org/wso2/carbon/identity/api/server/organization/management/common/OrganizationManagementServiceHolder.java
@@ -1,10 +1,19 @@
 /*
- * Copyright (c) 2022, WSO2 LLC. (http://www.wso2.com). All Rights Reserved.
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
  *
- * This software is the property of WSO2 LLC. and its suppliers, if any.
- * Dissemination of any information or reproduction of any material contained
- * herein in any form is strictly forbidden, unless permitted by WSO2 expressly.
- * You may not alter or remove any copyright or other notice from copies of this content.
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 
 package org.wso2.carbon.identity.api.server.organization.management.common;

--- a/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.common/src/main/java/org/wso2/carbon/identity/api/server/organization/management/common/OrganizationManagementServiceHolder.java
+++ b/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.common/src/main/java/org/wso2/carbon/identity/api/server/organization/management/common/OrganizationManagementServiceHolder.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2022, WSO2 LLC. (http://www.wso2.com). All Rights Reserved.
+ *
+ * This software is the property of WSO2 LLC. and its suppliers, if any.
+ * Dissemination of any information or reproduction of any material contained
+ * herein in any form is strictly forbidden, unless permitted by WSO2 expressly.
+ * You may not alter or remove any copyright or other notice from copies of this content.
+ */
+
+package org.wso2.carbon.identity.api.server.organization.management.common;
+
+import org.wso2.carbon.identity.organization.management.application.OrgApplicationManager;
+import org.wso2.carbon.identity.organization.management.service.OrganizationManager;
+
+/**
+ * Service holder class for organization management related services.
+ */
+public class OrganizationManagementServiceHolder {
+
+    private static OrganizationManagementServiceHolder instance = new OrganizationManagementServiceHolder();
+
+    private OrgApplicationManager orgApplicationManager;
+    private OrganizationManager organizationManager;
+
+    private OrganizationManagementServiceHolder() {
+
+    }
+
+    public static OrganizationManagementServiceHolder getInstance() {
+
+        return instance;
+    }
+
+    /**
+     * Get OrgApplicationManager OSGi service.
+     *
+     * @return OrgApplicationManager
+     */
+    public OrgApplicationManager getOrgApplicationManager() {
+
+        return OrganizationManagementServiceHolder.getInstance().orgApplicationManager;
+    }
+
+    /**
+     * Set OrgApplicationManager OSGi service.
+     *
+     * @param orgApplicationManager OrgApplicationManager.
+     */
+    public void setOrgApplicationManager(OrgApplicationManager orgApplicationManager) {
+
+        OrganizationManagementServiceHolder.getInstance().orgApplicationManager = orgApplicationManager;
+    }
+
+    /**
+     * Get OrganizationManager OSGi service.
+     *
+     * @return OrganizationManager
+     */
+    public OrganizationManager getOrganizationManager() {
+
+        return OrganizationManagementServiceHolder.getInstance().organizationManager;
+    }
+
+    /**
+     * Set OrganizationManager OSGi service.
+     *
+     * @param organizationManager IdentityProviderManager.
+     */
+    public void setOrganizationManager(OrganizationManager organizationManager) {
+
+        OrganizationManagementServiceHolder.getInstance().organizationManager = organizationManager;
+    }
+}

--- a/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.common/src/main/java/org/wso2/carbon/identity/api/server/organization/management/common/OrganizationManagementServiceHolder.java
+++ b/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.common/src/main/java/org/wso2/carbon/identity/api/server/organization/management/common/OrganizationManagementServiceHolder.java
@@ -43,7 +43,7 @@ public class OrganizationManagementServiceHolder {
     /**
      * Get OrgApplicationManager OSGi service.
      *
-     * @return OrgApplicationManager
+     * @return OrgApplicationManager.
      */
     public OrgApplicationManager getOrgApplicationManager() {
 
@@ -63,7 +63,7 @@ public class OrganizationManagementServiceHolder {
     /**
      * Get OrganizationManager OSGi service.
      *
-     * @return OrganizationManager
+     * @return OrganizationManager.
      */
     public OrganizationManager getOrganizationManager() {
 
@@ -73,7 +73,7 @@ public class OrganizationManagementServiceHolder {
     /**
      * Set OrganizationManager OSGi service.
      *
-     * @param organizationManager IdentityProviderManager.
+     * @param organizationManager OrganizationManager.
      */
     public void setOrganizationManager(OrganizationManager organizationManager) {
 

--- a/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.common/src/main/java/org/wso2/carbon/identity/api/server/organization/management/common/factory/OrgApplicationManagerOSGIServiceFactory.java
+++ b/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.common/src/main/java/org/wso2/carbon/identity/api/server/organization/management/common/factory/OrgApplicationManagerOSGIServiceFactory.java
@@ -1,10 +1,19 @@
 /*
- * Copyright (c) 2022, WSO2 LLC. (http://www.wso2.com). All Rights Reserved.
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
  *
- * This software is the property of WSO2 LLC. and its suppliers, if any.
- * Dissemination of any information or reproduction of any material contained
- * herein in any form is strictly forbidden, unless permitted by WSO2 expressly.
- * You may not alter or remove any copyright or other notice from copies of this content.
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 
 package org.wso2.carbon.identity.api.server.organization.management.common.factory;

--- a/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.common/src/main/java/org/wso2/carbon/identity/api/server/organization/management/common/factory/OrgApplicationManagerOSGIServiceFactory.java
+++ b/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.common/src/main/java/org/wso2/carbon/identity/api/server/organization/management/common/factory/OrgApplicationManagerOSGIServiceFactory.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2022, WSO2 LLC. (http://www.wso2.com). All Rights Reserved.
+ *
+ * This software is the property of WSO2 LLC. and its suppliers, if any.
+ * Dissemination of any information or reproduction of any material contained
+ * herein in any form is strictly forbidden, unless permitted by WSO2 expressly.
+ * You may not alter or remove any copyright or other notice from copies of this content.
+ */
+
+package org.wso2.carbon.identity.api.server.organization.management.common.factory;
+
+import org.springframework.beans.factory.config.AbstractFactoryBean;
+import org.wso2.carbon.context.PrivilegedCarbonContext;
+import org.wso2.carbon.identity.organization.management.application.OrgApplicationManager;
+
+/**
+ * Factory Beans serves as a factory for creating other beans within the IOC container. This factory bean is used to
+ * instantiate the OrgApplicationManager type of object inside the container.
+ */
+public class OrgApplicationManagerOSGIServiceFactory extends AbstractFactoryBean<OrgApplicationManager> {
+
+    private OrgApplicationManager orgApplicationManager;
+
+    @Override
+    public Class<?> getObjectType() {
+
+        return Object.class;
+    }
+
+    @Override
+    protected OrgApplicationManager createInstance() throws Exception {
+
+        if (this.orgApplicationManager == null) {
+            OrgApplicationManager service = (OrgApplicationManager) PrivilegedCarbonContext.
+                    getThreadLocalCarbonContext().getOSGiService(OrgApplicationManager.class, null);
+            if (service != null) {
+                this.orgApplicationManager = service;
+            } else {
+                throw new Exception("Unable to retrieve OrgApplicationManager service.");
+            }
+        }
+        return this.orgApplicationManager;
+    }
+}

--- a/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.common/src/main/java/org/wso2/carbon/identity/api/server/organization/management/common/factory/OrganizationManagementOSGIServiceFactory.java
+++ b/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.common/src/main/java/org/wso2/carbon/identity/api/server/organization/management/common/factory/OrganizationManagementOSGIServiceFactory.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2022, WSO2 LLC. (http://www.wso2.com). All Rights Reserved.
+ *
+ * This software is the property of WSO2 LLC. and its suppliers, if any.
+ * Dissemination of any information or reproduction of any material contained
+ * herein in any form is strictly forbidden, unless permitted by WSO2 expressly.
+ * You may not alter or remove any copyright or other notice from copies of this content.
+ */
+
+package org.wso2.carbon.identity.api.server.organization.management.common.factory;
+
+import org.springframework.beans.factory.config.AbstractFactoryBean;
+import org.wso2.carbon.context.PrivilegedCarbonContext;
+import org.wso2.carbon.identity.organization.management.service.OrganizationManager;
+
+/**
+ * Factory Beans serves as a factory for creating other beans within the IOC container. This factory bean is used to
+ * instantiate the OrganizationManager type of object inside the container.
+ */
+public class OrganizationManagementOSGIServiceFactory extends AbstractFactoryBean<OrganizationManager> {
+
+    private OrganizationManager organizationManager;
+
+    @Override
+    public Class<?> getObjectType() {
+
+        return Object.class;
+    }
+
+    @Override
+    protected OrganizationManager createInstance() throws Exception {
+
+        if (this.organizationManager == null) {
+            OrganizationManager service = (OrganizationManager) PrivilegedCarbonContext.
+                    getThreadLocalCarbonContext().getOSGiService(OrganizationManager.class, null);
+            if (service != null) {
+                this.organizationManager = service;
+            } else {
+                throw new Exception("Unable to retrieve OrganizationManager service.");
+            }
+        }
+        return this.organizationManager;
+    }
+}

--- a/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.common/src/main/java/org/wso2/carbon/identity/api/server/organization/management/common/factory/OrganizationManagementOSGIServiceFactory.java
+++ b/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.common/src/main/java/org/wso2/carbon/identity/api/server/organization/management/common/factory/OrganizationManagementOSGIServiceFactory.java
@@ -1,10 +1,19 @@
 /*
- * Copyright (c) 2022, WSO2 LLC. (http://www.wso2.com). All Rights Reserved.
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
  *
- * This software is the property of WSO2 LLC. and its suppliers, if any.
- * Dissemination of any information or reproduction of any material contained
- * herein in any form is strictly forbidden, unless permitted by WSO2 expressly.
- * You may not alter or remove any copyright or other notice from copies of this content.
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 
 package org.wso2.carbon.identity.api.server.organization.management.common.factory;

--- a/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.v1/pom.xml
+++ b/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.v1/pom.xml
@@ -1,11 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com). All Rights Reserved.
+  ~ Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
   ~
-  ~ This software is the property of WSO2 LLC. and its suppliers, if any.
-  ~ Dissemination of any information or reproduction of any material contained
-  ~ herein in any form is strictly forbidden, unless permitted by WSO2 expressly.
-  ~ You may not alter or remove any copyright or other notice from copies of this content.
+  ~ WSO2 LLC. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
   -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">

--- a/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.v1/pom.xml
+++ b/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.v1/pom.xml
@@ -1,0 +1,155 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com). All Rights Reserved.
+  ~
+  ~ This software is the property of WSO2 LLC. and its suppliers, if any.
+  ~ Dissemination of any information or reproduction of any material contained
+  ~ herein in any form is strictly forbidden, unless permitted by WSO2 expressly.
+  ~ You may not alter or remove any copyright or other notice from copies of this content.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <parent>
+        <groupId>org.wso2.carbon.identity.server.api</groupId>
+        <artifactId>org.wso2.carbon.identity.api.server.organization.management</artifactId>
+        <version>1.2.67-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>org.wso2.carbon.identity.api.server.organization.management.v1</artifactId>
+    <name>WSO2 Identity Server - Organization Management Rest API</name>
+    <url>http://www.wso2.com</url>
+    <packaging>jar</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.cxf</groupId>
+            <artifactId>cxf-rt-frontend-jaxrs</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.cxf</groupId>
+            <artifactId>cxf-rt-rs-service-description</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-web</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>javax.ws.rs</groupId>
+            <artifactId>javax.ws.rs-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.swagger</groupId>
+            <artifactId>swagger-jaxrs</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-databind</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-annotations</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.dataformat</groupId>
+                    <artifactId>jackson-dataformat-yaml</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>javax.ws.rs</groupId>
+                    <artifactId>jsr311-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.google.guava</groupId>
+                    <artifactId>guava</artifactId>
+                </exclusion>
+            </exclusions>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.jaxrs</groupId>
+            <artifactId>jackson-jaxrs-json-provider</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.wso2.carbon.identity.server.api</groupId>
+            <artifactId>org.wso2.carbon.identity.api.server.organization.management.common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.organization.management.core</groupId>
+            <artifactId>org.wso2.carbon.identity.organization.management.service</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.organization.management</groupId>
+            <artifactId>org.wso2.carbon.identity.organization.management.application</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <version>3.0.0</version>
+                <executions>
+                    <execution>
+                        <id>add-source</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>add-source</goal>
+                        </goals>
+                        <configuration>
+                            <sources>
+                                <source>src/gen/java</source>
+                            </sources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <!--<plugin>
+                <groupId>org.openapitools</groupId>
+                <artifactId>openapi-generator-maven-plugin</artifactId>
+                <version>4.1.2</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>generate</goal>
+                        </goals>
+                        <configuration>
+                            <inputSpec>${project.basedir}/src/main/resources/org.wso2.carbon.identity.organization.management.yaml</inputSpec>
+                            <generatorName>org.wso2.carbon.codegen.CxfWso2Generator</generatorName>
+                            <configOptions>
+                                <sourceFolder>src/gen/java</sourceFolder>
+                                <apiPackage>org.wso2.carbon.identity.api.server.organization.management.v1</apiPackage>
+                                <modelPackage>org.wso2.carbon.identity.api.server.organization.management.v1.model</modelPackage>
+                                <packageName>org.wso2.carbon.identity.api.server.organization.management.v1</packageName>
+                                <dateLibrary>java8</dateLibrary>
+                                <hideGenerationTimestamp>true</hideGenerationTimestamp>
+                            </configOptions>
+                            <output>.</output>
+                            <skipOverwrite>false</skipOverwrite>
+                        </configuration>
+                    </execution>
+                </executions>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.openapitools</groupId>
+                        <artifactId>cxf-wso2-openapi-generator</artifactId>
+                        <version>1.0.0</version>
+                    </dependency>
+                </dependencies>
+            </plugin>-->
+        </plugins>
+    </build>
+</project>

--- a/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/management/v1/OrganizationsApi.java
+++ b/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/management/v1/OrganizationsApi.java
@@ -1,0 +1,392 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.organization.management.v1;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.apache.cxf.jaxrs.ext.multipart.Attachment;
+import org.apache.cxf.jaxrs.ext.multipart.Multipart;
+import java.io.InputStream;
+import java.util.List;
+
+import org.wso2.carbon.identity.api.server.organization.management.v1.model.ApplicationSharePOSTRequest;
+import org.wso2.carbon.identity.api.server.organization.management.v1.model.Error;
+import org.wso2.carbon.identity.api.server.organization.management.v1.model.GetOrganizationResponse;
+import java.util.List;
+import org.wso2.carbon.identity.api.server.organization.management.v1.model.OrganizationNameCheckPOSTRequest;
+import org.wso2.carbon.identity.api.server.organization.management.v1.model.OrganizationNameCheckPOSTResponse;
+import org.wso2.carbon.identity.api.server.organization.management.v1.model.OrganizationPOSTRequest;
+import org.wso2.carbon.identity.api.server.organization.management.v1.model.OrganizationPUTRequest;
+import org.wso2.carbon.identity.api.server.organization.management.v1.model.OrganizationPatchRequestItem;
+import org.wso2.carbon.identity.api.server.organization.management.v1.model.OrganizationResponse;
+import org.wso2.carbon.identity.api.server.organization.management.v1.model.OrganizationsResponse;
+import org.wso2.carbon.identity.api.server.organization.management.v1.model.SharedApplicationsResponse;
+import org.wso2.carbon.identity.api.server.organization.management.v1.model.SharedOrganizationsResponse;
+import org.wso2.carbon.identity.api.server.organization.management.v1.OrganizationsApiService;
+
+import javax.validation.Valid;
+import javax.ws.rs.*;
+import javax.ws.rs.core.Response;
+import io.swagger.annotations.*;
+
+import javax.validation.constraints.*;
+
+@Path("/organizations")
+@Api(description = "The organizations API")
+
+public class OrganizationsApi  {
+
+    @Autowired
+    private OrganizationsApiService delegate;
+
+    @Valid
+    @POST
+    
+    @Consumes({ "application/json" })
+    @Produces({ "application/json" })
+    @ApiOperation(value = "Create a new organization.", notes = "This API is used to create the organization defined in the user input.", response = OrganizationResponse.class, authorizations = {
+        @Authorization(value = "BasicAuth"),
+        @Authorization(value = "OAuth2", scopes = {
+            
+        })
+    }, tags={ "Organization", })
+    @ApiResponses(value = { 
+        @ApiResponse(code = 201, message = "Successful response", response = OrganizationResponse.class),
+        @ApiResponse(code = 400, message = "Invalid input in the request.", response = Error.class),
+        @ApiResponse(code = 401, message = "Authentication information is missing or invalid.", response = Void.class),
+        @ApiResponse(code = 403, message = "Access forbidden.", response = Void.class),
+        @ApiResponse(code = 500, message = "Internal server error.", response = Error.class)
+    })
+    public Response organizationPost(@ApiParam(value = "This represents the organization to be added." ,required=true) @Valid OrganizationPOSTRequest organizationPOSTRequest) {
+
+        return delegate.organizationPost(organizationPOSTRequest );
+    }
+
+    @Valid
+    @POST
+    @Path("/check-name")
+    @Consumes({ "application/json" })
+    @Produces({ "application/json" })
+    @ApiOperation(value = "Check organization with given name exist among the organizations hierarchy.", notes = "This API is used to check whether organization with particular name exist or not.", response = OrganizationNameCheckPOSTResponse.class, authorizations = {
+        @Authorization(value = "BasicAuth"),
+        @Authorization(value = "OAuth2", scopes = {
+            
+        })
+    }, tags={ "Organization", })
+    @ApiResponses(value = { 
+        @ApiResponse(code = 200, message = "Successful response", response = OrganizationNameCheckPOSTResponse.class),
+        @ApiResponse(code = 404, message = "Requested resource is not found.", response = Error.class),
+        @ApiResponse(code = 400, message = "Invalid input in the request.", response = Error.class),
+        @ApiResponse(code = 401, message = "Authentication information is missing or invalid.", response = Void.class),
+        @ApiResponse(code = 403, message = "Access forbidden.", response = Void.class),
+        @ApiResponse(code = 500, message = "Internal server error.", response = Error.class)
+    })
+    public Response organizationsCheckNamePost(@ApiParam(value = "OrganizationNameCheckPOSTRequest object containing the organization name." ,required=true) @Valid OrganizationNameCheckPOSTRequest organizationNameCheckPOSTRequest) {
+
+        return delegate.organizationsCheckNamePost(organizationNameCheckPOSTRequest );
+    }
+
+    @Valid
+    @GET
+    
+    
+    @Produces({ "application/json" })
+    @ApiOperation(value = "Retrieve organizations created for this tenant which matches the defined search criteria, if any.", notes = "This API is used to search and retrieve organizations created for this tenant.", response = OrganizationsResponse.class, authorizations = {
+        @Authorization(value = "BasicAuth"),
+        @Authorization(value = "OAuth2", scopes = {
+            
+        })
+    }, tags={ "Organization", })
+    @ApiResponses(value = { 
+        @ApiResponse(code = 200, message = "Successful response", response = OrganizationsResponse.class),
+        @ApiResponse(code = 400, message = "Invalid input in the request.", response = Error.class),
+        @ApiResponse(code = 401, message = "Authentication information is missing or invalid.", response = Void.class),
+        @ApiResponse(code = 403, message = "Access forbidden.", response = Void.class),
+        @ApiResponse(code = 500, message = "Internal server error.", response = Error.class),
+        @ApiResponse(code = 501, message = "Not Implemented.", response = Error.class)
+    })
+    public Response organizationsGet(    @Valid@ApiParam(value = "Condition to filter the retrieval of records.")  @QueryParam("filter") String filter,     @Valid @Min(0)@ApiParam(value = "Maximum number of records to be returned. (Should be greater than 0)")  @QueryParam("limit") Integer limit,     @Valid@ApiParam(value = "Points to the next range of data to be returned.")  @QueryParam("after") String after,     @Valid@ApiParam(value = "Points to the previous range of data that can be retrieved.")  @QueryParam("before") String before,     @Valid@ApiParam(value = "Determines whether a recursive search should happen.", defaultValue="false") @DefaultValue("false")  @QueryParam("recursive") Boolean recursive) {
+
+        return delegate.organizationsGet(filter,  limit,  after,  before,  recursive );
+    }
+
+    @Valid
+    @GET
+    @Path("/me")
+    
+    @Produces({ "application/json" })
+    @ApiOperation(value = "This API is used to search and retrieve child organizations which are authorized for the user.", notes = "Retrieve authorized sub organizations which matches the defined search criteria, if any.", response = OrganizationsResponse.class, authorizations = {
+        @Authorization(value = "BasicAuth"),
+        @Authorization(value = "OAuth2", scopes = {
+            
+        })
+    }, tags={ "Organization", })
+    @ApiResponses(value = { 
+        @ApiResponse(code = 200, message = "Successful response", response = OrganizationsResponse.class),
+        @ApiResponse(code = 400, message = "Invalid input in the request.", response = Error.class),
+        @ApiResponse(code = 401, message = "Authentication information is missing or invalid.", response = Void.class),
+        @ApiResponse(code = 403, message = "Access forbidden.", response = Void.class),
+        @ApiResponse(code = 500, message = "Internal server error.", response = Error.class),
+        @ApiResponse(code = 501, message = "Not Implemented.", response = Error.class)
+    })
+    public Response organizationsGetMe(    @Valid@ApiParam(value = "Condition to filter the retrieval of records.")  @QueryParam("filter") String filter,     @Valid @Min(0)@ApiParam(value = "Maximum number of records to be returned. (Should be greater than 0)")  @QueryParam("limit") Integer limit,     @Valid@ApiParam(value = "Points to the next range of data to be returned.")  @QueryParam("after") String after,     @Valid@ApiParam(value = "Points to the previous range of data that can be retrieved.")  @QueryParam("before") String before,     @Valid@ApiParam(value = "Determines whether a recursive search should happen.", defaultValue="false") @DefaultValue("false")  @QueryParam("recursive") Boolean recursive) {
+
+        return delegate.organizationsGetMe(filter,  limit,  after,  before,  recursive );
+    }
+
+    @Valid
+    @DELETE
+    @Path("/{organization-id}")
+    
+    @Produces({ "application/json" })
+    @ApiOperation(value = "Delete an organization by using the organization's ID.", notes = "This API provides the capability to delete an organization by giving its ID.", response = Void.class, authorizations = {
+        @Authorization(value = "BasicAuth"),
+        @Authorization(value = "OAuth2", scopes = {
+            
+        })
+    }, tags={ "Organization", })
+    @ApiResponses(value = { 
+        @ApiResponse(code = 204, message = "Successfully deleted", response = Void.class),
+        @ApiResponse(code = 400, message = "Invalid input in the request.", response = Error.class),
+        @ApiResponse(code = 401, message = "Authentication information is missing or invalid.", response = Void.class),
+        @ApiResponse(code = 403, message = "Access forbidden.", response = Void.class),
+        @ApiResponse(code = 404, message = "Requested resource is not found.", response = Error.class),
+        @ApiResponse(code = 500, message = "Internal server error.", response = Error.class)
+    })
+    public Response organizationsOrganizationIdDelete(@ApiParam(value = "ID of the organization to be deleted.",required=true) @PathParam("organization-id") String organizationId) {
+
+        return delegate.organizationsOrganizationIdDelete(organizationId );
+    }
+
+    @Valid
+    @GET
+    @Path("/{organization-id}")
+    
+    @Produces({ "application/json" })
+    @ApiOperation(value = "Get an existing organization, identified by the organization ID.", notes = "This API is used to get an existing organization identified by the organization ID.", response = GetOrganizationResponse.class, authorizations = {
+        @Authorization(value = "BasicAuth"),
+        @Authorization(value = "OAuth2", scopes = {
+            
+        })
+    }, tags={ "Organization", })
+    @ApiResponses(value = { 
+        @ApiResponse(code = 200, message = "Successful response", response = GetOrganizationResponse.class),
+        @ApiResponse(code = 400, message = "Invalid input in the request.", response = Error.class),
+        @ApiResponse(code = 401, message = "Authentication information is missing or invalid.", response = Void.class),
+        @ApiResponse(code = 403, message = "Access forbidden.", response = Void.class),
+        @ApiResponse(code = 404, message = "Requested resource is not found.", response = Error.class),
+        @ApiResponse(code = 500, message = "Internal server error.", response = Error.class)
+    })
+    public Response organizationsOrganizationIdGet(@ApiParam(value = "ID of the organization.",required=true) @PathParam("organization-id") String organizationId,     @Valid@ApiParam(value = "Returns the organization details along with permissions assigned for the requested user in this organization.", defaultValue="false") @DefaultValue("false")  @QueryParam("includePermissions") Boolean includePermissions) {
+
+        return delegate.organizationsOrganizationIdGet(organizationId,  includePermissions );
+    }
+
+    @Valid
+    @PATCH
+    @Path("/{organization-id}")
+    @Consumes({ "application/json" })
+    @Produces({ "application/json" })
+    @ApiOperation(value = "Patch an organization property by ID. Patch is supported only for key-value pairs.", notes = "This API provides the capability to update an organization property using patch request. Organization patch is supported only for key-value pairs.", response = OrganizationResponse.class, authorizations = {
+        @Authorization(value = "BasicAuth"),
+        @Authorization(value = "OAuth2", scopes = {
+            
+        })
+    }, tags={ "Organization", })
+    @ApiResponses(value = { 
+        @ApiResponse(code = 200, message = "Successful response", response = OrganizationResponse.class),
+        @ApiResponse(code = 400, message = "Invalid input in the request.", response = Error.class),
+        @ApiResponse(code = 401, message = "Authentication information is missing or invalid.", response = Void.class),
+        @ApiResponse(code = 403, message = "Access forbidden.", response = Void.class),
+        @ApiResponse(code = 404, message = "Requested resource is not found.", response = Error.class),
+        @ApiResponse(code = 500, message = "Internal server error.", response = Error.class)
+    })
+    public Response organizationsOrganizationIdPatch(@ApiParam(value = "ID of the organization to be patched.",required=true) @PathParam("organization-id") String organizationId, @ApiParam(value = "" ,required=true) @Valid List<OrganizationPatchRequestItem> organizationPatchRequestItem) {
+
+        return delegate.organizationsOrganizationIdPatch(organizationId,  organizationPatchRequestItem );
+    }
+
+    @Valid
+    @PUT
+    @Path("/{organization-id}")
+    @Consumes({ "application/json" })
+    @Produces({ "application/json" })
+    @ApiOperation(value = "Update an organization by ID.", notes = "This API provides the capability to update an organization by its id.", response = OrganizationResponse.class, authorizations = {
+        @Authorization(value = "BasicAuth"),
+        @Authorization(value = "OAuth2", scopes = {
+            
+        })
+    }, tags={ "Organization", })
+    @ApiResponses(value = { 
+        @ApiResponse(code = 200, message = "Successful response", response = OrganizationResponse.class),
+        @ApiResponse(code = 400, message = "Invalid input in the request.", response = Error.class),
+        @ApiResponse(code = 401, message = "Authentication information is missing or invalid.", response = Void.class),
+        @ApiResponse(code = 403, message = "Access forbidden.", response = Void.class),
+        @ApiResponse(code = 404, message = "Requested resource is not found.", response = Error.class),
+        @ApiResponse(code = 500, message = "Internal server error.", response = Error.class)
+    })
+    public Response organizationsOrganizationIdPut(@ApiParam(value = "ID of the organization to be updated.",required=true) @PathParam("organization-id") String organizationId, @ApiParam(value = "" ,required=true) @Valid OrganizationPUTRequest organizationPUTRequest) {
+
+        return delegate.organizationsOrganizationIdPut(organizationId,  organizationPUTRequest );
+    }
+
+    @Valid
+    @POST
+    @Path("/{organization-id}/applications/{application-id}/share")
+    @Consumes({ "application/json" })
+    @Produces({ "application/json" })
+    @ApiOperation(value = "Share application from the parent organization to given organization ", notes = "This API creates an internal application to delegate access from ", response = Void.class, authorizations = {
+        @Authorization(value = "BasicAuth"),
+        @Authorization(value = "OAuth2", scopes = {
+            
+        })
+    }, tags={ "Organization Application Management", })
+    @ApiResponses(value = { 
+        @ApiResponse(code = 200, message = "Ok", response = Void.class),
+        @ApiResponse(code = 400, message = "Invalid input in the request.", response = Error.class),
+        @ApiResponse(code = 401, message = "Authentication information is missing or invalid.", response = Void.class),
+        @ApiResponse(code = 403, message = "Access forbidden.", response = Void.class),
+        @ApiResponse(code = 404, message = "Requested resource is not found.", response = Error.class),
+        @ApiResponse(code = 500, message = "Internal server error.", response = Error.class)
+    })
+    public Response shareOrgApplication(@ApiParam(value = "ID of the parent organization where the application is created.",required=true) @PathParam("organization-id") String organizationId, @ApiParam(value = "ID of the application which will be shared to child organizations.",required=true) @PathParam("application-id") String applicationId, @ApiParam(value = "ApplicationSharePOSTRequest object containing the sharing attributes." ,required=true) @Valid ApplicationSharePOSTRequest applicationSharePOSTRequest) {
+
+        return delegate.shareOrgApplication(organizationId,  applicationId,  applicationSharePOSTRequest );
+    }
+
+    @Valid
+    @DELETE
+    @Path("/{organization-id}/applications/{application-id}/share/{shared-organization-id}")
+    
+    @Produces({ "application/json" })
+    @ApiOperation(value = "Stop sharing an application to a organization. ", notes = "This API provides the capability to stop sharing an application to an organization by providing its ID. ", response = Void.class, authorizations = {
+        @Authorization(value = "BasicAuth"),
+        @Authorization(value = "OAuth2", scopes = {
+            
+        })
+    }, tags={ "Organization Application Management", })
+    @ApiResponses(value = { 
+        @ApiResponse(code = 204, message = "Successfully deleted", response = Void.class),
+        @ApiResponse(code = 400, message = "Invalid input in the request.", response = Error.class),
+        @ApiResponse(code = 401, message = "Authentication information is missing or invalid.", response = Void.class),
+        @ApiResponse(code = 403, message = "Access forbidden.", response = Void.class),
+        @ApiResponse(code = 404, message = "Requested resource is not found.", response = Error.class),
+        @ApiResponse(code = 500, message = "Internal server error.", response = Error.class)
+    })
+    public Response shareOrgApplicationDelete(@ApiParam(value = "ID of the organization to be deleted.",required=true) @PathParam("organization-id") String organizationId, @ApiParam(value = "ID of the application.",required=true) @PathParam("application-id") String applicationId, @ApiParam(value = "ID of the organization to stop sharing.",required=true) @PathParam("shared-organization-id") String sharedOrganizationId) {
+
+        return delegate.shareOrgApplicationDelete(organizationId,  applicationId,  sharedOrganizationId );
+    }
+
+    @Valid
+    @DELETE
+    @Path("/{organization-id}/applications/{application-id}/fragment-apps")
+    
+    @Produces({ "application/json" })
+    @ApiOperation(value = "Stop sharing an application with all sub-organizations. ", notes = "This API provides the capability to stop sharing an application to all organizations the application is shared to. ", response = Void.class, authorizations = {
+        @Authorization(value = "BasicAuth"),
+        @Authorization(value = "OAuth2", scopes = {
+            
+        })
+    }, tags={ "Organization Application Management", })
+    @ApiResponses(value = { 
+        @ApiResponse(code = 204, message = "Successfully deleted", response = Void.class),
+        @ApiResponse(code = 400, message = "Invalid input in the request.", response = Error.class),
+        @ApiResponse(code = 401, message = "Authentication information is missing or invalid.", response = Void.class),
+        @ApiResponse(code = 403, message = "Access forbidden.", response = Void.class),
+        @ApiResponse(code = 404, message = "Requested resource is not found.", response = Error.class),
+        @ApiResponse(code = 500, message = "Internal server error.", response = Error.class)
+    })
+    public Response shareOrgApplicationDeleteAll(@ApiParam(value = "ID of the parent organization where the application is created.",required=true) @PathParam("organization-id") String organizationId, @ApiParam(value = "ID of the application.",required=true) @PathParam("application-id") String applicationId) {
+
+        return delegate.shareOrgApplicationDeleteAll(organizationId,  applicationId );
+    }
+
+    @Valid
+    @GET
+    @Path("/{organization-id}/applications/{application-id}/share")
+    
+    @Produces({ "application/json" })
+    @ApiOperation(value = "List of organizations that the application is shared to. ", notes = "This API returns the list of organizations that the application is shared to. ", response = SharedOrganizationsResponse.class, authorizations = {
+        @Authorization(value = "BasicAuth"),
+        @Authorization(value = "OAuth2", scopes = {
+            
+        })
+    }, tags={ "Organization Application Management", })
+    @ApiResponses(value = { 
+        @ApiResponse(code = 200, message = "Successful response", response = SharedOrganizationsResponse.class),
+        @ApiResponse(code = 400, message = "Invalid input in the request.", response = Error.class),
+        @ApiResponse(code = 401, message = "Authentication information is missing or invalid.", response = Void.class),
+        @ApiResponse(code = 403, message = "Access forbidden.", response = Void.class),
+        @ApiResponse(code = 404, message = "Requested resource is not found.", response = Error.class),
+        @ApiResponse(code = 500, message = "Internal server error.", response = Error.class)
+    })
+    public Response shareOrgApplicationGet(@ApiParam(value = "ID of the parent organization where the application is created.",required=true) @PathParam("organization-id") String organizationId, @ApiParam(value = "ID of the application which will be shared to child organizations.",required=true) @PathParam("application-id") String applicationId) {
+
+        return delegate.shareOrgApplicationGet(organizationId,  applicationId );
+    }
+
+    @Valid
+    @DELETE
+    @Path("/{organization-id}/applications/{application-id}/shared-apps")
+    
+    @Produces({ "application/json" })
+    @ApiOperation(value = "Stop sharing an application with all sub-organizations. ", notes = "This API provides the capability to stop sharing an application to all organizations the application is shared to. ", response = Void.class, authorizations = {
+        @Authorization(value = "BasicAuth"),
+        @Authorization(value = "OAuth2", scopes = {
+            
+        })
+    }, tags={ "Organization Application Management", })
+    @ApiResponses(value = { 
+        @ApiResponse(code = 204, message = "Successfully deleted", response = Void.class),
+        @ApiResponse(code = 400, message = "Invalid input in the request.", response = Error.class),
+        @ApiResponse(code = 401, message = "Authentication information is missing or invalid.", response = Void.class),
+        @ApiResponse(code = 403, message = "Access forbidden.", response = Void.class),
+        @ApiResponse(code = 404, message = "Requested resource is not found.", response = Error.class),
+        @ApiResponse(code = 500, message = "Internal server error.", response = Error.class)
+    })
+    public Response sharedApplicationsAllDelete(@ApiParam(value = "ID of the parent organization where the application is created.",required=true) @PathParam("organization-id") String organizationId, @ApiParam(value = "ID of the application.",required=true) @PathParam("application-id") String applicationId) {
+
+        return delegate.sharedApplicationsAllDelete(organizationId,  applicationId );
+    }
+
+    @Valid
+    @GET
+    @Path("/{organization-id}/applications/{application-id}/shared-apps")
+    
+    @Produces({ "application/json" })
+    @ApiOperation(value = "List of shared applications along with its organization. ", notes = "This API returns the list of shared app ids along with the shared organization id. ", response = SharedApplicationsResponse.class, authorizations = {
+        @Authorization(value = "BasicAuth"),
+        @Authorization(value = "OAuth2", scopes = {
+            
+        })
+    }, tags={ "Organization Application Management" })
+    @ApiResponses(value = { 
+        @ApiResponse(code = 200, message = "Successful response", response = SharedApplicationsResponse.class),
+        @ApiResponse(code = 400, message = "Invalid input in the request.", response = Error.class),
+        @ApiResponse(code = 401, message = "Authentication information is missing or invalid.", response = Void.class),
+        @ApiResponse(code = 403, message = "Access forbidden.", response = Void.class),
+        @ApiResponse(code = 404, message = "Requested resource is not found.", response = Error.class),
+        @ApiResponse(code = 500, message = "Internal server error.", response = Error.class)
+    })
+    public Response sharedApplicationsGet(@ApiParam(value = "ID of the parent organization where the application is created.",required=true) @PathParam("organization-id") String organizationId, @ApiParam(value = "ID of the application which is shared to child organizations.",required=true) @PathParam("application-id") String applicationId) {
+
+        return delegate.sharedApplicationsGet(organizationId,  applicationId );
+    }
+
+}

--- a/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/management/v1/OrganizationsApiService.java
+++ b/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/management/v1/OrganizationsApiService.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.organization.management.v1;
+
+import org.wso2.carbon.identity.api.server.organization.management.v1.*;
+import org.wso2.carbon.identity.api.server.organization.management.v1.model.*;
+import org.apache.cxf.jaxrs.ext.multipart.Attachment;
+import org.apache.cxf.jaxrs.ext.multipart.Multipart;
+import java.io.InputStream;
+import java.util.List;
+import org.wso2.carbon.identity.api.server.organization.management.v1.model.ApplicationSharePOSTRequest;
+import org.wso2.carbon.identity.api.server.organization.management.v1.model.Error;
+import org.wso2.carbon.identity.api.server.organization.management.v1.model.GetOrganizationResponse;
+import java.util.List;
+import org.wso2.carbon.identity.api.server.organization.management.v1.model.OrganizationNameCheckPOSTRequest;
+import org.wso2.carbon.identity.api.server.organization.management.v1.model.OrganizationNameCheckPOSTResponse;
+import org.wso2.carbon.identity.api.server.organization.management.v1.model.OrganizationPOSTRequest;
+import org.wso2.carbon.identity.api.server.organization.management.v1.model.OrganizationPUTRequest;
+import org.wso2.carbon.identity.api.server.organization.management.v1.model.OrganizationPatchRequestItem;
+import org.wso2.carbon.identity.api.server.organization.management.v1.model.OrganizationResponse;
+import org.wso2.carbon.identity.api.server.organization.management.v1.model.OrganizationsResponse;
+import org.wso2.carbon.identity.api.server.organization.management.v1.model.SharedApplicationsResponse;
+import org.wso2.carbon.identity.api.server.organization.management.v1.model.SharedOrganizationsResponse;
+import javax.ws.rs.core.Response;
+
+
+public interface OrganizationsApiService {
+
+      public Response organizationPost(OrganizationPOSTRequest organizationPOSTRequest);
+
+      public Response organizationsCheckNamePost(OrganizationNameCheckPOSTRequest organizationNameCheckPOSTRequest);
+
+      public Response organizationsGet(String filter, Integer limit, String after, String before, Boolean recursive);
+
+      public Response organizationsGetMe(String filter, Integer limit, String after, String before, Boolean recursive);
+
+      public Response organizationsOrganizationIdDelete(String organizationId);
+
+      public Response organizationsOrganizationIdGet(String organizationId, Boolean includePermissions);
+
+      public Response organizationsOrganizationIdPatch(String organizationId, List<OrganizationPatchRequestItem> organizationPatchRequestItem);
+
+      public Response organizationsOrganizationIdPut(String organizationId, OrganizationPUTRequest organizationPUTRequest);
+
+      public Response shareOrgApplication(String organizationId, String applicationId, ApplicationSharePOSTRequest applicationSharePOSTRequest);
+
+      public Response shareOrgApplicationDelete(String organizationId, String applicationId, String sharedOrganizationId);
+
+      public Response shareOrgApplicationDeleteAll(String organizationId, String applicationId);
+
+      public Response shareOrgApplicationGet(String organizationId, String applicationId);
+
+      public Response sharedApplicationsAllDelete(String organizationId, String applicationId);
+
+      public Response sharedApplicationsGet(String organizationId, String applicationId);
+}

--- a/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/management/v1/factories/OrganizationsApiServiceFactory.java
+++ b/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/management/v1/factories/OrganizationsApiServiceFactory.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.organization.management.v1.factories;
+
+import org.wso2.carbon.identity.api.server.organization.management.v1.OrganizationsApiService;
+import org.wso2.carbon.identity.api.server.organization.management.v1.impl.OrganizationsApiServiceImpl;
+
+public class OrganizationsApiServiceFactory {
+
+   private final static OrganizationsApiService service = new OrganizationsApiServiceImpl();
+
+   public static OrganizationsApiService getOrganizationsApi()
+   {
+      return service;
+   }
+}

--- a/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/management/v1/model/ApplicationSharePOSTRequest.java
+++ b/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/management/v1/model/ApplicationSharePOSTRequest.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.organization.management.v1.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import java.util.ArrayList;
+import java.util.List;
+import javax.validation.constraints.*;
+
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+import javax.validation.Valid;
+import javax.xml.bind.annotation.*;
+
+public class ApplicationSharePOSTRequest  {
+  
+    private Boolean shareWithAllChildren = false;
+    private List<String> sharedOrganizations = null;
+
+
+    /**
+    **/
+    public ApplicationSharePOSTRequest shareWithAllChildren(Boolean shareWithAllChildren) {
+
+        this.shareWithAllChildren = shareWithAllChildren;
+        return this;
+    }
+    
+    @ApiModelProperty(value = "")
+    @JsonProperty("shareWithAllChildren")
+    @Valid
+    public Boolean getShareWithAllChildren() {
+        return shareWithAllChildren;
+    }
+    public void setShareWithAllChildren(Boolean shareWithAllChildren) {
+        this.shareWithAllChildren = shareWithAllChildren;
+    }
+
+    /**
+    **/
+    public ApplicationSharePOSTRequest sharedOrganizations(List<String> sharedOrganizations) {
+
+        this.sharedOrganizations = sharedOrganizations;
+        return this;
+    }
+    
+    @ApiModelProperty(value = "")
+    @JsonProperty("sharedOrganizations")
+    @Valid
+    public List<String> getSharedOrganizations() {
+        return sharedOrganizations;
+    }
+    public void setSharedOrganizations(List<String> sharedOrganizations) {
+        this.sharedOrganizations = sharedOrganizations;
+    }
+
+    public ApplicationSharePOSTRequest addSharedOrganizationsItem(String sharedOrganizationsItem) {
+        if (this.sharedOrganizations == null) {
+            this.sharedOrganizations = new ArrayList<>();
+        }
+        this.sharedOrganizations.add(sharedOrganizationsItem);
+        return this;
+    }
+
+    
+
+    @Override
+    public boolean equals(java.lang.Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ApplicationSharePOSTRequest applicationSharePOSTRequest = (ApplicationSharePOSTRequest) o;
+        return Objects.equals(this.shareWithAllChildren, applicationSharePOSTRequest.shareWithAllChildren) &&
+            Objects.equals(this.sharedOrganizations, applicationSharePOSTRequest.sharedOrganizations);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(shareWithAllChildren, sharedOrganizations);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class ApplicationSharePOSTRequest {\n");
+        
+        sb.append("    shareWithAllChildren: ").append(toIndentedString(shareWithAllChildren)).append("\n");
+        sb.append("    sharedOrganizations: ").append(toIndentedString(sharedOrganizations)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+    * Convert the given object to string with each line indented by 4 spaces
+    * (except the first line).
+    */
+    private String toIndentedString(java.lang.Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}
+

--- a/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/management/v1/model/Attribute.java
+++ b/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/management/v1/model/Attribute.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.organization.management.v1.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import javax.validation.constraints.*;
+
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+import javax.validation.Valid;
+import javax.xml.bind.annotation.*;
+
+public class Attribute  {
+  
+    private String key;
+    private String value;
+
+    /**
+    **/
+    public Attribute key(String key) {
+
+        this.key = key;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "Country", required = true, value = "")
+    @JsonProperty("key")
+    @Valid
+    @NotNull(message = "Property key cannot be null.")
+
+    public String getKey() {
+        return key;
+    }
+    public void setKey(String key) {
+        this.key = key;
+    }
+
+    /**
+    **/
+    public Attribute value(String value) {
+
+        this.value = value;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "Sri Lanka", required = true, value = "")
+    @JsonProperty("value")
+    @Valid
+    @NotNull(message = "Property value cannot be null.")
+
+    public String getValue() {
+        return value;
+    }
+    public void setValue(String value) {
+        this.value = value;
+    }
+
+
+
+    @Override
+    public boolean equals(java.lang.Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Attribute attribute = (Attribute) o;
+        return Objects.equals(this.key, attribute.key) &&
+            Objects.equals(this.value, attribute.value);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(key, value);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class Attribute {\n");
+        
+        sb.append("    key: ").append(toIndentedString(key)).append("\n");
+        sb.append("    value: ").append(toIndentedString(value)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+    * Convert the given object to string with each line indented by 4 spaces
+    * (except the first line).
+    */
+    private String toIndentedString(java.lang.Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}
+

--- a/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/management/v1/model/BasicOrganizationResponse.java
+++ b/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/management/v1/model/BasicOrganizationResponse.java
@@ -1,0 +1,202 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.organization.management.v1.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import javax.validation.constraints.*;
+
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+import javax.validation.Valid;
+import javax.xml.bind.annotation.*;
+
+public class BasicOrganizationResponse  {
+  
+    private String id;
+    private String name;
+
+@XmlType(name="StatusEnum")
+@XmlEnum(String.class)
+public enum StatusEnum {
+
+    @XmlEnumValue("ACTIVE") ACTIVE(String.valueOf("ACTIVE")), @XmlEnumValue("DISABLED") DISABLED(String.valueOf("DISABLED"));
+
+
+    private String value;
+
+    StatusEnum(String v) {
+        value = v;
+    }
+
+    public String value() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    public static StatusEnum fromValue(String value) {
+        for (StatusEnum b : StatusEnum.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
+}
+
+    private StatusEnum status;
+    private String ref;
+
+    /**
+    **/
+    public BasicOrganizationResponse id(String id) {
+
+        this.id = id;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "b4526d91-a8bf-43d2-8b14-c548cf73065b", required = true, value = "")
+    @JsonProperty("id")
+    @Valid
+    @NotNull(message = "Property id cannot be null.")
+
+    public String getId() {
+        return id;
+    }
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    /**
+    **/
+    public BasicOrganizationResponse name(String name) {
+
+        this.name = name;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "ABC Builders", required = true, value = "")
+    @JsonProperty("name")
+    @Valid
+    @NotNull(message = "Property name cannot be null.")
+
+    public String getName() {
+        return name;
+    }
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    /**
+    **/
+    public BasicOrganizationResponse status(StatusEnum status) {
+
+        this.status = status;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "ACTIVE", required = true, value = "")
+    @JsonProperty("status")
+    @Valid
+    @NotNull(message = "Property status cannot be null.")
+
+    public StatusEnum getStatus() {
+        return status;
+    }
+    public void setStatus(StatusEnum status) {
+        this.status = status;
+    }
+
+    /**
+    **/
+    public BasicOrganizationResponse ref(String ref) {
+
+        this.ref = ref;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "o/10084a8d-113f-4211-a0d5-efe36b082211/api/server/v1/organizations/b4526d91-a8bf-43d2-8b14-c548cf73065b", required = true, value = "")
+    @JsonProperty("ref")
+    @Valid
+    @NotNull(message = "Property ref cannot be null.")
+
+    public String getRef() {
+        return ref;
+    }
+    public void setRef(String ref) {
+        this.ref = ref;
+    }
+
+
+
+    @Override
+    public boolean equals(java.lang.Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        BasicOrganizationResponse basicOrganizationResponse = (BasicOrganizationResponse) o;
+        return Objects.equals(this.id, basicOrganizationResponse.id) &&
+            Objects.equals(this.name, basicOrganizationResponse.name) &&
+            Objects.equals(this.status, basicOrganizationResponse.status) &&
+            Objects.equals(this.ref, basicOrganizationResponse.ref);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, name, status, ref);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class BasicOrganizationResponse {\n");
+        
+        sb.append("    id: ").append(toIndentedString(id)).append("\n");
+        sb.append("    name: ").append(toIndentedString(name)).append("\n");
+        sb.append("    status: ").append(toIndentedString(status)).append("\n");
+        sb.append("    ref: ").append(toIndentedString(ref)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+    * Convert the given object to string with each line indented by 4 spaces
+    * (except the first line).
+    */
+    private String toIndentedString(java.lang.Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}
+

--- a/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/management/v1/model/Error.java
+++ b/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/management/v1/model/Error.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.organization.management.v1.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import javax.validation.constraints.*;
+
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+import javax.validation.Valid;
+import javax.xml.bind.annotation.*;
+
+public class Error  {
+  
+    private String code;
+    private String message;
+    private String description;
+    private String traceId;
+
+    /**
+    * An error code.
+    **/
+    public Error code(String code) {
+
+        this.code = code;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "ORG-00000", required = true, value = "An error code.")
+    @JsonProperty("code")
+    @Valid
+    @NotNull(message = "Property code cannot be null.")
+
+    public String getCode() {
+        return code;
+    }
+    public void setCode(String code) {
+        this.code = code;
+    }
+
+    /**
+    * An error message.
+    **/
+    public Error message(String message) {
+
+        this.message = message;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "Some Error Message", required = true, value = "An error message.")
+    @JsonProperty("message")
+    @Valid
+    @NotNull(message = "Property message cannot be null.")
+
+    public String getMessage() {
+        return message;
+    }
+    public void setMessage(String message) {
+        this.message = message;
+    }
+
+    /**
+    * An error description.
+    **/
+    public Error description(String description) {
+
+        this.description = description;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "Some Error Description", value = "An error description.")
+    @JsonProperty("description")
+    @Valid
+    public String getDescription() {
+        return description;
+    }
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    /**
+    * An error trace identifier.
+    **/
+    public Error traceId(String traceId) {
+
+        this.traceId = traceId;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "e0fbcfeb-3617-43c4-8dd0-7b7d38e13047", value = "An error trace identifier.")
+    @JsonProperty("traceId")
+    @Valid
+    public String getTraceId() {
+        return traceId;
+    }
+    public void setTraceId(String traceId) {
+        this.traceId = traceId;
+    }
+
+
+
+    @Override
+    public boolean equals(java.lang.Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Error error = (Error) o;
+        return Objects.equals(this.code, error.code) &&
+            Objects.equals(this.message, error.message) &&
+            Objects.equals(this.description, error.description) &&
+            Objects.equals(this.traceId, error.traceId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(code, message, description, traceId);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class Error {\n");
+        
+        sb.append("    code: ").append(toIndentedString(code)).append("\n");
+        sb.append("    message: ").append(toIndentedString(message)).append("\n");
+        sb.append("    description: ").append(toIndentedString(description)).append("\n");
+        sb.append("    traceId: ").append(toIndentedString(traceId)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+    * Convert the given object to string with each line indented by 4 spaces
+    * (except the first line).
+    */
+    private String toIndentedString(java.lang.Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}
+

--- a/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/management/v1/model/GetOrganizationResponse.java
+++ b/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/management/v1/model/GetOrganizationResponse.java
@@ -1,0 +1,387 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.organization.management.v1.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import java.util.ArrayList;
+import java.util.List;
+import org.wso2.carbon.identity.api.server.organization.management.v1.model.Attribute;
+import org.wso2.carbon.identity.api.server.organization.management.v1.model.ParentOrganization;
+import javax.validation.constraints.*;
+
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+import javax.validation.Valid;
+import javax.xml.bind.annotation.*;
+
+public class GetOrganizationResponse  {
+  
+    private String id;
+    private String name;
+    private String description;
+
+@XmlType(name="StatusEnum")
+@XmlEnum(String.class)
+public enum StatusEnum {
+
+    @XmlEnumValue("ACTIVE") ACTIVE(String.valueOf("ACTIVE")), @XmlEnumValue("DISABLED") DISABLED(String.valueOf("DISABLED"));
+
+
+    private String value;
+
+    StatusEnum(String v) {
+        value = v;
+    }
+
+    public String value() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    public static StatusEnum fromValue(String value) {
+        for (StatusEnum b : StatusEnum.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
+}
+
+    private StatusEnum status;
+    private String created;
+    private String lastModified;
+
+@XmlType(name="TypeEnum")
+@XmlEnum(String.class)
+public enum TypeEnum {
+
+    @XmlEnumValue("TENANT") TENANT(String.valueOf("TENANT")), @XmlEnumValue("STRUCTURAL") STRUCTURAL(String.valueOf("STRUCTURAL"));
+
+
+    private String value;
+
+    TypeEnum(String v) {
+        value = v;
+    }
+
+    public String value() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    public static TypeEnum fromValue(String value) {
+        for (TypeEnum b : TypeEnum.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
+}
+
+    private TypeEnum type;
+    private ParentOrganization parent;
+    private List<Attribute> attributes = null;
+
+    private List<String> permissions = null;
+
+
+    /**
+    **/
+    public GetOrganizationResponse id(String id) {
+
+        this.id = id;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "06c1f4e2-3339-44e4-a825-96585e3653b1", required = true, value = "")
+    @JsonProperty("id")
+    @Valid
+    @NotNull(message = "Property id cannot be null.")
+
+    public String getId() {
+        return id;
+    }
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    /**
+    **/
+    public GetOrganizationResponse name(String name) {
+
+        this.name = name;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "ABC Builders", required = true, value = "")
+    @JsonProperty("name")
+    @Valid
+    @NotNull(message = "Property name cannot be null.")
+
+    public String getName() {
+        return name;
+    }
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    /**
+    **/
+    public GetOrganizationResponse description(String description) {
+
+        this.description = description;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "Building constructions", value = "")
+    @JsonProperty("description")
+    @Valid
+    public String getDescription() {
+        return description;
+    }
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    /**
+    **/
+    public GetOrganizationResponse status(StatusEnum status) {
+
+        this.status = status;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "ACTIVE", required = true, value = "")
+    @JsonProperty("status")
+    @Valid
+    @NotNull(message = "Property status cannot be null.")
+
+    public StatusEnum getStatus() {
+        return status;
+    }
+    public void setStatus(StatusEnum status) {
+        this.status = status;
+    }
+
+    /**
+    **/
+    public GetOrganizationResponse created(String created) {
+
+        this.created = created;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "2021-10-25T12:31:53.406Z", required = true, value = "")
+    @JsonProperty("created")
+    @Valid
+    @NotNull(message = "Property created cannot be null.")
+
+    public String getCreated() {
+        return created;
+    }
+    public void setCreated(String created) {
+        this.created = created;
+    }
+
+    /**
+    **/
+    public GetOrganizationResponse lastModified(String lastModified) {
+
+        this.lastModified = lastModified;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "2021-10-25T12:31:53.406Z", required = true, value = "")
+    @JsonProperty("lastModified")
+    @Valid
+    @NotNull(message = "Property lastModified cannot be null.")
+
+    public String getLastModified() {
+        return lastModified;
+    }
+    public void setLastModified(String lastModified) {
+        this.lastModified = lastModified;
+    }
+
+    /**
+    **/
+    public GetOrganizationResponse type(TypeEnum type) {
+
+        this.type = type;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "TENANT", required = true, value = "")
+    @JsonProperty("type")
+    @Valid
+    @NotNull(message = "Property type cannot be null.")
+
+    public TypeEnum getType() {
+        return type;
+    }
+    public void setType(TypeEnum type) {
+        this.type = type;
+    }
+
+    /**
+    **/
+    public GetOrganizationResponse parent(ParentOrganization parent) {
+
+        this.parent = parent;
+        return this;
+    }
+    
+    @ApiModelProperty(value = "")
+    @JsonProperty("parent")
+    @Valid
+    public ParentOrganization getParent() {
+        return parent;
+    }
+    public void setParent(ParentOrganization parent) {
+        this.parent = parent;
+    }
+
+    /**
+    **/
+    public GetOrganizationResponse attributes(List<Attribute> attributes) {
+
+        this.attributes = attributes;
+        return this;
+    }
+    
+    @ApiModelProperty(value = "")
+    @JsonProperty("attributes")
+    @Valid
+    public List<Attribute> getAttributes() {
+        return attributes;
+    }
+    public void setAttributes(List<Attribute> attributes) {
+        this.attributes = attributes;
+    }
+
+    public GetOrganizationResponse addAttributesItem(Attribute attributesItem) {
+        if (this.attributes == null) {
+            this.attributes = new ArrayList<>();
+        }
+        this.attributes.add(attributesItem);
+        return this;
+    }
+
+        /**
+    **/
+    public GetOrganizationResponse permissions(List<String> permissions) {
+
+        this.permissions = permissions;
+        return this;
+    }
+    
+    @ApiModelProperty(value = "")
+    @JsonProperty("permissions")
+    @Valid
+    public List<String> getPermissions() {
+        return permissions;
+    }
+    public void setPermissions(List<String> permissions) {
+        this.permissions = permissions;
+    }
+
+    public GetOrganizationResponse addPermissionsItem(String permissionsItem) {
+        if (this.permissions == null) {
+            this.permissions = new ArrayList<>();
+        }
+        this.permissions.add(permissionsItem);
+        return this;
+    }
+
+    
+
+    @Override
+    public boolean equals(java.lang.Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        GetOrganizationResponse getOrganizationResponse = (GetOrganizationResponse) o;
+        return Objects.equals(this.id, getOrganizationResponse.id) &&
+            Objects.equals(this.name, getOrganizationResponse.name) &&
+            Objects.equals(this.description, getOrganizationResponse.description) &&
+            Objects.equals(this.status, getOrganizationResponse.status) &&
+            Objects.equals(this.created, getOrganizationResponse.created) &&
+            Objects.equals(this.lastModified, getOrganizationResponse.lastModified) &&
+            Objects.equals(this.type, getOrganizationResponse.type) &&
+            Objects.equals(this.parent, getOrganizationResponse.parent) &&
+            Objects.equals(this.attributes, getOrganizationResponse.attributes) &&
+            Objects.equals(this.permissions, getOrganizationResponse.permissions);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, name, description, status, created, lastModified, type, parent, attributes, permissions);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class GetOrganizationResponse {\n");
+        
+        sb.append("    id: ").append(toIndentedString(id)).append("\n");
+        sb.append("    name: ").append(toIndentedString(name)).append("\n");
+        sb.append("    description: ").append(toIndentedString(description)).append("\n");
+        sb.append("    status: ").append(toIndentedString(status)).append("\n");
+        sb.append("    created: ").append(toIndentedString(created)).append("\n");
+        sb.append("    lastModified: ").append(toIndentedString(lastModified)).append("\n");
+        sb.append("    type: ").append(toIndentedString(type)).append("\n");
+        sb.append("    parent: ").append(toIndentedString(parent)).append("\n");
+        sb.append("    attributes: ").append(toIndentedString(attributes)).append("\n");
+        sb.append("    permissions: ").append(toIndentedString(permissions)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+    * Convert the given object to string with each line indented by 4 spaces
+    * (except the first line).
+    */
+    private String toIndentedString(java.lang.Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}
+

--- a/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/management/v1/model/Link.java
+++ b/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/management/v1/model/Link.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.organization.management.v1.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import java.net.URI;
+import javax.validation.constraints.*;
+
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+import javax.validation.Valid;
+import javax.xml.bind.annotation.*;
+
+public class Link  {
+  
+    private URI href;
+    private String rel;
+
+    /**
+    * Endpoint that will return the next or previous page of data.
+    **/
+    public Link href(URI href) {
+
+        this.href = href;
+        return this;
+    }
+    
+    @ApiModelProperty(value = "Endpoint that will return the next or previous page of data.")
+    @JsonProperty("href")
+    @Valid
+    public URI getHref() {
+        return href;
+    }
+    public void setHref(URI href) {
+        this.href = href;
+    }
+
+    /**
+    * Describes whether the provided link is to access the next or previous page of data.
+    **/
+    public Link rel(String rel) {
+
+        this.rel = rel;
+        return this;
+    }
+    
+    @ApiModelProperty(value = "Describes whether the provided link is to access the next or previous page of data.")
+    @JsonProperty("rel")
+    @Valid
+    public String getRel() {
+        return rel;
+    }
+    public void setRel(String rel) {
+        this.rel = rel;
+    }
+
+
+
+    @Override
+    public boolean equals(java.lang.Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Link link = (Link) o;
+        return Objects.equals(this.href, link.href) &&
+            Objects.equals(this.rel, link.rel);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(href, rel);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class Link {\n");
+        
+        sb.append("    href: ").append(toIndentedString(href)).append("\n");
+        sb.append("    rel: ").append(toIndentedString(rel)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+    * Convert the given object to string with each line indented by 4 spaces
+    * (except the first line).
+    */
+    private String toIndentedString(java.lang.Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}
+

--- a/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/management/v1/model/OrganizationNameCheckPOSTRequest.java
+++ b/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/management/v1/model/OrganizationNameCheckPOSTRequest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.organization.management.v1.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import javax.validation.constraints.*;
+
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+import javax.validation.Valid;
+import javax.xml.bind.annotation.*;
+
+public class OrganizationNameCheckPOSTRequest  {
+  
+    private String name;
+
+    /**
+    **/
+    public OrganizationNameCheckPOSTRequest name(String name) {
+
+        this.name = name;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "ABC Builders", value = "")
+    @JsonProperty("name")
+    @Valid
+    public String getName() {
+        return name;
+    }
+    public void setName(String name) {
+        this.name = name;
+    }
+
+
+
+    @Override
+    public boolean equals(java.lang.Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OrganizationNameCheckPOSTRequest organizationNameCheckPOSTRequest = (OrganizationNameCheckPOSTRequest) o;
+        return Objects.equals(this.name, organizationNameCheckPOSTRequest.name);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OrganizationNameCheckPOSTRequest {\n");
+        
+        sb.append("    name: ").append(toIndentedString(name)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+    * Convert the given object to string with each line indented by 4 spaces
+    * (except the first line).
+    */
+    private String toIndentedString(java.lang.Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}
+

--- a/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/management/v1/model/OrganizationNameCheckPOSTResponse.java
+++ b/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/management/v1/model/OrganizationNameCheckPOSTResponse.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.organization.management.v1.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import javax.validation.constraints.*;
+
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+import javax.validation.Valid;
+import javax.xml.bind.annotation.*;
+
+public class OrganizationNameCheckPOSTResponse  {
+  
+    private Boolean available;
+
+    /**
+    **/
+    public OrganizationNameCheckPOSTResponse available(Boolean available) {
+
+        this.available = available;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "true", value = "")
+    @JsonProperty("available")
+    @Valid
+    public Boolean getAvailable() {
+        return available;
+    }
+    public void setAvailable(Boolean available) {
+        this.available = available;
+    }
+
+
+
+    @Override
+    public boolean equals(java.lang.Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OrganizationNameCheckPOSTResponse organizationNameCheckPOSTResponse = (OrganizationNameCheckPOSTResponse) o;
+        return Objects.equals(this.available, organizationNameCheckPOSTResponse.available);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(available);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OrganizationNameCheckPOSTResponse {\n");
+        
+        sb.append("    available: ").append(toIndentedString(available)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+    * Convert the given object to string with each line indented by 4 spaces
+    * (except the first line).
+    */
+    private String toIndentedString(java.lang.Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}
+

--- a/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/management/v1/model/OrganizationPOSTRequest.java
+++ b/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/management/v1/model/OrganizationPOSTRequest.java
@@ -1,0 +1,230 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.organization.management.v1.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import java.util.ArrayList;
+import java.util.List;
+import org.wso2.carbon.identity.api.server.organization.management.v1.model.Attribute;
+import javax.validation.constraints.*;
+
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+import javax.validation.Valid;
+import javax.xml.bind.annotation.*;
+
+public class OrganizationPOSTRequest  {
+  
+    private String name;
+    private String description;
+
+@XmlType(name="TypeEnum")
+@XmlEnum(String.class)
+public enum TypeEnum {
+
+    @XmlEnumValue("TENANT") TENANT(String.valueOf("TENANT")), @XmlEnumValue("STRUCTURAL") STRUCTURAL(String.valueOf("STRUCTURAL"));
+
+
+    private String value;
+
+    TypeEnum(String v) {
+        value = v;
+    }
+
+    public String value() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    public static TypeEnum fromValue(String value) {
+        for (TypeEnum b : TypeEnum.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
+}
+
+    private TypeEnum type = TypeEnum.TENANT;
+    private String parentId = "10084a8d-113f-4211-a0d5-efe36b082211";
+    private List<Attribute> attributes = null;
+
+
+    /**
+    **/
+    public OrganizationPOSTRequest name(String name) {
+
+        this.name = name;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "ABC Builders", required = true, value = "")
+    @JsonProperty("name")
+    @Valid
+    @NotNull(message = "Property name cannot be null.")
+
+    public String getName() {
+        return name;
+    }
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    /**
+    **/
+    public OrganizationPOSTRequest description(String description) {
+
+        this.description = description;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "Building constructions", value = "")
+    @JsonProperty("description")
+    @Valid
+    public String getDescription() {
+        return description;
+    }
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    /**
+    **/
+    public OrganizationPOSTRequest type(TypeEnum type) {
+
+        this.type = type;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "TENANT", value = "")
+    @JsonProperty("type")
+    @Valid
+    public TypeEnum getType() {
+        return type;
+    }
+    public void setType(TypeEnum type) {
+        this.type = type;
+    }
+
+    /**
+    * If the parentId is not present, Super will be taken as the parent organization.
+    **/
+    public OrganizationPOSTRequest parentId(String parentId) {
+
+        this.parentId = parentId;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "b4526d91-a8bf-43d2-8b14-c548cf73065b", value = "If the parentId is not present, Super will be taken as the parent organization.")
+    @JsonProperty("parentId")
+    @Valid
+    public String getParentId() {
+        return parentId;
+    }
+    public void setParentId(String parentId) {
+        this.parentId = parentId;
+    }
+
+    /**
+    **/
+    public OrganizationPOSTRequest attributes(List<Attribute> attributes) {
+
+        this.attributes = attributes;
+        return this;
+    }
+    
+    @ApiModelProperty(value = "")
+    @JsonProperty("attributes")
+    @Valid
+    public List<Attribute> getAttributes() {
+        return attributes;
+    }
+    public void setAttributes(List<Attribute> attributes) {
+        this.attributes = attributes;
+    }
+
+    public OrganizationPOSTRequest addAttributesItem(Attribute attributesItem) {
+        if (this.attributes == null) {
+            this.attributes = new ArrayList<>();
+        }
+        this.attributes.add(attributesItem);
+        return this;
+    }
+
+    
+
+    @Override
+    public boolean equals(java.lang.Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OrganizationPOSTRequest organizationPOSTRequest = (OrganizationPOSTRequest) o;
+        return Objects.equals(this.name, organizationPOSTRequest.name) &&
+            Objects.equals(this.description, organizationPOSTRequest.description) &&
+            Objects.equals(this.type, organizationPOSTRequest.type) &&
+            Objects.equals(this.parentId, organizationPOSTRequest.parentId) &&
+            Objects.equals(this.attributes, organizationPOSTRequest.attributes);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, description, type, parentId, attributes);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OrganizationPOSTRequest {\n");
+        
+        sb.append("    name: ").append(toIndentedString(name)).append("\n");
+        sb.append("    description: ").append(toIndentedString(description)).append("\n");
+        sb.append("    type: ").append(toIndentedString(type)).append("\n");
+        sb.append("    parentId: ").append(toIndentedString(parentId)).append("\n");
+        sb.append("    attributes: ").append(toIndentedString(attributes)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+    * Convert the given object to string with each line indented by 4 spaces
+    * (except the first line).
+    */
+    private String toIndentedString(java.lang.Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}
+

--- a/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/management/v1/model/OrganizationPUTRequest.java
+++ b/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/management/v1/model/OrganizationPUTRequest.java
@@ -1,0 +1,210 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.organization.management.v1.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import java.util.ArrayList;
+import java.util.List;
+import org.wso2.carbon.identity.api.server.organization.management.v1.model.Attribute;
+import javax.validation.constraints.*;
+
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+import javax.validation.Valid;
+import javax.xml.bind.annotation.*;
+
+public class OrganizationPUTRequest  {
+  
+    private String name;
+    private String description;
+
+@XmlType(name="StatusEnum")
+@XmlEnum(String.class)
+public enum StatusEnum {
+
+    @XmlEnumValue("ACTIVE") ACTIVE(String.valueOf("ACTIVE")), @XmlEnumValue("DISABLED") DISABLED(String.valueOf("DISABLED"));
+
+
+    private String value;
+
+    StatusEnum(String v) {
+        value = v;
+    }
+
+    public String value() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    public static StatusEnum fromValue(String value) {
+        for (StatusEnum b : StatusEnum.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
+}
+
+    private StatusEnum status;
+    private List<Attribute> attributes = null;
+
+
+    /**
+    **/
+    public OrganizationPUTRequest name(String name) {
+
+        this.name = name;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "ABC Builders", required = true, value = "")
+    @JsonProperty("name")
+    @Valid
+    @NotNull(message = "Property name cannot be null.")
+
+    public String getName() {
+        return name;
+    }
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    /**
+    **/
+    public OrganizationPUTRequest description(String description) {
+
+        this.description = description;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "Building constructions", value = "")
+    @JsonProperty("description")
+    @Valid
+    public String getDescription() {
+        return description;
+    }
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    /**
+    **/
+    public OrganizationPUTRequest status(StatusEnum status) {
+
+        this.status = status;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "ACTIVE", required = true, value = "")
+    @JsonProperty("status")
+    @Valid
+    @NotNull(message = "Property status cannot be null.")
+
+    public StatusEnum getStatus() {
+        return status;
+    }
+    public void setStatus(StatusEnum status) {
+        this.status = status;
+    }
+
+    /**
+    **/
+    public OrganizationPUTRequest attributes(List<Attribute> attributes) {
+
+        this.attributes = attributes;
+        return this;
+    }
+    
+    @ApiModelProperty(value = "")
+    @JsonProperty("attributes")
+    @Valid
+    public List<Attribute> getAttributes() {
+        return attributes;
+    }
+    public void setAttributes(List<Attribute> attributes) {
+        this.attributes = attributes;
+    }
+
+    public OrganizationPUTRequest addAttributesItem(Attribute attributesItem) {
+        if (this.attributes == null) {
+            this.attributes = new ArrayList<>();
+        }
+        this.attributes.add(attributesItem);
+        return this;
+    }
+
+    
+
+    @Override
+    public boolean equals(java.lang.Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OrganizationPUTRequest organizationPUTRequest = (OrganizationPUTRequest) o;
+        return Objects.equals(this.name, organizationPUTRequest.name) &&
+            Objects.equals(this.description, organizationPUTRequest.description) &&
+            Objects.equals(this.status, organizationPUTRequest.status) &&
+            Objects.equals(this.attributes, organizationPUTRequest.attributes);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, description, status, attributes);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OrganizationPUTRequest {\n");
+        
+        sb.append("    name: ").append(toIndentedString(name)).append("\n");
+        sb.append("    description: ").append(toIndentedString(description)).append("\n");
+        sb.append("    status: ").append(toIndentedString(status)).append("\n");
+        sb.append("    attributes: ").append(toIndentedString(attributes)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+    * Convert the given object to string with each line indented by 4 spaces
+    * (except the first line).
+    */
+    private String toIndentedString(java.lang.Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}
+

--- a/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/management/v1/model/OrganizationPatchRequestItem.java
+++ b/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/management/v1/model/OrganizationPatchRequestItem.java
@@ -1,0 +1,183 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.organization.management.v1.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import javax.validation.constraints.*;
+
+/**
+ * A JSONPatch as defined by RFC 6902. Patch operation is supported only for root level attributes of an organization.
+ **/
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+import javax.validation.Valid;
+import javax.xml.bind.annotation.*;
+@ApiModel(description = "A JSONPatch as defined by RFC 6902. Patch operation is supported only for root level attributes of an organization.")
+public class OrganizationPatchRequestItem  {
+  
+
+@XmlType(name="OperationEnum")
+@XmlEnum(String.class)
+public enum OperationEnum {
+
+    @XmlEnumValue("ADD") ADD(String.valueOf("ADD")), @XmlEnumValue("REMOVE") REMOVE(String.valueOf("REMOVE")), @XmlEnumValue("REPLACE") REPLACE(String.valueOf("REPLACE"));
+
+
+    private String value;
+
+    OperationEnum(String v) {
+        value = v;
+    }
+
+    public String value() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    public static OperationEnum fromValue(String value) {
+        for (OperationEnum b : OperationEnum.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
+}
+
+    private OperationEnum operation;
+    private String path;
+    private String value;
+
+    /**
+    * The operation to be performed.
+    **/
+    public OrganizationPatchRequestItem operation(OperationEnum operation) {
+
+        this.operation = operation;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "REPLACE", required = true, value = "The operation to be performed.")
+    @JsonProperty("operation")
+    @Valid
+    @NotNull(message = "Property operation cannot be null.")
+
+    public OperationEnum getOperation() {
+        return operation;
+    }
+    public void setOperation(OperationEnum operation) {
+        this.operation = operation;
+    }
+
+    /**
+    * A JSON-Pointer
+    **/
+    public OrganizationPatchRequestItem path(String path) {
+
+        this.path = path;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "/name", required = true, value = "A JSON-Pointer")
+    @JsonProperty("path")
+    @Valid
+    @NotNull(message = "Property path cannot be null.")
+
+    public String getPath() {
+        return path;
+    }
+    public void setPath(String path) {
+        this.path = path;
+    }
+
+    /**
+    * The value to be used within the operations.
+    **/
+    public OrganizationPatchRequestItem value(String value) {
+
+        this.value = value;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "XYZ Builders", value = "The value to be used within the operations.")
+    @JsonProperty("value")
+    @Valid
+    public String getValue() {
+        return value;
+    }
+    public void setValue(String value) {
+        this.value = value;
+    }
+
+
+
+    @Override
+    public boolean equals(java.lang.Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OrganizationPatchRequestItem organizationPatchRequestItem = (OrganizationPatchRequestItem) o;
+        return Objects.equals(this.operation, organizationPatchRequestItem.operation) &&
+            Objects.equals(this.path, organizationPatchRequestItem.path) &&
+            Objects.equals(this.value, organizationPatchRequestItem.value);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(operation, path, value);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OrganizationPatchRequestItem {\n");
+        
+        sb.append("    operation: ").append(toIndentedString(operation)).append("\n");
+        sb.append("    path: ").append(toIndentedString(path)).append("\n");
+        sb.append("    value: ").append(toIndentedString(value)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+    * Convert the given object to string with each line indented by 4 spaces
+    * (except the first line).
+    */
+    private String toIndentedString(java.lang.Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}
+

--- a/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/management/v1/model/OrganizationResponse.java
+++ b/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/management/v1/model/OrganizationResponse.java
@@ -1,0 +1,357 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.organization.management.v1.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import java.util.ArrayList;
+import java.util.List;
+import org.wso2.carbon.identity.api.server.organization.management.v1.model.Attribute;
+import org.wso2.carbon.identity.api.server.organization.management.v1.model.ParentOrganization;
+import javax.validation.constraints.*;
+
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+import javax.validation.Valid;
+import javax.xml.bind.annotation.*;
+
+public class OrganizationResponse  {
+  
+    private String id;
+    private String name;
+    private String description;
+
+@XmlType(name="StatusEnum")
+@XmlEnum(String.class)
+public enum StatusEnum {
+
+    @XmlEnumValue("ACTIVE") ACTIVE(String.valueOf("ACTIVE")), @XmlEnumValue("DISABLED") DISABLED(String.valueOf("DISABLED"));
+
+
+    private String value;
+
+    StatusEnum(String v) {
+        value = v;
+    }
+
+    public String value() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    public static StatusEnum fromValue(String value) {
+        for (StatusEnum b : StatusEnum.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
+}
+
+    private StatusEnum status;
+    private String created;
+    private String lastModified;
+
+@XmlType(name="TypeEnum")
+@XmlEnum(String.class)
+public enum TypeEnum {
+
+    @XmlEnumValue("TENANT") TENANT(String.valueOf("TENANT")), @XmlEnumValue("STRUCTURAL") STRUCTURAL(String.valueOf("STRUCTURAL"));
+
+
+    private String value;
+
+    TypeEnum(String v) {
+        value = v;
+    }
+
+    public String value() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    public static TypeEnum fromValue(String value) {
+        for (TypeEnum b : TypeEnum.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
+}
+
+    private TypeEnum type;
+    private ParentOrganization parent;
+    private List<Attribute> attributes = null;
+
+
+    /**
+    **/
+    public OrganizationResponse id(String id) {
+
+        this.id = id;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "06c1f4e2-3339-44e4-a825-96585e3653b1", required = true, value = "")
+    @JsonProperty("id")
+    @Valid
+    @NotNull(message = "Property id cannot be null.")
+
+    public String getId() {
+        return id;
+    }
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    /**
+    **/
+    public OrganizationResponse name(String name) {
+
+        this.name = name;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "ABC Builders", required = true, value = "")
+    @JsonProperty("name")
+    @Valid
+    @NotNull(message = "Property name cannot be null.")
+
+    public String getName() {
+        return name;
+    }
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    /**
+    **/
+    public OrganizationResponse description(String description) {
+
+        this.description = description;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "Building constructions", value = "")
+    @JsonProperty("description")
+    @Valid
+    public String getDescription() {
+        return description;
+    }
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    /**
+    **/
+    public OrganizationResponse status(StatusEnum status) {
+
+        this.status = status;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "ACTIVE", required = true, value = "")
+    @JsonProperty("status")
+    @Valid
+    @NotNull(message = "Property status cannot be null.")
+
+    public StatusEnum getStatus() {
+        return status;
+    }
+    public void setStatus(StatusEnum status) {
+        this.status = status;
+    }
+
+    /**
+    **/
+    public OrganizationResponse created(String created) {
+
+        this.created = created;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "2021-10-25T12:31:53.406Z", required = true, value = "")
+    @JsonProperty("created")
+    @Valid
+    @NotNull(message = "Property created cannot be null.")
+
+    public String getCreated() {
+        return created;
+    }
+    public void setCreated(String created) {
+        this.created = created;
+    }
+
+    /**
+    **/
+    public OrganizationResponse lastModified(String lastModified) {
+
+        this.lastModified = lastModified;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "2021-10-25T12:31:53.406Z", required = true, value = "")
+    @JsonProperty("lastModified")
+    @Valid
+    @NotNull(message = "Property lastModified cannot be null.")
+
+    public String getLastModified() {
+        return lastModified;
+    }
+    public void setLastModified(String lastModified) {
+        this.lastModified = lastModified;
+    }
+
+    /**
+    **/
+    public OrganizationResponse type(TypeEnum type) {
+
+        this.type = type;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "TENANT", required = true, value = "")
+    @JsonProperty("type")
+    @Valid
+    @NotNull(message = "Property type cannot be null.")
+
+    public TypeEnum getType() {
+        return type;
+    }
+    public void setType(TypeEnum type) {
+        this.type = type;
+    }
+
+    /**
+    **/
+    public OrganizationResponse parent(ParentOrganization parent) {
+
+        this.parent = parent;
+        return this;
+    }
+    
+    @ApiModelProperty(value = "")
+    @JsonProperty("parent")
+    @Valid
+    public ParentOrganization getParent() {
+        return parent;
+    }
+    public void setParent(ParentOrganization parent) {
+        this.parent = parent;
+    }
+
+    /**
+    **/
+    public OrganizationResponse attributes(List<Attribute> attributes) {
+
+        this.attributes = attributes;
+        return this;
+    }
+    
+    @ApiModelProperty(value = "")
+    @JsonProperty("attributes")
+    @Valid
+    public List<Attribute> getAttributes() {
+        return attributes;
+    }
+    public void setAttributes(List<Attribute> attributes) {
+        this.attributes = attributes;
+    }
+
+    public OrganizationResponse addAttributesItem(Attribute attributesItem) {
+        if (this.attributes == null) {
+            this.attributes = new ArrayList<>();
+        }
+        this.attributes.add(attributesItem);
+        return this;
+    }
+
+    
+
+    @Override
+    public boolean equals(java.lang.Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OrganizationResponse organizationResponse = (OrganizationResponse) o;
+        return Objects.equals(this.id, organizationResponse.id) &&
+            Objects.equals(this.name, organizationResponse.name) &&
+            Objects.equals(this.description, organizationResponse.description) &&
+            Objects.equals(this.status, organizationResponse.status) &&
+            Objects.equals(this.created, organizationResponse.created) &&
+            Objects.equals(this.lastModified, organizationResponse.lastModified) &&
+            Objects.equals(this.type, organizationResponse.type) &&
+            Objects.equals(this.parent, organizationResponse.parent) &&
+            Objects.equals(this.attributes, organizationResponse.attributes);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, name, description, status, created, lastModified, type, parent, attributes);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OrganizationResponse {\n");
+        
+        sb.append("    id: ").append(toIndentedString(id)).append("\n");
+        sb.append("    name: ").append(toIndentedString(name)).append("\n");
+        sb.append("    description: ").append(toIndentedString(description)).append("\n");
+        sb.append("    status: ").append(toIndentedString(status)).append("\n");
+        sb.append("    created: ").append(toIndentedString(created)).append("\n");
+        sb.append("    lastModified: ").append(toIndentedString(lastModified)).append("\n");
+        sb.append("    type: ").append(toIndentedString(type)).append("\n");
+        sb.append("    parent: ").append(toIndentedString(parent)).append("\n");
+        sb.append("    attributes: ").append(toIndentedString(attributes)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+    * Convert the given object to string with each line indented by 4 spaces
+    * (except the first line).
+    */
+    private String toIndentedString(java.lang.Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}
+

--- a/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/management/v1/model/OrganizationsResponse.java
+++ b/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/management/v1/model/OrganizationsResponse.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.organization.management.v1.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import java.util.ArrayList;
+import java.util.List;
+import org.wso2.carbon.identity.api.server.organization.management.v1.model.BasicOrganizationResponse;
+import org.wso2.carbon.identity.api.server.organization.management.v1.model.Link;
+import javax.validation.constraints.*;
+
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+import javax.validation.Valid;
+import javax.xml.bind.annotation.*;
+
+public class OrganizationsResponse  {
+  
+    private List<Link> links = null;
+
+    private List<BasicOrganizationResponse> organizations = null;
+
+
+    /**
+    **/
+    public OrganizationsResponse links(List<Link> links) {
+
+        this.links = links;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "[{\"href\":\"/o/10084a8d-113f-4211-a0d5-efe36b082211/api/server/v1/organizations?limit=10&filter=name+co+der&next=MjAyMS0xMi0yMSAwNToxODozMS4wMDQzNDg=\",\"rel\":\"next\"},{\"href\":\"/o/10084a8d-113f-4211-a0d5-efe36b082211/api/server/v1/organizations?limit=10&filter=name+co+der&before=MjAyMS0xMi0yMSAwNToxODozMS4wMDQzNDg=\",\"rel\":\"previous\"}]", value = "")
+    @JsonProperty("links")
+    @Valid
+    public List<Link> getLinks() {
+        return links;
+    }
+    public void setLinks(List<Link> links) {
+        this.links = links;
+    }
+
+    public OrganizationsResponse addLinksItem(Link linksItem) {
+        if (this.links == null) {
+            this.links = new ArrayList<>();
+        }
+        this.links.add(linksItem);
+        return this;
+    }
+
+        /**
+    **/
+    public OrganizationsResponse organizations(List<BasicOrganizationResponse> organizations) {
+
+        this.organizations = organizations;
+        return this;
+    }
+    
+    @ApiModelProperty(value = "")
+    @JsonProperty("organizations")
+    @Valid
+    public List<BasicOrganizationResponse> getOrganizations() {
+        return organizations;
+    }
+    public void setOrganizations(List<BasicOrganizationResponse> organizations) {
+        this.organizations = organizations;
+    }
+
+    public OrganizationsResponse addOrganizationsItem(BasicOrganizationResponse organizationsItem) {
+        if (this.organizations == null) {
+            this.organizations = new ArrayList<>();
+        }
+        this.organizations.add(organizationsItem);
+        return this;
+    }
+
+    
+
+    @Override
+    public boolean equals(java.lang.Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OrganizationsResponse organizationsResponse = (OrganizationsResponse) o;
+        return Objects.equals(this.links, organizationsResponse.links) &&
+            Objects.equals(this.organizations, organizationsResponse.organizations);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(links, organizations);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OrganizationsResponse {\n");
+        
+        sb.append("    links: ").append(toIndentedString(links)).append("\n");
+        sb.append("    organizations: ").append(toIndentedString(organizations)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+    * Convert the given object to string with each line indented by 4 spaces
+    * (except the first line).
+    */
+    private String toIndentedString(java.lang.Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}
+

--- a/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/management/v1/model/ParentOrganization.java
+++ b/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/management/v1/model/ParentOrganization.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.organization.management.v1.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import javax.validation.constraints.*;
+
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+import javax.validation.Valid;
+import javax.xml.bind.annotation.*;
+
+public class ParentOrganization  {
+  
+    private String id;
+    private String ref;
+
+    /**
+    **/
+    public ParentOrganization id(String id) {
+
+        this.id = id;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "b4526d91-a8bf-43d2-8b14-c548cf73065b", required = true, value = "")
+    @JsonProperty("id")
+    @Valid
+    @NotNull(message = "Property id cannot be null.")
+
+    public String getId() {
+        return id;
+    }
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    /**
+    **/
+    public ParentOrganization ref(String ref) {
+
+        this.ref = ref;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "o/10084a8d-113f-4211-a0d5-efe36b082211/api/server/v1/organizations/b4526d91-a8bf-43d2-8b14-c548cf73065b", required = true, value = "")
+    @JsonProperty("ref")
+    @Valid
+    @NotNull(message = "Property ref cannot be null.")
+
+    public String getRef() {
+        return ref;
+    }
+    public void setRef(String ref) {
+        this.ref = ref;
+    }
+
+
+
+    @Override
+    public boolean equals(java.lang.Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ParentOrganization parentOrganization = (ParentOrganization) o;
+        return Objects.equals(this.id, parentOrganization.id) &&
+            Objects.equals(this.ref, parentOrganization.ref);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, ref);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class ParentOrganization {\n");
+        
+        sb.append("    id: ").append(toIndentedString(id)).append("\n");
+        sb.append("    ref: ").append(toIndentedString(ref)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+    * Convert the given object to string with each line indented by 4 spaces
+    * (except the first line).
+    */
+    private String toIndentedString(java.lang.Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}
+

--- a/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/management/v1/model/SharedApplicationResponse.java
+++ b/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/management/v1/model/SharedApplicationResponse.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.organization.management.v1.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import javax.validation.constraints.*;
+
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+import javax.validation.Valid;
+import javax.xml.bind.annotation.*;
+
+public class SharedApplicationResponse  {
+  
+    private String applicationId;
+    private String organizationId;
+
+    /**
+    * Shared application&#39;s id.
+    **/
+    public SharedApplicationResponse applicationId(String applicationId) {
+
+        this.applicationId = applicationId;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "ca322554-fe79-4c04-9c94-492855ef92a3", value = "Shared application's id.")
+    @JsonProperty("applicationId")
+    @Valid
+    public String getApplicationId() {
+        return applicationId;
+    }
+    public void setApplicationId(String applicationId) {
+        this.applicationId = applicationId;
+    }
+
+    /**
+    * Shared application residing organization id.
+    **/
+    public SharedApplicationResponse organizationId(String organizationId) {
+
+        this.organizationId = organizationId;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "682edf68-4835-4bb8-961f-0a16bc6cc866", value = "Shared application residing organization id.")
+    @JsonProperty("organizationId")
+    @Valid
+    public String getOrganizationId() {
+        return organizationId;
+    }
+    public void setOrganizationId(String organizationId) {
+        this.organizationId = organizationId;
+    }
+
+
+
+    @Override
+    public boolean equals(java.lang.Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        SharedApplicationResponse sharedApplicationResponse = (SharedApplicationResponse) o;
+        return Objects.equals(this.applicationId, sharedApplicationResponse.applicationId) &&
+            Objects.equals(this.organizationId, sharedApplicationResponse.organizationId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(applicationId, organizationId);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class SharedApplicationResponse {\n");
+        
+        sb.append("    applicationId: ").append(toIndentedString(applicationId)).append("\n");
+        sb.append("    organizationId: ").append(toIndentedString(organizationId)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+    * Convert the given object to string with each line indented by 4 spaces
+    * (except the first line).
+    */
+    private String toIndentedString(java.lang.Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}
+

--- a/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/management/v1/model/SharedApplicationsResponse.java
+++ b/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/management/v1/model/SharedApplicationsResponse.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.organization.management.v1.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import java.util.ArrayList;
+import java.util.List;
+import org.wso2.carbon.identity.api.server.organization.management.v1.model.SharedApplicationResponse;
+import javax.validation.constraints.*;
+
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+import javax.validation.Valid;
+import javax.xml.bind.annotation.*;
+
+public class SharedApplicationsResponse  {
+  
+    private List<SharedApplicationResponse> sharedApplications = null;
+
+
+    /**
+    **/
+    public SharedApplicationsResponse sharedApplications(List<SharedApplicationResponse> sharedApplications) {
+
+        this.sharedApplications = sharedApplications;
+        return this;
+    }
+    
+    @ApiModelProperty(value = "")
+    @JsonProperty("sharedApplications")
+    @Valid
+    public List<SharedApplicationResponse> getSharedApplications() {
+        return sharedApplications;
+    }
+    public void setSharedApplications(List<SharedApplicationResponse> sharedApplications) {
+        this.sharedApplications = sharedApplications;
+    }
+
+    public SharedApplicationsResponse addSharedApplicationsItem(SharedApplicationResponse sharedApplicationsItem) {
+        if (this.sharedApplications == null) {
+            this.sharedApplications = new ArrayList<>();
+        }
+        this.sharedApplications.add(sharedApplicationsItem);
+        return this;
+    }
+
+    
+
+    @Override
+    public boolean equals(java.lang.Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        SharedApplicationsResponse sharedApplicationsResponse = (SharedApplicationsResponse) o;
+        return Objects.equals(this.sharedApplications, sharedApplicationsResponse.sharedApplications);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(sharedApplications);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class SharedApplicationsResponse {\n");
+        
+        sb.append("    sharedApplications: ").append(toIndentedString(sharedApplications)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+    * Convert the given object to string with each line indented by 4 spaces
+    * (except the first line).
+    */
+    private String toIndentedString(java.lang.Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}
+

--- a/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/management/v1/model/SharedOrganizationsResponse.java
+++ b/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/management/v1/model/SharedOrganizationsResponse.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.organization.management.v1.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import java.util.ArrayList;
+import java.util.List;
+import org.wso2.carbon.identity.api.server.organization.management.v1.model.BasicOrganizationResponse;
+import javax.validation.constraints.*;
+
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+import javax.validation.Valid;
+import javax.xml.bind.annotation.*;
+
+public class SharedOrganizationsResponse  {
+  
+    private List<BasicOrganizationResponse> organizations = null;
+
+
+    /**
+    **/
+    public SharedOrganizationsResponse organizations(List<BasicOrganizationResponse> organizations) {
+
+        this.organizations = organizations;
+        return this;
+    }
+    
+    @ApiModelProperty(value = "")
+    @JsonProperty("organizations")
+    @Valid
+    public List<BasicOrganizationResponse> getOrganizations() {
+        return organizations;
+    }
+    public void setOrganizations(List<BasicOrganizationResponse> organizations) {
+        this.organizations = organizations;
+    }
+
+    public SharedOrganizationsResponse addOrganizationsItem(BasicOrganizationResponse organizationsItem) {
+        if (this.organizations == null) {
+            this.organizations = new ArrayList<>();
+        }
+        this.organizations.add(organizationsItem);
+        return this;
+    }
+
+    
+
+    @Override
+    public boolean equals(java.lang.Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        SharedOrganizationsResponse sharedOrganizationsResponse = (SharedOrganizationsResponse) o;
+        return Objects.equals(this.organizations, sharedOrganizationsResponse.organizations);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(organizations);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class SharedOrganizationsResponse {\n");
+        
+        sb.append("    organizations: ").append(toIndentedString(organizations)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+    * Convert the given object to string with each line indented by 4 spaces
+    * (except the first line).
+    */
+    private String toIndentedString(java.lang.Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}
+

--- a/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.v1/src/main/java/org/wso2/carbon/identity/api/server/organization/management/v1/constants/OrganizationManagementEndpointConstants.java
+++ b/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.v1/src/main/java/org/wso2/carbon/identity/api/server/organization/management/v1/constants/OrganizationManagementEndpointConstants.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2022, WSO2 LLC. (http://www.wso2.com). All Rights Reserved.
+ *
+ * This software is the property of WSO2 LLC. and its suppliers, if any.
+ * Dissemination of any information or reproduction of any material contained
+ * herein in any form is strictly forbidden, unless permitted by WSO2 expressly.
+ * You may not alter or remove any copyright or other notice from copies of this content.
+ */
+
+package org.wso2.carbon.identity.api.server.organization.management.v1.constants;
+
+/**
+ * Organization management endpoint constants.
+ */
+public class OrganizationManagementEndpointConstants {
+
+    public static final String DESC_SORT_ORDER = "DESC";
+    public static final String ASC_SORT_ORDER = "ASC";
+}

--- a/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.v1/src/main/java/org/wso2/carbon/identity/api/server/organization/management/v1/constants/OrganizationManagementEndpointConstants.java
+++ b/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.v1/src/main/java/org/wso2/carbon/identity/api/server/organization/management/v1/constants/OrganizationManagementEndpointConstants.java
@@ -1,10 +1,19 @@
 /*
- * Copyright (c) 2022, WSO2 LLC. (http://www.wso2.com). All Rights Reserved.
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
  *
- * This software is the property of WSO2 LLC. and its suppliers, if any.
- * Dissemination of any information or reproduction of any material contained
- * herein in any form is strictly forbidden, unless permitted by WSO2 expressly.
- * You may not alter or remove any copyright or other notice from copies of this content.
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 
 package org.wso2.carbon.identity.api.server.organization.management.v1.constants;

--- a/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.v1/src/main/java/org/wso2/carbon/identity/api/server/organization/management/v1/exceptions/OrganizationManagementEndpointException.java
+++ b/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.v1/src/main/java/org/wso2/carbon/identity/api/server/organization/management/v1/exceptions/OrganizationManagementEndpointException.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2022, WSO2 LLC. (http://www.wso2.com). All Rights Reserved.
+ *
+ * This software is the property of WSO2 LLC. and its suppliers, if any.
+ * Dissemination of any information or reproduction of any material contained
+ * herein in any form is strictly forbidden, unless permitted by WSO2 expressly.
+ * You may not alter or remove any copyright or other notice from copies of this content.
+ */
+
+package org.wso2.carbon.identity.api.server.organization.management.v1.exceptions;
+
+import org.wso2.carbon.identity.api.server.organization.management.v1.model.Error;
+
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+/**
+ * Custom exception for organization management endpoint.
+ */
+public class OrganizationManagementEndpointException extends WebApplicationException {
+
+    public OrganizationManagementEndpointException(Response.Status status, Error error) {
+
+        super(Response.status(status).entity(error).header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON)
+                .build());
+    }
+
+    public OrganizationManagementEndpointException(Response.Status status) {
+
+        super(Response.status(status).build());
+    }
+}

--- a/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.v1/src/main/java/org/wso2/carbon/identity/api/server/organization/management/v1/exceptions/OrganizationManagementEndpointException.java
+++ b/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.v1/src/main/java/org/wso2/carbon/identity/api/server/organization/management/v1/exceptions/OrganizationManagementEndpointException.java
@@ -1,10 +1,19 @@
 /*
- * Copyright (c) 2022, WSO2 LLC. (http://www.wso2.com). All Rights Reserved.
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
  *
- * This software is the property of WSO2 LLC. and its suppliers, if any.
- * Dissemination of any information or reproduction of any material contained
- * herein in any form is strictly forbidden, unless permitted by WSO2 expressly.
- * You may not alter or remove any copyright or other notice from copies of this content.
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 
 package org.wso2.carbon.identity.api.server.organization.management.v1.exceptions;

--- a/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.v1/src/main/java/org/wso2/carbon/identity/api/server/organization/management/v1/impl/OrganizationsApiServiceImpl.java
+++ b/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.v1/src/main/java/org/wso2/carbon/identity/api/server/organization/management/v1/impl/OrganizationsApiServiceImpl.java
@@ -1,10 +1,19 @@
 /*
- * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com). All Rights Reserved.
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
  *
- * This software is the property of WSO2 LLC. and its suppliers, if any.
- * Dissemination of any information or reproduction of any material contained
- * herein in any form is strictly forbidden, unless permitted by WSO2 expressly.
- * You may not alter or remove any copyright or other notice from copies of this content.
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 
 package org.wso2.carbon.identity.api.server.organization.management.v1.impl;

--- a/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.v1/src/main/java/org/wso2/carbon/identity/api/server/organization/management/v1/impl/OrganizationsApiServiceImpl.java
+++ b/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.v1/src/main/java/org/wso2/carbon/identity/api/server/organization/management/v1/impl/OrganizationsApiServiceImpl.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com). All Rights Reserved.
+ *
+ * This software is the property of WSO2 LLC. and its suppliers, if any.
+ * Dissemination of any information or reproduction of any material contained
+ * herein in any form is strictly forbidden, unless permitted by WSO2 expressly.
+ * You may not alter or remove any copyright or other notice from copies of this content.
+ */
+
+package org.wso2.carbon.identity.api.server.organization.management.v1.impl;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.wso2.carbon.identity.api.server.organization.management.v1.OrganizationsApiService;
+import org.wso2.carbon.identity.api.server.organization.management.v1.model.ApplicationSharePOSTRequest;
+import org.wso2.carbon.identity.api.server.organization.management.v1.model.OrganizationNameCheckPOSTRequest;
+import org.wso2.carbon.identity.api.server.organization.management.v1.model.OrganizationPOSTRequest;
+import org.wso2.carbon.identity.api.server.organization.management.v1.model.OrganizationPUTRequest;
+import org.wso2.carbon.identity.api.server.organization.management.v1.model.OrganizationPatchRequestItem;
+import org.wso2.carbon.identity.api.server.organization.management.v1.service.OrganizationManagementService;
+
+import java.util.List;
+
+import javax.ws.rs.core.Response;
+
+/**
+ * Service implementation of organization management API.
+ */
+public class OrganizationsApiServiceImpl implements OrganizationsApiService {
+
+    @Autowired
+    private OrganizationManagementService organizationManagementService;
+
+    @Override
+    public Response organizationsGet(String filter, Integer limit, String after, String before, Boolean recursive) {
+
+        return organizationManagementService.getOrganizations(filter, limit, after, before, recursive);
+    }
+
+    @Override
+    public Response organizationsOrganizationIdDelete(String organizationId) {
+
+        return organizationManagementService.deleteOrganization(organizationId);
+    }
+
+    @Override
+    public Response organizationsOrganizationIdGet(String organizationId, Boolean includePermissions) {
+
+        return organizationManagementService.getOrganization(organizationId, includePermissions);
+    }
+
+    @Override
+    public Response organizationsOrganizationIdPatch(String organizationId, List<OrganizationPatchRequestItem>
+            organizationPatchRequestItem) {
+
+        return organizationManagementService.patchOrganization(organizationId, organizationPatchRequestItem);
+    }
+
+    @Override
+    public Response organizationsOrganizationIdPut(String organizationId, OrganizationPUTRequest
+            organizationPUTRequest) {
+
+        return organizationManagementService.updateOrganization(organizationId, organizationPUTRequest);
+    }
+
+    @Override
+    public Response organizationPost(OrganizationPOSTRequest organizationPOSTRequest) {
+
+        return organizationManagementService.addOrganization(organizationPOSTRequest);
+    }
+
+    @Override
+    public Response shareOrgApplication(String organizationId, String applicationId,
+                                        ApplicationSharePOSTRequest applicationSharePOSTRequest) {
+
+        return organizationManagementService.shareOrganizationApplication(organizationId, applicationId,
+                applicationSharePOSTRequest);
+    }
+
+    @Override
+    public Response shareOrgApplicationDelete(String organizationId, String applicationId,
+                                              String sharedOrganizationId) {
+
+        return organizationManagementService.deleteSharedApplication(organizationId, applicationId,
+                sharedOrganizationId);
+    }
+
+    @Override
+    public Response shareOrgApplicationGet(String organizationId, String applicationId) {
+
+        return organizationManagementService.getApplicationSharedOrganizations(organizationId, applicationId);
+    }
+
+    @Override
+    public Response sharedApplicationsAllDelete(String organizationId, String applicationId) {
+
+        return organizationManagementService.deleteAllSharedApplications(organizationId, applicationId);
+    }
+
+    @Deprecated
+    @Override
+    public Response shareOrgApplicationDeleteAll(String organizationId, String applicationId) {
+
+        return organizationManagementService.deleteAllSharedApplications(organizationId, applicationId);
+    }
+
+    @Override
+    public Response sharedApplicationsGet(String organizationId, String applicationId) {
+
+        return organizationManagementService.getSharedApplications(organizationId, applicationId);
+    }
+
+    @Override
+    public Response organizationsCheckNamePost(OrganizationNameCheckPOSTRequest organizationNameCheckPOSTRequest) {
+
+        return organizationManagementService.checkOrganizationName(organizationNameCheckPOSTRequest.getName());
+    }
+
+    @Override
+    public Response organizationsGetMe(String filter, Integer limit, String after, String before, Boolean recursive) {
+
+        return organizationManagementService.getAuthorizedOrganizations(filter, limit, after, before, recursive);
+    }
+}

--- a/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.v1/src/main/java/org/wso2/carbon/identity/api/server/organization/management/v1/service/OrganizationManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.v1/src/main/java/org/wso2/carbon/identity/api/server/organization/management/v1/service/OrganizationManagementService.java
@@ -1,10 +1,19 @@
 /*
- * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com). All Rights Reserved.
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
  *
- * This software is the property of WSO2 LLC. and its suppliers, if any.
- * Dissemination of any information or reproduction of any material contained
- * herein in any form is strictly forbidden, unless permitted by WSO2 expressly.
- * You may not alter or remove any copyright or other notice from copies of this content.
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 
 package org.wso2.carbon.identity.api.server.organization.management.v1.service;

--- a/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.v1/src/main/java/org/wso2/carbon/identity/api/server/organization/management/v1/service/OrganizationManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.v1/src/main/java/org/wso2/carbon/identity/api/server/organization/management/v1/service/OrganizationManagementService.java
@@ -1,0 +1,656 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com). All Rights Reserved.
+ *
+ * This software is the property of WSO2 LLC. and its suppliers, if any.
+ * Dissemination of any information or reproduction of any material contained
+ * herein in any form is strictly forbidden, unless permitted by WSO2 expressly.
+ * You may not alter or remove any copyright or other notice from copies of this content.
+ */
+
+package org.wso2.carbon.identity.api.server.organization.management.v1.service;
+
+import com.google.gson.Gson;
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.lang.StringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.identity.api.server.organization.management.common.OrganizationManagementServiceHolder;
+import org.wso2.carbon.identity.api.server.organization.management.v1.exceptions.OrganizationManagementEndpointException;
+import org.wso2.carbon.identity.api.server.organization.management.v1.model.ApplicationSharePOSTRequest;
+import org.wso2.carbon.identity.api.server.organization.management.v1.model.Attribute;
+import org.wso2.carbon.identity.api.server.organization.management.v1.model.BasicOrganizationResponse;
+import org.wso2.carbon.identity.api.server.organization.management.v1.model.Error;
+import org.wso2.carbon.identity.api.server.organization.management.v1.model.GetOrganizationResponse;
+import org.wso2.carbon.identity.api.server.organization.management.v1.model.Link;
+import org.wso2.carbon.identity.api.server.organization.management.v1.model.OrganizationNameCheckPOSTResponse;
+import org.wso2.carbon.identity.api.server.organization.management.v1.model.OrganizationPOSTRequest;
+import org.wso2.carbon.identity.api.server.organization.management.v1.model.OrganizationPUTRequest;
+import org.wso2.carbon.identity.api.server.organization.management.v1.model.OrganizationPatchRequestItem;
+import org.wso2.carbon.identity.api.server.organization.management.v1.model.OrganizationResponse;
+import org.wso2.carbon.identity.api.server.organization.management.v1.model.OrganizationsResponse;
+import org.wso2.carbon.identity.api.server.organization.management.v1.model.ParentOrganization;
+import org.wso2.carbon.identity.api.server.organization.management.v1.model.SharedApplicationResponse;
+import org.wso2.carbon.identity.api.server.organization.management.v1.model.SharedApplicationsResponse;
+import org.wso2.carbon.identity.api.server.organization.management.v1.model.SharedOrganizationsResponse;
+import org.wso2.carbon.identity.api.server.organization.management.v1.util.OrganizationManagementEndpointUtil;
+import org.wso2.carbon.identity.core.util.IdentityUtil;
+import org.wso2.carbon.identity.organization.management.application.OrgApplicationManager;
+import org.wso2.carbon.identity.organization.management.application.model.SharedApplication;
+import org.wso2.carbon.identity.organization.management.service.OrganizationManager;
+import org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants;
+import org.wso2.carbon.identity.organization.management.service.exception.OrganizationManagementClientException;
+import org.wso2.carbon.identity.organization.management.service.exception.OrganizationManagementException;
+import org.wso2.carbon.identity.organization.management.service.exception.OrganizationManagementServerException;
+import org.wso2.carbon.identity.organization.management.service.model.BasicOrganization;
+import org.wso2.carbon.identity.organization.management.service.model.Organization;
+import org.wso2.carbon.identity.organization.management.service.model.OrganizationAttribute;
+import org.wso2.carbon.identity.organization.management.service.model.ParentOrganizationDO;
+import org.wso2.carbon.identity.organization.management.service.model.PatchOperation;
+import org.wso2.carbon.identity.organization.management.service.model.TenantTypeOrganization;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URI;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import javax.ws.rs.core.Response;
+
+import static org.wso2.carbon.identity.api.server.organization.management.v1.constants.OrganizationManagementEndpointConstants.ASC_SORT_ORDER;
+import static org.wso2.carbon.identity.api.server.organization.management.v1.constants.OrganizationManagementEndpointConstants.DESC_SORT_ORDER;
+import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.ErrorMessages.ERROR_CODE_ERROR_BUILDING_PAGINATED_RESPONSE_URL;
+import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.ErrorMessages.ERROR_CODE_INVALID_PAGINATION_PARAMETER_NEGATIVE_LIMIT;
+import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.ErrorMessages.ERROR_CODE_INVALID_SHARE_APPLICATION_EMPTY_REQUEST_BODY;
+import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.ErrorMessages.ERROR_CODE_INVALID_SHARE_APPLICATION_REQUEST_BODY;
+import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.SUPER;
+import static org.wso2.carbon.identity.organization.management.service.util.Utils.buildURIForBody;
+import static org.wso2.carbon.identity.organization.management.service.util.Utils.generateUniqueID;
+import static org.wso2.carbon.identity.organization.management.service.util.Utils.handleClientException;
+
+/**
+ * Perform organization management related operations.
+ */
+public class OrganizationManagementService {
+
+    private static final Log LOG = LogFactory.getLog(OrganizationManagementService.class);
+
+    /**
+     * Retrieve organization IDs.
+     *
+     * @param filter    The filter string.
+     * @param limit     The maximum number of records to be returned.
+     * @param after     The pointer to next page.
+     * @param before    The pointer to previous page.
+     * @param recursive Determines whether recursive search is required.
+     * @return The list of organization IDs.
+     */
+    public Response getOrganizations(String filter, Integer limit, String after, String before, Boolean recursive) {
+
+        return getOrganizationList(false, filter, limit, after, before, recursive);
+    }
+
+    /**
+     * Retrieve organization IDs for authorized user.
+     *
+     * @param filter    The filter string.
+     * @param limit     The maximum number of records to be returned.
+     * @param after     The pointer to next page.
+     * @param before    The pointer to previous page.
+     * @param recursive Determines whether recursive search is required.
+     * @return The list of organization IDs.
+     */
+    public Response getAuthorizedOrganizations(String filter, Integer limit, String after, String before,
+                                               Boolean recursive) {
+
+        return getOrganizationList(true, filter, limit, after, before, recursive);
+    }
+
+    private Response getOrganizationList(boolean authorizedSubOrgsOnly, String filter, Integer limit, String after,
+                                         String before, Boolean recursive) {
+
+        try {
+            limit = validateLimit(limit);
+            String sortOrder = StringUtils.isNotBlank(before) ? ASC_SORT_ORDER : DESC_SORT_ORDER;
+            List<BasicOrganization> organizations = authorizedSubOrgsOnly ?
+                    getOrganizationManager().getUserAuthorizedOrganizations(
+                            limit + 1, after, before, sortOrder, filter, Boolean.TRUE.equals(recursive))
+                    : getOrganizationManager().getOrganizations(
+                    limit + 1, after, before, sortOrder, filter, Boolean.TRUE.equals(recursive));
+            return Response.ok().entity(getOrganizationsResponse(limit, after, before, filter, organizations,
+                    Boolean.TRUE.equals(recursive))).build();
+        } catch (OrganizationManagementClientException e) {
+            return OrganizationManagementEndpointUtil.handleClientErrorResponse(e, LOG);
+        } catch (OrganizationManagementException e) {
+            return OrganizationManagementEndpointUtil.handleServerErrorResponse(e, LOG);
+        }
+    }
+
+    /**
+     * Check if organization exist for given name.
+     *
+     * @param organizationName Organization name.
+     * @return Organization name check response.
+     */
+    public Response checkOrganizationName(String organizationName) {
+
+        boolean nameExist = getOrganizationManager().isOrganizationExistByNameInGivenHierarchy(organizationName);
+        OrganizationNameCheckPOSTResponse response = new OrganizationNameCheckPOSTResponse().available(false);
+        if (!nameExist) {
+            response.setAvailable(true);
+        }
+        return Response.ok().entity(response).build();
+    }
+
+    /**
+     * Delete an organization.
+     *
+     * @param organizationId Unique identifier for the requested organization to be deleted.
+     * @return Organization deletion response.
+     */
+    public Response deleteOrganization(String organizationId) {
+
+        try {
+            getOrganizationManager().deleteOrganization(organizationId);
+            return Response.noContent().build();
+        } catch (OrganizationManagementClientException e) {
+            return OrganizationManagementEndpointUtil.handleClientErrorResponse(e, LOG);
+        } catch (OrganizationManagementException e) {
+            return OrganizationManagementEndpointUtil.handleServerErrorResponse(e, LOG);
+        }
+    }
+
+    /**
+     * Fetch an organization.
+     *
+     * @param organizationId Unique identifier for the requested organization to be fetched.
+     * @return Requested organization details.
+     */
+    public Response getOrganization(String organizationId, Boolean includePermissions) {
+
+        try {
+            Organization organization = getOrganizationManager().getOrganization(organizationId,
+                    false, Boolean.TRUE.equals(includePermissions));
+            return Response.ok().entity(getOrganizationResponseWithPermission(organization)).build();
+        } catch (OrganizationManagementClientException e) {
+            return OrganizationManagementEndpointUtil.handleClientErrorResponse(e, LOG);
+        } catch (OrganizationManagementException e) {
+            return OrganizationManagementEndpointUtil.handleServerErrorResponse(e, LOG);
+        }
+    }
+
+    /**
+     * Patch an organization.
+     *
+     * @param organizationId               Unique identifier for the requested organization to be patched.
+     * @param organizationPatchRequestItem The list of organization details to be patched.
+     * @return The patched organization.
+     */
+    public Response patchOrganization(String organizationId, List<OrganizationPatchRequestItem>
+            organizationPatchRequestItem) {
+
+        try {
+            Organization organization = getOrganizationManager().patchOrganization(organizationId,
+                    organizationPatchRequestItem.stream().map(op ->
+                            new PatchOperation(op.getOperation() == null ? null : op.getOperation().toString(),
+                                    op.getPath(), op.getValue())).collect(Collectors.toList()));
+            return Response.ok().entity(getOrganizationResponse(organization)).build();
+        } catch (OrganizationManagementClientException e) {
+            return OrganizationManagementEndpointUtil.handleClientErrorResponse(e, LOG);
+        } catch (OrganizationManagementException e) {
+            return OrganizationManagementEndpointUtil.handleServerErrorResponse(e, LOG);
+        }
+    }
+
+    /**
+     * Update an organization.
+     *
+     * @param organizationId         Unique identifier for the requested organization to be updated.
+     * @param organizationPUTRequest The organization update request.
+     * @return The updated organization.
+     */
+    public Response updateOrganization(String organizationId, OrganizationPUTRequest organizationPUTRequest) {
+
+        try {
+            Organization updatedOrganization = getUpdatedOrganization(organizationId, organizationPUTRequest);
+            return Response.ok().entity(getOrganizationResponse(updatedOrganization)).build();
+        } catch (OrganizationManagementClientException e) {
+            return OrganizationManagementEndpointUtil.handleClientErrorResponse(e, LOG);
+        } catch (OrganizationManagementException e) {
+            return OrganizationManagementEndpointUtil.handleServerErrorResponse(e, LOG);
+        }
+    }
+
+    /**
+     * Add an organization.
+     *
+     * @param organizationPOSTRequest Add organization request.
+     * @return The newly created organization.
+     */
+    public Response addOrganization(OrganizationPOSTRequest organizationPOSTRequest) {
+
+        try {
+            Organization organization = getOrganizationManager().addOrganization(getOrganizationFromPostRequest
+                    (organizationPOSTRequest));
+            String organizationId = organization.getId();
+            return Response.created(OrganizationManagementEndpointUtil.getResourceLocation(organizationId)).entity
+                    (getOrganizationResponse(organization)).build();
+        } catch (OrganizationManagementClientException e) {
+            return OrganizationManagementEndpointUtil.handleClientErrorResponse(e, LOG);
+        } catch (OrganizationManagementException e) {
+            return OrganizationManagementEndpointUtil.handleServerErrorResponse(e, LOG);
+        }
+    }
+
+    /**
+     * Share an application to child organizations.
+     *
+     * @param organizationId Unique identifier of the organization owning the application.
+     * @param applicationId  Application identifier.
+     * @param requestBody    Request body of the share request.
+     * @return The status of the operation.
+     */
+    public Response shareOrganizationApplication(String organizationId, String applicationId,
+                                                 ApplicationSharePOSTRequest requestBody) {
+
+        try {
+            validateApplicationSharePostRequestBody(requestBody);
+            boolean shareWithAllChildren = (requestBody.getShareWithAllChildren() != null)
+                    ? requestBody.getShareWithAllChildren() : false;
+            getOrgApplicationManager().shareOrganizationApplication(organizationId, applicationId,
+                    shareWithAllChildren, requestBody.getSharedOrganizations());
+            return Response.ok().build();
+        } catch (OrganizationManagementClientException e) {
+            return OrganizationManagementEndpointUtil.handleClientErrorResponse(e, LOG);
+        } catch (OrganizationManagementException e) {
+            return OrganizationManagementEndpointUtil.handleServerErrorResponse(e, LOG);
+        }
+    }
+
+    private void validateApplicationSharePostRequestBody(ApplicationSharePOSTRequest requestBody)
+            throws OrganizationManagementClientException {
+
+        if (requestBody == null) {
+            throw handleClientException(ERROR_CODE_INVALID_SHARE_APPLICATION_EMPTY_REQUEST_BODY);
+        }
+        if (requestBody.getShareWithAllChildren() == null && requestBody.getSharedOrganizations() == null) {
+            throw handleClientException(ERROR_CODE_INVALID_SHARE_APPLICATION_EMPTY_REQUEST_BODY);
+        }
+        if (requestBody.getShareWithAllChildren() != null
+                && requestBody.getShareWithAllChildren()
+                && CollectionUtils.isNotEmpty(requestBody.getSharedOrganizations())) {
+            throw handleClientException(ERROR_CODE_INVALID_SHARE_APPLICATION_REQUEST_BODY);
+        }
+    }
+
+    /**
+     * Stop application sharing to an organization by removing the fragment application from the given organization.
+     *
+     * @param organizationId       ID of the organization owning the primary application.
+     * @param applicationId        primary application ID.
+     * @param sharedOrganizationId ID of the organization owning the fragment application.
+     * @return the stop application sharing response.
+     */
+    public Response deleteSharedApplication(String organizationId, String applicationId, String sharedOrganizationId) {
+
+        try {
+            getOrgApplicationManager().deleteSharedApplication(organizationId, applicationId, sharedOrganizationId);
+            return Response.noContent().build();
+        } catch (OrganizationManagementClientException e) {
+            return OrganizationManagementEndpointUtil.handleClientErrorResponse(e, LOG);
+        } catch (OrganizationManagementException e) {
+            return OrganizationManagementEndpointUtil.handleServerErrorResponse(e, LOG);
+        }
+    }
+
+    /**
+     * Stop application sharing to all organizations by removing the fragment applications from the given organization.
+     *
+     * @param organizationId ID of the organization owning the main application.
+     * @param applicationId  Main application ID.
+     * @return The application unsharing response.
+     */
+    public Response deleteAllSharedApplications(String organizationId, String applicationId) {
+
+        try {
+            getOrgApplicationManager().deleteSharedApplication(organizationId, applicationId, null);
+            return Response.noContent().build();
+        } catch (OrganizationManagementClientException e) {
+            return OrganizationManagementEndpointUtil.handleClientErrorResponse(e, LOG);
+        } catch (OrganizationManagementException e) {
+            return OrganizationManagementEndpointUtil.handleServerErrorResponse(e, LOG);
+        }
+    }
+
+    /**
+     * Returns the list of organization with whom the primary application is shared.
+     *
+     * @param organizationId ID of the organization owning the primary application.
+     * @param applicationId  ID of the primary application.
+     * @return list of organization having the fragment applications.
+     */
+    public Response getApplicationSharedOrganizations(String organizationId, String applicationId) {
+
+        try {
+            List<BasicOrganization> basicOrganizations =
+                    getOrgApplicationManager().getApplicationSharedOrganizations(organizationId, applicationId);
+            return Response.ok(createSharedOrgResponse(basicOrganizations)).build();
+        } catch (OrganizationManagementClientException e) {
+            return OrganizationManagementEndpointUtil.handleClientErrorResponse(e, LOG);
+        } catch (OrganizationManagementException e) {
+            return OrganizationManagementEndpointUtil.handleServerErrorResponse(e, LOG);
+        }
+    }
+
+    /**
+     * Returns the shared applications list of a given primary application, along with their organizations.
+     *
+     * @param organizationId ID of the organization owning the primary application.
+     * @param applicationId  ID of the primary application.
+     * @return shared applications list of a given primary application.
+     */
+    public Response getSharedApplications(String organizationId, String applicationId) {
+
+        try {
+            List<SharedApplication> sharedApplications =
+                    getOrgApplicationManager().getSharedApplications(organizationId, applicationId);
+            return Response.ok(createSharedApplicationsResponse(sharedApplications)).build();
+        } catch (OrganizationManagementClientException e) {
+            return OrganizationManagementEndpointUtil.handleClientErrorResponse(e, LOG);
+        } catch (OrganizationManagementException e) {
+            return OrganizationManagementEndpointUtil.handleServerErrorResponse(e, LOG);
+        }
+    }
+
+    private Organization getOrganizationFromPostRequest(OrganizationPOSTRequest organizationPOSTRequest) {
+
+        String organizationId = generateUniqueID();
+        OrganizationPOSTRequest.TypeEnum type = organizationPOSTRequest.getType();
+        Organization organization;
+        if (OrganizationPOSTRequest.TypeEnum.TENANT.equals(type)) {
+            // Set the organization id as the default domain name of the underlying tenant.
+            organization = new TenantTypeOrganization(organizationId);
+        } else {
+            organization = new Organization();
+        }
+        organization.setId(organizationId);
+        organization.setName(organizationPOSTRequest.getName());
+        organization.setDescription(organizationPOSTRequest.getDescription());
+        organization.setStatus(OrganizationManagementConstants.OrganizationStatus.ACTIVE.toString());
+        organization.setType(type != null ? type.toString() : null);
+        String parentId = organizationPOSTRequest.getParentId();
+        if (StringUtils.isNotBlank(parentId)) {
+            organization.getParent().setId(parentId);
+        } else {
+            organization.getParent().setId(SUPER);
+        }
+        List<Attribute> organizationAttributes = organizationPOSTRequest.getAttributes();
+        if (CollectionUtils.isNotEmpty(organizationAttributes)) {
+            organization.setAttributes(organizationAttributes.stream().map(attribute ->
+                    new OrganizationAttribute(attribute.getKey(), attribute.getValue())).collect(Collectors.toList()));
+        }
+        return organization;
+    }
+
+    private OrganizationResponse getOrganizationResponse(Organization organization) {
+
+        OrganizationResponse organizationResponse = new OrganizationResponse();
+        organizationResponse.setId(organization.getId());
+        organizationResponse.setName(organization.getName());
+        organizationResponse.setDescription(organization.getDescription());
+
+        OrganizationResponse.StatusEnum status;
+        try {
+            status = OrganizationResponse.StatusEnum.valueOf(organization.getStatus());
+        } catch (IllegalArgumentException e) {
+            status = OrganizationResponse.StatusEnum.DISABLED;
+        }
+        organizationResponse.setStatus(status);
+
+        organizationResponse.setCreated(organization.getCreated().toString());
+        organizationResponse.setLastModified(organization.getLastModified().toString());
+
+        String type = organization.getType();
+        if (StringUtils.equals(type, OrganizationResponse.TypeEnum.TENANT.toString())) {
+            organizationResponse.setType(OrganizationResponse.TypeEnum.TENANT);
+        } else {
+            organizationResponse.setType(OrganizationResponse.TypeEnum.STRUCTURAL);
+        }
+
+        ParentOrganizationDO parentOrganizationDO = organization.getParent();
+        if (parentOrganizationDO != null) {
+            organizationResponse.setParent(getParentOrganization(parentOrganizationDO));
+        }
+
+        List<Attribute> attributeList = getOrganizationAttributes(organization);
+        if (!attributeList.isEmpty()) {
+            organizationResponse.setAttributes(attributeList);
+        }
+        return organizationResponse;
+    }
+
+    private GetOrganizationResponse getOrganizationResponseWithPermission(Organization organization) {
+
+        GetOrganizationResponse organizationResponse = new GetOrganizationResponse();
+        organizationResponse.setId(organization.getId());
+        organizationResponse.setName(organization.getName());
+        organizationResponse.setDescription(organization.getDescription());
+        organizationResponse.setCreated(organization.getCreated().toString());
+        organizationResponse.setLastModified(organization.getLastModified().toString());
+        organizationResponse.setPermissions(organization.getPermissions());
+
+        GetOrganizationResponse.StatusEnum status;
+        try {
+            status = GetOrganizationResponse.StatusEnum.valueOf(organization.getStatus());
+        } catch (IllegalArgumentException e) {
+            status = GetOrganizationResponse.StatusEnum.DISABLED;
+        }
+        organizationResponse.setStatus(status);
+
+        String type = organization.getType();
+        if (StringUtils.equals(type, GetOrganizationResponse.TypeEnum.TENANT.toString())) {
+            organizationResponse.setType(GetOrganizationResponse.TypeEnum.TENANT);
+        } else {
+            organizationResponse.setType(GetOrganizationResponse.TypeEnum.STRUCTURAL);
+        }
+
+        ParentOrganizationDO parentOrganizationDO = organization.getParent();
+        if (parentOrganizationDO != null) {
+            organizationResponse.setParent(getParentOrganization(parentOrganizationDO));
+        }
+
+        List<Attribute> attributeList = getOrganizationAttributes(organization);
+        if (!attributeList.isEmpty()) {
+            organizationResponse.setAttributes(attributeList);
+        }
+        return organizationResponse;
+    }
+
+    private List<Attribute> getOrganizationAttributes(Organization organization) {
+
+        List<Attribute> attributeList = new ArrayList<>();
+        for (OrganizationAttribute attributeModel : organization.getAttributes()) {
+            Attribute attribute = new Attribute();
+            attribute.setKey(attributeModel.getKey());
+            attribute.setValue(attributeModel.getValue());
+            attributeList.add(attribute);
+        }
+        return attributeList;
+    }
+
+    private ParentOrganization getParentOrganization(ParentOrganizationDO parentOrganizationDO) {
+
+        ParentOrganization parentOrganization = new ParentOrganization();
+        parentOrganization.setId(parentOrganizationDO.getId());
+        parentOrganization.setRef(parentOrganizationDO.getRef());
+        return parentOrganization;
+    }
+
+    private int validateLimit(Integer limit) throws OrganizationManagementClientException {
+
+        if (limit == null) {
+            int defaultItemsPerPage = IdentityUtil.getDefaultItemsPerPage();
+            if (LOG.isDebugEnabled()) {
+                LOG.debug(String.format("Given limit is null. Therefore the default limit is set to %s.",
+                        defaultItemsPerPage));
+            }
+            return defaultItemsPerPage;
+        }
+
+        if (limit < 0) {
+            throw handleClientException(ERROR_CODE_INVALID_PAGINATION_PARAMETER_NEGATIVE_LIMIT);
+        }
+
+        int maximumItemsPerPage = IdentityUtil.getMaximumItemPerPage();
+        if (limit > maximumItemsPerPage) {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug(String.format("Given limit exceeds the maximum limit. Therefore the limit is set to %s.",
+                        maximumItemsPerPage));
+            }
+            return maximumItemsPerPage;
+        }
+
+        return limit;
+    }
+
+    private OrganizationsResponse getOrganizationsResponse(Integer limit, String after, String before, String filter,
+                                                           List<BasicOrganization> organizations, boolean recursive)
+            throws OrganizationManagementServerException {
+
+        OrganizationsResponse organizationsResponse = new OrganizationsResponse();
+
+        if (limit != 0 && CollectionUtils.isNotEmpty(organizations)) {
+            boolean hasMoreItems = organizations.size() > limit;
+            boolean needsReverse = StringUtils.isNotBlank(before);
+            boolean isFirstPage = (StringUtils.isBlank(before) && StringUtils.isBlank(after)) ||
+                    (StringUtils.isNotBlank(before) && !hasMoreItems);
+            boolean isLastPage = !hasMoreItems && (StringUtils.isNotBlank(after) || StringUtils.isBlank(before));
+
+            String url = "?limit=" + limit + "&recursive=" + recursive;
+            if (StringUtils.isNotBlank(filter)) {
+                try {
+                    url += "&filter=" + URLEncoder.encode(filter, StandardCharsets.UTF_8.name());
+                } catch (UnsupportedEncodingException e) {
+                    LOG.error("Server encountered an error while building pagination URL for the response.", e);
+                    Error error = OrganizationManagementEndpointUtil.getError(
+                            ERROR_CODE_ERROR_BUILDING_PAGINATED_RESPONSE_URL.getCode(),
+                            ERROR_CODE_ERROR_BUILDING_PAGINATED_RESPONSE_URL.getMessage(),
+                            ERROR_CODE_ERROR_BUILDING_PAGINATED_RESPONSE_URL.getDescription());
+                    throw new OrganizationManagementEndpointException(Response.Status.INTERNAL_SERVER_ERROR, error);
+                }
+            }
+
+            if (hasMoreItems) {
+                organizations.remove(organizations.size() - 1);
+            }
+            if (needsReverse) {
+                Collections.reverse(organizations);
+            }
+            if (!isFirstPage) {
+                String encodedString = Base64.getEncoder().encodeToString(organizations.get(0).getCreated()
+                        .getBytes(StandardCharsets.UTF_8));
+                Link link = new Link();
+                link.setHref(URI.create(
+                        OrganizationManagementEndpointUtil.buildURIForPagination(url) + "&before=" + encodedString));
+                link.setRel("previous");
+                organizationsResponse.addLinksItem(link);
+            }
+            if (!isLastPage) {
+                String encodedString = Base64.getEncoder().encodeToString(organizations.get(organizations.size() - 1)
+                        .getCreated().getBytes(StandardCharsets.UTF_8));
+                Link link = new Link();
+                link.setHref(URI.create(
+                        OrganizationManagementEndpointUtil.buildURIForPagination(url) + "&after=" + encodedString));
+                link.setRel("next");
+                organizationsResponse.addLinksItem(link);
+            }
+
+            List<BasicOrganizationResponse> organizationDTOs = new ArrayList<>();
+            for (BasicOrganization organization : organizations) {
+                BasicOrganizationResponse organizationDTO = new BasicOrganizationResponse();
+                organizationDTO.setId(organization.getId());
+                organizationDTO.setName(organization.getName());
+                organizationDTO.setStatus(BasicOrganizationResponse.StatusEnum.valueOf(organization.getStatus()));
+                organizationDTO.setRef(buildURIForBody(organization.getId()));
+                organizationDTOs.add(organizationDTO);
+            }
+            organizationsResponse.setOrganizations(organizationDTOs);
+        }
+        return organizationsResponse;
+    }
+
+    private Organization getUpdatedOrganization(String organizationId, OrganizationPUTRequest organizationPUTRequest)
+            throws OrganizationManagementException {
+
+        Organization oldOrganization = getOrganizationManager().getOrganization(organizationId, false, false);
+        String currentOrganizationName = oldOrganization.getName();
+        Organization organization = createOrganizationClone(oldOrganization);
+
+        organization.setName(organizationPUTRequest.getName());
+        organization.setDescription(organizationPUTRequest.getDescription());
+
+        OrganizationPUTRequest.StatusEnum statusEnum = organizationPUTRequest.getStatus();
+        if (statusEnum != null) {
+            String organizationStatus = statusEnum.toString();
+            if (StringUtils.isNotBlank(organizationStatus)) {
+                organization.setStatus(organizationStatus);
+            }
+        } else {
+            organization.setStatus(null);
+        }
+
+        List<Attribute> organizationAttributes = organizationPUTRequest.getAttributes();
+        if (CollectionUtils.isNotEmpty(organizationAttributes)) {
+            organization.setAttributes(organizationAttributes.stream().map(attribute ->
+                    new OrganizationAttribute(attribute.getKey(), attribute.getValue())).collect(Collectors.toList()));
+        } else {
+            organization.setAttributes(null);
+        }
+        return getOrganizationManager().updateOrganization(organizationId, currentOrganizationName, organization);
+    }
+
+    private Organization createOrganizationClone(Organization organization) {
+
+        Gson gson = new Gson();
+        return gson.fromJson(gson.toJson(organization), Organization.class);
+    }
+
+    private SharedOrganizationsResponse createSharedOrgResponse(List<BasicOrganization> organizations)
+            throws OrganizationManagementServerException {
+
+        SharedOrganizationsResponse response = new SharedOrganizationsResponse();
+        for (BasicOrganization org : organizations) {
+            BasicOrganizationResponse basicOrganizationResponse =
+                    new BasicOrganizationResponse().id(org.getId()).name(org.getName())
+                            .ref(buildURIForBody(org.getId()));
+            response.addOrganizationsItem(basicOrganizationResponse);
+        }
+        return response;
+    }
+
+    private SharedApplicationsResponse createSharedApplicationsResponse(List<SharedApplication> sharedApplications)
+            throws OrganizationManagementServerException {
+
+        SharedApplicationsResponse response = new SharedApplicationsResponse();
+        for (SharedApplication sharedApp : sharedApplications) {
+            SharedApplicationResponse sharedApplicationResponse =
+                    new SharedApplicationResponse().applicationId(sharedApp.getSharedApplicationId())
+                            .organizationId(sharedApp.getOrganizationId());
+            response.addSharedApplicationsItem(sharedApplicationResponse);
+        }
+        return response;
+    }
+
+    private OrganizationManager getOrganizationManager() {
+
+        return OrganizationManagementServiceHolder.getInstance().getOrganizationManager();
+    }
+
+    private OrgApplicationManager getOrgApplicationManager() {
+
+        return OrganizationManagementServiceHolder.getInstance().getOrgApplicationManager();
+    }
+}

--- a/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.v1/src/main/java/org/wso2/carbon/identity/api/server/organization/management/v1/util/OrganizationManagementEndpointUtil.java
+++ b/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.v1/src/main/java/org/wso2/carbon/identity/api/server/organization/management/v1/util/OrganizationManagementEndpointUtil.java
@@ -1,10 +1,19 @@
 /*
- * Copyright (c) 2022, WSO2 LLC. (http://www.wso2.com). All Rights Reserved.
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
  *
- * This software is the property of WSO2 LLC. and its suppliers, if any.
- * Dissemination of any information or reproduction of any material contained
- * herein in any form is strictly forbidden, unless permitted by WSO2 expressly.
- * You may not alter or remove any copyright or other notice from copies of this content.
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 
 package org.wso2.carbon.identity.api.server.organization.management.v1.util;

--- a/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.v1/src/main/java/org/wso2/carbon/identity/api/server/organization/management/v1/util/OrganizationManagementEndpointUtil.java
+++ b/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.v1/src/main/java/org/wso2/carbon/identity/api/server/organization/management/v1/util/OrganizationManagementEndpointUtil.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright (c) 2022, WSO2 LLC. (http://www.wso2.com). All Rights Reserved.
+ *
+ * This software is the property of WSO2 LLC. and its suppliers, if any.
+ * Dissemination of any information or reproduction of any material contained
+ * herein in any form is strictly forbidden, unless permitted by WSO2 expressly.
+ * You may not alter or remove any copyright or other notice from copies of this content.
+ */
+
+package org.wso2.carbon.identity.api.server.organization.management.v1.util;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.identity.api.server.organization.management.v1.exceptions.OrganizationManagementEndpointException;
+import org.wso2.carbon.identity.api.server.organization.management.v1.model.Error;
+import org.wso2.carbon.identity.core.ServiceURLBuilder;
+import org.wso2.carbon.identity.core.URLBuilderException;
+import org.wso2.carbon.identity.organization.management.service.exception.OrganizationManagementClientException;
+import org.wso2.carbon.identity.organization.management.service.exception.OrganizationManagementException;
+
+import java.net.URI;
+
+import javax.ws.rs.core.Response;
+
+import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.ErrorMessages.ERROR_CODE_ERROR_BUILDING_PAGINATED_RESPONSE_URL;
+import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.ErrorMessages.ERROR_CODE_ERROR_BUILDING_RESPONSE_HEADER_URL;
+import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.ErrorMessages.ERROR_CODE_INVALID_APPLICATION;
+import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.ErrorMessages.ERROR_CODE_INVALID_ORGANIZATION;
+import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.ErrorMessages.ERROR_CODE_USER_NOT_AUTHORIZED_TO_CREATE_ORGANIZATION;
+import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.ORGANIZATION_PATH;
+import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.PATH_SEPARATOR;
+import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.V1_API_PATH_COMPONENT;
+import static org.wso2.carbon.identity.organization.management.service.util.Utils.getContext;
+
+/**
+ * This class provides util functions to the organization management endpoint.
+ */
+public class OrganizationManagementEndpointUtil {
+
+    private static final Log LOG = LogFactory.getLog(OrganizationManagementEndpointUtil.class);
+
+    /**
+     * Handles the response for client errors.
+     *
+     * @param e   The client exception thrown.
+     * @param log The logger.
+     * @return The response for the client error.
+     */
+    public static Response handleClientErrorResponse(OrganizationManagementClientException e, Log log) {
+
+        if (isNotFoundError(e)) {
+            throw buildException(Response.Status.NOT_FOUND, log, e);
+        }
+
+        if (isForbiddenError(e)) {
+            throw buildException(Response.Status.FORBIDDEN, log, e);
+        }
+
+        throw buildException(Response.Status.BAD_REQUEST, log, e);
+    }
+
+    /**
+     * Handles the response for server errors.
+     *
+     * @param e   The server exception thrown.
+     * @param log The logger.
+     * @return The response for the server error.
+     */
+    public static Response handleServerErrorResponse(OrganizationManagementException e, Log log) {
+
+        throw buildException(Response.Status.INTERNAL_SERVER_ERROR, log, e);
+    }
+
+    private static boolean isNotFoundError(OrganizationManagementClientException e) {
+
+        return ERROR_CODE_INVALID_ORGANIZATION.getCode().equals(e.getErrorCode()) ||
+                ERROR_CODE_INVALID_APPLICATION.getCode().equals(e.getErrorCode());
+
+    }
+
+    private static boolean isForbiddenError(OrganizationManagementClientException e) {
+
+        return ERROR_CODE_USER_NOT_AUTHORIZED_TO_CREATE_ORGANIZATION.getCode().equals(e.getErrorCode());
+    }
+
+    private static OrganizationManagementEndpointException buildException(Response.Status status, Log log,
+                                                                          OrganizationManagementException e) {
+
+        if (e instanceof OrganizationManagementClientException) {
+            logDebug(log, e);
+        } else {
+            logError(log, e);
+        }
+        return new OrganizationManagementEndpointException(status, getError(e.getErrorCode(), e.getMessage(),
+                e.getDescription()));
+    }
+
+    /**
+     * Returns a generic error object.
+     *
+     * @param errorCode        The error code.
+     * @param errorMessage     The error message.
+     * @param errorDescription The error description.
+     * @return A generic error with the specified details.
+     */
+    public static Error getError(String errorCode, String errorMessage, String errorDescription) {
+
+        Error error = new Error();
+        error.setCode(errorCode);
+        error.setMessage(errorMessage);
+        error.setDescription(errorDescription);
+        return error;
+    }
+
+    private static void logDebug(Log log, OrganizationManagementException e) {
+
+        if (log.isDebugEnabled()) {
+            String errorMessageFormat = "errorCode: %s | message: %s";
+            String errorMessage = String.format(errorMessageFormat, e.getErrorCode(), e.getDescription());
+            log.debug(errorMessage, e);
+        }
+    }
+
+    private static void logError(Log log, OrganizationManagementException e) {
+
+        String errorMessageFormat = "errorCode: %s | message: %s";
+        String errorMessage = String.format(errorMessageFormat, e.getErrorCode(), e.getDescription());
+        log.error(errorMessage, e);
+    }
+
+    /**
+     * Get location of the created organization.
+     *
+     * @param organizationId The unique identifier of the created organization.
+     * @return URI
+     */
+    public static URI getResourceLocation(String organizationId) {
+
+        return buildURIForHeader(V1_API_PATH_COMPONENT + PATH_SEPARATOR + ORGANIZATION_PATH + PATH_SEPARATOR
+                + organizationId);
+    }
+
+    private static URI buildURIForHeader(String endpoint) {
+
+        String context = getContext(endpoint);
+        try {
+            String url = ServiceURLBuilder.create().addPath(context).build().getAbsolutePublicURL();
+            return URI.create(url);
+        } catch (URLBuilderException e) {
+            LOG.error("Server encountered an error while building URL for response header.");
+            Error error = getError(ERROR_CODE_ERROR_BUILDING_RESPONSE_HEADER_URL.getCode(),
+                    ERROR_CODE_ERROR_BUILDING_RESPONSE_HEADER_URL.getMessage(),
+                    ERROR_CODE_ERROR_BUILDING_RESPONSE_HEADER_URL.getDescription());
+            throw new OrganizationManagementEndpointException(Response.Status.INTERNAL_SERVER_ERROR, error);
+        }
+    }
+
+    public static String buildURIForPagination(String paginationURL) {
+
+        String context = getContext(V1_API_PATH_COMPONENT + PATH_SEPARATOR + ORGANIZATION_PATH + paginationURL);
+
+        try {
+            return ServiceURLBuilder.create().addPath(context).build().getRelativePublicURL();
+        } catch (URLBuilderException e) {
+            LOG.error("Server encountered an error while building paginated URL for the response.", e);
+            Error error = getError(ERROR_CODE_ERROR_BUILDING_PAGINATED_RESPONSE_URL.getCode(),
+                    ERROR_CODE_ERROR_BUILDING_PAGINATED_RESPONSE_URL.getMessage(),
+                    ERROR_CODE_ERROR_BUILDING_PAGINATED_RESPONSE_URL.getDescription());
+            throw new OrganizationManagementEndpointException(Response.Status.INTERNAL_SERVER_ERROR, error);
+        }
+    }
+
+}

--- a/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.v1/src/main/resources/META-INF/cxf/org-mgt-server-v1-cxf.xml
+++ b/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.v1/src/main/resources/META-INF/cxf/org-mgt-server-v1-cxf.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2022, WSO2 LLC. (http://www.wso2.com). All Rights Reserved.
+  ~
+  ~ This software is the property of WSO2 LLC. and its suppliers, if any.
+  ~ Dissemination of any information or reproduction of any material contained
+  ~ herein in any form is strictly forbidden, unless permitted by WSO2 expressly.
+  ~ You may not alter or remove any copyright or other notice from copies of this content.
+  -->
+
+<beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:jaxrs="http://cxf.apache.org/jaxrs" xmlns:context="http://www.springframework.org/schema/context"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans  http://www.springframework.org/schema/beans/spring-beans-3.0.xsd http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.0.xsd http://cxf.apache.org/jaxrs http://cxf.apache.org/schemas/jaxrs.xsd">
+
+    <bean class="org.wso2.carbon.identity.api.server.organization.management.v1.impl.OrganizationsApiServiceImpl"/>
+    <bean class="org.wso2.carbon.identity.api.server.organization.management.v1.service.OrganizationManagementService"/>
+    <bean id="OrgMgtServiceFactoryBean"
+          class="org.wso2.carbon.identity.api.server.organization.management.common.factory.OrganizationManagementOSGIServiceFactory"/>
+    <bean id="OrgApplicationMgtServiceFactoryBean"
+          class="org.wso2.carbon.identity.api.server.organization.management.common.factory.OrgApplicationManagerOSGIServiceFactory"/>
+    <bean id="OrganizationManagementServiceHolderBean"
+          class="org.wso2.carbon.identity.api.server.organization.management.common.OrganizationManagementServiceHolder">
+        <property name="organizationManager" ref="OrgMgtServiceFactoryBean"/>
+        <property name="orgApplicationManager" ref="OrgApplicationMgtServiceFactoryBean"/>
+    </bean>
+</beans>

--- a/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.v1/src/main/resources/META-INF/cxf/org-mgt-server-v1-cxf.xml
+++ b/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.v1/src/main/resources/META-INF/cxf/org-mgt-server-v1-cxf.xml
@@ -1,11 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2022, WSO2 LLC. (http://www.wso2.com). All Rights Reserved.
+  ~ Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
   ~
-  ~ This software is the property of WSO2 LLC. and its suppliers, if any.
-  ~ Dissemination of any information or reproduction of any material contained
-  ~ herein in any form is strictly forbidden, unless permitted by WSO2 expressly.
-  ~ You may not alter or remove any copyright or other notice from copies of this content.
+  ~ WSO2 LLC. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
   -->
 
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.v1/src/main/resources/org.wso2.carbon.identity.organization.management.yaml
+++ b/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.v1/src/main/resources/org.wso2.carbon.identity.organization.management.yaml
@@ -1,0 +1,958 @@
+openapi: 3.0.0
+info:
+  version: "v1"
+  title: 'Private CIAM Cloud - Organization Management API Definition'
+  description: 'This is the RESTful API for organization management in CIAM Cloud. This API allows users to create, 
+  update, retrieve and delete organizations. 
+  Other than that the API supports to share application from the parent organization to given organization, getting the 
+  list of organizations that the application is shared to and delete the shared application from the organization.'
+  contact:
+    name: WSO2
+    url: 'https://wso2.com/ciam-suite/private-ciam-cloud/b2b-ciam'
+    email: iam-dev@wso2.org
+  license:
+    name: Apache 2.0
+    url: 'http://www.apache.org/licenses/LICENSE-2.0.html'
+servers:
+  - url: 'https://localhost:9443/o/{organization-domain}/api/server/v1/organizations'
+    variables:
+      organization-domain:
+        default: 10084a8d-113f-4211-a0d5-efe36b082211
+security:
+  - OAuth2: []
+  - BasicAuth: []
+
+paths:
+  /organizations:
+    post:
+      tags:
+        - Organization
+      description:
+        This API is used to create the organization defined in the user input.
+      summary:
+        Create a new organization.
+      operationId: organizationPost
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrganizationPOSTRequest'
+        description: This represents the organization to be added.
+        required: true
+      responses:
+        '201':
+          description: Successful response
+          headers:
+            Location:
+              description: Location of the newly created organization.
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrganizationResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '500':
+          $ref: '#/components/responses/ServerError'
+    get:
+      description:
+        This API is used to search and retrieve organizations created for this tenant.
+      summary:
+        Retrieve organizations created for this tenant which matches the defined search criteria, if any.
+      operationId: organizationsGet
+      parameters:
+        - $ref: '#/components/parameters/filterQueryParam'
+        - $ref: '#/components/parameters/limitQueryParam'
+        - $ref: '#/components/parameters/afterQueryParam'
+        - $ref: '#/components/parameters/beforeQueryParam'
+        - $ref: '#/components/parameters/recursiveQueryParam'
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrganizationsResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '500':
+          $ref: '#/components/responses/ServerError'
+        '501':
+          $ref: '#/components/responses/NotImplemented'
+      tags:
+        - Organization
+  /organizations/me:
+    get:
+      description:
+        Retrieve authorized sub organizations which matches the defined search criteria, if any.
+      summary:
+        This API is used to search and retrieve child organizations which are authorized for the user.
+      operationId: organizationsGetMe
+      parameters:
+        - $ref: '#/components/parameters/filterQueryParam'
+        - $ref: '#/components/parameters/limitQueryParam'
+        - $ref: '#/components/parameters/afterQueryParam'
+        - $ref: '#/components/parameters/beforeQueryParam'
+        - $ref: '#/components/parameters/recursiveQueryParam'
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrganizationsResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '500':
+          $ref: '#/components/responses/ServerError'
+        '501':
+          $ref: '#/components/responses/NotImplemented'
+      tags:
+        - Organization
+  /organizations/check-name:
+    post:
+      summary: Check organization with given name exist among the organizations hierarchy.
+      description: This API is used to check whether organization with particular name exist or not.
+      operationId: organizationsCheckNamePost
+      requestBody:
+        description: OrganizationNameCheckPOSTRequest object containing the organization name.
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrganizationNameCheckPOSTRequest'
+        required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrganizationNameCheckPOSTResponse'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '500':
+          $ref: '#/components/responses/ServerError'
+      tags:
+        - Organization
+
+  /organizations/{organization-id}:
+    get:
+      description:
+        This API is used to get an existing organization identified by the organization ID.
+      summary:
+        Get an existing organization, identified by the organization ID.
+      parameters:
+        - name: organization-id
+          in: path
+          description: ID of the organization.
+          required: true
+          schema:
+            type: string
+        - $ref: '#/components/parameters/includePermissionsQueryParam'
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetOrganizationResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/ServerError'
+      tags:
+        - Organization
+    patch:
+      description:
+        This API provides the capability to update an organization property
+        using patch request. Organization patch is supported only for key-value pairs.
+      summary:
+        Patch an organization property by ID. Patch is supported only for
+        key-value pairs.
+      parameters:
+        - name: organization-id
+          in: path
+          description:  ID of the organization to be patched.
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrganizationPatchRequest'
+        required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrganizationResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/ServerError'
+      tags:
+        - Organization
+    put:
+      description:
+        This API provides the capability to update an organization by its id.
+      summary:
+        Update an organization by ID.
+      parameters:
+        - name: organization-id
+          in: path
+          description: ID of the organization to be updated.
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrganizationPUTRequest'
+        required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrganizationResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/ServerError'
+      tags:
+        - Organization
+    delete:
+      description:
+        This API provides the capability to delete an organization by
+        giving its ID.
+      summary:
+        Delete an organization by using the organization's ID.
+      parameters:
+        - name: organization-id
+          in: path
+          description:  ID of the organization to be deleted.
+          required: true
+          schema:
+            type: string
+      responses:
+        '204':
+          description: Successfully deleted
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/ServerError'
+      tags:
+        - Organization
+  /organizations/{organization-id}/applications/{application-id}/share:
+    post:
+      summary: |
+        Share application from the parent organization to given organization
+      description: |
+        This API creates an internal application to delegate access from
+      operationId: shareOrgApplication
+      parameters:
+        - name: organization-id
+          in: path
+          description: ID of the parent organization where the application is created.
+          required: true
+          schema:
+            type: string
+        - name: application-id
+          in: path
+          description: ID of the application which will be shared to child organizations.
+          required: true
+          schema:
+            type: string
+      requestBody:
+        description: ApplicationSharePOSTRequest object containing the sharing attributes.
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ApplicationSharePOSTRequest'
+        required: true
+      responses:
+        '200':
+          description: Ok
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/ServerError'
+      tags:
+        - Organization Application Management
+    get:
+      summary: |
+        List of organizations that the application is shared to.
+      description: |
+        This API returns the list of organizations that the application is shared to.
+      operationId: shareOrgApplicationGet
+      parameters:
+        - name: organization-id
+          in: path
+          description: ID of the parent organization where the application is created.
+          required: true
+          schema:
+            type: string
+        - name: application-id
+          in: path
+          description: ID of the application which will be shared to child organizations.
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SharedOrganizationsResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/ServerError'
+      tags:
+        - Organization Application Management
+  /organizations/{organization-id}/applications/{application-id}/fragment-apps:
+    delete:
+      deprecated: true
+      description: |
+        This API provides the capability to stop sharing an application to all organizations the application is shared to.
+      summary: |
+        Stop sharing an application with all sub-organizations.
+      operationId: shareOrgApplicationDeleteAll
+      parameters:
+        - name: organization-id
+          in: path
+          description: ID of the parent organization where the application is created.
+          required: true
+          schema:
+            type: string
+        - name: application-id
+          in: path
+          description: ID of the application.
+          required: true
+          schema:
+            type: string
+      responses:
+        '204':
+          description: Successfully deleted
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/ServerError'
+      tags:
+        - Organization Application Management
+  /organizations/{organization-id}/applications/{application-id}/shared-apps:
+    get:
+      summary: |
+        List of shared applications along with its organization.
+      description: |
+        This API returns the list of shared app ids along with the shared organization id.
+      operationId: sharedApplicationsGet
+      parameters:
+        - name: organization-id
+          in: path
+          description: ID of the parent organization where the application is created.
+          required: true
+          schema:
+            type: string
+        - name: application-id
+          in: path
+          description: ID of the application which is shared to child organizations.
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SharedApplicationsResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/ServerError'
+      tags:
+        - Organization Application Management
+    delete:
+      description: |
+        This API provides the capability to stop sharing an application to all organizations the application is shared to.
+      summary: |
+        Stop sharing an application with all sub-organizations.
+      operationId: sharedApplicationsAllDelete
+      parameters:
+        - name: organization-id
+          in: path
+          description: ID of the parent organization where the application is created.
+          required: true
+          schema:
+            type: string
+        - name: application-id
+          in: path
+          description: ID of the application.
+          required: true
+          schema:
+            type: string
+      responses:
+        '204':
+          description: Successfully deleted
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/ServerError'
+      tags:
+        - Organization Application Management
+  /organizations/{organization-id}/applications/{application-id}/share/{shared-organization-id}:
+    delete:
+      description: |
+        This API provides the capability to stop sharing an application to an organization by providing its ID.
+      summary: |
+        Stop sharing an application to a organization.
+      operationId: shareOrgApplicationDelete
+      parameters:
+        - name: organization-id
+          in: path
+          description: ID of the organization to be deleted.
+          required: true
+          schema:
+            type: string
+        - name: application-id
+          in: path
+          description: ID of the application.
+          required: true
+          schema:
+            type: string
+        - name: shared-organization-id
+          in: path
+          description: ID of the organization to stop sharing.
+          required: true
+          schema:
+            type: string
+      responses:
+        '204':
+          description: Successfully deleted
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/ServerError'
+      tags:
+        - Organization Application Management
+
+components:
+  parameters:
+    filterQueryParam:
+      in: query
+      name: filter
+      required: false
+      description:
+        Condition to filter the retrieval of records.
+      schema:
+        type: string
+    limitQueryParam:
+      in: query
+      name: limit
+      required: false
+      description:
+        Maximum number of records to be returned. (Should be greater than 0)
+      schema:
+        type: integer
+        format: int32
+        minimum: 0
+    beforeQueryParam:
+      in: query
+      name: before
+      required: false
+      description:
+        Points to the previous range of data that can be retrieved.
+      schema:
+        type: string
+    afterQueryParam:
+      in: query
+      name: after
+      required: false
+      description:
+        Points to the next range of data to be returned.
+      schema:
+        type: string
+    recursiveQueryParam:
+      in: query
+      name: recursive
+      required: false
+      description:
+        Determines whether a recursive search should happen.
+      schema:
+        type: boolean
+        default: false
+    showChildrenQueryParam:
+      in: query
+      name: showChildren
+      required: false
+      description:
+        Returns the organization details along with the child organization IDs belonging to this organization.
+      schema:
+        type: boolean
+        default: false
+    includePermissionsQueryParam:
+      in: query
+      name: includePermissions
+      required: false
+      description:
+        Returns the organization details along with permissions assigned for the requested user in this organization.
+      schema:
+        type: boolean
+        default: false
+
+  schemas:
+    Error:
+      type: object
+      required:
+        - code
+        - message
+      properties:
+        code:
+          type: string
+          example: ORG-00000
+          description: An error code.
+        message:
+          type: string
+          example: Some Error Message
+          description: An error message.
+        description:
+          type: string
+          example: Some Error Description
+          description: An error description.
+        traceId:
+          type: string
+          example: e0fbcfeb-3617-43c4-8dd0-7b7d38e13047
+          description: An error trace identifier.
+
+    OrganizationPOSTRequest:
+      type: object
+      required:
+        - name
+      properties:
+        name:
+          type: string
+          example: "ABC Builders"
+        description:
+          type: string
+          example: "Building constructions"
+        type:
+          type: string
+          example: "TENANT"
+          enum:
+            - TENANT
+            - STRUCTURAL
+          default: "TENANT"
+        parentId:
+          type: string
+          example: "b4526d91-a8bf-43d2-8b14-c548cf73065b"
+          description: "If the parentId is not present, Super will be taken as the parent organization."
+          default: "10084a8d-113f-4211-a0d5-efe36b082211"
+        attributes:
+          type: array
+          items:
+            $ref: '#/components/schemas/Attribute'
+    OrganizationPUTRequest:
+      type: object
+      required:
+        - name
+        - status
+      properties:
+        name:
+          type: string
+          example: "ABC Builders"
+        description:
+          type: string
+          example: "Building constructions"
+        status:
+          type: string
+          enum: [ACTIVE, DISABLED]
+          example: ACTIVE
+        attributes:
+          type: array
+          items:
+            $ref: '#/components/schemas/Attribute'
+    ApplicationSharePOSTRequest:
+      type: object
+      properties:
+        shareWithAllChildren:
+          type: boolean
+          default: false
+        sharedOrganizations:
+          type: array
+          items:
+            type: string
+    OrganizationNameCheckPOSTRequest:
+      type: object
+      properties:
+        name:
+          type: string
+          example: "ABC Builders"
+    OrganizationNameCheckPOSTResponse:
+      type: object
+      properties:
+        available:
+          type: boolean
+          example: true
+    Attribute:
+      type: object
+      required:
+        - key
+        - value
+      properties:
+        key:
+          type: string
+          example: "Country"
+        value:
+          type: string
+          example: "Sri Lanka"
+    OrganizationsResponse:
+      type: object
+      properties:
+        links:
+          type: array
+          items:
+            $ref: '#/components/schemas/Link'
+          example:
+            [
+              {
+                "href": "/o/10084a8d-113f-4211-a0d5-efe36b082211/api/server/v1/organizations?limit=10&filter=name+co+der&next=MjAyMS0xMi0yMSAwNToxODozMS4wMDQzNDg=",
+                "rel": "next",
+              },  {
+                "href": "/o/10084a8d-113f-4211-a0d5-efe36b082211/api/server/v1/organizations?limit=10&filter=name+co+der&before=MjAyMS0xMi0yMSAwNToxODozMS4wMDQzNDg=",
+                "rel": "previous",
+              }
+            ]
+        organizations:
+          type: array
+          items:
+            $ref: '#/components/schemas/BasicOrganizationResponse'
+    Link:
+      type: object
+      properties:
+        href:
+          type: string
+          format: uri
+          description: Endpoint that will return the next or previous page of data.
+        rel:
+          type: string
+          description: Describes whether the provided link is to access the next or previous page of data.
+      readOnly: true
+    BasicOrganizationResponse:
+      type: object
+      required:
+        - id
+        - name
+        - status
+        - ref
+      properties:
+        id:
+          type: string
+          example: 'b4526d91-a8bf-43d2-8b14-c548cf73065b'
+        name:
+          type: string
+          example: 'ABC Builders'
+        status:
+          type: string
+          enum: [ ACTIVE, DISABLED ]
+          example: ACTIVE
+        ref:
+          type: string
+          example: 'o/10084a8d-113f-4211-a0d5-efe36b082211/api/server/v1/organizations/b4526d91-a8bf-43d2-8b14-c548cf73065b'
+    OrganizationResponse:
+      type: object
+      required:
+        - id
+        - name
+        - status
+        - created
+        - lastModified
+        - type
+      properties:
+        id:
+          type: string
+          example: '06c1f4e2-3339-44e4-a825-96585e3653b1'
+        name:
+          type: string
+          example: 'ABC Builders'
+        description:
+          type: string
+          example: 'Building constructions'
+        status:
+          type: string
+          enum: [ACTIVE, DISABLED]
+          example: ACTIVE
+        created:
+          type: string
+          example: '2021-10-25T12:31:53.406Z'
+        lastModified:
+          type: string
+          example: '2021-10-25T12:31:53.406Z'
+        type:
+          type: string
+          example: "TENANT"
+          enum:
+            - TENANT
+            - STRUCTURAL
+        parent:
+          $ref: '#/components/schemas/ParentOrganization'
+        attributes:
+          type: array
+          items:
+            $ref: '#/components/schemas/Attribute'
+    GetOrganizationResponse:
+      type: object
+      required:
+        - id
+        - name
+        - status
+        - created
+        - lastModified
+        - type
+      properties:
+        id:
+          type: string
+          example: '06c1f4e2-3339-44e4-a825-96585e3653b1'
+        name:
+          type: string
+          example: 'ABC Builders'
+        description:
+          type: string
+          example: 'Building constructions'
+        status:
+          type: string
+          enum: [ACTIVE, DISABLED]
+          example: ACTIVE
+        created:
+          type: string
+          example: '2021-10-25T12:31:53.406Z'
+        lastModified:
+          type: string
+          example: '2021-10-25T12:31:53.406Z'
+        type:
+          type: string
+          example: "TENANT"
+          enum:
+            - TENANT
+            - STRUCTURAL
+        parent:
+          $ref: '#/components/schemas/ParentOrganization'
+        attributes:
+          type: array
+          items:
+            $ref: '#/components/schemas/Attribute'
+        permissions:
+          type: array
+          items:
+            type: string
+    #-----------------------------------------------------
+    # Organization Parent Object
+    #-----------------------------------------------------
+    ParentOrganization:
+      type: object
+      required:
+        - id
+        - ref
+      properties:
+        id:
+          type: string
+          example: 'b4526d91-a8bf-43d2-8b14-c548cf73065b'
+        ref:
+          type: string
+          example: 'o/10084a8d-113f-4211-a0d5-efe36b082211/api/server/v1/organizations/b4526d91-a8bf-43d2-8b14-c548cf73065b'
+
+    #-----------------------------------------------------
+    # Organization Patch Operation Object
+    #-----------------------------------------------------
+    OrganizationPatchRequest:
+      type: array
+      items:
+        $ref: '#/components/schemas/OrganizationPatchRequestItem'
+    OrganizationPatchRequestItem:
+      description: A JSONPatch as defined by RFC 6902. Patch operation is supported only for root level attributes of an organization.
+      required:
+        - operation
+        - path
+      properties:
+        operation:
+          type: string
+          description: The operation to be performed.
+          enum:
+            - ADD
+            - REMOVE
+            - REPLACE
+          example: REPLACE
+        path:
+          type: string
+          description: A JSON-Pointer
+          example: '/name'
+        value:
+          type: string
+          description: The value to be used within the operations.
+          example: 'XYZ Builders'
+    #-----------------------------------------------------
+    # Get Application shared organizations
+    #-----------------------------------------------------
+    SharedOrganizationsResponse:
+      type: object
+      properties:
+        organizations:
+          type: array
+          items:
+            $ref: '#/components/schemas/BasicOrganizationResponse'
+    #-----------------------------------------------------
+    # Get shared applications of a given application
+    #-----------------------------------------------------
+    SharedApplicationsResponse:
+      type: object
+      properties:
+        sharedApplications:
+          type: array
+          items:
+            $ref: '#/components/schemas/SharedApplicationResponse'
+    SharedApplicationResponse:
+      type: object
+      properties:
+        applicationId:
+          type: string
+          description: Shared application's id.
+          example: 'ca322554-fe79-4c04-9c94-492855ef92a3'
+        organizationId:
+          type: string
+          description: Shared application residing organization id.
+          example: '682edf68-4835-4bb8-961f-0a16bc6cc866'
+  #--------------------------------------------------------
+  # Descriptions of Organization Management API responses.
+  #--------------------------------------------------------
+  responses:
+    BadRequest:
+      description: Invalid input in the request.
+      content:
+        'application/json':
+          schema:
+            $ref: '#/components/schemas/Error'
+    NotFound:
+      description: Requested resource is not found.
+      content:
+        'application/json':
+          schema:
+            $ref: '#/components/schemas/Error'
+    Unauthorized:
+      description: Authentication information is missing or invalid.
+    Forbidden:
+      description: Access forbidden.
+    ServerError:
+      description: Internal server error.
+      content:
+        'application/json':
+          schema:
+            $ref: '#/components/schemas/Error'
+    NotImplemented:
+      description: Not Implemented.
+      content:
+        'application/json':
+          schema:
+            $ref: '#/components/schemas/Error'
+    OrgNotFound:
+      description: Organization Not Found
+    OrgExist:
+      description: Organization Exist
+  #-----------------------------------------------------
+  # Applicable authentication mechanisms.
+  #-----------------------------------------------------
+  securitySchemes:
+    BasicAuth:
+      type: http
+      scheme: basic
+    OAuth2:
+      type: oauth2
+      flows:
+        authorizationCode:
+          authorizationUrl: 'https://localhost:9443/oauth2/authorize'
+          tokenUrl: 'https://localhost:9443/oauth2/token'
+          scopes: {}

--- a/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.v1/src/main/resources/org.wso2.carbon.identity.organization.management.yaml
+++ b/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.v1/src/main/resources/org.wso2.carbon.identity.organization.management.yaml
@@ -1,14 +1,14 @@
 openapi: 3.0.0
 info:
   version: "v1"
-  title: 'Private CIAM Cloud - Organization Management API Definition'
-  description: 'This is the RESTful API for organization management in CIAM Cloud. This API allows users to create, 
-  update, retrieve and delete organizations. 
+  title: 'WSO2 Identity Server - Organization Management API Definition'
+  description: 'This is the RESTful API for organization management in WSO2 Identity Server. This API allows users 
+  to create, update, retrieve and delete organizations. 
   Other than that the API supports to share application from the parent organization to given organization, getting the 
   list of organizations that the application is shared to and delete the shared application from the organization.'
   contact:
     name: WSO2
-    url: 'https://wso2.com/ciam-suite/private-ciam-cloud/b2b-ciam'
+    url: 'http://wso2.com/products/identity-server/'
     email: iam-dev@wso2.org
   license:
     name: Apache 2.0

--- a/components/org.wso2.carbon.identity.api.server.organization.management/pom.xml
+++ b/components/org.wso2.carbon.identity.api.server.organization.management/pom.xml
@@ -1,11 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com). All Rights Reserved.
+  ~ Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
   ~
-  ~ This software is the property of WSO2 LLC. and its suppliers, if any.
-  ~ Dissemination of any information or reproduction of any material contained
-  ~ herein in any form is strictly forbidden, unless permitted by WSO2 expressly.
-  ~ You may not alter or remove any copyright or other notice from copies of this content.
+  ~ WSO2 LLC. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
   -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">

--- a/components/org.wso2.carbon.identity.api.server.organization.management/pom.xml
+++ b/components/org.wso2.carbon.identity.api.server.organization.management/pom.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com). All Rights Reserved.
+  ~
+  ~ This software is the property of WSO2 LLC. and its suppliers, if any.
+  ~ Dissemination of any information or reproduction of any material contained
+  ~ herein in any form is strictly forbidden, unless permitted by WSO2 expressly.
+  ~ You may not alter or remove any copyright or other notice from copies of this content.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>identity-api-server</artifactId>
+        <groupId>org.wso2.carbon.identity.server.api</groupId>
+        <version>1.2.67-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>org.wso2.carbon.identity.api.server.organization.management</artifactId>
+    <packaging>pom</packaging>
+    <modules>
+        <module>org.wso2.carbon.identity.api.server.organization.management.common</module>
+        <module>org.wso2.carbon.identity.api.server.organization.management.v1</module>
+    </modules>
+</project>

--- a/components/org.wso2.carbon.identity.api.server.organization.role.management/org.wso2.carbon.identity.api.server.organization.role.management.common/pom.xml
+++ b/components/org.wso2.carbon.identity.api.server.organization.role.management/org.wso2.carbon.identity.api.server.organization.role.management.common/pom.xml
@@ -1,11 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com). All Rights Reserved.
+  ~ Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
   ~
-  ~ This software is the property of WSO2 LLC. and its suppliers, if any.
-  ~ Dissemination of any information or reproduction of any material contained
-  ~ herein in any form is strictly forbidden, unless permitted by WSO2 expressly.
-  ~ You may not alter or remove any copyright or other notice from copies of this content.
+  ~ WSO2 LLC. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
   -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">

--- a/components/org.wso2.carbon.identity.api.server.organization.role.management/org.wso2.carbon.identity.api.server.organization.role.management.common/pom.xml
+++ b/components/org.wso2.carbon.identity.api.server.organization.role.management/org.wso2.carbon.identity.api.server.organization.role.management.common/pom.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com). All Rights Reserved.
+  ~
+  ~ This software is the property of WSO2 LLC. and its suppliers, if any.
+  ~ Dissemination of any information or reproduction of any material contained
+  ~ herein in any form is strictly forbidden, unless permitted by WSO2 expressly.
+  ~ You may not alter or remove any copyright or other notice from copies of this content.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <parent>
+        <groupId>org.wso2.carbon.identity.server.api</groupId>
+        <artifactId>org.wso2.carbon.identity.api.server.organization.role.management</artifactId>
+        <version>1.2.67-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>org.wso2.carbon.identity.api.server.organization.role.management.common</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-web</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.organization.management</groupId>
+            <artifactId>org.wso2.carbon.identity.organization.management.role.management.service</artifactId>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/components/org.wso2.carbon.identity.api.server.organization.role.management/org.wso2.carbon.identity.api.server.organization.role.management.common/src/main/java/org/wso2/carbon/identity/api/server/organization/role/management/common/OrganizationRoleManagementServiceHolder.java
+++ b/components/org.wso2.carbon.identity.api.server.organization.role.management/org.wso2.carbon.identity.api.server.organization.role.management.common/src/main/java/org/wso2/carbon/identity/api/server/organization/role/management/common/OrganizationRoleManagementServiceHolder.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.organization.role.management.common;
+
+import org.wso2.carbon.identity.organization.management.role.management.service.RoleManager;
+import org.wso2.carbon.identity.organization.management.service.OrganizationUserResidentResolverService;
+
+/**
+ * Service holder class for role management related services.
+ */
+public class OrganizationRoleManagementServiceHolder {
+
+    private static OrganizationRoleManagementServiceHolder instance = new OrganizationRoleManagementServiceHolder();
+
+    private RoleManager roleManager;
+
+    private OrganizationUserResidentResolverService organizationUserResidentResolverService;
+
+    private OrganizationRoleManagementServiceHolder() {
+
+    }
+
+    public static OrganizationRoleManagementServiceHolder getInstance() {
+
+        return instance;
+    }
+
+    /**
+     * Get RoleManager OSGi service.
+     *
+     * @return RoleManager
+     */
+    public RoleManager getRoleManager() {
+
+        return OrganizationRoleManagementServiceHolder.getInstance().roleManager;
+    }
+
+    /**
+     * Set RoleManager OSGi service.
+     *
+     * @param roleManager RoleManager.
+     */
+    public void setRoleManager(RoleManager roleManager) {
+
+        OrganizationRoleManagementServiceHolder.getInstance().roleManager = roleManager;
+    }
+
+    /**
+     * Method to get the organization user resident resolver osgi service.
+     *
+     * @return OrganizationUserResidentResolverService.
+     */
+    public OrganizationUserResidentResolverService getOrganizationUserResidentResolverService() {
+
+        return OrganizationRoleManagementServiceHolder.getInstance().organizationUserResidentResolverService;
+    }
+
+    /**
+     * Set OrganizationUserResidentResolverService osgi service.
+     *
+     * @param organizationUserResidentResolverService OrganizationUserResidentResolverService.
+     */
+    public void setOrganizationUserResidentResolverService(
+            OrganizationUserResidentResolverService organizationUserResidentResolverService) {
+
+        OrganizationRoleManagementServiceHolder.getInstance().organizationUserResidentResolverService
+                = organizationUserResidentResolverService;
+    }
+}

--- a/components/org.wso2.carbon.identity.api.server.organization.role.management/org.wso2.carbon.identity.api.server.organization.role.management.common/src/main/java/org/wso2/carbon/identity/api/server/organization/role/management/common/OrganizationRoleManagementServiceHolder.java
+++ b/components/org.wso2.carbon.identity.api.server.organization.role.management/org.wso2.carbon.identity.api.server.organization.role.management.common/src/main/java/org/wso2/carbon/identity/api/server/organization/role/management/common/OrganizationRoleManagementServiceHolder.java
@@ -44,7 +44,7 @@ public class OrganizationRoleManagementServiceHolder {
     /**
      * Get RoleManager OSGi service.
      *
-     * @return RoleManager
+     * @return RoleManager.
      */
     public RoleManager getRoleManager() {
 
@@ -62,7 +62,7 @@ public class OrganizationRoleManagementServiceHolder {
     }
 
     /**
-     * Method to get the organization user resident resolver osgi service.
+     * Method to get the organization user resident resolver OSGi service.
      *
      * @return OrganizationUserResidentResolverService.
      */
@@ -72,7 +72,7 @@ public class OrganizationRoleManagementServiceHolder {
     }
 
     /**
-     * Set OrganizationUserResidentResolverService osgi service.
+     * Set OrganizationUserResidentResolverService OSGi service.
      *
      * @param organizationUserResidentResolverService OrganizationUserResidentResolverService.
      */

--- a/components/org.wso2.carbon.identity.api.server.organization.role.management/org.wso2.carbon.identity.api.server.organization.role.management.common/src/main/java/org/wso2/carbon/identity/api/server/organization/role/management/common/factory/OrganizationRoleManagementOSGIServiceFactory.java
+++ b/components/org.wso2.carbon.identity.api.server.organization.role.management/org.wso2.carbon.identity.api.server.organization.role.management.common/src/main/java/org/wso2/carbon/identity/api/server/organization/role/management/common/factory/OrganizationRoleManagementOSGIServiceFactory.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.organization.role.management.common.factory;
+
+import org.springframework.beans.factory.config.AbstractFactoryBean;
+import org.wso2.carbon.context.PrivilegedCarbonContext;
+import org.wso2.carbon.identity.organization.management.role.management.service.RoleManager;
+
+/**
+ * Factory Beans serves as a factory for creating other beans within the IOC container. This factory bean is used to
+ * instantiate the RoleManager type of object inside the container.
+ */
+public class OrganizationRoleManagementOSGIServiceFactory extends AbstractFactoryBean<RoleManager> {
+
+    private RoleManager roleManager;
+
+    @Override
+    public Class<?> getObjectType() {
+
+        return Object.class;
+    }
+
+    @Override
+    protected RoleManager createInstance() throws Exception {
+
+        if (this.roleManager == null) {
+            RoleManager service = (RoleManager) PrivilegedCarbonContext.
+                    getThreadLocalCarbonContext().getOSGiService(RoleManager.class, null);
+            if (service != null) {
+                this.roleManager = service;
+            } else {
+                throw new Exception("Unable to retrieve RoleManager service.");
+            }
+        }
+        return this.roleManager;
+    }
+}

--- a/components/org.wso2.carbon.identity.api.server.organization.role.management/org.wso2.carbon.identity.api.server.organization.role.management.common/src/main/java/org/wso2/carbon/identity/api/server/organization/role/management/common/factory/OrganizationUserResidentResolverOSGIServiceFactory.java
+++ b/components/org.wso2.carbon.identity.api.server.organization.role.management/org.wso2.carbon.identity.api.server.organization.role.management.common/src/main/java/org/wso2/carbon/identity/api/server/organization/role/management/common/factory/OrganizationUserResidentResolverOSGIServiceFactory.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.organization.role.management.common.factory;
+
+import org.springframework.beans.factory.config.AbstractFactoryBean;
+import org.wso2.carbon.context.PrivilegedCarbonContext;
+import org.wso2.carbon.identity.organization.management.service.OrganizationUserResidentResolverService;
+
+/**
+ * Factory Beans serves as a factory for creating other beans within the IOC container. This factory bean is used to
+ * instantiate the OrganizationUserResidentResolverService type of object inside the container.
+ */
+public class OrganizationUserResidentResolverOSGIServiceFactory extends
+        AbstractFactoryBean<OrganizationUserResidentResolverService> {
+
+    private OrganizationUserResidentResolverService organizationUserResidentResolverService;
+
+    @Override
+    public Class<?> getObjectType() {
+
+        return Object.class;
+    }
+
+    @Override
+    protected OrganizationUserResidentResolverService createInstance() throws Exception {
+
+        if (this.organizationUserResidentResolverService == null) {
+            OrganizationUserResidentResolverService service =
+                    (OrganizationUserResidentResolverService) PrivilegedCarbonContext.
+                            getThreadLocalCarbonContext()
+                            .getOSGiService(OrganizationUserResidentResolverService.class, null);
+            if (service != null) {
+                this.organizationUserResidentResolverService = service;
+            } else {
+                throw new Exception("Unable to retrieve OrganizationUserResidentResolverService service.");
+            }
+        }
+        return this.organizationUserResidentResolverService;
+    }
+}

--- a/components/org.wso2.carbon.identity.api.server.organization.role.management/org.wso2.carbon.identity.api.server.organization.role.management.v1/pom.xml
+++ b/components/org.wso2.carbon.identity.api.server.organization.role.management/org.wso2.carbon.identity.api.server.organization.role.management.v1/pom.xml
@@ -1,0 +1,164 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2022, WSO2 LLC. (http://www.wso2.com). All Rights Reserved.
+  ~
+  ~ This software is the property of WSO2 LLC. and its suppliers, if any.
+  ~ Dissemination of any information or reproduction of any material contained
+  ~ herein in any form is strictly forbidden, unless permitted by WSO2 expressly.
+  ~ You may not alter or remove any copyright or other notice from copies of this content.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <parent>
+        <groupId>org.wso2.carbon.identity.server.api</groupId>
+        <artifactId>org.wso2.carbon.identity.api.server.organization.role.management</artifactId>
+        <version>1.2.67-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>org.wso2.carbon.identity.api.server.organization.role.management.v1</artifactId>
+    <name>WSO2 Identity Server - Organization Role Management Rest API</name>
+    <url>http://www.wso2.com</url>
+    <packaging>jar</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.cxf</groupId>
+            <artifactId>cxf-rt-frontend-jaxrs</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.cxf</groupId>
+            <artifactId>cxf-rt-rs-service-description</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-web</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>javax.ws.rs</groupId>
+            <artifactId>javax.ws.rs-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.orbit.javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.swagger</groupId>
+            <artifactId>swagger-jaxrs</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-databind</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-annotations</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.dataformat</groupId>
+                    <artifactId>jackson-dataformat-yaml</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>javax.ws.rs</groupId>
+                    <artifactId>jsr311-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.google.guava</groupId>
+                    <artifactId>guava</artifactId>
+                </exclusion>
+            </exclusions>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.jaxrs</groupId>
+            <artifactId>jackson-jaxrs-json-provider</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.server.api</groupId>
+            <artifactId>org.wso2.carbon.identity.api.server.organization.role.management.common</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.organization.management</groupId>
+            <artifactId>org.wso2.carbon.identity.organization.management.role.management.service</artifactId>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <version>3.0.0</version>
+                <executions>
+                    <execution>
+                        <id>add-source</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>add-source</goal>
+                        </goals>
+                        <configuration>
+                            <sources>
+                                <source>src/gen/java</source>
+                            </sources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <!--<plugin>
+                <groupId>org.openapitools</groupId>
+                <artifactId>openapi-generator-maven-plugin</artifactId>
+                <version>4.1.2</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>generate</goal>
+                        </goals>
+                        <configuration>
+                            <inputSpec>${project.basedir}/src/main/resources/org.wso2.carbon.identity.organization.role.management.yaml</inputSpec>
+                            <generatorName>org.wso2.carbon.codegen.CxfWso2Generator</generatorName>
+                            <configOptions>
+                                <sourceFolder>src/gen/java</sourceFolder>
+                                <apiPackage>org.wso2.carbon.identity.api.server.organization.role.management.v1</apiPackage>
+                                <modelPackage>org.wso2.carbon.identity.api.server.organization.role.management.v1.model</modelPackage>
+                                <packageName>org.wso2.carbon.identity.api.server.organization.role.management.v1</packageName>
+                                <dateLibrary>java8</dateLibrary>
+                                <hideGenerationTimestamp>true</hideGenerationTimestamp>
+                            </configOptions>
+                            <output>.</output>
+                            <skipOverwrite>false</skipOverwrite>
+                        </configuration>
+                    </execution>
+                </executions>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.openapitools</groupId>
+                        <artifactId>cxf-wso2-openapi-generator</artifactId>
+                        <version>1.0.0</version>
+                    </dependency>
+                </dependencies>
+            </plugin>-->
+        </plugins>
+    </build>
+</project>

--- a/components/org.wso2.carbon.identity.api.server.organization.role.management/org.wso2.carbon.identity.api.server.organization.role.management.v1/pom.xml
+++ b/components/org.wso2.carbon.identity.api.server.organization.role.management/org.wso2.carbon.identity.api.server.organization.role.management.v1/pom.xml
@@ -1,11 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2022, WSO2 LLC. (http://www.wso2.com). All Rights Reserved.
+  ~ Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
   ~
-  ~ This software is the property of WSO2 LLC. and its suppliers, if any.
-  ~ Dissemination of any information or reproduction of any material contained
-  ~ herein in any form is strictly forbidden, unless permitted by WSO2 expressly.
-  ~ You may not alter or remove any copyright or other notice from copies of this content.
+  ~ WSO2 LLC. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
   -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">

--- a/components/org.wso2.carbon.identity.api.server.organization.role.management/org.wso2.carbon.identity.api.server.organization.role.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/role/management/v1/OrganizationsApi.java
+++ b/components/org.wso2.carbon.identity.api.server.organization.role.management/org.wso2.carbon.identity.api.server.organization.role.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/role/management/v1/OrganizationsApi.java
@@ -1,0 +1,219 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.organization.role.management.v1;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.apache.cxf.jaxrs.ext.multipart.Attachment;
+import org.apache.cxf.jaxrs.ext.multipart.Multipart;
+import java.io.InputStream;
+import java.util.List;
+
+import org.wso2.carbon.identity.api.server.organization.role.management.v1.model.Error;
+import org.wso2.carbon.identity.api.server.organization.role.management.v1.model.RoleGetResponse;
+import org.wso2.carbon.identity.api.server.organization.role.management.v1.model.RoleObj;
+import org.wso2.carbon.identity.api.server.organization.role.management.v1.model.RolePatchRequest;
+import org.wso2.carbon.identity.api.server.organization.role.management.v1.model.RolePatchResponse;
+import org.wso2.carbon.identity.api.server.organization.role.management.v1.model.RolePostRequest;
+import org.wso2.carbon.identity.api.server.organization.role.management.v1.model.RolePostResponse;
+import org.wso2.carbon.identity.api.server.organization.role.management.v1.model.RolePutRequest;
+import org.wso2.carbon.identity.api.server.organization.role.management.v1.model.RolePutResponse;
+import org.wso2.carbon.identity.api.server.organization.role.management.v1.model.RolesListResponse;
+import org.wso2.carbon.identity.api.server.organization.role.management.v1.OrganizationsApiService;
+
+import javax.validation.Valid;
+import javax.ws.rs.*;
+import javax.ws.rs.core.Response;
+import io.swagger.annotations.*;
+
+import javax.validation.constraints.*;
+
+@Path("/organizations")
+@Api(description = "The organizations API")
+
+public class OrganizationsApi  {
+
+    @Autowired
+    private OrganizationsApiService delegate;
+
+    @Valid
+    @POST
+    @Path("/{organization-id}/roles")
+    @Consumes({ "application/json" })
+    @Produces({ "application/json" })
+    @ApiOperation(value = "Create a role inside an organization.", notes = "This API creates a role inside an organization, assigns users, groups and permissions, and returns the details of the created role including its unique id.", response = RolePostResponse.class, authorizations = {
+        @Authorization(value = "BasicAuth"),
+        @Authorization(value = "OAuth2", scopes = {
+            
+        })
+    }, tags={ "Organization Role Management", })
+    @ApiResponses(value = { 
+        @ApiResponse(code = 201, message = "Valid role is created.", response = RolePostResponse.class),
+        @ApiResponse(code = 400, message = "Invalid input in the request.", response = Error.class),
+        @ApiResponse(code = 401, message = "Authentication information is missing or invalid.", response = Void.class),
+        @ApiResponse(code = 403, message = "Access forbidden.", response = Void.class),
+        @ApiResponse(code = 404, message = "Requested resource is not found.", response = Error.class),
+        @ApiResponse(code = 409, message = "Conflict response.", response = Error.class),
+        @ApiResponse(code = 500, message = "Internal server error.", response = Error.class)
+    })
+    public Response createRole(@ApiParam(value = "ID of the organization.",required=true) @PathParam("organization-id") String organizationId, @ApiParam(value = "Represents display name, set of permissions, set of groups, set of users that are to be assigned to the role." ,required=true) @Valid RolePostRequest rolePostRequest) {
+
+        return delegate.createRole(organizationId,  rolePostRequest );
+    }
+
+    @Valid
+    @GET
+    @Path("/{organization-id}/roles")
+    
+    @Produces({ "application/json" })
+    @ApiOperation(value = "Get roles inside an organization.", notes = "This API returns roles in an organization based on the provided filter and limit.", response = RolesListResponse.class, authorizations = {
+        @Authorization(value = "BasicAuth"),
+        @Authorization(value = "OAuth2", scopes = {
+            
+        })
+    }, tags={ "Organization Role Management", })
+    @ApiResponses(value = { 
+        @ApiResponse(code = 200, message = "Successful response.", response = RolesListResponse.class),
+        @ApiResponse(code = 401, message = "Authentication information is missing or invalid.", response = Void.class),
+        @ApiResponse(code = 403, message = "Access forbidden.", response = Void.class),
+        @ApiResponse(code = 404, message = "Requested resource is not found.", response = Error.class),
+        @ApiResponse(code = 500, message = "Internal server error.", response = Error.class)
+    })
+    public Response organizationsOrganizationIdRolesGet(@ApiParam(value = "ID of the organization.",required=true) @PathParam("organization-id") String organizationId,     @Valid@ApiParam(value = "Condition to filter the retrieval of records.")  @QueryParam("filter") String filter,     @Valid @Min(0)@ApiParam(value = "Maximum number of records to be returned. (Should be greater than 0)")  @QueryParam("count") Integer count,     @Valid@ApiParam(value = "The cursor to retrieve the records.")  @QueryParam("cursor") String cursor) {
+
+        return delegate.organizationsOrganizationIdRolesGet(organizationId,  filter,  count,  cursor );
+    }
+
+    @Valid
+    @DELETE
+    @Path("/{organization-id}/roles/{role-id}")
+    
+    @Produces({ "application/json" })
+    @ApiOperation(value = "Delete a role inside an organization.", notes = "This API deletes a particular role inside an organization using its unique ID.", response = Void.class, authorizations = {
+        @Authorization(value = "BasicAuth"),
+        @Authorization(value = "OAuth2", scopes = {
+            
+        })
+    }, tags={ "Organization Role Management", })
+    @ApiResponses(value = { 
+        @ApiResponse(code = 204, message = "Role is deleted.", response = Void.class),
+        @ApiResponse(code = 401, message = "Authentication information is missing or invalid.", response = Void.class),
+        @ApiResponse(code = 403, message = "Access forbidden.", response = Void.class),
+        @ApiResponse(code = 404, message = "Requested resource is not found.", response = Error.class),
+        @ApiResponse(code = 500, message = "Internal server error.", response = Error.class)
+    })
+    public Response organizationsOrganizationIdRolesRoleIdDelete(@ApiParam(value = "ID of the role.",required=true) @PathParam("role-id") String roleId, @ApiParam(value = "ID of the organization.",required=true) @PathParam("organization-id") String organizationId) {
+
+        return delegate.organizationsOrganizationIdRolesRoleIdDelete(roleId,  organizationId );
+    }
+
+    @Valid
+    @GET
+    @Path("/{organization-id}/roles/{role-id}")
+    
+    @Produces({ "application/json" })
+    @ApiOperation(value = "Get role by ID", notes = "This API returns the role details of a particular role using its unique id.", response = RoleGetResponse.class, authorizations = {
+        @Authorization(value = "BasicAuth"),
+        @Authorization(value = "OAuth2", scopes = {
+            
+        })
+    }, tags={ "Organization Role Management", })
+    @ApiResponses(value = { 
+        @ApiResponse(code = 200, message = "Valid role is found.", response = RoleGetResponse.class),
+        @ApiResponse(code = 401, message = "Authentication information is missing or invalid.", response = Void.class),
+        @ApiResponse(code = 403, message = "Access forbidden.", response = Void.class),
+        @ApiResponse(code = 404, message = "Requested resource is not found.", response = Error.class),
+        @ApiResponse(code = 500, message = "Internal server error.", response = Error.class)
+    })
+    public Response organizationsOrganizationIdRolesRoleIdGet(@ApiParam(value = "ID of the role.",required=true) @PathParam("role-id") String roleId, @ApiParam(value = "ID of the organization.",required=true) @PathParam("organization-id") String organizationId) {
+
+        return delegate.organizationsOrganizationIdRolesRoleIdGet(roleId,  organizationId );
+    }
+
+    @Valid
+    @PATCH
+    @Path("/{organization-id}/roles/{role-id}")
+    @Consumes({ "application/json" })
+    @Produces({ "application/json" })
+    @ApiOperation(value = "Update Role - PATCH", notes = "This API updates the role details and returns the updated role details.", response = RolePatchResponse.class, authorizations = {
+        @Authorization(value = "BasicAuth"),
+        @Authorization(value = "OAuth2", scopes = {
+            
+        })
+    }, tags={ "Organization Role Management", })
+    @ApiResponses(value = { 
+        @ApiResponse(code = 200, message = "Role is updated.", response = RolePatchResponse.class),
+        @ApiResponse(code = 400, message = "Invalid input in the request.", response = Error.class),
+        @ApiResponse(code = 401, message = "Authentication information is missing or invalid.", response = Void.class),
+        @ApiResponse(code = 403, message = "Access forbidden.", response = Void.class),
+        @ApiResponse(code = 404, message = "Requested resource is not found.", response = Error.class),
+        @ApiResponse(code = 500, message = "Internal server error.", response = Error.class)
+    })
+    public Response organizationsOrganizationIdRolesRoleIdPatch(@ApiParam(value = "ID of the role.",required=true) @PathParam("role-id") String roleId, @ApiParam(value = "ID of the organization.",required=true) @PathParam("organization-id") String organizationId, @ApiParam(value = "This represents a set of values that need to be changed in the role." ,required=true) @Valid RolePatchRequest rolePatchRequest) {
+
+        return delegate.organizationsOrganizationIdRolesRoleIdPatch(roleId,  organizationId,  rolePatchRequest );
+    }
+
+    @Valid
+    @PUT
+    @Path("/{organization-id}/roles/{role-id}")
+    @Consumes({ "application/json" })
+    @Produces({ "application/json" })
+    @ApiOperation(value = "Update Role - PUT", notes = "This API updates the role details and returns the updated role details using a PUT operation.", response = RolePutResponse.class, authorizations = {
+        @Authorization(value = "BasicAuth"),
+        @Authorization(value = "OAuth2", scopes = {
+            
+        })
+    }, tags={ "Organization Role Management", })
+    @ApiResponses(value = { 
+        @ApiResponse(code = 200, message = "Role is successfully updated.", response = RolePutResponse.class),
+        @ApiResponse(code = 400, message = "Invalid input in the request.", response = Error.class),
+        @ApiResponse(code = 401, message = "Authentication information is missing or invalid.", response = Void.class),
+        @ApiResponse(code = 403, message = "Access forbidden.", response = Void.class),
+        @ApiResponse(code = 404, message = "Requested resource is not found.", response = Error.class),
+        @ApiResponse(code = 500, message = "Internal server error.", response = Error.class)
+    })
+    public Response organizationsOrganizationIdRolesRoleIdPut(@ApiParam(value = "ID of the role.",required=true) @PathParam("role-id") String roleId, @ApiParam(value = "ID of the organization.",required=true) @PathParam("organization-id") String organizationId, @ApiParam(value = "This represents a set of values that need to be changed in the role." ,required=true) @Valid RolePutRequest rolePutRequest) {
+
+        return delegate.organizationsOrganizationIdRolesRoleIdPut(roleId,  organizationId,  rolePutRequest );
+    }
+
+    @Valid
+    @GET
+    @Path("/{organization-id}/users/{user-id}/roles")
+    
+    @Produces({ "application/json" })
+    @ApiOperation(value = "Get user roles by user id", notes = "This API returns the list of roles assigned to a user against an organization. This API is not capable of returning users' assigned roles to other organizations except for the resident organization.", response = RoleObj.class, responseContainer = "List", authorizations = {
+        @Authorization(value = "BasicAuth"),
+        @Authorization(value = "OAuth2", scopes = {
+            
+        })
+    }, tags={ "Organization Role Management" })
+    @ApiResponses(value = { 
+        @ApiResponse(code = 200, message = "Valid user roles are found.", response = RoleObj.class, responseContainer = "List"),
+        @ApiResponse(code = 401, message = "Authentication information is missing or invalid.", response = Void.class),
+        @ApiResponse(code = 403, message = "Access forbidden.", response = Void.class),
+        @ApiResponse(code = 404, message = "Requested resource is not found.", response = Error.class),
+        @ApiResponse(code = 500, message = "Internal server error.", response = Error.class)
+    })
+    public Response organizationsOrganizationIdUsersUserIdRolesGet(@ApiParam(value = "ID of the user.",required=true) @PathParam("user-id") String userId, @ApiParam(value = "ID of the organization.",required=true) @PathParam("organization-id") String organizationId) {
+
+        return delegate.organizationsOrganizationIdUsersUserIdRolesGet(userId,  organizationId );
+    }
+
+}

--- a/components/org.wso2.carbon.identity.api.server.organization.role.management/org.wso2.carbon.identity.api.server.organization.role.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/role/management/v1/OrganizationsApiService.java
+++ b/components/org.wso2.carbon.identity.api.server.organization.role.management/org.wso2.carbon.identity.api.server.organization.role.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/role/management/v1/OrganizationsApiService.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.organization.role.management.v1;
+
+import org.wso2.carbon.identity.api.server.organization.role.management.v1.*;
+import org.wso2.carbon.identity.api.server.organization.role.management.v1.model.*;
+import org.apache.cxf.jaxrs.ext.multipart.Attachment;
+import org.apache.cxf.jaxrs.ext.multipart.Multipart;
+import java.io.InputStream;
+import java.util.List;
+import org.wso2.carbon.identity.api.server.organization.role.management.v1.model.Error;
+import org.wso2.carbon.identity.api.server.organization.role.management.v1.model.RoleGetResponse;
+import org.wso2.carbon.identity.api.server.organization.role.management.v1.model.RoleObj;
+import org.wso2.carbon.identity.api.server.organization.role.management.v1.model.RolePatchRequest;
+import org.wso2.carbon.identity.api.server.organization.role.management.v1.model.RolePatchResponse;
+import org.wso2.carbon.identity.api.server.organization.role.management.v1.model.RolePostRequest;
+import org.wso2.carbon.identity.api.server.organization.role.management.v1.model.RolePostResponse;
+import org.wso2.carbon.identity.api.server.organization.role.management.v1.model.RolePutRequest;
+import org.wso2.carbon.identity.api.server.organization.role.management.v1.model.RolePutResponse;
+import org.wso2.carbon.identity.api.server.organization.role.management.v1.model.RolesListResponse;
+import javax.ws.rs.core.Response;
+
+
+public interface OrganizationsApiService {
+
+      public Response createRole(String organizationId, RolePostRequest rolePostRequest);
+
+      public Response organizationsOrganizationIdRolesGet(String organizationId, String filter, Integer count, String cursor);
+
+      public Response organizationsOrganizationIdRolesRoleIdDelete(String roleId, String organizationId);
+
+      public Response organizationsOrganizationIdRolesRoleIdGet(String roleId, String organizationId);
+
+      public Response organizationsOrganizationIdRolesRoleIdPatch(String roleId, String organizationId, RolePatchRequest rolePatchRequest);
+
+      public Response organizationsOrganizationIdRolesRoleIdPut(String roleId, String organizationId, RolePutRequest rolePutRequest);
+
+      public Response organizationsOrganizationIdUsersUserIdRolesGet(String userId, String organizationId);
+}

--- a/components/org.wso2.carbon.identity.api.server.organization.role.management/org.wso2.carbon.identity.api.server.organization.role.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/role/management/v1/factories/OrganizationsApiServiceFactory.java
+++ b/components/org.wso2.carbon.identity.api.server.organization.role.management/org.wso2.carbon.identity.api.server.organization.role.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/role/management/v1/factories/OrganizationsApiServiceFactory.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.organization.role.management.v1.factories;
+
+import org.wso2.carbon.identity.api.server.organization.role.management.v1.OrganizationsApiService;
+import org.wso2.carbon.identity.api.server.organization.role.management.v1.impl.OrganizationsApiServiceImpl;
+
+public class OrganizationsApiServiceFactory {
+
+   private final static OrganizationsApiService service = new OrganizationsApiServiceImpl();
+
+   public static OrganizationsApiService getOrganizationsApi()
+   {
+      return service;
+   }
+}

--- a/components/org.wso2.carbon.identity.api.server.organization.role.management/org.wso2.carbon.identity.api.server.organization.role.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/role/management/v1/model/Error.java
+++ b/components/org.wso2.carbon.identity.api.server.organization.role.management/org.wso2.carbon.identity.api.server.organization.role.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/role/management/v1/model/Error.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.organization.role.management.v1.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import javax.validation.constraints.*;
+
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+import javax.validation.Valid;
+import javax.xml.bind.annotation.*;
+
+public class Error  {
+  
+    private String code;
+    private String message;
+    private String description;
+    private String traceId;
+
+    /**
+    * An error code.
+    **/
+    public Error code(String code) {
+
+        this.code = code;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "ORG-00000", required = true, value = "An error code.")
+    @JsonProperty("code")
+    @Valid
+    @NotNull(message = "Property code cannot be null.")
+
+    public String getCode() {
+        return code;
+    }
+    public void setCode(String code) {
+        this.code = code;
+    }
+
+    /**
+    * An error message.
+    **/
+    public Error message(String message) {
+
+        this.message = message;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "Some error message", required = true, value = "An error message.")
+    @JsonProperty("message")
+    @Valid
+    @NotNull(message = "Property message cannot be null.")
+
+    public String getMessage() {
+        return message;
+    }
+    public void setMessage(String message) {
+        this.message = message;
+    }
+
+    /**
+    * An error description.
+    **/
+    public Error description(String description) {
+
+        this.description = description;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "Some error description", value = "An error description.")
+    @JsonProperty("description")
+    @Valid
+    public String getDescription() {
+        return description;
+    }
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    /**
+    * An error trace identifier.
+    **/
+    public Error traceId(String traceId) {
+
+        this.traceId = traceId;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "e0fbcfeb-3617-43c4-8dd0-7b7d38e13047", value = "An error trace identifier.")
+    @JsonProperty("traceId")
+    @Valid
+    public String getTraceId() {
+        return traceId;
+    }
+    public void setTraceId(String traceId) {
+        this.traceId = traceId;
+    }
+
+
+
+    @Override
+    public boolean equals(java.lang.Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Error error = (Error) o;
+        return Objects.equals(this.code, error.code) &&
+            Objects.equals(this.message, error.message) &&
+            Objects.equals(this.description, error.description) &&
+            Objects.equals(this.traceId, error.traceId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(code, message, description, traceId);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class Error {\n");
+        
+        sb.append("    code: ").append(toIndentedString(code)).append("\n");
+        sb.append("    message: ").append(toIndentedString(message)).append("\n");
+        sb.append("    description: ").append(toIndentedString(description)).append("\n");
+        sb.append("    traceId: ").append(toIndentedString(traceId)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+    * Convert the given object to string with each line indented by 4 spaces
+    * (except the first line).
+    */
+    private String toIndentedString(java.lang.Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}
+

--- a/components/org.wso2.carbon.identity.api.server.organization.role.management/org.wso2.carbon.identity.api.server.organization.role.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/role/management/v1/model/RoleGetResponse.java
+++ b/components/org.wso2.carbon.identity.api.server.organization.role.management/org.wso2.carbon.identity.api.server.organization.role.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/role/management/v1/model/RoleGetResponse.java
@@ -1,0 +1,235 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.organization.role.management.v1.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import java.util.ArrayList;
+import java.util.List;
+import org.wso2.carbon.identity.api.server.organization.role.management.v1.model.RoleGetResponseGroup;
+import org.wso2.carbon.identity.api.server.organization.role.management.v1.model.RoleGetResponseUser;
+import org.wso2.carbon.identity.api.server.organization.role.management.v1.model.RoleObjMeta;
+import javax.validation.constraints.*;
+
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+import javax.validation.Valid;
+import javax.xml.bind.annotation.*;
+
+public class RoleGetResponse  {
+  
+    private String displayName;
+    private RoleObjMeta meta;
+    private String id;
+    private List<RoleGetResponseUser> users = null;
+
+    private List<RoleGetResponseGroup> groups = null;
+
+    private List<String> permissions = null;
+
+
+    /**
+    **/
+    public RoleGetResponse displayName(String displayName) {
+
+        this.displayName = displayName;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "loginRole", value = "")
+    @JsonProperty("displayName")
+    @Valid
+    public String getDisplayName() {
+        return displayName;
+    }
+    public void setDisplayName(String displayName) {
+        this.displayName = displayName;
+    }
+
+    /**
+    **/
+    public RoleGetResponse meta(RoleObjMeta meta) {
+
+        this.meta = meta;
+        return this;
+    }
+    
+    @ApiModelProperty(value = "")
+    @JsonProperty("meta")
+    @Valid
+    public RoleObjMeta getMeta() {
+        return meta;
+    }
+    public void setMeta(RoleObjMeta meta) {
+        this.meta = meta;
+    }
+
+    /**
+    **/
+    public RoleGetResponse id(String id) {
+
+        this.id = id;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "4645709c-ea8c-4495-8590-e1fa0efe3de0", value = "")
+    @JsonProperty("id")
+    @Valid
+    public String getId() {
+        return id;
+    }
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    /**
+    **/
+    public RoleGetResponse users(List<RoleGetResponseUser> users) {
+
+        this.users = users;
+        return this;
+    }
+    
+    @ApiModelProperty(value = "")
+    @JsonProperty("users")
+    @Valid
+    public List<RoleGetResponseUser> getUsers() {
+        return users;
+    }
+    public void setUsers(List<RoleGetResponseUser> users) {
+        this.users = users;
+    }
+
+    public RoleGetResponse addUsersItem(RoleGetResponseUser usersItem) {
+        if (this.users == null) {
+            this.users = new ArrayList<>();
+        }
+        this.users.add(usersItem);
+        return this;
+    }
+
+        /**
+    **/
+    public RoleGetResponse groups(List<RoleGetResponseGroup> groups) {
+
+        this.groups = groups;
+        return this;
+    }
+    
+    @ApiModelProperty(value = "")
+    @JsonProperty("groups")
+    @Valid
+    public List<RoleGetResponseGroup> getGroups() {
+        return groups;
+    }
+    public void setGroups(List<RoleGetResponseGroup> groups) {
+        this.groups = groups;
+    }
+
+    public RoleGetResponse addGroupsItem(RoleGetResponseGroup groupsItem) {
+        if (this.groups == null) {
+            this.groups = new ArrayList<>();
+        }
+        this.groups.add(groupsItem);
+        return this;
+    }
+
+        /**
+    **/
+    public RoleGetResponse permissions(List<String> permissions) {
+
+        this.permissions = permissions;
+        return this;
+    }
+    
+    @ApiModelProperty(value = "")
+    @JsonProperty("permissions")
+    @Valid
+    public List<String> getPermissions() {
+        return permissions;
+    }
+    public void setPermissions(List<String> permissions) {
+        this.permissions = permissions;
+    }
+
+    public RoleGetResponse addPermissionsItem(String permissionsItem) {
+        if (this.permissions == null) {
+            this.permissions = new ArrayList<>();
+        }
+        this.permissions.add(permissionsItem);
+        return this;
+    }
+
+    
+
+    @Override
+    public boolean equals(java.lang.Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        RoleGetResponse roleGetResponse = (RoleGetResponse) o;
+        return Objects.equals(this.displayName, roleGetResponse.displayName) &&
+            Objects.equals(this.meta, roleGetResponse.meta) &&
+            Objects.equals(this.id, roleGetResponse.id) &&
+            Objects.equals(this.users, roleGetResponse.users) &&
+            Objects.equals(this.groups, roleGetResponse.groups) &&
+            Objects.equals(this.permissions, roleGetResponse.permissions);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(displayName, meta, id, users, groups, permissions);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class RoleGetResponse {\n");
+        
+        sb.append("    displayName: ").append(toIndentedString(displayName)).append("\n");
+        sb.append("    meta: ").append(toIndentedString(meta)).append("\n");
+        sb.append("    id: ").append(toIndentedString(id)).append("\n");
+        sb.append("    users: ").append(toIndentedString(users)).append("\n");
+        sb.append("    groups: ").append(toIndentedString(groups)).append("\n");
+        sb.append("    permissions: ").append(toIndentedString(permissions)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+    * Convert the given object to string with each line indented by 4 spaces
+    * (except the first line).
+    */
+    private String toIndentedString(java.lang.Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}
+

--- a/components/org.wso2.carbon.identity.api.server.organization.role.management/org.wso2.carbon.identity.api.server.organization.role.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/role/management/v1/model/RoleGetResponseGroup.java
+++ b/components/org.wso2.carbon.identity.api.server.organization.role.management/org.wso2.carbon.identity.api.server.organization.role.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/role/management/v1/model/RoleGetResponseGroup.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.organization.role.management.v1.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import javax.validation.constraints.*;
+
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+import javax.validation.Valid;
+import javax.xml.bind.annotation.*;
+
+public class RoleGetResponseGroup  {
+  
+    private String $ref;
+    private String display;
+    private String value;
+
+    /**
+    **/
+    public RoleGetResponseGroup $ref(String $ref) {
+
+        this.$ref = $ref;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "https://localhost:9443/o/10084a8d-113f-4211-a0d5-efe36b082211/api/server/v1/organizations/48e31bc5-1669-4de1-bb22-c71e443aeb8b/groups/7bac6a86-1f21-4937-9fb1-5be4a93ef469", value = "")
+    @JsonProperty("$ref")
+    @Valid
+    public String get$Ref() {
+        return $ref;
+    }
+    public void set$Ref(String $ref) {
+        this.$ref = $ref;
+    }
+
+    /**
+    **/
+    public RoleGetResponseGroup display(String display) {
+
+        this.display = display;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "PRIMARY/manager", value = "")
+    @JsonProperty("display")
+    @Valid
+    public String getDisplay() {
+        return display;
+    }
+    public void setDisplay(String display) {
+        this.display = display;
+    }
+
+    /**
+    **/
+    public RoleGetResponseGroup value(String value) {
+
+        this.value = value;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "7bac6a86-1f21-4937-9fb1-5be4a93ef469", value = "")
+    @JsonProperty("value")
+    @Valid
+    public String getValue() {
+        return value;
+    }
+    public void setValue(String value) {
+        this.value = value;
+    }
+
+
+
+    @Override
+    public boolean equals(java.lang.Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        RoleGetResponseGroup roleGetResponseGroup = (RoleGetResponseGroup) o;
+        return Objects.equals(this.$ref, roleGetResponseGroup.$ref) &&
+            Objects.equals(this.display, roleGetResponseGroup.display) &&
+            Objects.equals(this.value, roleGetResponseGroup.value);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash($ref, display, value);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class RoleGetResponseGroup {\n");
+        
+        sb.append("    $ref: ").append(toIndentedString($ref)).append("\n");
+        sb.append("    display: ").append(toIndentedString(display)).append("\n");
+        sb.append("    value: ").append(toIndentedString(value)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+    * Convert the given object to string with each line indented by 4 spaces
+    * (except the first line).
+    */
+    private String toIndentedString(java.lang.Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}
+

--- a/components/org.wso2.carbon.identity.api.server.organization.role.management/org.wso2.carbon.identity.api.server.organization.role.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/role/management/v1/model/RoleGetResponseUser.java
+++ b/components/org.wso2.carbon.identity.api.server.organization.role.management/org.wso2.carbon.identity.api.server.organization.role.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/role/management/v1/model/RoleGetResponseUser.java
@@ -1,0 +1,182 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.organization.role.management.v1.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import javax.validation.constraints.*;
+
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+import javax.validation.Valid;
+import javax.xml.bind.annotation.*;
+
+public class RoleGetResponseUser  {
+  
+    private String $ref;
+    private String display;
+    private String value;
+    private String orgId;
+    private String orgName;
+
+    /**
+    **/
+    public RoleGetResponseUser $ref(String $ref) {
+
+        this.$ref = $ref;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "https://localhost:9443/o/e5198bbf-7448-49c9-b5f1-44ae2fa39bb6/scim2/Users/f78b1b05-dea5-4572-99c8-4dc649887c20", value = "")
+    @JsonProperty("$ref")
+    @Valid
+    public String get$Ref() {
+        return $ref;
+    }
+    public void set$Ref(String $ref) {
+        this.$ref = $ref;
+    }
+
+    /**
+    **/
+    public RoleGetResponseUser display(String display) {
+
+        this.display = display;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "kim", value = "")
+    @JsonProperty("display")
+    @Valid
+    public String getDisplay() {
+        return display;
+    }
+    public void setDisplay(String display) {
+        this.display = display;
+    }
+
+    /**
+    **/
+    public RoleGetResponseUser value(String value) {
+
+        this.value = value;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "3a12bae9-4386-44be-befd-caf349297f45", value = "")
+    @JsonProperty("value")
+    @Valid
+    public String getValue() {
+        return value;
+    }
+    public void setValue(String value) {
+        this.value = value;
+    }
+
+    /**
+    **/
+    public RoleGetResponseUser orgId(String orgId) {
+
+        this.orgId = orgId;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "48e31bc5-1669-4de1-bb22-c71e443aeb8b", value = "")
+    @JsonProperty("orgId")
+    @Valid
+    public String getOrgId() {
+        return orgId;
+    }
+    public void setOrgId(String orgId) {
+        this.orgId = orgId;
+    }
+
+    /**
+    **/
+    public RoleGetResponseUser orgName(String orgName) {
+
+        this.orgName = orgName;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "SubOrganization", value = "")
+    @JsonProperty("orgName")
+    @Valid
+    public String getOrgName() {
+        return orgName;
+    }
+    public void setOrgName(String orgName) {
+        this.orgName = orgName;
+    }
+
+
+
+    @Override
+    public boolean equals(java.lang.Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        RoleGetResponseUser roleGetResponseUser = (RoleGetResponseUser) o;
+        return Objects.equals(this.$ref, roleGetResponseUser.$ref) &&
+            Objects.equals(this.display, roleGetResponseUser.display) &&
+            Objects.equals(this.value, roleGetResponseUser.value) &&
+            Objects.equals(this.orgId, roleGetResponseUser.orgId) &&
+            Objects.equals(this.orgName, roleGetResponseUser.orgName);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash($ref, display, value, orgId, orgName);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class RoleGetResponseUser {\n");
+        
+        sb.append("    $ref: ").append(toIndentedString($ref)).append("\n");
+        sb.append("    display: ").append(toIndentedString(display)).append("\n");
+        sb.append("    value: ").append(toIndentedString(value)).append("\n");
+        sb.append("    orgId: ").append(toIndentedString(orgId)).append("\n");
+        sb.append("    orgName: ").append(toIndentedString(orgName)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+    * Convert the given object to string with each line indented by 4 spaces
+    * (except the first line).
+    */
+    private String toIndentedString(java.lang.Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}
+

--- a/components/org.wso2.carbon.identity.api.server.organization.role.management/org.wso2.carbon.identity.api.server.organization.role.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/role/management/v1/model/RoleObj.java
+++ b/components/org.wso2.carbon.identity.api.server.organization.role.management/org.wso2.carbon.identity.api.server.organization.role.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/role/management/v1/model/RoleObj.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.organization.role.management.v1.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import org.wso2.carbon.identity.api.server.organization.role.management.v1.model.RoleObjMeta;
+import javax.validation.constraints.*;
+
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+import javax.validation.Valid;
+import javax.xml.bind.annotation.*;
+
+public class RoleObj  {
+  
+    private String id;
+    private String displayName;
+    private RoleObjMeta meta;
+
+    /**
+    **/
+    public RoleObj id(String id) {
+
+        this.id = id;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "4645709c-ea8c-4495-8590-e1fa0efe3de0", value = "")
+    @JsonProperty("id")
+    @Valid
+    public String getId() {
+        return id;
+    }
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    /**
+    **/
+    public RoleObj displayName(String displayName) {
+
+        this.displayName = displayName;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "loginRole", value = "")
+    @JsonProperty("displayName")
+    @Valid
+    public String getDisplayName() {
+        return displayName;
+    }
+    public void setDisplayName(String displayName) {
+        this.displayName = displayName;
+    }
+
+    /**
+    **/
+    public RoleObj meta(RoleObjMeta meta) {
+
+        this.meta = meta;
+        return this;
+    }
+    
+    @ApiModelProperty(value = "")
+    @JsonProperty("meta")
+    @Valid
+    public RoleObjMeta getMeta() {
+        return meta;
+    }
+    public void setMeta(RoleObjMeta meta) {
+        this.meta = meta;
+    }
+
+
+
+    @Override
+    public boolean equals(java.lang.Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        RoleObj roleObj = (RoleObj) o;
+        return Objects.equals(this.id, roleObj.id) &&
+            Objects.equals(this.displayName, roleObj.displayName) &&
+            Objects.equals(this.meta, roleObj.meta);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, displayName, meta);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class RoleObj {\n");
+        
+        sb.append("    id: ").append(toIndentedString(id)).append("\n");
+        sb.append("    displayName: ").append(toIndentedString(displayName)).append("\n");
+        sb.append("    meta: ").append(toIndentedString(meta)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+    * Convert the given object to string with each line indented by 4 spaces
+    * (except the first line).
+    */
+    private String toIndentedString(java.lang.Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}
+

--- a/components/org.wso2.carbon.identity.api.server.organization.role.management/org.wso2.carbon.identity.api.server.organization.role.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/role/management/v1/model/RoleObjMeta.java
+++ b/components/org.wso2.carbon.identity.api.server.organization.role.management/org.wso2.carbon.identity.api.server.organization.role.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/role/management/v1/model/RoleObjMeta.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.organization.role.management.v1.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import javax.validation.constraints.*;
+
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+import javax.validation.Valid;
+import javax.xml.bind.annotation.*;
+
+public class RoleObjMeta  {
+  
+    private String location;
+
+    /**
+    **/
+    public RoleObjMeta location(String location) {
+
+        this.location = location;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "https://localhost:9443/o/10084a8d-113f-4211-a0d5-efe36b082211/api/server/v1/organizations/48e31bc5-1669-4de1-bb22-c71e443aeb8b/roles/4645709c-ea8c-4495-8590-e1fa0efe3de0", value = "")
+    @JsonProperty("location")
+    @Valid
+    public String getLocation() {
+        return location;
+    }
+    public void setLocation(String location) {
+        this.location = location;
+    }
+
+
+
+    @Override
+    public boolean equals(java.lang.Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        RoleObjMeta roleObjMeta = (RoleObjMeta) o;
+        return Objects.equals(this.location, roleObjMeta.location);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(location);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class RoleObjMeta {\n");
+        
+        sb.append("    location: ").append(toIndentedString(location)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+    * Convert the given object to string with each line indented by 4 spaces
+    * (except the first line).
+    */
+    private String toIndentedString(java.lang.Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}
+

--- a/components/org.wso2.carbon.identity.api.server.organization.role.management/org.wso2.carbon.identity.api.server.organization.role.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/role/management/v1/model/RolePatchOperation.java
+++ b/components/org.wso2.carbon.identity.api.server.organization.role.management/org.wso2.carbon.identity.api.server.organization.role.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/role/management/v1/model/RolePatchOperation.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.organization.role.management.v1.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import java.util.ArrayList;
+import java.util.List;
+import javax.validation.constraints.*;
+
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+import javax.validation.Valid;
+import javax.xml.bind.annotation.*;
+
+public class RolePatchOperation  {
+  
+
+@XmlType(name="OpEnum")
+@XmlEnum(String.class)
+public enum OpEnum {
+
+    @XmlEnumValue("add") ADD(String.valueOf("add")), @XmlEnumValue("remove") REMOVE(String.valueOf("remove")), @XmlEnumValue("replace") REPLACE(String.valueOf("replace"));
+
+
+    private String value;
+
+    OpEnum(String v) {
+        value = v;
+    }
+
+    public String value() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    public static OpEnum fromValue(String value) {
+        for (OpEnum b : OpEnum.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
+}
+
+    private OpEnum op;
+    private String path;
+    private List<String> value = null;
+
+
+    /**
+    **/
+    public RolePatchOperation op(OpEnum op) {
+
+        this.op = op;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "add", value = "")
+    @JsonProperty("op")
+    @Valid
+    public OpEnum getOp() {
+        return op;
+    }
+    public void setOp(OpEnum op) {
+        this.op = op;
+    }
+
+    /**
+    **/
+    public RolePatchOperation path(String path) {
+
+        this.path = path;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "groups", value = "")
+    @JsonProperty("path")
+    @Valid
+    public String getPath() {
+        return path;
+    }
+    public void setPath(String path) {
+        this.path = path;
+    }
+
+    /**
+    **/
+    public RolePatchOperation value(List<String> value) {
+
+        this.value = value;
+        return this;
+    }
+    
+    @ApiModelProperty(value = "")
+    @JsonProperty("value")
+    @Valid
+    public List<String> getValue() {
+        return value;
+    }
+    public void setValue(List<String> value) {
+        this.value = value;
+    }
+
+    public RolePatchOperation addValueItem(String valueItem) {
+        if (this.value == null) {
+            this.value = new ArrayList<>();
+        }
+        this.value.add(valueItem);
+        return this;
+    }
+
+    
+
+    @Override
+    public boolean equals(java.lang.Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        RolePatchOperation rolePatchOperation = (RolePatchOperation) o;
+        return Objects.equals(this.op, rolePatchOperation.op) &&
+            Objects.equals(this.path, rolePatchOperation.path) &&
+            Objects.equals(this.value, rolePatchOperation.value);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(op, path, value);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class RolePatchOperation {\n");
+        
+        sb.append("    op: ").append(toIndentedString(op)).append("\n");
+        sb.append("    path: ").append(toIndentedString(path)).append("\n");
+        sb.append("    value: ").append(toIndentedString(value)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+    * Convert the given object to string with each line indented by 4 spaces
+    * (except the first line).
+    */
+    private String toIndentedString(java.lang.Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}
+

--- a/components/org.wso2.carbon.identity.api.server.organization.role.management/org.wso2.carbon.identity.api.server.organization.role.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/role/management/v1/model/RolePatchRequest.java
+++ b/components/org.wso2.carbon.identity.api.server.organization.role.management/org.wso2.carbon.identity.api.server.organization.role.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/role/management/v1/model/RolePatchRequest.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.organization.role.management.v1.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import java.util.ArrayList;
+import java.util.List;
+import org.wso2.carbon.identity.api.server.organization.role.management.v1.model.RolePatchOperation;
+import javax.validation.constraints.*;
+
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+import javax.validation.Valid;
+import javax.xml.bind.annotation.*;
+
+public class RolePatchRequest  {
+  
+    private List<RolePatchOperation> operations = null;
+
+
+    /**
+    **/
+    public RolePatchRequest operations(List<RolePatchOperation> operations) {
+
+        this.operations = operations;
+        return this;
+    }
+    
+    @ApiModelProperty(value = "")
+    @JsonProperty("operations")
+    @Valid
+    public List<RolePatchOperation> getOperations() {
+        return operations;
+    }
+    public void setOperations(List<RolePatchOperation> operations) {
+        this.operations = operations;
+    }
+
+    public RolePatchRequest addOperationsItem(RolePatchOperation operationsItem) {
+        if (this.operations == null) {
+            this.operations = new ArrayList<>();
+        }
+        this.operations.add(operationsItem);
+        return this;
+    }
+
+    
+
+    @Override
+    public boolean equals(java.lang.Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        RolePatchRequest rolePatchRequest = (RolePatchRequest) o;
+        return Objects.equals(this.operations, rolePatchRequest.operations);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(operations);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class RolePatchRequest {\n");
+        
+        sb.append("    operations: ").append(toIndentedString(operations)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+    * Convert the given object to string with each line indented by 4 spaces
+    * (except the first line).
+    */
+    private String toIndentedString(java.lang.Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}
+

--- a/components/org.wso2.carbon.identity.api.server.organization.role.management/org.wso2.carbon.identity.api.server.organization.role.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/role/management/v1/model/RolePatchResponse.java
+++ b/components/org.wso2.carbon.identity.api.server.organization.role.management/org.wso2.carbon.identity.api.server.organization.role.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/role/management/v1/model/RolePatchResponse.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.organization.role.management.v1.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import org.wso2.carbon.identity.api.server.organization.role.management.v1.model.RolePutResponseMeta;
+import javax.validation.constraints.*;
+
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+import javax.validation.Valid;
+import javax.xml.bind.annotation.*;
+
+public class RolePatchResponse  {
+  
+    private String displayName;
+    private RolePutResponseMeta meta;
+    private String id;
+
+    /**
+    **/
+    public RolePatchResponse displayName(String displayName) {
+
+        this.displayName = displayName;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "loginRole", value = "")
+    @JsonProperty("displayName")
+    @Valid
+    public String getDisplayName() {
+        return displayName;
+    }
+    public void setDisplayName(String displayName) {
+        this.displayName = displayName;
+    }
+
+    /**
+    **/
+    public RolePatchResponse meta(RolePutResponseMeta meta) {
+
+        this.meta = meta;
+        return this;
+    }
+    
+    @ApiModelProperty(value = "")
+    @JsonProperty("meta")
+    @Valid
+    public RolePutResponseMeta getMeta() {
+        return meta;
+    }
+    public void setMeta(RolePutResponseMeta meta) {
+        this.meta = meta;
+    }
+
+    /**
+    **/
+    public RolePatchResponse id(String id) {
+
+        this.id = id;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "4645709c-ea8c-4495-8590-e1fa0fe3de0", value = "")
+    @JsonProperty("id")
+    @Valid
+    public String getId() {
+        return id;
+    }
+    public void setId(String id) {
+        this.id = id;
+    }
+
+
+
+    @Override
+    public boolean equals(java.lang.Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        RolePatchResponse rolePatchResponse = (RolePatchResponse) o;
+        return Objects.equals(this.displayName, rolePatchResponse.displayName) &&
+            Objects.equals(this.meta, rolePatchResponse.meta) &&
+            Objects.equals(this.id, rolePatchResponse.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(displayName, meta, id);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class RolePatchResponse {\n");
+        
+        sb.append("    displayName: ").append(toIndentedString(displayName)).append("\n");
+        sb.append("    meta: ").append(toIndentedString(meta)).append("\n");
+        sb.append("    id: ").append(toIndentedString(id)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+    * Convert the given object to string with each line indented by 4 spaces
+    * (except the first line).
+    */
+    private String toIndentedString(java.lang.Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}
+

--- a/components/org.wso2.carbon.identity.api.server.organization.role.management/org.wso2.carbon.identity.api.server.organization.role.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/role/management/v1/model/RolePostRequest.java
+++ b/components/org.wso2.carbon.identity.api.server.organization.role.management/org.wso2.carbon.identity.api.server.organization.role.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/role/management/v1/model/RolePostRequest.java
@@ -1,0 +1,194 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.organization.role.management.v1.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import java.util.ArrayList;
+import java.util.List;
+import org.wso2.carbon.identity.api.server.organization.role.management.v1.model.RolePostRequestGroup;
+import org.wso2.carbon.identity.api.server.organization.role.management.v1.model.RolePostRequestUser;
+import javax.validation.constraints.*;
+
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+import javax.validation.Valid;
+import javax.xml.bind.annotation.*;
+
+public class RolePostRequest  {
+  
+    private String displayName;
+    private List<RolePostRequestUser> users = null;
+
+    private List<RolePostRequestGroup> groups = null;
+
+    private List<String> permissions = null;
+
+
+    /**
+    **/
+    public RolePostRequest displayName(String displayName) {
+
+        this.displayName = displayName;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "loginRole", required = true, value = "")
+    @JsonProperty("displayName")
+    @Valid
+    @NotNull(message = "Property displayName cannot be null.")
+
+    public String getDisplayName() {
+        return displayName;
+    }
+    public void setDisplayName(String displayName) {
+        this.displayName = displayName;
+    }
+
+    /**
+    **/
+    public RolePostRequest users(List<RolePostRequestUser> users) {
+
+        this.users = users;
+        return this;
+    }
+    
+    @ApiModelProperty(value = "")
+    @JsonProperty("users")
+    @Valid
+    public List<RolePostRequestUser> getUsers() {
+        return users;
+    }
+    public void setUsers(List<RolePostRequestUser> users) {
+        this.users = users;
+    }
+
+    public RolePostRequest addUsersItem(RolePostRequestUser usersItem) {
+        if (this.users == null) {
+            this.users = new ArrayList<>();
+        }
+        this.users.add(usersItem);
+        return this;
+    }
+
+        /**
+    **/
+    public RolePostRequest groups(List<RolePostRequestGroup> groups) {
+
+        this.groups = groups;
+        return this;
+    }
+    
+    @ApiModelProperty(value = "")
+    @JsonProperty("groups")
+    @Valid
+    public List<RolePostRequestGroup> getGroups() {
+        return groups;
+    }
+    public void setGroups(List<RolePostRequestGroup> groups) {
+        this.groups = groups;
+    }
+
+    public RolePostRequest addGroupsItem(RolePostRequestGroup groupsItem) {
+        if (this.groups == null) {
+            this.groups = new ArrayList<>();
+        }
+        this.groups.add(groupsItem);
+        return this;
+    }
+
+        /**
+    **/
+    public RolePostRequest permissions(List<String> permissions) {
+
+        this.permissions = permissions;
+        return this;
+    }
+    
+    @ApiModelProperty(value = "")
+    @JsonProperty("permissions")
+    @Valid
+    public List<String> getPermissions() {
+        return permissions;
+    }
+    public void setPermissions(List<String> permissions) {
+        this.permissions = permissions;
+    }
+
+    public RolePostRequest addPermissionsItem(String permissionsItem) {
+        if (this.permissions == null) {
+            this.permissions = new ArrayList<>();
+        }
+        this.permissions.add(permissionsItem);
+        return this;
+    }
+
+    
+
+    @Override
+    public boolean equals(java.lang.Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        RolePostRequest rolePostRequest = (RolePostRequest) o;
+        return Objects.equals(this.displayName, rolePostRequest.displayName) &&
+            Objects.equals(this.users, rolePostRequest.users) &&
+            Objects.equals(this.groups, rolePostRequest.groups) &&
+            Objects.equals(this.permissions, rolePostRequest.permissions);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(displayName, users, groups, permissions);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class RolePostRequest {\n");
+        
+        sb.append("    displayName: ").append(toIndentedString(displayName)).append("\n");
+        sb.append("    users: ").append(toIndentedString(users)).append("\n");
+        sb.append("    groups: ").append(toIndentedString(groups)).append("\n");
+        sb.append("    permissions: ").append(toIndentedString(permissions)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+    * Convert the given object to string with each line indented by 4 spaces
+    * (except the first line).
+    */
+    private String toIndentedString(java.lang.Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}
+

--- a/components/org.wso2.carbon.identity.api.server.organization.role.management/org.wso2.carbon.identity.api.server.organization.role.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/role/management/v1/model/RolePostRequestGroup.java
+++ b/components/org.wso2.carbon.identity.api.server.organization.role.management/org.wso2.carbon.identity.api.server.organization.role.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/role/management/v1/model/RolePostRequestGroup.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.organization.role.management.v1.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import javax.validation.constraints.*;
+
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+import javax.validation.Valid;
+import javax.xml.bind.annotation.*;
+
+public class RolePostRequestGroup  {
+  
+    private String value;
+
+    /**
+    **/
+    public RolePostRequestGroup value(String value) {
+
+        this.value = value;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "7bac6a86-1f21-4937-9fb1-5be4a93ef469", value = "")
+    @JsonProperty("value")
+    @Valid
+    public String getValue() {
+        return value;
+    }
+    public void setValue(String value) {
+        this.value = value;
+    }
+
+
+
+    @Override
+    public boolean equals(java.lang.Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        RolePostRequestGroup rolePostRequestGroup = (RolePostRequestGroup) o;
+        return Objects.equals(this.value, rolePostRequestGroup.value);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(value);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class RolePostRequestGroup {\n");
+        
+        sb.append("    value: ").append(toIndentedString(value)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+    * Convert the given object to string with each line indented by 4 spaces
+    * (except the first line).
+    */
+    private String toIndentedString(java.lang.Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}
+

--- a/components/org.wso2.carbon.identity.api.server.organization.role.management/org.wso2.carbon.identity.api.server.organization.role.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/role/management/v1/model/RolePostRequestUser.java
+++ b/components/org.wso2.carbon.identity.api.server.organization.role.management/org.wso2.carbon.identity.api.server.organization.role.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/role/management/v1/model/RolePostRequestUser.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.organization.role.management.v1.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import javax.validation.constraints.*;
+
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+import javax.validation.Valid;
+import javax.xml.bind.annotation.*;
+
+public class RolePostRequestUser  {
+  
+    private String value;
+
+    /**
+    **/
+    public RolePostRequestUser value(String value) {
+
+        this.value = value;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "008bba85-451d-414b-87de-c03b5a1f4217", value = "")
+    @JsonProperty("value")
+    @Valid
+    public String getValue() {
+        return value;
+    }
+    public void setValue(String value) {
+        this.value = value;
+    }
+
+
+
+    @Override
+    public boolean equals(java.lang.Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        RolePostRequestUser rolePostRequestUser = (RolePostRequestUser) o;
+        return Objects.equals(this.value, rolePostRequestUser.value);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(value);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class RolePostRequestUser {\n");
+        
+        sb.append("    value: ").append(toIndentedString(value)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+    * Convert the given object to string with each line indented by 4 spaces
+    * (except the first line).
+    */
+    private String toIndentedString(java.lang.Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}
+

--- a/components/org.wso2.carbon.identity.api.server.organization.role.management/org.wso2.carbon.identity.api.server.organization.role.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/role/management/v1/model/RolePostResponse.java
+++ b/components/org.wso2.carbon.identity.api.server.organization.role.management/org.wso2.carbon.identity.api.server.organization.role.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/role/management/v1/model/RolePostResponse.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.organization.role.management.v1.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import org.wso2.carbon.identity.api.server.organization.role.management.v1.model.RoleObjMeta;
+import javax.validation.constraints.*;
+
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+import javax.validation.Valid;
+import javax.xml.bind.annotation.*;
+
+public class RolePostResponse  {
+  
+    private String displayName;
+    private RoleObjMeta meta;
+    private String id;
+
+    /**
+    **/
+    public RolePostResponse displayName(String displayName) {
+
+        this.displayName = displayName;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "loginRole", value = "")
+    @JsonProperty("displayName")
+    @Valid
+    public String getDisplayName() {
+        return displayName;
+    }
+    public void setDisplayName(String displayName) {
+        this.displayName = displayName;
+    }
+
+    /**
+    **/
+    public RolePostResponse meta(RoleObjMeta meta) {
+
+        this.meta = meta;
+        return this;
+    }
+    
+    @ApiModelProperty(value = "")
+    @JsonProperty("meta")
+    @Valid
+    public RoleObjMeta getMeta() {
+        return meta;
+    }
+    public void setMeta(RoleObjMeta meta) {
+        this.meta = meta;
+    }
+
+    /**
+    **/
+    public RolePostResponse id(String id) {
+
+        this.id = id;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "4645709c-ea8c-4495-8590-e1fa0efe3de0", value = "")
+    @JsonProperty("id")
+    @Valid
+    public String getId() {
+        return id;
+    }
+    public void setId(String id) {
+        this.id = id;
+    }
+
+
+
+    @Override
+    public boolean equals(java.lang.Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        RolePostResponse rolePostResponse = (RolePostResponse) o;
+        return Objects.equals(this.displayName, rolePostResponse.displayName) &&
+            Objects.equals(this.meta, rolePostResponse.meta) &&
+            Objects.equals(this.id, rolePostResponse.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(displayName, meta, id);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class RolePostResponse {\n");
+        
+        sb.append("    displayName: ").append(toIndentedString(displayName)).append("\n");
+        sb.append("    meta: ").append(toIndentedString(meta)).append("\n");
+        sb.append("    id: ").append(toIndentedString(id)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+    * Convert the given object to string with each line indented by 4 spaces
+    * (except the first line).
+    */
+    private String toIndentedString(java.lang.Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}
+

--- a/components/org.wso2.carbon.identity.api.server.organization.role.management/org.wso2.carbon.identity.api.server.organization.role.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/role/management/v1/model/RolePutRequest.java
+++ b/components/org.wso2.carbon.identity.api.server.organization.role.management/org.wso2.carbon.identity.api.server.organization.role.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/role/management/v1/model/RolePutRequest.java
@@ -1,0 +1,194 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.organization.role.management.v1.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import java.util.ArrayList;
+import java.util.List;
+import org.wso2.carbon.identity.api.server.organization.role.management.v1.model.RolePutRequestGroup;
+import org.wso2.carbon.identity.api.server.organization.role.management.v1.model.RolePutRequestUser;
+import javax.validation.constraints.*;
+
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+import javax.validation.Valid;
+import javax.xml.bind.annotation.*;
+
+public class RolePutRequest  {
+  
+    private String displayName;
+    private List<RolePutRequestUser> users = null;
+
+    private List<RolePutRequestGroup> groups = null;
+
+    private List<String> permissions = null;
+
+
+    /**
+    **/
+    public RolePutRequest displayName(String displayName) {
+
+        this.displayName = displayName;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "loginRole", required = true, value = "")
+    @JsonProperty("displayName")
+    @Valid
+    @NotNull(message = "Property displayName cannot be null.")
+
+    public String getDisplayName() {
+        return displayName;
+    }
+    public void setDisplayName(String displayName) {
+        this.displayName = displayName;
+    }
+
+    /**
+    **/
+    public RolePutRequest users(List<RolePutRequestUser> users) {
+
+        this.users = users;
+        return this;
+    }
+    
+    @ApiModelProperty(value = "")
+    @JsonProperty("users")
+    @Valid
+    public List<RolePutRequestUser> getUsers() {
+        return users;
+    }
+    public void setUsers(List<RolePutRequestUser> users) {
+        this.users = users;
+    }
+
+    public RolePutRequest addUsersItem(RolePutRequestUser usersItem) {
+        if (this.users == null) {
+            this.users = new ArrayList<>();
+        }
+        this.users.add(usersItem);
+        return this;
+    }
+
+        /**
+    **/
+    public RolePutRequest groups(List<RolePutRequestGroup> groups) {
+
+        this.groups = groups;
+        return this;
+    }
+    
+    @ApiModelProperty(value = "")
+    @JsonProperty("groups")
+    @Valid
+    public List<RolePutRequestGroup> getGroups() {
+        return groups;
+    }
+    public void setGroups(List<RolePutRequestGroup> groups) {
+        this.groups = groups;
+    }
+
+    public RolePutRequest addGroupsItem(RolePutRequestGroup groupsItem) {
+        if (this.groups == null) {
+            this.groups = new ArrayList<>();
+        }
+        this.groups.add(groupsItem);
+        return this;
+    }
+
+        /**
+    **/
+    public RolePutRequest permissions(List<String> permissions) {
+
+        this.permissions = permissions;
+        return this;
+    }
+    
+    @ApiModelProperty(value = "")
+    @JsonProperty("permissions")
+    @Valid
+    public List<String> getPermissions() {
+        return permissions;
+    }
+    public void setPermissions(List<String> permissions) {
+        this.permissions = permissions;
+    }
+
+    public RolePutRequest addPermissionsItem(String permissionsItem) {
+        if (this.permissions == null) {
+            this.permissions = new ArrayList<>();
+        }
+        this.permissions.add(permissionsItem);
+        return this;
+    }
+
+    
+
+    @Override
+    public boolean equals(java.lang.Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        RolePutRequest rolePutRequest = (RolePutRequest) o;
+        return Objects.equals(this.displayName, rolePutRequest.displayName) &&
+            Objects.equals(this.users, rolePutRequest.users) &&
+            Objects.equals(this.groups, rolePutRequest.groups) &&
+            Objects.equals(this.permissions, rolePutRequest.permissions);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(displayName, users, groups, permissions);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class RolePutRequest {\n");
+        
+        sb.append("    displayName: ").append(toIndentedString(displayName)).append("\n");
+        sb.append("    users: ").append(toIndentedString(users)).append("\n");
+        sb.append("    groups: ").append(toIndentedString(groups)).append("\n");
+        sb.append("    permissions: ").append(toIndentedString(permissions)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+    * Convert the given object to string with each line indented by 4 spaces
+    * (except the first line).
+    */
+    private String toIndentedString(java.lang.Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}
+

--- a/components/org.wso2.carbon.identity.api.server.organization.role.management/org.wso2.carbon.identity.api.server.organization.role.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/role/management/v1/model/RolePutRequestGroup.java
+++ b/components/org.wso2.carbon.identity.api.server.organization.role.management/org.wso2.carbon.identity.api.server.organization.role.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/role/management/v1/model/RolePutRequestGroup.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.organization.role.management.v1.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import javax.validation.constraints.*;
+
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+import javax.validation.Valid;
+import javax.xml.bind.annotation.*;
+
+public class RolePutRequestGroup  {
+  
+    private String value;
+
+    /**
+    **/
+    public RolePutRequestGroup value(String value) {
+
+        this.value = value;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "7bac6a86-1f21-4937-9fb1-5be4a93ef469", value = "")
+    @JsonProperty("value")
+    @Valid
+    public String getValue() {
+        return value;
+    }
+    public void setValue(String value) {
+        this.value = value;
+    }
+
+
+
+    @Override
+    public boolean equals(java.lang.Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        RolePutRequestGroup rolePutRequestGroup = (RolePutRequestGroup) o;
+        return Objects.equals(this.value, rolePutRequestGroup.value);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(value);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class RolePutRequestGroup {\n");
+        
+        sb.append("    value: ").append(toIndentedString(value)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+    * Convert the given object to string with each line indented by 4 spaces
+    * (except the first line).
+    */
+    private String toIndentedString(java.lang.Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}
+

--- a/components/org.wso2.carbon.identity.api.server.organization.role.management/org.wso2.carbon.identity.api.server.organization.role.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/role/management/v1/model/RolePutRequestUser.java
+++ b/components/org.wso2.carbon.identity.api.server.organization.role.management/org.wso2.carbon.identity.api.server.organization.role.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/role/management/v1/model/RolePutRequestUser.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.organization.role.management.v1.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import javax.validation.constraints.*;
+
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+import javax.validation.Valid;
+import javax.xml.bind.annotation.*;
+
+public class RolePutRequestUser  {
+  
+    private String value;
+
+    /**
+    **/
+    public RolePutRequestUser value(String value) {
+
+        this.value = value;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "409ca90b-2ba6-4474-9a45-2cf7376e6e43", value = "")
+    @JsonProperty("value")
+    @Valid
+    public String getValue() {
+        return value;
+    }
+    public void setValue(String value) {
+        this.value = value;
+    }
+
+
+
+    @Override
+    public boolean equals(java.lang.Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        RolePutRequestUser rolePutRequestUser = (RolePutRequestUser) o;
+        return Objects.equals(this.value, rolePutRequestUser.value);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(value);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class RolePutRequestUser {\n");
+        
+        sb.append("    value: ").append(toIndentedString(value)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+    * Convert the given object to string with each line indented by 4 spaces
+    * (except the first line).
+    */
+    private String toIndentedString(java.lang.Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}
+

--- a/components/org.wso2.carbon.identity.api.server.organization.role.management/org.wso2.carbon.identity.api.server.organization.role.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/role/management/v1/model/RolePutResponse.java
+++ b/components/org.wso2.carbon.identity.api.server.organization.role.management/org.wso2.carbon.identity.api.server.organization.role.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/role/management/v1/model/RolePutResponse.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.organization.role.management.v1.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import org.wso2.carbon.identity.api.server.organization.role.management.v1.model.RolePutResponseMeta;
+import javax.validation.constraints.*;
+
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+import javax.validation.Valid;
+import javax.xml.bind.annotation.*;
+
+public class RolePutResponse  {
+  
+    private String displayName;
+    private RolePutResponseMeta meta;
+    private String value;
+
+    /**
+    **/
+    public RolePutResponse displayName(String displayName) {
+
+        this.displayName = displayName;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "loginRole", value = "")
+    @JsonProperty("displayName")
+    @Valid
+    public String getDisplayName() {
+        return displayName;
+    }
+    public void setDisplayName(String displayName) {
+        this.displayName = displayName;
+    }
+
+    /**
+    **/
+    public RolePutResponse meta(RolePutResponseMeta meta) {
+
+        this.meta = meta;
+        return this;
+    }
+    
+    @ApiModelProperty(value = "")
+    @JsonProperty("meta")
+    @Valid
+    public RolePutResponseMeta getMeta() {
+        return meta;
+    }
+    public void setMeta(RolePutResponseMeta meta) {
+        this.meta = meta;
+    }
+
+    /**
+    **/
+    public RolePutResponse value(String value) {
+
+        this.value = value;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "4645709c-ea8c-4495-8590-e1fa0fe3de0", value = "")
+    @JsonProperty("value")
+    @Valid
+    public String getValue() {
+        return value;
+    }
+    public void setValue(String value) {
+        this.value = value;
+    }
+
+
+
+    @Override
+    public boolean equals(java.lang.Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        RolePutResponse rolePutResponse = (RolePutResponse) o;
+        return Objects.equals(this.displayName, rolePutResponse.displayName) &&
+            Objects.equals(this.meta, rolePutResponse.meta) &&
+            Objects.equals(this.value, rolePutResponse.value);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(displayName, meta, value);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class RolePutResponse {\n");
+        
+        sb.append("    displayName: ").append(toIndentedString(displayName)).append("\n");
+        sb.append("    meta: ").append(toIndentedString(meta)).append("\n");
+        sb.append("    value: ").append(toIndentedString(value)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+    * Convert the given object to string with each line indented by 4 spaces
+    * (except the first line).
+    */
+    private String toIndentedString(java.lang.Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}
+

--- a/components/org.wso2.carbon.identity.api.server.organization.role.management/org.wso2.carbon.identity.api.server.organization.role.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/role/management/v1/model/RolePutResponseMeta.java
+++ b/components/org.wso2.carbon.identity.api.server.organization.role.management/org.wso2.carbon.identity.api.server.organization.role.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/role/management/v1/model/RolePutResponseMeta.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.organization.role.management.v1.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import javax.validation.constraints.*;
+
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+import javax.validation.Valid;
+import javax.xml.bind.annotation.*;
+
+public class RolePutResponseMeta  {
+  
+    private String location;
+
+    /**
+    **/
+    public RolePutResponseMeta location(String location) {
+
+        this.location = location;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "https://localhost:9443/o/10084a8d-113f-4211-a0d5-efe36b082211/api/server/v1/organizations/48e31bc5-1669-4de1-bb22-c71e443aeb8b/roles/4645709c-ea8c-4495-8590-e1fa0fe3de0", value = "")
+    @JsonProperty("location")
+    @Valid
+    public String getLocation() {
+        return location;
+    }
+    public void setLocation(String location) {
+        this.location = location;
+    }
+
+
+
+    @Override
+    public boolean equals(java.lang.Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        RolePutResponseMeta rolePutResponseMeta = (RolePutResponseMeta) o;
+        return Objects.equals(this.location, rolePutResponseMeta.location);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(location);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class RolePutResponseMeta {\n");
+        
+        sb.append("    location: ").append(toIndentedString(location)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+    * Convert the given object to string with each line indented by 4 spaces
+    * (except the first line).
+    */
+    private String toIndentedString(java.lang.Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}
+

--- a/components/org.wso2.carbon.identity.api.server.organization.role.management/org.wso2.carbon.identity.api.server.organization.role.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/role/management/v1/model/RolesListResponse.java
+++ b/components/org.wso2.carbon.identity.api.server.organization.role.management/org.wso2.carbon.identity.api.server.organization.role.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/role/management/v1/model/RolesListResponse.java
@@ -1,0 +1,198 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.organization.role.management.v1.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import java.util.ArrayList;
+import java.util.List;
+import org.wso2.carbon.identity.api.server.organization.role.management.v1.model.RoleObj;
+import javax.validation.constraints.*;
+
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+import javax.validation.Valid;
+import javax.xml.bind.annotation.*;
+
+public class RolesListResponse  {
+  
+    private Integer totalResults;
+    private String nextCursor;
+    private String previousCursor;
+    private Integer itemsPerPage;
+    private List<RoleObj> resources = null;
+
+
+    /**
+    * Total results to be fetched.
+    **/
+    public RolesListResponse totalResults(Integer totalResults) {
+
+        this.totalResults = totalResults;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "100", value = "Total results to be fetched.")
+    @JsonProperty("totalResults")
+    @Valid
+    public Integer getTotalResults() {
+        return totalResults;
+    }
+    public void setTotalResults(Integer totalResults) {
+        this.totalResults = totalResults;
+    }
+
+    /**
+    * A cursor to obtain the next page of results in a subsequent request.
+    **/
+    public RolesListResponse nextCursor(String nextCursor) {
+
+        this.nextCursor = nextCursor;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "eyJjdXJzb3JWYWx1ZSI6ImQgcm9sZSIsImRpcmVjdGlvbiI6IkZPUldBUkQifQ", value = "A cursor to obtain the next page of results in a subsequent request.")
+    @JsonProperty("nextCursor")
+    @Valid
+    public String getNextCursor() {
+        return nextCursor;
+    }
+    public void setNextCursor(String nextCursor) {
+        this.nextCursor = nextCursor;
+    }
+
+    /**
+    * A cursor to obtain the previous page of results in a subsequent request.
+    **/
+    public RolesListResponse previousCursor(String previousCursor) {
+
+        this.previousCursor = previousCursor;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "eyJjdXJzb3JWYWx1ZSI6ImIgcm9sZSIsImRpcmVjdGlvbiI6IkJBQ0tXQVJEIn0", value = "A cursor to obtain the previous page of results in a subsequent request.")
+    @JsonProperty("previousCursor")
+    @Valid
+    public String getPreviousCursor() {
+        return previousCursor;
+    }
+    public void setPreviousCursor(String previousCursor) {
+        this.previousCursor = previousCursor;
+    }
+
+    /**
+    * Number of roles per page.
+    **/
+    public RolesListResponse itemsPerPage(Integer itemsPerPage) {
+
+        this.itemsPerPage = itemsPerPage;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "10", value = "Number of roles per page.")
+    @JsonProperty("itemsPerPage")
+    @Valid
+    public Integer getItemsPerPage() {
+        return itemsPerPage;
+    }
+    public void setItemsPerPage(Integer itemsPerPage) {
+        this.itemsPerPage = itemsPerPage;
+    }
+
+    /**
+    **/
+    public RolesListResponse resources(List<RoleObj> resources) {
+
+        this.resources = resources;
+        return this;
+    }
+    
+    @ApiModelProperty(value = "")
+    @JsonProperty("Resources")
+    @Valid
+    public List<RoleObj> getResources() {
+        return resources;
+    }
+    public void setResources(List<RoleObj> resources) {
+        this.resources = resources;
+    }
+
+    public RolesListResponse addResourcesItem(RoleObj resourcesItem) {
+        if (this.resources == null) {
+            this.resources = new ArrayList<>();
+        }
+        this.resources.add(resourcesItem);
+        return this;
+    }
+
+    
+
+    @Override
+    public boolean equals(java.lang.Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        RolesListResponse rolesListResponse = (RolesListResponse) o;
+        return Objects.equals(this.totalResults, rolesListResponse.totalResults) &&
+            Objects.equals(this.nextCursor, rolesListResponse.nextCursor) &&
+            Objects.equals(this.previousCursor, rolesListResponse.previousCursor) &&
+            Objects.equals(this.itemsPerPage, rolesListResponse.itemsPerPage) &&
+            Objects.equals(this.resources, rolesListResponse.resources);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(totalResults, nextCursor, previousCursor, itemsPerPage, resources);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class RolesListResponse {\n");
+        
+        sb.append("    totalResults: ").append(toIndentedString(totalResults)).append("\n");
+        sb.append("    nextCursor: ").append(toIndentedString(nextCursor)).append("\n");
+        sb.append("    previousCursor: ").append(toIndentedString(previousCursor)).append("\n");
+        sb.append("    itemsPerPage: ").append(toIndentedString(itemsPerPage)).append("\n");
+        sb.append("    resources: ").append(toIndentedString(resources)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+    * Convert the given object to string with each line indented by 4 spaces
+    * (except the first line).
+    */
+    private String toIndentedString(java.lang.Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}
+

--- a/components/org.wso2.carbon.identity.api.server.organization.role.management/org.wso2.carbon.identity.api.server.organization.role.management.v1/src/main/java/org/wso2/carbon/identity/api/server/organization/role/management/v1/constant/RoleManagementEndpointConstants.java
+++ b/components/org.wso2.carbon.identity.api.server.organization.role.management/org.wso2.carbon.identity.api.server.organization.role.management.v1/src/main/java/org/wso2/carbon/identity/api/server/organization/role/management/v1/constant/RoleManagementEndpointConstants.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.organization.role.management.v1.constant;
+
+/**
+ * Constants of Role Management Endpoint module.
+ */
+public class RoleManagementEndpointConstants {
+
+    public static final String PATH_SEPARATOR = "/";
+    public static final String SCIM2_API_PATH_COMPONENT = "scim2";
+    public static final String V1_API_PATH_COMPONENT = "v1";
+    public static final String ORGANIZATION_PATH = "organizations";
+    public static final String ROLE_PATH = "roles";
+    public static final String GROUP_PATH = "groups";
+    public static final String USER_PATH = "users";
+    public static final String SCIM_USER_PATH = "Users";
+}

--- a/components/org.wso2.carbon.identity.api.server.organization.role.management/org.wso2.carbon.identity.api.server.organization.role.management.v1/src/main/java/org/wso2/carbon/identity/api/server/organization/role/management/v1/exception/RoleManagementEndpointException.java
+++ b/components/org.wso2.carbon.identity.api.server.organization.role.management/org.wso2.carbon.identity.api.server.organization.role.management.v1/src/main/java/org/wso2/carbon/identity/api/server/organization/role/management/v1/exception/RoleManagementEndpointException.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.organization.role.management.v1.exception;
+
+import org.wso2.carbon.identity.api.server.organization.role.management.v1.model.Error;
+
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+/**
+ * Custom exception class for Role Management endpoint.
+ */
+public class RoleManagementEndpointException extends WebApplicationException {
+
+    public RoleManagementEndpointException(Response.Status status, Error error) {
+
+        super(Response.status(status).entity(error).header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON)
+                .build());
+    }
+
+    public RoleManagementEndpointException(Response.Status status) {
+
+        super(Response.status(status).build());
+    }
+}

--- a/components/org.wso2.carbon.identity.api.server.organization.role.management/org.wso2.carbon.identity.api.server.organization.role.management.v1/src/main/java/org/wso2/carbon/identity/api/server/organization/role/management/v1/impl/OrganizationsApiServiceImpl.java
+++ b/components/org.wso2.carbon.identity.api.server.organization.role.management/org.wso2.carbon.identity.api.server.organization.role.management.v1/src/main/java/org/wso2/carbon/identity/api/server/organization/role/management/v1/impl/OrganizationsApiServiceImpl.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.organization.role.management.v1.impl;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.wso2.carbon.identity.api.server.organization.role.management.v1.OrganizationsApiService;
+import org.wso2.carbon.identity.api.server.organization.role.management.v1.model.RolePatchRequest;
+import org.wso2.carbon.identity.api.server.organization.role.management.v1.model.RolePostRequest;
+import org.wso2.carbon.identity.api.server.organization.role.management.v1.model.RolePutRequest;
+import org.wso2.carbon.identity.api.server.organization.role.management.v1.service.RoleManagementService;
+
+import javax.ws.rs.core.Response;
+
+/**
+ * Implementation of the RolesApi Service.
+ */
+public class OrganizationsApiServiceImpl implements OrganizationsApiService {
+
+    @Autowired
+    private RoleManagementService roleManagementService;
+
+    @Override
+    public Response createRole(String organizationId, RolePostRequest rolePostRequest) {
+
+        return roleManagementService.createRole(organizationId, rolePostRequest);
+    }
+
+    @Override
+    public Response organizationsOrganizationIdRolesGet(String organizationId, String filter, Integer count,
+                                                        String cursor) {
+
+        return roleManagementService.getRolesOfOrganization(organizationId, filter, count, cursor);
+    }
+
+    @Override
+    public Response organizationsOrganizationIdRolesRoleIdDelete(String roleId, String organizationId) {
+
+        return roleManagementService.deleteRole(organizationId, roleId);
+    }
+
+    @Override
+    public Response organizationsOrganizationIdRolesRoleIdGet(String roleId, String organizationId) {
+
+        return roleManagementService.getRoleUsingOrganizationIdAndRoleId(organizationId, roleId);
+    }
+
+    @Override
+    public Response organizationsOrganizationIdRolesRoleIdPatch(String roleId, String organizationId,
+                                                                RolePatchRequest rolePatchRequest) {
+
+        return roleManagementService.patchRole(organizationId, roleId, rolePatchRequest);
+    }
+
+    @Override
+    public Response organizationsOrganizationIdRolesRoleIdPut(String roleId, String organizationId,
+                                                              RolePutRequest rolePutRequest) {
+
+        return roleManagementService.putRole(organizationId, roleId, rolePutRequest);
+    }
+
+    @Override
+    public Response organizationsOrganizationIdUsersUserIdRolesGet(String userId, String organizationId) {
+
+        return roleManagementService.getUserRolesOfOrganization(organizationId, userId);
+    }
+}

--- a/components/org.wso2.carbon.identity.api.server.organization.role.management/org.wso2.carbon.identity.api.server.organization.role.management.v1/src/main/java/org/wso2/carbon/identity/api/server/organization/role/management/v1/service/RoleManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.organization.role.management/org.wso2.carbon.identity.api.server.organization.role.management.v1/src/main/java/org/wso2/carbon/identity/api/server/organization/role/management/v1/service/RoleManagementService.java
@@ -1,0 +1,537 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.organization.role.management.v1.service;
+
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.identity.api.server.organization.role.management.v1.constant.RoleManagementEndpointConstants;
+import org.wso2.carbon.identity.api.server.organization.role.management.v1.model.RoleGetResponse;
+import org.wso2.carbon.identity.api.server.organization.role.management.v1.model.RoleGetResponseGroup;
+import org.wso2.carbon.identity.api.server.organization.role.management.v1.model.RoleGetResponseUser;
+import org.wso2.carbon.identity.api.server.organization.role.management.v1.model.RoleObj;
+import org.wso2.carbon.identity.api.server.organization.role.management.v1.model.RoleObjMeta;
+import org.wso2.carbon.identity.api.server.organization.role.management.v1.model.RolePatchOperation;
+import org.wso2.carbon.identity.api.server.organization.role.management.v1.model.RolePatchRequest;
+import org.wso2.carbon.identity.api.server.organization.role.management.v1.model.RolePatchResponse;
+import org.wso2.carbon.identity.api.server.organization.role.management.v1.model.RolePostRequest;
+import org.wso2.carbon.identity.api.server.organization.role.management.v1.model.RolePostRequestGroup;
+import org.wso2.carbon.identity.api.server.organization.role.management.v1.model.RolePostRequestUser;
+import org.wso2.carbon.identity.api.server.organization.role.management.v1.model.RolePostResponse;
+import org.wso2.carbon.identity.api.server.organization.role.management.v1.model.RolePutRequest;
+import org.wso2.carbon.identity.api.server.organization.role.management.v1.model.RolePutRequestGroup;
+import org.wso2.carbon.identity.api.server.organization.role.management.v1.model.RolePutRequestUser;
+import org.wso2.carbon.identity.api.server.organization.role.management.v1.model.RolePutResponse;
+import org.wso2.carbon.identity.api.server.organization.role.management.v1.model.RolePutResponseMeta;
+import org.wso2.carbon.identity.api.server.organization.role.management.v1.model.RolesListResponse;
+import org.wso2.carbon.identity.api.server.organization.role.management.v1.util.RoleManagementEndpointUtils;
+import org.wso2.carbon.identity.core.util.IdentityUtil;
+import org.wso2.carbon.identity.organization.management.role.management.service.models.Group;
+import org.wso2.carbon.identity.organization.management.role.management.service.models.PatchOperation;
+import org.wso2.carbon.identity.organization.management.role.management.service.models.Role;
+import org.wso2.carbon.identity.organization.management.role.management.service.models.RolesResponse;
+import org.wso2.carbon.identity.organization.management.role.management.service.models.User;
+import org.wso2.carbon.identity.organization.management.service.exception.OrganizationManagementClientException;
+import org.wso2.carbon.identity.organization.management.service.exception.OrganizationManagementException;
+
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import javax.ws.rs.core.Response;
+
+import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.ErrorMessages.ERROR_CODE_ERROR_BUILDING_GROUP_URI;
+import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.ErrorMessages.ERROR_CODE_ERROR_BUILDING_ROLE_URI;
+import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.ErrorMessages.ERROR_CODE_ERROR_BUILDING_USER_URI;
+import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.ErrorMessages.ERROR_CODE_ERROR_WHILE_RESOLVING_USER_FROM_RESIDENT_ORG;
+import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.ErrorMessages.ERROR_CODE_PATCH_VALUE_EMPTY;
+import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.ErrorMessages.ERROR_CODE_ROLE_DISPLAY_NAME_NULL;
+import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.ErrorMessages.ERROR_CODE_USER_ROOT_ORGANIZATION_NOT_FOUND;
+import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.PATCH_OP_ADD;
+import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.PATCH_OP_REMOVE;
+import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.PATCH_OP_REPLACE;
+import static org.wso2.carbon.identity.organization.management.service.util.Utils.handleClientException;
+
+/**
+ * The service class for Role Management in Organization Management.
+ */
+public class RoleManagementService {
+
+    private static final Log LOG = LogFactory.getLog(RoleManagementService.class);
+
+    /**
+     * Service for creating a role inside an organization.
+     *
+     * @param organizationId  The ID of the organization.
+     * @param rolePostRequest The object created from request body.
+     * @return The role creation response.
+     */
+    public Response createRole(String organizationId, RolePostRequest rolePostRequest) {
+
+        try {
+            Role role = RoleManagementEndpointUtils.getRoleManager().createRole(organizationId,
+                    generateRoleFromPostRequest(rolePostRequest));
+            URI roleURI = RoleManagementEndpointUtils.getUri(organizationId, role.getId(),
+                    RoleManagementEndpointConstants.ROLE_PATH,
+                    ERROR_CODE_ERROR_BUILDING_ROLE_URI);
+            return Response.created(roleURI).entity(getRolePostResponse(role, roleURI)).build();
+        } catch (OrganizationManagementClientException e) {
+            return RoleManagementEndpointUtils.handleClientErrorResponse(e, LOG);
+        } catch (OrganizationManagementException e) {
+            return RoleManagementEndpointUtils.handleServerErrorResponse(e, LOG);
+        }
+    }
+
+    /**
+     * Service for deleting a role inside an organization.
+     *
+     * @param organizationId The ID of the organization.
+     * @param roleId         The ID of the role.
+     * @return The role deletion response.
+     */
+    public Response deleteRole(String organizationId, String roleId) {
+
+        try {
+            RoleManagementEndpointUtils.getRoleManager().deleteRole(organizationId, roleId);
+            return Response.noContent().build();
+        } catch (OrganizationManagementClientException e) {
+            return RoleManagementEndpointUtils.handleClientErrorResponse(e, LOG);
+        } catch (OrganizationManagementException e) {
+            return RoleManagementEndpointUtils.handleServerErrorResponse(e, LOG);
+        }
+    }
+
+    /**
+     * Service for getting a role using role ID and organization ID.
+     *
+     * @param organizationId The ID of the organization.
+     * @param roleId         The ID of the role.
+     * @return The role corresponding to roleId and organizationId.
+     */
+    public Response getRoleUsingOrganizationIdAndRoleId(String organizationId, String roleId) {
+
+        try {
+            Role role = RoleManagementEndpointUtils.getRoleManager().getRoleById(organizationId, roleId);
+            URI roleURI = RoleManagementEndpointUtils.getUri(organizationId, roleId,
+                    RoleManagementEndpointConstants.ROLE_PATH,
+                    ERROR_CODE_ERROR_BUILDING_ROLE_URI);
+            return Response.ok().entity(getRoleGetResponse(organizationId, role, roleURI)).build();
+        } catch (OrganizationManagementClientException e) {
+            return RoleManagementEndpointUtils.handleClientErrorResponse(e, LOG);
+        } catch (OrganizationManagementException e) {
+            return RoleManagementEndpointUtils.handleServerErrorResponse(e, LOG);
+        }
+    }
+
+    /**
+     * Get the roles inside an organization.
+     *
+     * @param organizationId The ID of the organization.
+     * @param filter         Param for filtering the results.
+     * @param count          Param for desired maximum number of query results per page.
+     * @param cursor         Param for cursor to fetch the next page of results.
+     * @return The roles inside an organization.
+     */
+    public Response getRolesOfOrganization(String organizationId, String filter, Integer count, String cursor) {
+
+        try {
+            int limitValue = validateCount(count);
+            RolesResponse rolesResponse = RoleManagementEndpointUtils.getRoleManager()
+                    .getOrganizationRoles(limitValue, filter, organizationId, cursor);
+            return Response.ok().entity(getRoleListResponse(organizationId, rolesResponse)).build();
+        } catch (OrganizationManagementClientException e) {
+            return RoleManagementEndpointUtils.handleClientErrorResponse(e, LOG);
+        } catch (OrganizationManagementException e) {
+            return RoleManagementEndpointUtils.handleServerErrorResponse(e, LOG);
+        }
+    }
+
+    /**
+     * Get the user roles inside an organization.
+     *
+     * @param organizationId The ID of the organization.
+     * @param userId         The ID of the user.
+     * @return The user roles inside an organization.
+     */
+    public Response getUserRolesOfOrganization(String organizationId, String userId) {
+
+        try {
+            String userResidentOrgId = String.valueOf(RoleManagementEndpointUtils
+                    .getOrganizationUserResidentResolverService()
+                    .resolveResidentOrganization(userId, organizationId)
+                    .orElseThrow(() -> handleClientException(ERROR_CODE_USER_ROOT_ORGANIZATION_NOT_FOUND, userId)));
+            if (!StringUtils.equals(userResidentOrgId, organizationId)) {
+                throw handleClientException
+                        (ERROR_CODE_ERROR_WHILE_RESOLVING_USER_FROM_RESIDENT_ORG, userResidentOrgId, organizationId);
+            }
+
+            List<Role> userRolesResponse = RoleManagementEndpointUtils.getRoleManager()
+                    .getUserOrganizationRoles(userId, organizationId);
+            return Response.ok().entity(getUserRoleListResponse(organizationId, userRolesResponse)).build();
+        } catch (OrganizationManagementClientException e) {
+            return RoleManagementEndpointUtils.handleClientErrorResponse(e, LOG);
+        } catch (OrganizationManagementException e) {
+            return RoleManagementEndpointUtils.handleServerErrorResponse(e, LOG);
+        }
+    }
+
+    /**
+     * Service for patching a role using role ID and organization ID.
+     *
+     * @param organizationId   The ID of the organization.
+     * @param roleId           The ID of the role.
+     * @param rolePatchRequest The request object created using request body.
+     * @return The role patch response.
+     */
+    public Response patchRole(String organizationId, String roleId, RolePatchRequest rolePatchRequest) {
+
+        try {
+            List<RolePatchOperation> patchOperationList = rolePatchRequest.getOperations();
+            List<PatchOperation> patchOperations = new ArrayList<>();
+
+            for (RolePatchOperation rolePatchOperation : patchOperationList) {
+                List<String> values = rolePatchOperation.getValue();
+                String patchOp = rolePatchOperation.getOp().toString();
+                if (StringUtils.equalsIgnoreCase(patchOp, PATCH_OP_REMOVE)) {
+                    PatchOperation patchOperation = new PatchOperation(StringUtils.strip(rolePatchOperation.getOp()
+                            .toString()), StringUtils.strip(rolePatchOperation.getPath()));
+                    patchOperations.add(patchOperation);
+                } else if ((CollectionUtils.isNotEmpty(values) && StringUtils.equalsIgnoreCase(patchOp, PATCH_OP_ADD))
+                        || StringUtils.equalsIgnoreCase(patchOp, PATCH_OP_REPLACE)) {
+                    PatchOperation patchOperation = new PatchOperation(StringUtils.strip(rolePatchOperation.getOp()
+                            .toString()), StringUtils.strip(rolePatchOperation.getPath()), values);
+                    patchOperations.add(patchOperation);
+                } else {
+                    // Invalid patch operations cannot be sent due to swagger validation.
+                    // But, if values are not passed along with ADD operations, an error is thrown.
+                    throw handleClientException(ERROR_CODE_PATCH_VALUE_EMPTY);
+                }
+            }
+            Role role = RoleManagementEndpointUtils.getRoleManager().patchRole(organizationId, roleId,
+                    patchOperations);
+            URI roleURI = RoleManagementEndpointUtils.getUri(organizationId, roleId,
+                    RoleManagementEndpointConstants.ROLE_PATH,
+                    ERROR_CODE_ERROR_BUILDING_ROLE_URI);
+            return Response.ok().entity(getRolePatchResponse(role, roleURI)).build();
+        } catch (OrganizationManagementClientException e) {
+            return RoleManagementEndpointUtils.handleClientErrorResponse(e, LOG);
+        } catch (OrganizationManagementException e) {
+            return RoleManagementEndpointUtils.handleServerErrorResponse(e, LOG);
+        }
+    }
+
+    /**
+     * Patching a role using PUT request.
+     *
+     * @param organizationId The organization ID.
+     * @param roleId         The role ID.
+     * @param rolePutRequest The request object created using request body.
+     * @return Put role response.
+     */
+    public Response putRole(String organizationId, String roleId, RolePutRequest rolePutRequest) {
+
+        try {
+            if (StringUtils.isBlank(rolePutRequest.getDisplayName())) {
+                throw handleClientException(ERROR_CODE_ROLE_DISPLAY_NAME_NULL);
+            }
+            String displayName = rolePutRequest.getDisplayName();
+            List<RolePutRequestUser> users = rolePutRequest.getUsers();
+            List<RolePutRequestGroup> groups = rolePutRequest.getGroups();
+            List<String> permissions = rolePutRequest.getPermissions();
+
+            Role role = RoleManagementEndpointUtils.getRoleManager().putRole(organizationId, roleId,
+                    new Role(roleId, displayName,
+                            (groups == null ? Collections.emptyList() : groups.stream().map(group ->
+                                    new Group(group.getValue())).collect(Collectors.toList())),
+                            (users == null ? Collections.emptyList() : users.stream().map(user ->
+                                    new User(user.getValue())).collect(Collectors.toList())),
+                            permissions));
+            URI roleURI = RoleManagementEndpointUtils.getUri(organizationId, roleId,
+                    RoleManagementEndpointConstants.ROLE_PATH,
+                    ERROR_CODE_ERROR_BUILDING_ROLE_URI);
+
+            return Response.ok().entity(getRolePutResponse(role, roleURI)).build();
+        } catch (OrganizationManagementClientException e) {
+            return RoleManagementEndpointUtils.handleClientErrorResponse(e, LOG);
+        } catch (OrganizationManagementException e) {
+            return RoleManagementEndpointUtils.handleServerErrorResponse(e, LOG);
+        }
+    }
+
+    /**
+     * Generating a Role object from the RoleRequest.
+     *
+     * @param rolePostRequest The request object coming from the API.
+     * @return A role object.
+     */
+    private Role generateRoleFromPostRequest(RolePostRequest rolePostRequest) {
+
+        Role role = new Role();
+        role.setDisplayName(StringUtils.strip(rolePostRequest.getDisplayName()));
+        if (CollectionUtils.isNotEmpty(rolePostRequest.getUsers())) {
+            role.setUsers(rolePostRequest.getUsers().stream().map(RolePostRequestUser::getValue)
+                    .map(User::new).collect(Collectors.toList()));
+        }
+        if (CollectionUtils.isNotEmpty(rolePostRequest.getGroups())) {
+            role.setGroups(rolePostRequest.getGroups().stream().map(RolePostRequestGroup::getValue)
+                    .map(Group::new).collect(Collectors.toList()));
+        }
+        if (CollectionUtils.isNotEmpty(rolePostRequest.getPermissions())) {
+            role.setPermissions(rolePostRequest.getPermissions());
+        }
+
+        return role;
+    }
+
+    /**
+     * Generating a RolePostResponse object for the response.
+     *
+     * @param role    A role object.
+     * @param roleURI The URI of the role.
+     * @return A RolePostResponse.
+     */
+    private RolePostResponse getRolePostResponse(Role role, URI roleURI) {
+
+        RoleObjMeta roleObjMeta = new RoleObjMeta();
+        roleObjMeta.location(roleURI.toString());
+
+        RolePostResponse response = new RolePostResponse();
+        response.setId(role.getId());
+        response.setDisplayName(role.getDisplayName());
+        response.setMeta(roleObjMeta);
+
+        return response;
+    }
+
+    /**
+     * Generating  RoleGetResponse for the response.
+     *
+     * @param organizationId The ID of the organization.
+     * @param role           A role object.
+     * @param roleURI        The URI of the role.
+     * @return A RoleGetResponse.
+     */
+    private RoleGetResponse getRoleGetResponse(String organizationId, Role role, URI roleURI) {
+
+        RoleObjMeta roleObjMeta = new RoleObjMeta();
+        roleObjMeta.location(roleURI.toString());
+
+        RoleGetResponse response = new RoleGetResponse();
+        response.setId(role.getId());
+        response.setDisplayName(role.getDisplayName());
+        response.setMeta(roleObjMeta);
+        response.setPermissions(role.getPermissions());
+
+        if (CollectionUtils.isNotEmpty(role.getGroups())) {
+            response.setGroups(getGroupsForResponseObject(role.getGroups(), organizationId));
+        }
+
+        if (CollectionUtils.isNotEmpty(role.getUsers())) {
+            response.setUsers(getUsersForResponseObject(role.getUsers(), organizationId));
+        }
+
+        return response;
+    }
+
+    /**
+     * Set the groups for the response if they exist.
+     *
+     * @param roleGroups     The groups assigned to a role.
+     * @param organizationId The organizationId.
+     * @return The RoleGetResponseGroup list.
+     */
+    private List<RoleGetResponseGroup> getGroupsForResponseObject(List<Group> roleGroups, String organizationId) {
+
+        List<RoleGetResponseGroup> groups = new ArrayList<>();
+        for (Group basicGroup : roleGroups) {
+            RoleGetResponseGroup group = new RoleGetResponseGroup();
+            group.value(basicGroup.getGroupId());
+            group.display(basicGroup.getGroupName());
+            group.$ref(RoleManagementEndpointUtils.getUri(organizationId, basicGroup.getGroupId(),
+                    RoleManagementEndpointConstants.GROUP_PATH,
+                    ERROR_CODE_ERROR_BUILDING_GROUP_URI).toString());
+            groups.add(group);
+        }
+        return groups;
+    }
+
+    /**
+     * Set the users for the response if they exist.
+     *
+     * @param roleUsers      The users assigned to a role.
+     * @param organizationId The organizationId.
+     * @return The RoleGetResponseUser list.
+     */
+    private List<RoleGetResponseUser> getUsersForResponseObject(List<User> roleUsers, String organizationId) {
+
+        List<RoleGetResponseUser> users = new ArrayList<>();
+        for (User basicUser : roleUsers) {
+            String uri;
+            if (StringUtils.isNotBlank(basicUser.getUserResidentOrgId())) {
+                uri = RoleManagementEndpointUtils.buildSCIM2Uri(basicUser.getId(),
+                        RoleManagementEndpointConstants.SCIM_USER_PATH,
+                        ERROR_CODE_ERROR_BUILDING_USER_URI).toString();
+                uri = uri.replace(organizationId, basicUser.getUserResidentOrgId());
+            } else {
+                uri = RoleManagementEndpointUtils.getUri(organizationId, basicUser.getId(),
+                        RoleManagementEndpointConstants.USER_PATH,
+                        ERROR_CODE_ERROR_BUILDING_USER_URI).toString();
+            }
+
+            RoleGetResponseUser user = new RoleGetResponseUser();
+            user.value(basicUser.getId());
+            user.display(basicUser.getUserName());
+            user.$ref(uri);
+            user.orgId(basicUser.getUserResidentOrgId());
+            user.orgName(basicUser.getUserResidentOrgName());
+            users.add(user);
+        }
+        return users;
+    }
+
+    /**
+     * Generate a response object for patch operation.
+     *
+     * @param role    The role which needed to be included in the response.
+     * @param roleURI The URI of the role.
+     * @return A RolePatchResponse.
+     */
+    private RolePatchResponse getRolePatchResponse(Role role, URI roleURI) {
+
+        RolePutResponseMeta roleObjMeta = new RolePutResponseMeta();
+        roleObjMeta.setLocation(roleURI.toString());
+
+        RolePatchResponse response = new RolePatchResponse();
+        response.setDisplayName(role.getDisplayName());
+        response.setMeta(roleObjMeta);
+        response.setId(role.getId());
+
+        return response;
+    }
+
+    /**
+     * Generate a response object for put operation.
+     *
+     * @param role    The role which needed to be included in the response.
+     * @param roleURI The URI of the role.
+     * @return A RolePutResponse.
+     */
+    private RolePutResponse getRolePutResponse(Role role, URI roleURI) {
+
+        RolePutResponseMeta roleObjMeta = new RolePutResponseMeta();
+        roleObjMeta.setLocation(roleURI.toString());
+
+        RolePutResponse responseObject = new RolePutResponse();
+        responseObject.setDisplayName(role.getDisplayName());
+        responseObject.setMeta(roleObjMeta);
+        responseObject.setValue(role.getId());
+
+        return responseObject;
+    }
+
+    /**
+     * Generate a response object for get operation.
+     *
+     * @param organizationId The ID of the organization.
+     * @param rolesResponse  Roles response including list of roles.
+     * @return The RoleListResponse.
+     */
+    private RolesListResponse getRoleListResponse(String organizationId, RolesResponse rolesResponse) {
+
+        RolesListResponse response = new RolesListResponse();
+        response.setNextCursor(rolesResponse.getNextCursor());
+        response.setPreviousCursor(rolesResponse.getPreviousCursor());
+        response.setItemsPerPage(rolesResponse.getItemsPerPage());
+        response.setTotalResults(rolesResponse.getTotalResults());
+
+        if (rolesResponse.getRoles() != null) {
+            List<RoleObj> roleDTOs = new ArrayList<>();
+            for (Role role : rolesResponse.getRoles()) {
+                RoleObj roleObj = new RoleObj();
+                RoleObjMeta roleObjMeta = new RoleObjMeta();
+                roleObjMeta.setLocation(RoleManagementEndpointUtils.getUri(organizationId, role.getId(),
+                        RoleManagementEndpointConstants.ROLE_PATH,
+                        ERROR_CODE_ERROR_BUILDING_ROLE_URI).toString());
+                roleObj.setId(role.getId());
+                roleObj.setDisplayName(role.getDisplayName());
+                roleObj.setMeta(roleObjMeta);
+                roleDTOs.add(roleObj);
+            }
+            response.setResources(roleDTOs);
+        }
+        return response;
+    }
+
+    /**
+     * Generate a response object for get operation.
+     *
+     * @param organizationId    The ID of the organization.
+     * @param userRolesResponse List of user roles.
+     * @return The UserRolesListResponse.
+     */
+    private List<RoleObj> getUserRoleListResponse(String organizationId, List<Role> userRolesResponse) {
+
+        List<RoleObj> roleDTOs = new ArrayList<>();
+        for (Role role : userRolesResponse) {
+            RoleObj roleObj = new RoleObj();
+            RoleObjMeta roleObjMeta = new RoleObjMeta();
+            roleObjMeta.setLocation(RoleManagementEndpointUtils.getUri(organizationId, role.getId(),
+                    RoleManagementEndpointConstants.ROLE_PATH,
+                    ERROR_CODE_ERROR_BUILDING_ROLE_URI).toString());
+            roleObj.setId(role.getId());
+            roleObj.setDisplayName(role.getDisplayName());
+            roleObj.setMeta(roleObjMeta);
+            roleDTOs.add(roleObj);
+        }
+        return roleDTOs;
+    }
+
+    /**
+     * @param count The param for desired maximum number of query results per page.
+     * @return The count.
+     */
+    private int validateCount(Integer count) {
+
+        if (count == null) {
+            int defaultItemsPerPage = IdentityUtil.getDefaultItemsPerPage();
+            if (LOG.isDebugEnabled()) {
+                LOG.debug(String.format("Given count is null. Therefore the default count is set to %s.",
+                        defaultItemsPerPage));
+            }
+            return defaultItemsPerPage;
+        }
+
+        if (count < 0) {
+            count = 0;
+        }
+
+        int maximumItemsPerPage = IdentityUtil.getMaximumItemPerPage();
+        if (count > maximumItemsPerPage) {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug(String.format("Given count exceeds the maximum count. Therefore the count is set to %s.",
+                        maximumItemsPerPage));
+            }
+            return maximumItemsPerPage;
+        }
+        return count;
+    }
+}

--- a/components/org.wso2.carbon.identity.api.server.organization.role.management/org.wso2.carbon.identity.api.server.organization.role.management.v1/src/main/java/org/wso2/carbon/identity/api/server/organization/role/management/v1/util/RoleManagementEndpointUtils.java
+++ b/components/org.wso2.carbon.identity.api.server.organization.role.management/org.wso2.carbon.identity.api.server.organization.role.management.v1/src/main/java/org/wso2/carbon/identity/api/server/organization/role/management/v1/util/RoleManagementEndpointUtils.java
@@ -1,0 +1,250 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.organization.role.management.v1.util;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.identity.api.server.organization.role.management.common.OrganizationRoleManagementServiceHolder;
+import org.wso2.carbon.identity.api.server.organization.role.management.v1.exception.RoleManagementEndpointException;
+import org.wso2.carbon.identity.api.server.organization.role.management.v1.model.Error;
+import org.wso2.carbon.identity.core.ServiceURLBuilder;
+import org.wso2.carbon.identity.core.URLBuilderException;
+import org.wso2.carbon.identity.organization.management.role.management.service.RoleManager;
+import org.wso2.carbon.identity.organization.management.service.OrganizationUserResidentResolverService;
+import org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.ErrorMessages;
+import org.wso2.carbon.identity.organization.management.service.exception.OrganizationManagementClientException;
+import org.wso2.carbon.identity.organization.management.service.exception.OrganizationManagementException;
+
+import java.net.URI;
+
+import javax.ws.rs.core.Response;
+
+import static org.wso2.carbon.identity.api.server.organization.role.management.v1.constant.RoleManagementEndpointConstants.ORGANIZATION_PATH;
+import static org.wso2.carbon.identity.api.server.organization.role.management.v1.constant.RoleManagementEndpointConstants.PATH_SEPARATOR;
+import static org.wso2.carbon.identity.api.server.organization.role.management.v1.constant.RoleManagementEndpointConstants.SCIM2_API_PATH_COMPONENT;
+import static org.wso2.carbon.identity.api.server.organization.role.management.v1.constant.RoleManagementEndpointConstants.V1_API_PATH_COMPONENT;
+import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.ErrorMessages.ERROR_CODE_INVALID_ORGANIZATION;
+import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.ErrorMessages.ERROR_CODE_INVALID_ROLE;
+import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.ErrorMessages.ERROR_CODE_REMOVING_REQUIRED_ATTRIBUTE;
+import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.ErrorMessages.ERROR_CODE_ROLE_DISPLAY_NAME_ALREADY_EXISTS;
+import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.ErrorMessages.ERROR_CODE_ROLE_DISPLAY_NAME_MULTIPLE_VALUES;
+import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.SERVER_API_PATH_COMPONENT;
+
+/**
+ * The utility class for role management endpoints.
+ */
+public class RoleManagementEndpointUtils {
+
+    private static final Log LOG = LogFactory.getLog(RoleManagementEndpointUtils.class);
+
+    /**
+     * Get an instance of role manager.
+     */
+    public static RoleManager getRoleManager() {
+
+        return OrganizationRoleManagementServiceHolder.getInstance().getRoleManager();
+    }
+
+    /**
+     * Get an instance of Organization User Resident Resolver Service.
+     */
+    public static OrganizationUserResidentResolverService getOrganizationUserResidentResolverService() {
+
+        return OrganizationRoleManagementServiceHolder.getInstance().getOrganizationUserResidentResolverService();
+    }
+
+    /**
+     * Handles client exception for role management.
+     *
+     * @param e   The role management exception.
+     * @param log The Log instance.
+     * @return The response for the error.
+     */
+    public static Response handleClientErrorResponse(OrganizationManagementException e, Log log) {
+
+        if (isNotFoundError(e)) {
+            throw buildException(Response.Status.NOT_FOUND, log, e);
+        }
+        if (isForbiddenError(e)) {
+            throw buildException(Response.Status.FORBIDDEN, log, e);
+        }
+        if (isConflictError(e)) {
+            throw buildException(Response.Status.CONFLICT, log, e);
+        }
+        throw buildException(Response.Status.BAD_REQUEST, log, e);
+    }
+
+    /**
+     * Handles server exception for role management.
+     *
+     * @param e   The role management exception.
+     * @param log The Log instance.
+     * @return The response for the error.
+     */
+    public static Response handleServerErrorResponse(OrganizationManagementException e, Log log) {
+
+        throw buildException(Response.Status.INTERNAL_SERVER_ERROR, log, e);
+    }
+
+    /**
+     * Returns a generic error object.
+     *
+     * @param errorCode        The error code.
+     * @param errorMessage     The error message.
+     * @param errorDescription The error description.
+     * @return A generic error with specified details.
+     */
+    public static Error getError(String errorCode, String errorMessage, String errorDescription) {
+
+        Error error = new Error();
+        error.setCode(errorCode);
+        error.setMessage(errorMessage);
+        error.setDescription(errorDescription);
+        return error;
+    }
+
+    /**
+     * Get the URI from context.
+     *
+     * @param organizationId The organization ID.
+     * @param id             The id of the resource.
+     * @param resourcePath   The path for the resource.
+     * @param errorMessage   The error message specific to the resources.
+     * @return The URI.
+     */
+    public static URI getUri(String organizationId, String id, String resourcePath, ErrorMessages errorMessage) {
+
+        String endpoint = SERVER_API_PATH_COMPONENT + V1_API_PATH_COMPONENT + PATH_SEPARATOR + ORGANIZATION_PATH +
+                PATH_SEPARATOR + organizationId + PATH_SEPARATOR + resourcePath + PATH_SEPARATOR + id;
+        try {
+            return URI.create(ServiceURLBuilder.create().addPath(endpoint)
+                    .build().getAbsolutePublicURL());
+        } catch (URLBuilderException e) {
+            Error error = getError(errorMessage.getCode(), errorMessage.getMessage(),
+                    String.format(errorMessage.getDescription(), id));
+            LOG.error(String.format("Server encountered an error while building URL for %s ",
+                    resourcePath.substring(0, resourcePath.length() - 1)) + id);
+            throw new RoleManagementEndpointException(Response.Status.INTERNAL_SERVER_ERROR, error);
+        }
+    }
+
+    /**
+     * Get the SCIM2 URI from context.
+     *
+     * @param id           The id of the resource.
+     * @param resourcePath The path for the resource.
+     * @param errorMessage The error message specific to the resources.
+     * @return The SCIM2 URI.
+     */
+    public static URI buildSCIM2Uri(String id, String resourcePath, ErrorMessages errorMessage) {
+
+        String endpoint = SCIM2_API_PATH_COMPONENT + PATH_SEPARATOR + resourcePath + PATH_SEPARATOR + id;
+        try {
+            return URI.create(ServiceURLBuilder.create().addPath(endpoint)
+                    .build().getAbsolutePublicURL());
+        } catch (URLBuilderException e) {
+            Error error = getError(errorMessage.getCode(), errorMessage.getMessage(),
+                    String.format(errorMessage.getDescription(), id));
+            throw new RoleManagementEndpointException(Response.Status.INTERNAL_SERVER_ERROR, error);
+        }
+    }
+
+    /**
+     * Checks the exception key code and returns true if it is a conflict error.
+     *
+     * @param e The role management exception.
+     * @return If the exception is thrown due to conflict error it returns true, else false.
+     */
+    private static boolean isConflictError(OrganizationManagementException e) {
+
+        return ERROR_CODE_ROLE_DISPLAY_NAME_MULTIPLE_VALUES.getCode().equals(e.getErrorCode())
+                || ERROR_CODE_ROLE_DISPLAY_NAME_ALREADY_EXISTS.getCode().equals(e.getErrorCode());
+    }
+
+    /**
+     * Checks the exception key code and returns true if it is a forbidden error.
+     *
+     * @param e The role management exception.
+     * @return If the exception is thrown due to forbidden error it returns true, else false.
+     */
+    private static boolean isForbiddenError(OrganizationManagementException e) {
+
+        return ERROR_CODE_REMOVING_REQUIRED_ATTRIBUTE.getCode().equals(e.getErrorCode());
+    }
+
+    /**
+     * Checks the exception key code and returns true if it is a not-found error.
+     *
+     * @param e The role management exception.
+     * @return If the exception is thrown due to not-found error it returns true, else false.
+     */
+    private static boolean isNotFoundError(OrganizationManagementException e) {
+
+        return ERROR_CODE_INVALID_ORGANIZATION.getCode().equals(e.getErrorCode()) || ERROR_CODE_INVALID_ROLE.getCode()
+                .equals(e.getErrorCode());
+    }
+
+    /**
+     * Building the RoleManagementEndpointException according to the RoleManagementException.
+     *
+     * @param status The status of the response.
+     * @param log    The Log instance.
+     * @param e      The  role management exception.
+     * @return A RoleManagementEndpointException.
+     */
+    private static RoleManagementEndpointException buildException(Response.Status status, Log log,
+                                                                  OrganizationManagementException e) {
+
+        if (e instanceof OrganizationManagementClientException) {
+            logDebug(log, e);
+        } else {
+            logError(log, e);
+        }
+        return new RoleManagementEndpointException(status, getError(e.getErrorCode(), e.getMessage(),
+                e.getDescription()));
+    }
+
+    /**
+     * If debug is enabled, log the role management errors.
+     *
+     * @param log Log instance.
+     * @param e   The role management exception.
+     */
+    private static void logDebug(Log log, OrganizationManagementException e) {
+
+        if (log.isDebugEnabled()) {
+            String errorMessageFormat = "errorCode: %s | message: %s";
+            String errorMessage = String.format(errorMessageFormat, e.getErrorCode(), e.getDescription());
+            log.debug(errorMessage, e);
+        }
+    }
+
+    /**
+     * Log the error if it is a role management exception.
+     *
+     * @param log Log instance.
+     * @param e   The role management exception.
+     */
+    private static void logError(Log log, OrganizationManagementException e) {
+
+        String errorMessageFormat = "errorCode: %s | message: %s";
+        String errorMessage = String.format(errorMessageFormat, e.getErrorCode(), e.getDescription());
+        log.error(errorMessage, e);
+    }
+}

--- a/components/org.wso2.carbon.identity.api.server.organization.role.management/org.wso2.carbon.identity.api.server.organization.role.management.v1/src/main/resources/META-INF/cxf/org-role-mgt-server-v1-cxf.xml
+++ b/components/org.wso2.carbon.identity.api.server.organization.role.management/org.wso2.carbon.identity.api.server.organization.role.management.v1/src/main/resources/META-INF/cxf/org-role-mgt-server-v1-cxf.xml
@@ -1,11 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com). All Rights Reserved.
+  ~ Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
   ~
-  ~ This software is the property of WSO2 LLC. and its suppliers, if any.
-  ~ Dissemination of any information or reproduction of any material contained
-  ~ herein in any form is strictly forbidden, unless permitted by WSO2 expressly.
-  ~ You may not alter or remove any copyright or other notice from copies of this content.
+  ~ WSO2 LLC. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
   -->
 
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/components/org.wso2.carbon.identity.api.server.organization.role.management/org.wso2.carbon.identity.api.server.organization.role.management.v1/src/main/resources/META-INF/cxf/org-role-mgt-server-v1-cxf.xml
+++ b/components/org.wso2.carbon.identity.api.server.organization.role.management/org.wso2.carbon.identity.api.server.organization.role.management.v1/src/main/resources/META-INF/cxf/org-role-mgt-server-v1-cxf.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com). All Rights Reserved.
+  ~
+  ~ This software is the property of WSO2 LLC. and its suppliers, if any.
+  ~ Dissemination of any information or reproduction of any material contained
+  ~ herein in any form is strictly forbidden, unless permitted by WSO2 expressly.
+  ~ You may not alter or remove any copyright or other notice from copies of this content.
+  -->
+
+<beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:jaxrs="http://cxf.apache.org/jaxrs" xmlns:context="http://www.springframework.org/schema/context"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans  http://www.springframework.org/schema/beans/spring-beans-3.0.xsd http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.0.xsd http://cxf.apache.org/jaxrs http://cxf.apache.org/schemas/jaxrs.xsd">
+
+    <bean class="org.wso2.carbon.identity.api.server.organization.role.management.v1.impl.OrganizationsApiServiceImpl"/>
+    <bean class="org.wso2.carbon.identity.api.server.organization.role.management.v1.service.RoleManagementService"/>
+    <bean id="OrganizationUserResidentResolverServiceFactoryBean"
+          class="org.wso2.carbon.identity.api.server.organization.role.management.common.factory.OrganizationUserResidentResolverOSGIServiceFactory"/>
+    <bean id="RoleMgtServiceFactoryBean" class="org.wso2.carbon.identity.api.server.organization.role.management.common.factory.OrganizationRoleManagementOSGIServiceFactory"/>
+    <bean id="RoleManagementServiceHolderBean"
+          class="org.wso2.carbon.identity.api.server.organization.role.management.common.OrganizationRoleManagementServiceHolder">
+        <property name="organizationUserResidentResolverService" ref="OrganizationUserResidentResolverServiceFactoryBean"/>
+        <property name="roleManager" ref="RoleMgtServiceFactoryBean"/>
+    </bean>
+</beans>

--- a/components/org.wso2.carbon.identity.api.server.organization.role.management/org.wso2.carbon.identity.api.server.organization.role.management.v1/src/main/resources/org.wso2.carbon.identity.organization.role.management.yaml
+++ b/components/org.wso2.carbon.identity.api.server.organization.role.management/org.wso2.carbon.identity.api.server.organization.role.management.v1/src/main/resources/org.wso2.carbon.identity.organization.role.management.yaml
@@ -1,12 +1,12 @@
 openapi: 3.0.0
 info:
   version: 'v1'
-  title: 'Private CIAM Cloud - Organizational Role Management'
-  description: 'This is the RESTful API for managing organizational roles in CIAM Cloud. 
+  title: 'WSO2 Identity Server - Organizational Role Management'
+  description: 'This is the RESTful API for managing organizational roles in WSO2 Identity Server. 
   This API allows users to create, update, retrieve and delete organization roles.'
   contact:
     name: WSO2
-    url: 'https://wso2.com/ciam-suite/private-ciam-cloud/b2b-ciam'
+    url: 'http://wso2.com/products/identity-server/'
     email: iam-dev@wso2.org
   license:
     name: Apache 2.0

--- a/components/org.wso2.carbon.identity.api.server.organization.role.management/org.wso2.carbon.identity.api.server.organization.role.management.v1/src/main/resources/org.wso2.carbon.identity.organization.role.management.yaml
+++ b/components/org.wso2.carbon.identity.api.server.organization.role.management/org.wso2.carbon.identity.api.server.organization.role.management.v1/src/main/resources/org.wso2.carbon.identity.organization.role.management.yaml
@@ -1,0 +1,680 @@
+openapi: 3.0.0
+info:
+  version: 'v1'
+  title: 'Private CIAM Cloud - Organizational Role Management'
+  description: 'This is the RESTful API for managing organizational roles in CIAM Cloud. 
+  This API allows users to create, update, retrieve and delete organization roles.'
+  contact:
+    name: WSO2
+    url: 'https://wso2.com/ciam-suite/private-ciam-cloud/b2b-ciam'
+    email: iam-dev@wso2.org
+  license:
+    name: Apache 2.0
+    url: 'http://www.apache.org/licenses/LICENSE-2.0.html'
+servers:
+  - url: 'https://{server-url}/o/{organization-domain}/api/server/v1/organizations'
+    variables:
+      server-url:
+        default: 'localhost:9443'
+      organization-domain:
+        default: 10084a8d-113f-4211-a0d5-efe36b082211
+security:
+  - OAuth2: [ ]
+  - BasicAuth: [ ]
+
+paths:
+  /organizations/{organization-id}/roles:
+    post:
+      summary:
+        Create a role inside an organization.
+      description:
+        This API creates a role inside an organization, assigns users, groups and permissions, and returns the details of the created role including its unique id.
+      parameters:
+        - name: organization-id
+          in: path
+          description: ID of the organization.
+          required: true
+          schema:
+            type: string
+      operationId: createRole
+      requestBody:
+        description: Represents display name, set of permissions, set of groups, set of users that are to be assigned to the role.
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RolePostRequest'
+        required: true
+      responses:
+        '201':
+          description: Valid role is created.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RolePostResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          $ref: '#/components/responses/Conflict'
+        '500':
+          $ref: '#/components/responses/ServerError'
+      tags:
+        - Organization Role Management
+    get:
+      summary:
+        Get roles inside an organization.
+      description:
+        This API returns roles in an organization based on the provided filter and limit.
+      parameters:
+        - name: organization-id
+          in: path
+          description: ID of the organization.
+          required: true
+          schema:
+            type: string
+        - $ref: '#/components/parameters/filterQueryParam'
+        - $ref: '#/components/parameters/countQueryParam'
+        - $ref: '#/components/parameters/cursorQueryParam'
+      responses:
+        '200':
+          description: Successful response.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RolesListResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/ServerError'
+      tags:
+        - Organization Role Management
+
+  /organizations/{organization-id}/users/{user-id}/roles:
+    get:
+      summary:
+        Get user roles by user id
+      description:
+        This API returns the list of roles assigned to a user against an organization.
+        This API is not capable of returning users' assigned roles to other organizations except for the resident 
+        organization.
+      parameters:
+        - name: user-id
+          in: path
+          description: ID of the user.
+          required: true
+          schema:
+            type: string
+        - name: organization-id
+          in: path
+          description: ID of the organization.
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Valid user roles are found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UserRolesListResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/ServerError'
+      tags:
+        - Organization Role Management
+
+  /organizations/{organization-id}/roles/{role-id}:
+    get:
+      summary:
+        Get role by ID
+      description:
+        This API returns the role details of a particular role using its unique id.
+      parameters:
+        - name: role-id
+          in: path
+          description: ID of the role.
+          required: true
+          schema:
+            type: string
+        - name: organization-id
+          in: path
+          description: ID of the organization.
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Valid role is found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RoleGetResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/ServerError'
+      tags:
+        - Organization Role Management
+    put:
+      summary: Update Role - PUT
+      description:
+        This API updates the role details and returns the updated role details using a PUT operation.
+      parameters:
+        - name: role-id
+          in: path
+          description: ID of the role.
+          required: true
+          schema:
+            type: string
+        - name: organization-id
+          in: path
+          description: ID of the organization.
+          required: true
+          schema:
+            type: string
+      requestBody:
+        description: This represents a set of values that need to be changed in the role.
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RolePutRequest'
+        required: true
+      responses:
+        '200':
+          description: Role is successfully updated.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RolePutResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/ServerError'
+      tags:
+        - Organization Role Management
+    delete:
+      summary: Delete a role inside an organization.
+      description: This API deletes a particular role inside an organization using its unique ID.
+      parameters:
+        - name: role-id
+          in: path
+          description: ID of the role.
+          required: true
+          schema:
+            type: string
+        - name: organization-id
+          in: path
+          description: ID of the organization.
+          required: true
+          schema:
+            type: string
+      responses:
+        '204':
+          description: Role is deleted.
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/ServerError'
+      tags:
+        - Organization Role Management
+    patch:
+      summary: Update Role - PATCH
+      description: This API updates the role details and returns the updated role details.
+      tags:
+        - Organization Role Management
+      parameters:
+        - name: role-id
+          in: path
+          description: ID of the role.
+          required: true
+          schema:
+            type: string
+        - name: organization-id
+          in: path
+          description: ID of the organization.
+          required: true
+          schema:
+            type: string
+      requestBody:
+        description: This represents a set of values that need to be changed in the role.
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RolePatchRequest'
+        required: true
+      responses:
+        '200':
+          description: Role is updated.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RolePatchResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/ServerError'
+
+components:
+  parameters:
+    filterQueryParam:
+      in: query
+      name: filter
+      required: false
+      description:
+        Condition to filter the retrieval of records.
+      schema:
+        type: string
+    countQueryParam:
+      in: query
+      name: count
+      required: false
+      description:
+        Maximum number of records to be returned. (Should be greater than 0)
+      schema:
+        type: integer
+        format: int32
+        minimum: 0
+    cursorQueryParam:
+      in: query
+      name: cursor
+      required: false
+      description:
+        The cursor to retrieve the records.
+      schema:
+        type: string
+  schemas:
+    #------------------------------------------------------------------------
+    # Error response object.
+    #------------------------------------------------------------------------
+    Error:
+      type: object
+      required:
+        - code
+        - message
+      properties:
+        code:
+          type: string
+          example: ORG-00000
+          description: An error code.
+        message:
+          type: string
+          example: Some error message
+          description: An error message.
+        description:
+          type: string
+          example: Some error description
+          description: An error description.
+        traceId:
+          type: string
+          example: e0fbcfeb-3617-43c4-8dd0-7b7d38e13047
+          description: An error trace identifier.
+    #------------------------------------------------------------------------
+    # The Roles Search Response Object.
+    #------------------------------------------------------------------------
+    RolesListResponse:
+      type: object
+      properties:
+        totalResults:
+          type: integer
+          format: int32
+          example: 100
+          description: Total results to be fetched.
+        nextCursor:
+          type: string
+          example: eyJjdXJzb3JWYWx1ZSI6ImQgcm9sZSIsImRpcmVjdGlvbiI6IkZPUldBUkQifQ
+          description: A cursor to obtain the next page of results in a subsequent request.
+        previousCursor:
+          type: string
+          example: eyJjdXJzb3JWYWx1ZSI6ImIgcm9sZSIsImRpcmVjdGlvbiI6IkJBQ0tXQVJEIn0
+          description: A cursor to obtain the previous page of results in a subsequent request.
+        itemsPerPage:
+          type: integer
+          format: int32
+          example: 10
+          description: Number of roles per page.
+        Resources:
+          type: array
+          items:
+            $ref: '#/components/schemas/RoleObj'
+    #------------------------------------------------------------------------
+    # The Roles Search Response Object.
+    #------------------------------------------------------------------------
+    UserRolesListResponse:
+      type: array
+      items:
+        $ref: '#/components/schemas/RoleObj'
+    #------------------------------------------------------------------------
+    # The Roles List Response Object.
+    #------------------------------------------------------------------------
+    RoleObj:
+      type: object
+      properties:
+        id:
+          type: string
+          example: '4645709c-ea8c-4495-8590-e1fa0efe3de0'
+        displayName:
+          type: string
+          example: 'loginRole'
+        meta:
+          type: object
+          properties:
+            location:
+              type: string
+              example: 'https://localhost:9443/o/10084a8d-113f-4211-a0d5-efe36b082211/api/server/v1/organizations/48e31bc5-1669-4de1-bb22-c71e443aeb8b/roles/4645709c-ea8c-4495-8590-e1fa0efe3de0'
+    #------------------------------------------------------------------------
+    # The Role Request Object.
+    #------------------------------------------------------------------------
+    RolePostRequest:
+      type: object
+      required:
+        - displayName
+      properties:
+        displayName:
+          type: string
+          example: "loginRole"
+        users:
+          type: array
+          items:
+            $ref: '#/components/schemas/RolePostRequestUser'
+        groups:
+          type: array
+          items:
+            $ref: '#/components/schemas/RolePostRequestGroup'
+        permissions:
+          type: array
+          items:
+            type: string
+            example: "/permission/admin/login"
+    #------------------------------------------------------------------------
+    # The Role POST Request User Object.
+    #------------------------------------------------------------------------
+    RolePostRequestUser:
+      type: object
+      properties:
+        value:
+          type: string
+          example: '008bba85-451d-414b-87de-c03b5a1f4217'
+    #------------------------------------------------------------------------
+    # The Role POST Request Group Object.
+    #------------------------------------------------------------------------
+    RolePostRequestGroup:
+      type: object
+      properties:
+        value:
+          type: string
+          example: '7bac6a86-1f21-4937-9fb1-5be4a93ef469'
+    #------------------------------------------------------------------------
+    # The Role POST Response Object.
+    #------------------------------------------------------------------------
+    RolePostResponse:
+      type: object
+      properties:
+        displayName:
+          type: string
+          example: 'loginRole'
+        meta:
+          type: object
+          properties:
+            location:
+              type: string
+              example: 'https://localhost:9443/o/10084a8d-113f-4211-a0d5-efe36b082211/api/server/v1/organizations/48e31bc5-1669-4de1-bb22-c71e443aeb8b/roles/4645709c-ea8c-4495-8590-e1fa0efe3de0'
+        id:
+          type: string
+          example: '4645709c-ea8c-4495-8590-e1fa0efe3de0'
+    #------------------------------------------------------------------------
+    # The Role GET Response Object.
+    #------------------------------------------------------------------------
+    RoleGetResponse:
+      type: object
+      properties:
+        displayName:
+          type: string
+          example: 'loginRole'
+        meta:
+          type: object
+          properties:
+            location:
+              type: string
+              example: 'https://localhost:9443/o/10084a8d-113f-4211-a0d5-efe36b082211/api/server/v1/organizations/48e31bc5-1669-4de1-bb22-c71e443aeb8b/roles/4645709c-ea8c-4495-8590-e1fa0efe3de0'
+        id:
+          type: string
+          example: "4645709c-ea8c-4495-8590-e1fa0efe3de0"
+        users:
+          type: array
+          items:
+            $ref: '#/components/schemas/RoleGetResponseUser'
+        groups:
+          type: array
+          items:
+            $ref: '#/components/schemas/RoleGetResponseGroup'
+        permissions:
+          type: array
+          items:
+            type: string
+            example: '/permission/admin/login'
+    #------------------------------------------------------------------------
+    # The Role GET Response User Object.
+    #------------------------------------------------------------------------
+    RoleGetResponseUser:
+      type: object
+      properties:
+        $ref:
+          type: string
+          example:  'https://localhost:9443/o/e5198bbf-7448-49c9-b5f1-44ae2fa39bb6/scim2/Users/f78b1b05-dea5-4572-99c8-4dc649887c20'
+        display:
+          type: string
+          example: "kim"
+        value:
+          type: string
+          example: "3a12bae9-4386-44be-befd-caf349297f45"
+        orgId:
+          type: string
+          example: "48e31bc5-1669-4de1-bb22-c71e443aeb8b"
+        orgName:
+          type: string
+          example: "SubOrganization"
+    #------------------------------------------------------------------------
+    # The Role GET Response Group Object.
+    #------------------------------------------------------------------------
+    RoleGetResponseGroup:
+      type: object
+      properties:
+        $ref:
+          type: string
+          example: 'https://localhost:9443/o/10084a8d-113f-4211-a0d5-efe36b082211/api/server/v1/organizations/48e31bc5-1669-4de1-bb22-c71e443aeb8b/groups/7bac6a86-1f21-4937-9fb1-5be4a93ef469'
+        display:
+          type: string
+          example:  'PRIMARY/manager'
+        value:
+          type: string
+          example: '7bac6a86-1f21-4937-9fb1-5be4a93ef469'
+    #------------------------------------------------------------------------
+    # The Role PUT Request Object.
+    #------------------------------------------------------------------------
+    RolePutRequest:
+      type: object
+      required:
+        - displayName
+      properties:
+        displayName:
+          type: string
+          example: 'loginRole'
+        users:
+          type: array
+          items:
+            $ref: '#/components/schemas/RolePutRequestUser'
+        groups:
+          type: array
+          items:
+            $ref: '#/components/schemas/RolePutRequestGroup'
+        permissions:
+          type: array
+          items:
+            type: string
+            example: '/permission/admin/manage/add'
+    #------------------------------------------------------------------------
+    # The Role PUT Request User Object.
+    #------------------------------------------------------------------------
+    RolePutRequestUser:
+      type: object
+      properties:
+        value:
+          type: string
+          example: '409ca90b-2ba6-4474-9a45-2cf7376e6e43'
+    #------------------------------------------------------------------------
+    # The Role PUT Request Group Object.
+    #------------------------------------------------------------------------
+    RolePutRequestGroup:
+      type: object
+      properties:
+        value:
+          type: string
+          example: '7bac6a86-1f21-4937-9fb1-5be4a93ef469'
+    #------------------------------------------------------------------------
+    # The Role PUT Response Object.
+    #------------------------------------------------------------------------
+    RolePutResponse:
+      type: object
+      properties:
+        displayName:
+          type: string
+          example: 'loginRole'
+        meta:
+          type: object
+          properties:
+            location:
+              type: string
+              example: 'https://localhost:9443/o/10084a8d-113f-4211-a0d5-efe36b082211/api/server/v1/organizations/48e31bc5-1669-4de1-bb22-c71e443aeb8b/roles/4645709c-ea8c-4495-8590-e1fa0fe3de0'
+        value:
+          type: string
+          example: '4645709c-ea8c-4495-8590-e1fa0fe3de0'
+    #------------------------------------------------------------------------
+    # The Role PATCH Request Object.
+    #------------------------------------------------------------------------
+    RolePatchRequest:
+      type: object
+      properties:
+        operations:
+          type: array
+          items:
+            $ref: '#/components/schemas/RolePatchOperation'
+    #------------------------------------------------------------------------
+    # The Role PATCH Operation Object.
+    #------------------------------------------------------------------------
+    RolePatchOperation:
+      type: object
+      properties:
+        op:
+          type: string
+          enum:
+            - add
+            - remove
+            - replace
+          example: add
+        path:
+          type: string
+          example: groups
+        value:
+          type: array
+          items:
+            type: string
+            example: '7bac6a86-1f21-4937-9fb1-5be4a93ef469'
+    #------------------------------------------------------------------------
+    # The Role PATCH Response Object.
+    #------------------------------------------------------------------------
+    RolePatchResponse:
+      type: object
+      properties:
+        displayName:
+          type: string
+          example: 'loginRole'
+        meta:
+          type: object
+          properties:
+            location:
+              type: string
+              example: 'https://localhost:9443/o/10084a8d-113f-4211-a0d5-efe36b082211/api/server/v1/organizations/48e31bc5-1669-4de1-bb22-c71e443aeb8b/roles/4645709c-ea8c-4495-8590-e1fa0fe3de0'
+        id:
+          type: string
+          example: '4645709c-ea8c-4495-8590-e1fa0fe3de0'
+
+  #-------------------------------------------------------------------------
+  # Descriptions of Organization Management Role Management API Responses.
+  #-------------------------------------------------------------------------
+  responses:
+    BadRequest:
+      description: Invalid input in the request.
+      content:
+        'application/json':
+          schema:
+            $ref: '#/components/schemas/Error'
+    NotFound:
+      description: Requested resource is not found.
+      content:
+        'application/json':
+          schema:
+            $ref: '#/components/schemas/Error'
+    Unauthorized:
+      description: Authentication information is missing or invalid.
+    Forbidden:
+      description: Access forbidden.
+    Conflict:
+      description: Conflict response.
+      content:
+        'application/json':
+          schema:
+            $ref: '#/components/schemas/Error'
+    ServerError:
+      description: Internal server error.
+      content:
+        'application/json':
+          schema:
+            $ref: '#/components/schemas/Error'
+  #-------------------------------------------------------------------------
+  # Applicable authentication mechanisms.
+  #-------------------------------------------------------------------------
+  securitySchemes:
+    BasicAuth:
+      type: http
+      scheme: basic
+    OAuth2:
+      type: oauth2
+      flows:
+        authorizationCode:
+          authorizationUrl: 'https://localhost:9443/oauth2/authorize'
+          tokenUrl: 'https://localhost:9443/oauth2/token'
+          scopes: { }

--- a/components/org.wso2.carbon.identity.api.server.organization.role.management/pom.xml
+++ b/components/org.wso2.carbon.identity.api.server.organization.role.management/pom.xml
@@ -1,11 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com). All Rights Reserved.
+  ~ Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
   ~
-  ~ This software is the property of WSO2 LLC. and its suppliers, if any.
-  ~ Dissemination of any information or reproduction of any material contained
-  ~ herein in any form is strictly forbidden, unless permitted by WSO2 expressly.
-  ~ You may not alter or remove any copyright or other notice from copies of this content.
+  ~ WSO2 LLC. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
   -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">

--- a/components/org.wso2.carbon.identity.api.server.organization.role.management/pom.xml
+++ b/components/org.wso2.carbon.identity.api.server.organization.role.management/pom.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com). All Rights Reserved.
+  ~
+  ~ This software is the property of WSO2 LLC. and its suppliers, if any.
+  ~ Dissemination of any information or reproduction of any material contained
+  ~ herein in any form is strictly forbidden, unless permitted by WSO2 expressly.
+  ~ You may not alter or remove any copyright or other notice from copies of this content.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>identity-api-server</artifactId>
+        <groupId>org.wso2.carbon.identity.server.api</groupId>
+        <version>1.2.67-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>org.wso2.carbon.identity.api.server.organization.role.management</artifactId>
+    <packaging>pom</packaging>
+    <modules>
+        <module>org.wso2.carbon.identity.api.server.organization.role.management.common</module>
+        <module>org.wso2.carbon.identity.api.server.organization.role.management.v1</module>
+    </modules>
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -73,6 +73,11 @@
                 <version>${javax.ws.rs-api.version}</version>
             </dependency>
             <dependency>
+                <groupId>org.wso2.orbit.javax.xml.bind</groupId>
+                <artifactId>jaxb-api</artifactId>
+                <version>${version.org.wso2.orbit.javax.xml.bind}</version>
+            </dependency>
+            <dependency>
                 <groupId>io.swagger</groupId>
                 <artifactId>swagger-jaxrs</artifactId>
                 <version>${swagger-jaxrs.version}</version>
@@ -508,8 +513,20 @@
                 <scope>provided</scope>
             </dependency>
             <dependency>
+                <groupId>org.wso2.carbon.identity.organization.management</groupId>
+                <artifactId>org.wso2.carbon.identity.organization.management.role.management.service</artifactId>
+                <version>${org.wso2.carbon.identity.organization.management.version}</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
                 <groupId>org.wso2.carbon.identity.server.api</groupId>
                 <artifactId>org.wso2.carbon.identity.api.server.organization.management.common</artifactId>
+                <version>${project.version}</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.wso2.carbon.identity.server.api</groupId>
+                <artifactId>org.wso2.carbon.identity.api.server.organization.role.management.common</artifactId>
                 <version>${project.version}</version>
                 <scope>provided</scope>
             </dependency>
@@ -608,6 +625,7 @@
         <spring-web.version>5.3.25</spring-web.version>
         <swagger-jaxrs.version>1.6.2</swagger-jaxrs.version>
         <javax.ws.rs-api.version>2.1.1</javax.ws.rs-api.version>
+        <version.org.wso2.orbit.javax.xml.bind>2.3.1.wso2v1</version.org.wso2.orbit.javax.xml.bind>
         <maven.buildnumber.plugin.version>1.4</maven.buildnumber.plugin.version>
         <org.apache.felix.annotations.version>1.2.4</org.apache.felix.annotations.version>
         <identity.governance.version>1.8.23</identity.governance.version>
@@ -669,6 +687,7 @@
         <module>components/org.wso2.carbon.identity.api.server.admin.advisory.management</module>
         <module>components/org.wso2.carbon.identity.api.server.idv.provider</module>
         <module>components/org.wso2.carbon.identity.api.server.organization.management</module>
+        <module>components/org.wso2.carbon.identity.api.server.organization.role.management</module>
     </modules>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright (c) 2019, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+  ~ Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
   ~
   ~ WSO2 LLC. licenses this file to you under the Apache License,
   ~ Version 2.0 (the "License"); you may not use this file except
@@ -16,6 +16,7 @@
   ~ specific language governing permissions and limitations
   ~ under the License.
   -->
+
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
     <parent>

--- a/pom.xml
+++ b/pom.xml
@@ -502,6 +502,18 @@
                 <scope>provided</scope>
             </dependency>
             <dependency>
+                <groupId>org.wso2.carbon.identity.organization.management</groupId>
+                <artifactId>org.wso2.carbon.identity.organization.management.application</artifactId>
+                <version>${org.wso2.carbon.identity.organization.management.version}</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.wso2.carbon.identity.server.api</groupId>
+                <artifactId>org.wso2.carbon.identity.api.server.organization.management.common</artifactId>
+                <version>${project.version}</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
                 <groupId>org.wso2.carbon.extension.identity.verification</groupId>
                 <artifactId>org.wso2.carbon.extension.identity.verification.provider</artifactId>
                 <version>${identity.verification.version}</version>
@@ -620,10 +632,14 @@
         <identity.verification.version>1.0.3</identity.verification.version>
 
         <!-- Organization management core Version -->
-        <org.wso2.carbon.identity.organization.management.core.version>1.0.42
+        <org.wso2.carbon.identity.organization.management.core.version>1.0.56
         </org.wso2.carbon.identity.organization.management.core.version>
         <org.wso2.carbon.identity.organization.management.core.version.range>[1.0.0, 2.0.0)
         </org.wso2.carbon.identity.organization.management.core.version.range>
+
+        <!-- Organization management service Version -->
+        <org.wso2.carbon.identity.organization.management.version>1.3.50
+        </org.wso2.carbon.identity.organization.management.version>
     </properties>
 
     <modules>
@@ -652,6 +668,7 @@
         <module>components/org.wso2.carbon.identity.api.server.extension.management</module>
         <module>components/org.wso2.carbon.identity.api.server.admin.advisory.management</module>
         <module>components/org.wso2.carbon.identity.api.server.idv.provider</module>
+        <module>components/org.wso2.carbon.identity.api.server.organization.management</module>
     </modules>
 
 </project>


### PR DESCRIPTION
## Purpose
> Onboard organization management APIs and role management APIs

Additional improvements made.

- Previously the path is marked as empty as the organization-management APIs were exposed  with the servlet map to `/api/server/v1/organizations`. But as shown in the right hand side of the below image, the `organizations` path is added as with this effort the APIs is exposed with the servlet which expose the server APIs by default `/api/server/v1`

![Untitled Diagram-Page-3 (1)](https://github.com/wso2/identity-api-server/assets/35717390/72d206bc-b602-4614-a4dd-113b959000b2)

- The above change is done for the role-management API also.

- The package name was changed from `org.wso2.identity.rest.api.organization.management.v1` to `org.wso2.identity.api.server.organization.management.v1` as most of the modules in this repo adhere to that pattern. The same change was done for the role-management API related module.

### Related Issues
- https://github.com/wso2/product-is/issues/16359