### PR TITLE
Add API Layer for Organization User Invitation MGT

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.organization.role.management/org.wso2.carbon.identity.api.server.organization.role.management.common/pom.xml
+++ b/components/org.wso2.carbon.identity.api.server.organization.role.management/org.wso2.carbon.identity.api.server.organization.role.management.common/pom.xml
@@ -40,5 +40,10 @@
             <artifactId>org.wso2.carbon.identity.organization.management.role.management.service</artifactId>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.organization.management.core</groupId>
+            <artifactId>org.wso2.carbon.identity.organization.management.service</artifactId>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/components/org.wso2.carbon.identity.api.server.organization.role.management/org.wso2.carbon.identity.api.server.organization.role.management.v1/pom.xml
+++ b/components/org.wso2.carbon.identity.api.server.organization.role.management/org.wso2.carbon.identity.api.server.organization.role.management.v1/pom.xml
@@ -104,6 +104,11 @@
             <artifactId>org.wso2.carbon.identity.organization.management.role.management.service</artifactId>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.organization.management.core</groupId>
+            <artifactId>org.wso2.carbon.identity.organization.management.service</artifactId>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/components/org.wso2.carbon.identity.api.server.organization.user.invitation.management/org.wso2.carbon.identity.api.server.organization.user.invitation.management.common/pom.xml
+++ b/components/org.wso2.carbon.identity.api.server.organization.user.invitation.management/org.wso2.carbon.identity.api.server.organization.user.invitation.management.common/pom.xml
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+  ~
+  ~ WSO2 LLC. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.wso2.carbon.identity.server.api</groupId>
+        <artifactId>org.wso2.carbon.identity.api.server.organization.user.invitation.management</artifactId>
+        <version>1.2.69-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>org.wso2.carbon.identity.api.server.organization.user.invitation.management.common</artifactId>
+    <packaging>jar</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.wso2.carbon.multitenancy</groupId>
+            <artifactId>org.wso2.carbon.tenant.mgt</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.extension.identity.verification</groupId>
+            <artifactId>org.wso2.carbon.extension.identity.verification.provider</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.organization.management</groupId>
+            <artifactId>org.wso2.carbon.identity.organization.user.invitation.management</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.cxf</groupId>
+            <artifactId>cxf-rt-frontend-jaxrs</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.cxf</groupId>
+            <artifactId>cxf-rt-rs-service-description</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>javax.ws.rs</groupId>
+            <artifactId>javax.ws.rs-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-web</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.jaxrs</groupId>
+            <artifactId>jackson-jaxrs-json-provider</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.swagger</groupId>
+            <artifactId>swagger-jaxrs</artifactId>
+            <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-databind</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-annotations</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.dataformat</groupId>
+                    <artifactId>jackson-dataformat-yaml</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>javax.ws.rs</groupId>
+                    <artifactId>jsr311-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.google.guava</groupId>
+                    <artifactId>guava</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
+
+    <properties>
+        <maven.compiler.source>8</maven.compiler.source>
+        <maven.compiler.target>8</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+</project>

--- a/components/org.wso2.carbon.identity.api.server.organization.user.invitation.management/org.wso2.carbon.identity.api.server.organization.user.invitation.management.common/src/main/java/org/wso2/carbon/identity/api/server/organization/user/invitation/management/common/UserInvitationMgtConstants.java
+++ b/components/org.wso2.carbon.identity.api.server.organization.user.invitation.management/org.wso2.carbon.identity.api.server.organization.user.invitation.management.common/src/main/java/org/wso2/carbon/identity/api/server/organization/user/invitation/management/common/UserInvitationMgtConstants.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.organization.user.invitation.management.common;
+
+/**
+ * Holds the constants which the shared user invitation management API component is using.
+ */
+public class UserInvitationMgtConstants {
+
+    public static final String ERROR_PREFIX = "OUI-";
+
+    /**
+     * Enum for shared user invitation management related errors.
+     * Error Code - code to identify the error.
+     * Error Message - What went wrong.
+     * Error Description - Why it went wrong.
+     */
+    public enum ErrorMessage {
+
+        // Client errors.
+        ERROR_CODE_USER_NOT_FOUND("60000",
+                "Invalid user identifier is provided.",
+                "Invalid user identifier %s is provided."),
+        ERROR_CODE_INVALID_INVITATION("60001",
+                "Invalid invitation.",
+                "Provided invitation with the id %s is invalid."),
+        ERROR_CODE_INVALID_CONFIRMATION_CODE("60002",
+                "Invalid confirmation code.",
+                "Could not validate the confirmation code %s."),
+        ERROR_CODE_MULTIPLE_INVITATIONS_FOR_USER("60003",
+                "Unable to create the invitation.",
+                "Multiple invitations found for the user %s."),
+        ERROR_CODE_UNSUPPORTED_LIMIT("60004",
+                "Unsupported param.",
+                "Limit param is not supported yet."),
+        ERROR_CODE_UNSUPPORTED_OFFSET("60005",
+                "Unsupported param.",
+                "Offset param is not supported yet."),
+        ERROR_CODE_UNSUPPORTED_SORT_ORDER("60006",
+                "Unsupported param.",
+                "Sort order param is not supported yet."),
+        ERROR_CODE_UNSUPPORTED_SORT_BY("60007",
+                "Unsupported param.",
+                "Sort order param is not supported yet."),
+        ERROR_CODE_ACTIVE_INVITATION_AVAILABLE("60008",
+                "Invitation already exists.",
+                "An active invitation already exists for the user %s."),
+        ERROR_CODE_INVALID_FILTER("60009",
+                "Invalid filter.",
+                "Provided filter %s is not valid."),
+
+        // Server errors.
+        ERROR_CODE_CREATE_INVITATION("65001",
+                "Unable to create the invitation.",
+                "Could not create the invitation to the user %s."),
+        ERROR_CODE_GET_INVITATIONS("65002",
+                "Unable to retrieve the invitations.",
+                "Could not retrieve the invitations for the organization."),
+        ERROR_CODE_VALIDATE_INVITATION("65003",
+                "Unable to validate the invitation.",
+                "Could not validate the invitation with the confirmation code %s."),
+        ERROR_CODE_DELETE_INVITATION("65004",
+                "Unable to delete the invitation.",
+                "Could not delete the invitation with the id %s."),
+        ERROR_CODE_NOT_IMPLEMENTED("65100",
+                "Not Implemented.",
+                "Method is not implemented.");
+
+
+        private final String code;
+        private final String message;
+        private final String description;
+
+        ErrorMessage(String code, String message, String description) {
+
+            this.code = code;
+            this.message = message;
+            this.description = description;
+        }
+
+        public String getCode() {
+
+            return ERROR_PREFIX + code;
+        }
+
+        public String getMessage() {
+
+            return message;
+        }
+
+        public String getDescription() {
+
+            return description;
+        }
+
+        @Override
+        public String toString() {
+
+            return code + " | " + message;
+        }
+    }
+}

--- a/components/org.wso2.carbon.identity.api.server.organization.user.invitation.management/org.wso2.carbon.identity.api.server.organization.user.invitation.management.common/src/main/java/org/wso2/carbon/identity/api/server/organization/user/invitation/management/common/UserInvitationMgtServiceHolder.java
+++ b/components/org.wso2.carbon.identity.api.server.organization.user.invitation.management/org.wso2.carbon.identity.api.server.organization.user.invitation.management.common/src/main/java/org/wso2/carbon/identity/api/server/organization/user/invitation/management/common/UserInvitationMgtServiceHolder.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.organization.user.invitation.management.common;
+
+import org.wso2.carbon.identity.organization.user.invitation.management.InvitationCoreService;
+
+/**
+ * Holds the services which the shared user invitation management API component is using.
+ */
+public class UserInvitationMgtServiceHolder {
+
+    private static InvitationCoreService invitationCoreService;
+
+    /**
+     * Get Invitation Core osgi service.
+     *
+     * @return InvitationCoreService.
+     */
+    public static InvitationCoreService getInvitationCoreService() {
+
+        return invitationCoreService;
+    }
+
+    /**
+     * Set Invitation Core osgi service.
+     *
+     * @param invitationCoreService InvitationCoreService.
+     */
+    public static void setInvitationCoreService(InvitationCoreService invitationCoreService) {
+
+        UserInvitationMgtServiceHolder.invitationCoreService = invitationCoreService;
+    }
+}

--- a/components/org.wso2.carbon.identity.api.server.organization.user.invitation.management/org.wso2.carbon.identity.api.server.organization.user.invitation.management.common/src/main/java/org/wso2/carbon/identity/api/server/organization/user/invitation/management/common/factory/UserInvitationMgtOSGIServiceFactory.java
+++ b/components/org.wso2.carbon.identity.api.server.organization.user.invitation.management/org.wso2.carbon.identity.api.server.organization.user.invitation.management.common/src/main/java/org/wso2/carbon/identity/api/server/organization/user/invitation/management/common/factory/UserInvitationMgtOSGIServiceFactory.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.organization.user.invitation.management.common.factory;
+
+import org.springframework.beans.factory.config.AbstractFactoryBean;
+import org.wso2.carbon.context.PrivilegedCarbonContext;
+import org.wso2.carbon.identity.organization.user.invitation.management.InvitationCoreService;
+
+/**
+ * Factory Beans serves as a factory for creating other beans within the IOC container. This factory bean is used to
+ * instantiate the Invitation Core Service inside the container.
+ */
+public class UserInvitationMgtOSGIServiceFactory extends AbstractFactoryBean<InvitationCoreService> {
+
+    private InvitationCoreService invitationCoreService;
+
+    @Override
+    public Class<?> getObjectType() {
+
+        return Object.class;
+    }
+
+    @Override
+    protected InvitationCoreService createInstance() throws Exception {
+
+        if (this.invitationCoreService == null) {
+            InvitationCoreService invitationCoreService = (InvitationCoreService)
+                    PrivilegedCarbonContext.getThreadLocalCarbonContext()
+                            .getOSGiService(InvitationCoreService.class, null);
+            if (invitationCoreService == null) {
+                throw new Exception("Unable to retrieve InvitationCoreService.");
+            }
+            this.invitationCoreService = invitationCoreService;
+        }
+        return this.invitationCoreService;
+    }
+}

--- a/components/org.wso2.carbon.identity.api.server.organization.user.invitation.management/org.wso2.carbon.identity.api.server.organization.user.invitation.management.v1/pom.xml
+++ b/components/org.wso2.carbon.identity.api.server.organization.user.invitation.management/org.wso2.carbon.identity.api.server.organization.user.invitation.management.v1/pom.xml
@@ -1,0 +1,180 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+  ~
+  ~ WSO2 LLC. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.wso2.carbon.identity.server.api</groupId>
+        <artifactId>org.wso2.carbon.identity.api.server.organization.user.invitation.management</artifactId>
+        <version>1.2.69-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>org.wso2.carbon.identity.api.server.organization.user.invitation.management.v1</artifactId>
+    <packaging>jar</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>javax.ws.rs</groupId>
+            <artifactId>javax.ws.rs-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-web</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-beans</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.jaxrs</groupId>
+            <artifactId>jackson-jaxrs-json-provider</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.cxf</groupId>
+            <artifactId>cxf-rt-frontend-jaxrs</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.cxf</groupId>
+            <artifactId>cxf-rt-rs-service-description</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.swagger</groupId>
+            <artifactId>swagger-jaxrs</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-databind</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-annotations</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.dataformat</groupId>
+                    <artifactId>jackson-dataformat-yaml</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>javax.ws.rs</groupId>
+                    <artifactId>jsr311-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.google.guava</groupId>
+                    <artifactId>guava</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.server.api</groupId>
+            <artifactId>org.wso2.carbon.identity.api.server.organization.user.invitation.management.common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.server.api</groupId>
+            <artifactId>org.wso2.carbon.identity.api.server.common</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.organization.management</groupId>
+            <artifactId>org.wso2.carbon.identity.organization.user.invitation.management</artifactId>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+<!--            <plugin>-->
+<!--                <groupId>org.openapitools</groupId>-->
+<!--                <artifactId>openapi-generator-maven-plugin</artifactId>-->
+<!--                <version>4.1.2</version>-->
+<!--                <executions>-->
+<!--                    <execution>-->
+<!--                        <goals>-->
+<!--                            <goal>generate</goal>-->
+<!--                        </goals>-->
+<!--                        <configuration>-->
+<!--                            <inputSpec>${project.basedir}/src/main/resources/organization-user-invitation.yaml</inputSpec>-->
+<!--                            <generatorName>org.wso2.carbon.codegen.CxfWso2Generator</generatorName>-->
+<!--                            <configOptions>-->
+<!--                                <sourceFolder>src/gen/java</sourceFolder>-->
+<!--                                <apiPackage>org.wso2.carbon.identity.api.server.organization.user.invitation.management.v1</apiPackage>-->
+<!--                                <modelPackage>org.wso2.carbon.identity.api.server.organization.user.invitation.management.v1.model</modelPackage>-->
+<!--                                <packageName>org.wso2.carbon.identity.api.server.organization.user.invitation.management.v1</packageName>-->
+<!--                                <dateLibrary>java8</dateLibrary>-->
+<!--                                <hideGenerationTimestamp>true</hideGenerationTimestamp>-->
+<!--                            </configOptions>-->
+<!--                            <output>.</output>-->
+<!--                            <skipOverwrite>false</skipOverwrite>-->
+<!--                        </configuration>-->
+<!--                    </execution>-->
+<!--                </executions>-->
+<!--                <dependencies>-->
+<!--                    <dependency>-->
+<!--                        <groupId>org.openapitools</groupId>-->
+<!--                        <artifactId>cxf-wso2-openapi-generator</artifactId>-->
+<!--                        <version>1.0.0</version>-->
+<!--                    </dependency>-->
+<!--                </dependencies>-->
+<!--            </plugin>-->
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <version>1.8</version>
+                <executions>
+                    <execution>
+                        <id>add-source</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>add-source</goal>
+                        </goals>
+                        <configuration>
+                            <sources>
+                                <source>src/gen/java</source>
+                            </sources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>${maven.compiler.plugin.version}</version>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <properties>
+        <maven.compiler.source>8</maven.compiler.source>
+        <maven.compiler.target>8</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+</project>

--- a/components/org.wso2.carbon.identity.api.server.organization.user.invitation.management/org.wso2.carbon.identity.api.server.organization.user.invitation.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/user/invitation/management/v1/GuestsApi.java
+++ b/components/org.wso2.carbon.identity.api.server.organization.user.invitation.management/org.wso2.carbon.identity.api.server.organization.user.invitation.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/user/invitation/management/v1/GuestsApi.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.organization.user.invitation.management.v1;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.apache.cxf.jaxrs.ext.multipart.Attachment;
+import org.apache.cxf.jaxrs.ext.multipart.Multipart;
+import java.io.InputStream;
+import java.util.List;
+
+import org.wso2.carbon.identity.api.server.organization.user.invitation.management.v1.model.AcceptanceRequestBody;
+import org.wso2.carbon.identity.api.server.organization.user.invitation.management.v1.model.Error;
+import org.wso2.carbon.identity.api.server.organization.user.invitation.management.v1.model.IntrospectRequestBody;
+import org.wso2.carbon.identity.api.server.organization.user.invitation.management.v1.model.IntrospectSuccessResponse;
+import org.wso2.carbon.identity.api.server.organization.user.invitation.management.v1.model.InvitationRequestBody;
+import org.wso2.carbon.identity.api.server.organization.user.invitation.management.v1.model.InvitationSuccessResponse;
+import org.wso2.carbon.identity.api.server.organization.user.invitation.management.v1.model.InvitationsListResponse;
+import org.wso2.carbon.identity.api.server.organization.user.invitation.management.v1.GuestsApiService;
+
+import javax.validation.Valid;
+import javax.ws.rs.*;
+import javax.ws.rs.core.Response;
+import io.swagger.annotations.*;
+
+import javax.validation.constraints.*;
+
+@Path("/guests")
+@Api(description = "The guests API")
+
+public class GuestsApi  {
+
+    @Autowired
+    private GuestsApiService delegate;
+
+    @Valid
+    @POST
+    @Path("/invitation/accept")
+    @Consumes({ "application/json" })
+    @Produces({ "application/json" })
+    @ApiOperation(value = "Accepts an invitation from a user in the parent organization", notes = "After user clicks on the link provided, the application should invoke this API. In order to invoke this API a user should be logged in to the application. Then this API can be initiated with the access token issued for that user. This logged in user should be the same user which the invitation was initiated to.  <b>Scope required:</b> <br/>  - none ", response = Void.class, tags={ "Parent Organization User Invitation", })
+    @ApiResponses(value = { 
+        @ApiResponse(code = 200, message = "Successful Response", response = Void.class),
+        @ApiResponse(code = 400, message = "Bad Request", response = Error.class),
+        @ApiResponse(code = 401, message = "Unauthorized", response = Error.class),
+        @ApiResponse(code = 403, message = "Forbidden", response = Error.class),
+        @ApiResponse(code = 500, message = "Internal Server Error", response = Error.class)
+    })
+    public Response invitationAcceptPost(@ApiParam(value = "Details that need to confirm an invitation" ,required=true) @Valid AcceptanceRequestBody acceptanceRequestBody) {
+
+        return delegate.invitationAcceptPost(acceptanceRequestBody );
+    }
+
+    @Valid
+    @DELETE
+    @Path("/invitations/{invitationId}")
+    
+    @Produces({ "application/json" })
+    @ApiOperation(value = "Delete an invitation", notes = "Based on the requirements the invitations which are initiated by the same organization can be deleted. This should be invoked from an access token issued from an administrator of that organization.  <b>Scope required:</b> <br/>  - internal_guest_mgt_invite_delete ", response = Void.class, tags={ "Invitation Management", })
+    @ApiResponses(value = { 
+        @ApiResponse(code = 204, message = "Successful Response and if the resource not found", response = Void.class),
+        @ApiResponse(code = 400, message = "Bad Request", response = Error.class),
+        @ApiResponse(code = 401, message = "Unauthorized", response = Error.class),
+        @ApiResponse(code = 403, message = "Forbidden", response = Error.class),
+        @ApiResponse(code = 500, message = "Internal Server Error", response = Error.class)
+    })
+    public Response invitationDelete(@ApiParam(value = "ID of the invitation to delete",required=true) @PathParam("invitationId") String invitationId) {
+
+        return delegate.invitationDelete(invitationId );
+    }
+
+    @Valid
+    @POST
+    @Path("/invitation/introspect")
+    @Consumes({ "application/json" })
+    @Produces({ "application/json" })
+    @ApiOperation(value = "introspect an invitation's confirmation code", notes = "This API can be used to introspect the confirmation code. This will be  invoked from the application with the access token of the user which was logged into the application and switched to the organization where  the user resides in.  <b>Scope required:</b> <br/>  - none ", response = IntrospectSuccessResponse.class, tags={ "Parent Organization User Invitation", })
+    @ApiResponses(value = { 
+        @ApiResponse(code = 200, message = "Successful Response", response = IntrospectSuccessResponse.class),
+        @ApiResponse(code = 400, message = "Bad Request", response = Error.class),
+        @ApiResponse(code = 401, message = "Unauthorized", response = Error.class),
+        @ApiResponse(code = 403, message = "Forbidden", response = Error.class),
+        @ApiResponse(code = 500, message = "Internal Server Error", response = Error.class)
+    })
+    public Response invitationIntrospectPost(@ApiParam(value = "Details that need to introspect an invitation" ,required=true) @Valid IntrospectRequestBody introspectRequestBody) {
+
+        return delegate.invitationIntrospectPost(introspectRequestBody );
+    }
+
+    @Valid
+    @GET
+    @Path("/invitations")
+    
+    @Produces({ "application/json" })
+    @ApiOperation(value = "List down the user invitations", notes = "List down the invitations triggered from the current organization. This should be invoked from an access token issued from an administrator of that organization.  <b>Scope required:</b> <br/>  - internal_guest_mgt_invite_list ", response = InvitationsListResponse.class, tags={ "Invitation Management", })
+    @ApiResponses(value = { 
+        @ApiResponse(code = 200, message = "Successful Response", response = InvitationsListResponse.class),
+        @ApiResponse(code = 401, message = "Unauthorized", response = Error.class),
+        @ApiResponse(code = 403, message = "Forbidden", response = Error.class),
+        @ApiResponse(code = 500, message = "Internal Server Error", response = Error.class)
+    })
+    public Response invitationListGet(    @Valid@ApiParam(value = "Filtering the invitation based on the status. Status can be PENDING or EXPIRED.")  @QueryParam("filter") String filter,     @Valid@ApiParam(value = "Maximum number of records to return _This parameter is not supported yet._ ")  @QueryParam("limit") Integer limit,     @Valid@ApiParam(value = "Starting index of the pagination _This parameter is not supported yet._ ")  @QueryParam("offset") Integer offset,     @Valid@ApiParam(value = "Sort order of the returned records. Either ASC or DESC _This parameter is not supported yet._ ", allowableValues="ASC, DESC")  @QueryParam("sortOrder") String sortOrder,     @Valid@ApiParam(value = "Sort by a specific field _This parameter is not supported yet._ ")  @QueryParam("sortBy") String sortBy) {
+
+        return delegate.invitationListGet(filter,  limit,  offset,  sortOrder,  sortBy );
+    }
+
+    @Valid
+    @POST
+    @Path("/invite")
+    @Consumes({ "application/json" })
+    @Produces({ "application/json" })
+    @ApiOperation(value = "Invite a parent organization user to a child organization", notes = "Initiates an invitation to a user in the parent organization to onboard to the child organization. This will be initiated from the child organization.  <b>Scope required:</b> <br/>  - internal_guest_mgt_invite_add ", response = InvitationSuccessResponse.class, tags={ "Parent Organization User Invitation" })
+    @ApiResponses(value = { 
+        @ApiResponse(code = 201, message = "Successful Response", response = InvitationSuccessResponse.class),
+        @ApiResponse(code = 400, message = "Bad Request", response = Error.class),
+        @ApiResponse(code = 500, message = "Internal Server Error", response = Error.class)
+    })
+    public Response invitationTriggerPost(@ApiParam(value = "Details that need to initiate an invitation" ,required=true) @Valid InvitationRequestBody invitationRequestBody) {
+
+        return delegate.invitationTriggerPost(invitationRequestBody );
+    }
+
+}

--- a/components/org.wso2.carbon.identity.api.server.organization.user.invitation.management/org.wso2.carbon.identity.api.server.organization.user.invitation.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/user/invitation/management/v1/GuestsApiService.java
+++ b/components/org.wso2.carbon.identity.api.server.organization.user.invitation.management/org.wso2.carbon.identity.api.server.organization.user.invitation.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/user/invitation/management/v1/GuestsApiService.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.organization.user.invitation.management.v1;
+
+import org.wso2.carbon.identity.api.server.organization.user.invitation.management.v1.*;
+import org.wso2.carbon.identity.api.server.organization.user.invitation.management.v1.model.*;
+import org.apache.cxf.jaxrs.ext.multipart.Attachment;
+import org.apache.cxf.jaxrs.ext.multipart.Multipart;
+import java.io.InputStream;
+import java.util.List;
+import org.wso2.carbon.identity.api.server.organization.user.invitation.management.v1.model.AcceptanceRequestBody;
+import org.wso2.carbon.identity.api.server.organization.user.invitation.management.v1.model.Error;
+import org.wso2.carbon.identity.api.server.organization.user.invitation.management.v1.model.IntrospectRequestBody;
+import org.wso2.carbon.identity.api.server.organization.user.invitation.management.v1.model.IntrospectSuccessResponse;
+import org.wso2.carbon.identity.api.server.organization.user.invitation.management.v1.model.InvitationRequestBody;
+import org.wso2.carbon.identity.api.server.organization.user.invitation.management.v1.model.InvitationSuccessResponse;
+import org.wso2.carbon.identity.api.server.organization.user.invitation.management.v1.model.InvitationsListResponse;
+import javax.ws.rs.core.Response;
+
+
+public interface GuestsApiService {
+
+      public Response invitationAcceptPost(AcceptanceRequestBody acceptanceRequestBody);
+
+      public Response invitationDelete(String invitationId);
+
+      public Response invitationIntrospectPost(IntrospectRequestBody introspectRequestBody);
+
+      public Response invitationListGet(String filter, Integer limit, Integer offset, String sortOrder, String sortBy);
+
+      public Response invitationTriggerPost(InvitationRequestBody invitationRequestBody);
+}

--- a/components/org.wso2.carbon.identity.api.server.organization.user.invitation.management/org.wso2.carbon.identity.api.server.organization.user.invitation.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/user/invitation/management/v1/factories/GuestsApiServiceFactory.java
+++ b/components/org.wso2.carbon.identity.api.server.organization.user.invitation.management/org.wso2.carbon.identity.api.server.organization.user.invitation.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/user/invitation/management/v1/factories/GuestsApiServiceFactory.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.organization.user.invitation.management.v1.factories;
+
+import org.wso2.carbon.identity.api.server.organization.user.invitation.management.v1.GuestsApiService;
+import org.wso2.carbon.identity.api.server.organization.user.invitation.management.v1.impl.GuestsApiServiceImpl;
+
+public class GuestsApiServiceFactory {
+
+   private final static GuestsApiService service = new GuestsApiServiceImpl();
+
+   public static GuestsApiService getGuestsApi()
+   {
+      return service;
+   }
+}

--- a/components/org.wso2.carbon.identity.api.server.organization.user.invitation.management/org.wso2.carbon.identity.api.server.organization.user.invitation.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/user/invitation/management/v1/model/AcceptanceRequestBody.java
+++ b/components/org.wso2.carbon.identity.api.server.organization.user.invitation.management/org.wso2.carbon.identity.api.server.organization.user.invitation.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/user/invitation/management/v1/model/AcceptanceRequestBody.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.organization.user.invitation.management.v1.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import javax.validation.constraints.*;
+
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+import javax.validation.Valid;
+import javax.xml.bind.annotation.*;
+
+public class AcceptanceRequestBody  {
+  
+    private String confirmationCode;
+
+    /**
+    **/
+    public AcceptanceRequestBody confirmationCode(String confirmationCode) {
+
+        this.confirmationCode = confirmationCode;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "2663329b-c8c5-4c71-9500-9ea8c4e77d94", required = true, value = "")
+    @JsonProperty("confirmationCode")
+    @Valid
+    @NotNull(message = "Property confirmationCode cannot be null.")
+
+    public String getConfirmationCode() {
+        return confirmationCode;
+    }
+    public void setConfirmationCode(String confirmationCode) {
+        this.confirmationCode = confirmationCode;
+    }
+
+
+
+    @Override
+    public boolean equals(java.lang.Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        AcceptanceRequestBody acceptanceRequestBody = (AcceptanceRequestBody) o;
+        return Objects.equals(this.confirmationCode, acceptanceRequestBody.confirmationCode);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(confirmationCode);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class AcceptanceRequestBody {\n");
+        
+        sb.append("    confirmationCode: ").append(toIndentedString(confirmationCode)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+    * Convert the given object to string with each line indented by 4 spaces
+    * (except the first line).
+    */
+    private String toIndentedString(java.lang.Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}
+

--- a/components/org.wso2.carbon.identity.api.server.organization.user.invitation.management/org.wso2.carbon.identity.api.server.organization.user.invitation.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/user/invitation/management/v1/model/Error.java
+++ b/components/org.wso2.carbon.identity.api.server.organization.user.invitation.management/org.wso2.carbon.identity.api.server.organization.user.invitation.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/user/invitation/management/v1/model/Error.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.organization.user.invitation.management.v1.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import javax.validation.constraints.*;
+
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+import javax.validation.Valid;
+import javax.xml.bind.annotation.*;
+
+public class Error  {
+  
+    private String code;
+    private String message;
+    private String description;
+    private String traceId;
+
+    /**
+    * An error code.
+    **/
+    public Error code(String code) {
+
+        this.code = code;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "OUI-00000", required = true, value = "An error code.")
+    @JsonProperty("code")
+    @Valid
+    @NotNull(message = "Property code cannot be null.")
+
+    public String getCode() {
+        return code;
+    }
+    public void setCode(String code) {
+        this.code = code;
+    }
+
+    /**
+    * An error message.
+    **/
+    public Error message(String message) {
+
+        this.message = message;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "Some Error Message", required = true, value = "An error message.")
+    @JsonProperty("message")
+    @Valid
+    @NotNull(message = "Property message cannot be null.")
+
+    public String getMessage() {
+        return message;
+    }
+    public void setMessage(String message) {
+        this.message = message;
+    }
+
+    /**
+    * An error description.
+    **/
+    public Error description(String description) {
+
+        this.description = description;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "Some Error Description", value = "An error description.")
+    @JsonProperty("description")
+    @Valid
+    public String getDescription() {
+        return description;
+    }
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    /**
+    * An error trace identifier.
+    **/
+    public Error traceId(String traceId) {
+
+        this.traceId = traceId;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "e0fbcfeb-3617-43c4-8dd0-7b7d38e13047", value = "An error trace identifier.")
+    @JsonProperty("traceId")
+    @Valid
+    public String getTraceId() {
+        return traceId;
+    }
+    public void setTraceId(String traceId) {
+        this.traceId = traceId;
+    }
+
+
+
+    @Override
+    public boolean equals(java.lang.Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Error error = (Error) o;
+        return Objects.equals(this.code, error.code) &&
+            Objects.equals(this.message, error.message) &&
+            Objects.equals(this.description, error.description) &&
+            Objects.equals(this.traceId, error.traceId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(code, message, description, traceId);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class Error {\n");
+        
+        sb.append("    code: ").append(toIndentedString(code)).append("\n");
+        sb.append("    message: ").append(toIndentedString(message)).append("\n");
+        sb.append("    description: ").append(toIndentedString(description)).append("\n");
+        sb.append("    traceId: ").append(toIndentedString(traceId)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+    * Convert the given object to string with each line indented by 4 spaces
+    * (except the first line).
+    */
+    private String toIndentedString(java.lang.Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}
+

--- a/components/org.wso2.carbon.identity.api.server.organization.user.invitation.management/org.wso2.carbon.identity.api.server.organization.user.invitation.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/user/invitation/management/v1/model/IntrospectRequestBody.java
+++ b/components/org.wso2.carbon.identity.api.server.organization.user.invitation.management/org.wso2.carbon.identity.api.server.organization.user.invitation.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/user/invitation/management/v1/model/IntrospectRequestBody.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.organization.user.invitation.management.v1.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import javax.validation.constraints.*;
+
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+import javax.validation.Valid;
+import javax.xml.bind.annotation.*;
+
+public class IntrospectRequestBody  {
+  
+    private String confirmationCode;
+
+    /**
+    **/
+    public IntrospectRequestBody confirmationCode(String confirmationCode) {
+
+        this.confirmationCode = confirmationCode;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "2663329b-c8c5-4c71-9500-9ea8c4e77d94", required = true, value = "")
+    @JsonProperty("confirmationCode")
+    @Valid
+    @NotNull(message = "Property confirmationCode cannot be null.")
+
+    public String getConfirmationCode() {
+        return confirmationCode;
+    }
+    public void setConfirmationCode(String confirmationCode) {
+        this.confirmationCode = confirmationCode;
+    }
+
+
+
+    @Override
+    public boolean equals(java.lang.Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        IntrospectRequestBody introspectRequestBody = (IntrospectRequestBody) o;
+        return Objects.equals(this.confirmationCode, introspectRequestBody.confirmationCode);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(confirmationCode);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class IntrospectRequestBody {\n");
+        
+        sb.append("    confirmationCode: ").append(toIndentedString(confirmationCode)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+    * Convert the given object to string with each line indented by 4 spaces
+    * (except the first line).
+    */
+    private String toIndentedString(java.lang.Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}
+

--- a/components/org.wso2.carbon.identity.api.server.organization.user.invitation.management/org.wso2.carbon.identity.api.server.organization.user.invitation.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/user/invitation/management/v1/model/IntrospectSuccessResponse.java
+++ b/components/org.wso2.carbon.identity.api.server.organization.user.invitation.management/org.wso2.carbon.identity.api.server.organization.user.invitation.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/user/invitation/management/v1/model/IntrospectSuccessResponse.java
@@ -1,0 +1,197 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.organization.user.invitation.management.v1.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import javax.validation.constraints.*;
+
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+import javax.validation.Valid;
+import javax.xml.bind.annotation.*;
+
+public class IntrospectSuccessResponse  {
+  
+    private String confirmationCode;
+    private String username;
+    private String userOrganization;
+    private String initiatedOrganization;
+    private String status;
+
+    /**
+    * Confirmation code of the invitation which needs to be introspected.
+    **/
+    public IntrospectSuccessResponse confirmationCode(String confirmationCode) {
+
+        this.confirmationCode = confirmationCode;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "2663329b-c8c5-4c71-9500-9ea8c4e77d94", required = true, value = "Confirmation code of the invitation which needs to be introspected.")
+    @JsonProperty("confirmationCode")
+    @Valid
+    @NotNull(message = "Property confirmationCode cannot be null.")
+
+    public String getConfirmationCode() {
+        return confirmationCode;
+    }
+    public void setConfirmationCode(String confirmationCode) {
+        this.confirmationCode = confirmationCode;
+    }
+
+    /**
+    * Username of the user who will be invited to the organization. This can be an email or an alphanumeric username.
+    **/
+    public IntrospectSuccessResponse username(String username) {
+
+        this.username = username;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "alex@gmail.com/alex", required = true, value = "Username of the user who will be invited to the organization. This can be an email or an alphanumeric username.")
+    @JsonProperty("username")
+    @Valid
+    @NotNull(message = "Property username cannot be null.")
+
+    public String getUsername() {
+        return username;
+    }
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    /**
+    * Organization which the user is residing.
+    **/
+    public IntrospectSuccessResponse userOrganization(String userOrganization) {
+
+        this.userOrganization = userOrganization;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "8763329b-c8c5-4c71-9500-9ea8c4e77345", required = true, value = "Organization which the user is residing.")
+    @JsonProperty("userOrganization")
+    @Valid
+    @NotNull(message = "Property userOrganization cannot be null.")
+
+    public String getUserOrganization() {
+        return userOrganization;
+    }
+    public void setUserOrganization(String userOrganization) {
+        this.userOrganization = userOrganization;
+    }
+
+    /**
+    * Organization which the invitation is initiated.
+    **/
+    public IntrospectSuccessResponse initiatedOrganization(String initiatedOrganization) {
+
+        this.initiatedOrganization = initiatedOrganization;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "1239329b-c8c5-4c71-9500-9ea8c4e70987", required = true, value = "Organization which the invitation is initiated.")
+    @JsonProperty("initiatedOrganization")
+    @Valid
+    @NotNull(message = "Property initiatedOrganization cannot be null.")
+
+    public String getInitiatedOrganization() {
+        return initiatedOrganization;
+    }
+    public void setInitiatedOrganization(String initiatedOrganization) {
+        this.initiatedOrganization = initiatedOrganization;
+    }
+
+    /**
+    * Status of the invitation.
+    **/
+    public IntrospectSuccessResponse status(String status) {
+
+        this.status = status;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "PENDING/EXPIRED", required = true, value = "Status of the invitation.")
+    @JsonProperty("status")
+    @Valid
+    @NotNull(message = "Property status cannot be null.")
+
+    public String getStatus() {
+        return status;
+    }
+    public void setStatus(String status) {
+        this.status = status;
+    }
+
+
+
+    @Override
+    public boolean equals(java.lang.Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        IntrospectSuccessResponse introspectSuccessResponse = (IntrospectSuccessResponse) o;
+        return Objects.equals(this.confirmationCode, introspectSuccessResponse.confirmationCode) &&
+            Objects.equals(this.username, introspectSuccessResponse.username) &&
+            Objects.equals(this.userOrganization, introspectSuccessResponse.userOrganization) &&
+            Objects.equals(this.initiatedOrganization, introspectSuccessResponse.initiatedOrganization) &&
+            Objects.equals(this.status, introspectSuccessResponse.status);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(confirmationCode, username, userOrganization, initiatedOrganization, status);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class IntrospectSuccessResponse {\n");
+        
+        sb.append("    confirmationCode: ").append(toIndentedString(confirmationCode)).append("\n");
+        sb.append("    username: ").append(toIndentedString(username)).append("\n");
+        sb.append("    userOrganization: ").append(toIndentedString(userOrganization)).append("\n");
+        sb.append("    initiatedOrganization: ").append(toIndentedString(initiatedOrganization)).append("\n");
+        sb.append("    status: ").append(toIndentedString(status)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+    * Convert the given object to string with each line indented by 4 spaces
+    * (except the first line).
+    */
+    private String toIndentedString(java.lang.Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}
+

--- a/components/org.wso2.carbon.identity.api.server.organization.user.invitation.management/org.wso2.carbon.identity.api.server.organization.user.invitation.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/user/invitation/management/v1/model/InvitationRequestBody.java
+++ b/components/org.wso2.carbon.identity.api.server.organization.user.invitation.management/org.wso2.carbon.identity.api.server.organization.user.invitation.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/user/invitation/management/v1/model/InvitationRequestBody.java
@@ -1,0 +1,179 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.organization.user.invitation.management.v1.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import java.util.ArrayList;
+import java.util.List;
+import org.wso2.carbon.identity.api.server.organization.user.invitation.management.v1.model.RoleAssignmentRequestBody;
+import javax.validation.constraints.*;
+
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+import javax.validation.Valid;
+import javax.xml.bind.annotation.*;
+
+public class InvitationRequestBody  {
+  
+    private String username;
+    private String userDomain;
+    private List<RoleAssignmentRequestBody> roleAssignments = null;
+
+    private String userRedirectUrl;
+
+    /**
+    * Username of the user who will be invited to the organization. This can be an email or an alphanumeric username.
+    **/
+    public InvitationRequestBody username(String username) {
+
+        this.username = username;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "alex@gmail.com/alex", required = true, value = "Username of the user who will be invited to the organization. This can be an email or an alphanumeric username.")
+    @JsonProperty("username")
+    @Valid
+    @NotNull(message = "Property username cannot be null.")
+
+    public String getUsername() {
+        return username;
+    }
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    /**
+    * User store domain of the user. If not provided, PRIMARY will be used.
+    **/
+    public InvitationRequestBody userDomain(String userDomain) {
+
+        this.userDomain = userDomain;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "PRIMARY", value = "User store domain of the user. If not provided, PRIMARY will be used.")
+    @JsonProperty("userDomain")
+    @Valid
+    public String getUserDomain() {
+        return userDomain;
+    }
+    public void setUserDomain(String userDomain) {
+        this.userDomain = userDomain;
+    }
+
+    /**
+    * Role assignments which the user will be assigned to.
+    **/
+    public InvitationRequestBody roleAssignments(List<RoleAssignmentRequestBody> roleAssignments) {
+
+        this.roleAssignments = roleAssignments;
+        return this;
+    }
+    
+    @ApiModelProperty(value = "Role assignments which the user will be assigned to.")
+    @JsonProperty("roleAssignments")
+    @Valid
+    public List<RoleAssignmentRequestBody> getRoleAssignments() {
+        return roleAssignments;
+    }
+    public void setRoleAssignments(List<RoleAssignmentRequestBody> roleAssignments) {
+        this.roleAssignments = roleAssignments;
+    }
+
+    public InvitationRequestBody addRoleAssignmentsItem(RoleAssignmentRequestBody roleAssignmentsItem) {
+        if (this.roleAssignments == null) {
+            this.roleAssignments = new ArrayList<>();
+        }
+        this.roleAssignments.add(roleAssignmentsItem);
+        return this;
+    }
+
+        /**
+    * URL to which the user should be redirected for authenticate and a place where accepting API can be invoked. This should be able to invoke switch grant and get the token from the organization where the user is existing.
+    **/
+    public InvitationRequestBody userRedirectUrl(String userRedirectUrl) {
+
+        this.userRedirectUrl = userRedirectUrl;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "https://localhost:8080/travel-manager/invitations/accept", value = "URL to which the user should be redirected for authenticate and a place where accepting API can be invoked. This should be able to invoke switch grant and get the token from the organization where the user is existing.")
+    @JsonProperty("userRedirectUrl")
+    @Valid
+    public String getUserRedirectUrl() {
+        return userRedirectUrl;
+    }
+    public void setUserRedirectUrl(String userRedirectUrl) {
+        this.userRedirectUrl = userRedirectUrl;
+    }
+
+
+
+    @Override
+    public boolean equals(java.lang.Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        InvitationRequestBody invitationRequestBody = (InvitationRequestBody) o;
+        return Objects.equals(this.username, invitationRequestBody.username) &&
+            Objects.equals(this.userDomain, invitationRequestBody.userDomain) &&
+            Objects.equals(this.roleAssignments, invitationRequestBody.roleAssignments) &&
+            Objects.equals(this.userRedirectUrl, invitationRequestBody.userRedirectUrl);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(username, userDomain, roleAssignments, userRedirectUrl);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class InvitationRequestBody {\n");
+        
+        sb.append("    username: ").append(toIndentedString(username)).append("\n");
+        sb.append("    userDomain: ").append(toIndentedString(userDomain)).append("\n");
+        sb.append("    roleAssignments: ").append(toIndentedString(roleAssignments)).append("\n");
+        sb.append("    userRedirectUrl: ").append(toIndentedString(userRedirectUrl)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+    * Convert the given object to string with each line indented by 4 spaces
+    * (except the first line).
+    */
+    private String toIndentedString(java.lang.Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}
+

--- a/components/org.wso2.carbon.identity.api.server.organization.user.invitation.management/org.wso2.carbon.identity.api.server.organization.user.invitation.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/user/invitation/management/v1/model/InvitationResponse.java
+++ b/components/org.wso2.carbon.identity.api.server.organization.user.invitation.management/org.wso2.carbon.identity.api.server.organization.user.invitation.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/user/invitation/management/v1/model/InvitationResponse.java
@@ -1,0 +1,269 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.organization.user.invitation.management.v1.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import java.util.ArrayList;
+import java.util.List;
+import org.wso2.carbon.identity.api.server.organization.user.invitation.management.v1.model.RoleAssignmentResponse;
+import javax.validation.constraints.*;
+
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+import javax.validation.Valid;
+import javax.xml.bind.annotation.*;
+
+public class InvitationResponse  {
+  
+    private String id;
+    private String confirmationCode;
+    private String username;
+    private String email;
+    private List<RoleAssignmentResponse> roleAssignments = null;
+
+    private String status;
+    private String expiredAt;
+    private String userRedirectUrl;
+
+    /**
+    **/
+    public InvitationResponse id(String id) {
+
+        this.id = id;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "f7594498-5b52-4201-abd5-d7cf72565c73", required = true, value = "")
+    @JsonProperty("id")
+    @Valid
+    @NotNull(message = "Property id cannot be null.")
+
+    public String getId() {
+        return id;
+    }
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    /**
+    **/
+    public InvitationResponse confirmationCode(String confirmationCode) {
+
+        this.confirmationCode = confirmationCode;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "2663329b-c8c5-4c71-9500-9ea8c4e77d94", required = true, value = "")
+    @JsonProperty("confirmationCode")
+    @Valid
+    @NotNull(message = "Property confirmationCode cannot be null.")
+
+    public String getConfirmationCode() {
+        return confirmationCode;
+    }
+    public void setConfirmationCode(String confirmationCode) {
+        this.confirmationCode = confirmationCode;
+    }
+
+    /**
+    **/
+    public InvitationResponse username(String username) {
+
+        this.username = username;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "alex@gmail.com/alex", required = true, value = "")
+    @JsonProperty("username")
+    @Valid
+    @NotNull(message = "Property username cannot be null.")
+
+    public String getUsername() {
+        return username;
+    }
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    /**
+    **/
+    public InvitationResponse email(String email) {
+
+        this.email = email;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "alex@gmail.com", required = true, value = "")
+    @JsonProperty("email")
+    @Valid
+    @NotNull(message = "Property email cannot be null.")
+
+    public String getEmail() {
+        return email;
+    }
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    /**
+    **/
+    public InvitationResponse roleAssignments(List<RoleAssignmentResponse> roleAssignments) {
+
+        this.roleAssignments = roleAssignments;
+        return this;
+    }
+    
+    @ApiModelProperty(value = "")
+    @JsonProperty("roleAssignments")
+    @Valid
+    public List<RoleAssignmentResponse> getRoleAssignments() {
+        return roleAssignments;
+    }
+    public void setRoleAssignments(List<RoleAssignmentResponse> roleAssignments) {
+        this.roleAssignments = roleAssignments;
+    }
+
+    public InvitationResponse addRoleAssignmentsItem(RoleAssignmentResponse roleAssignmentsItem) {
+        if (this.roleAssignments == null) {
+            this.roleAssignments = new ArrayList<>();
+        }
+        this.roleAssignments.add(roleAssignmentsItem);
+        return this;
+    }
+
+        /**
+    **/
+    public InvitationResponse status(String status) {
+
+        this.status = status;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "PENDING/EXPIRED", required = true, value = "")
+    @JsonProperty("status")
+    @Valid
+    @NotNull(message = "Property status cannot be null.")
+
+    public String getStatus() {
+        return status;
+    }
+    public void setStatus(String status) {
+        this.status = status;
+    }
+
+    /**
+    **/
+    public InvitationResponse expiredAt(String expiredAt) {
+
+        this.expiredAt = expiredAt;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "2021-08-10T10:15:30.00Z", value = "")
+    @JsonProperty("expiredAt")
+    @Valid
+    public String getExpiredAt() {
+        return expiredAt;
+    }
+    public void setExpiredAt(String expiredAt) {
+        this.expiredAt = expiredAt;
+    }
+
+    /**
+    **/
+    public InvitationResponse userRedirectUrl(String userRedirectUrl) {
+
+        this.userRedirectUrl = userRedirectUrl;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "https://localhost:8080/travel-manager/login", required = true, value = "")
+    @JsonProperty("userRedirectUrl")
+    @Valid
+    @NotNull(message = "Property userRedirectUrl cannot be null.")
+
+    public String getUserRedirectUrl() {
+        return userRedirectUrl;
+    }
+    public void setUserRedirectUrl(String userRedirectUrl) {
+        this.userRedirectUrl = userRedirectUrl;
+    }
+
+
+
+    @Override
+    public boolean equals(java.lang.Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        InvitationResponse invitationResponse = (InvitationResponse) o;
+        return Objects.equals(this.id, invitationResponse.id) &&
+            Objects.equals(this.confirmationCode, invitationResponse.confirmationCode) &&
+            Objects.equals(this.username, invitationResponse.username) &&
+            Objects.equals(this.email, invitationResponse.email) &&
+            Objects.equals(this.roleAssignments, invitationResponse.roleAssignments) &&
+            Objects.equals(this.status, invitationResponse.status) &&
+            Objects.equals(this.expiredAt, invitationResponse.expiredAt) &&
+            Objects.equals(this.userRedirectUrl, invitationResponse.userRedirectUrl);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, confirmationCode, username, email, roleAssignments, status, expiredAt, userRedirectUrl);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class InvitationResponse {\n");
+        
+        sb.append("    id: ").append(toIndentedString(id)).append("\n");
+        sb.append("    confirmationCode: ").append(toIndentedString(confirmationCode)).append("\n");
+        sb.append("    username: ").append(toIndentedString(username)).append("\n");
+        sb.append("    email: ").append(toIndentedString(email)).append("\n");
+        sb.append("    roleAssignments: ").append(toIndentedString(roleAssignments)).append("\n");
+        sb.append("    status: ").append(toIndentedString(status)).append("\n");
+        sb.append("    expiredAt: ").append(toIndentedString(expiredAt)).append("\n");
+        sb.append("    userRedirectUrl: ").append(toIndentedString(userRedirectUrl)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+    * Convert the given object to string with each line indented by 4 spaces
+    * (except the first line).
+    */
+    private String toIndentedString(java.lang.Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}
+

--- a/components/org.wso2.carbon.identity.api.server.organization.user.invitation.management/org.wso2.carbon.identity.api.server.organization.user.invitation.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/user/invitation/management/v1/model/InvitationSuccessResponse.java
+++ b/components/org.wso2.carbon.identity.api.server.organization.user.invitation.management/org.wso2.carbon.identity.api.server.organization.user.invitation.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/user/invitation/management/v1/model/InvitationSuccessResponse.java
@@ -1,0 +1,206 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.organization.user.invitation.management.v1.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import java.util.ArrayList;
+import java.util.List;
+import org.wso2.carbon.identity.api.server.organization.user.invitation.management.v1.model.RoleAssignmentResponse;
+import javax.validation.constraints.*;
+
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+import javax.validation.Valid;
+import javax.xml.bind.annotation.*;
+
+public class InvitationSuccessResponse  {
+  
+    private String confirmationCode;
+    private String username;
+    private String email;
+    private List<RoleAssignmentResponse> roleAssignments = new ArrayList<>();
+
+    private String userRedirectUrl;
+
+    /**
+    * Confirmation code of the invitation which needs to be passed back from the confirmation API to accept the invitation.
+    **/
+    public InvitationSuccessResponse confirmationCode(String confirmationCode) {
+
+        this.confirmationCode = confirmationCode;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "2663329b-c8c5-4c71-9500-9ea8c4e77d94", required = true, value = "Confirmation code of the invitation which needs to be passed back from the confirmation API to accept the invitation.")
+    @JsonProperty("confirmationCode")
+    @Valid
+    @NotNull(message = "Property confirmationCode cannot be null.")
+
+    public String getConfirmationCode() {
+        return confirmationCode;
+    }
+    public void setConfirmationCode(String confirmationCode) {
+        this.confirmationCode = confirmationCode;
+    }
+
+    /**
+    * Username of the user who will be invited to the organization. This can be an email or an alphanumeric username.
+    **/
+    public InvitationSuccessResponse username(String username) {
+
+        this.username = username;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "alex@gmail.com/alex", required = true, value = "Username of the user who will be invited to the organization. This can be an email or an alphanumeric username.")
+    @JsonProperty("username")
+    @Valid
+    @NotNull(message = "Property username cannot be null.")
+
+    public String getUsername() {
+        return username;
+    }
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    /**
+    * Email of the user who will be invited to the organization.
+    **/
+    public InvitationSuccessResponse email(String email) {
+
+        this.email = email;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "alex@gmail.com", required = true, value = "Email of the user who will be invited to the organization.")
+    @JsonProperty("email")
+    @Valid
+    @NotNull(message = "Property email cannot be null.")
+
+    public String getEmail() {
+        return email;
+    }
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    /**
+    * Role assignments which the user will be assigned to.
+    **/
+    public InvitationSuccessResponse roleAssignments(List<RoleAssignmentResponse> roleAssignments) {
+
+        this.roleAssignments = roleAssignments;
+        return this;
+    }
+    
+    @ApiModelProperty(required = true, value = "Role assignments which the user will be assigned to.")
+    @JsonProperty("roleAssignments")
+    @Valid
+    @NotNull(message = "Property roleAssignments cannot be null.")
+
+    public List<RoleAssignmentResponse> getRoleAssignments() {
+        return roleAssignments;
+    }
+    public void setRoleAssignments(List<RoleAssignmentResponse> roleAssignments) {
+        this.roleAssignments = roleAssignments;
+    }
+
+    public InvitationSuccessResponse addRoleAssignmentsItem(RoleAssignmentResponse roleAssignmentsItem) {
+        this.roleAssignments.add(roleAssignmentsItem);
+        return this;
+    }
+
+        /**
+    * URL to which the user should be redirected for authenticate before accepting API is invoked.
+    **/
+    public InvitationSuccessResponse userRedirectUrl(String userRedirectUrl) {
+
+        this.userRedirectUrl = userRedirectUrl;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "https://localhost:8080/travel-manager/login", required = true, value = "URL to which the user should be redirected for authenticate before accepting API is invoked.")
+    @JsonProperty("userRedirectUrl")
+    @Valid
+    @NotNull(message = "Property userRedirectUrl cannot be null.")
+
+    public String getUserRedirectUrl() {
+        return userRedirectUrl;
+    }
+    public void setUserRedirectUrl(String userRedirectUrl) {
+        this.userRedirectUrl = userRedirectUrl;
+    }
+
+
+
+    @Override
+    public boolean equals(java.lang.Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        InvitationSuccessResponse invitationSuccessResponse = (InvitationSuccessResponse) o;
+        return Objects.equals(this.confirmationCode, invitationSuccessResponse.confirmationCode) &&
+            Objects.equals(this.username, invitationSuccessResponse.username) &&
+            Objects.equals(this.email, invitationSuccessResponse.email) &&
+            Objects.equals(this.roleAssignments, invitationSuccessResponse.roleAssignments) &&
+            Objects.equals(this.userRedirectUrl, invitationSuccessResponse.userRedirectUrl);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(confirmationCode, username, email, roleAssignments, userRedirectUrl);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class InvitationSuccessResponse {\n");
+        
+        sb.append("    confirmationCode: ").append(toIndentedString(confirmationCode)).append("\n");
+        sb.append("    username: ").append(toIndentedString(username)).append("\n");
+        sb.append("    email: ").append(toIndentedString(email)).append("\n");
+        sb.append("    roleAssignments: ").append(toIndentedString(roleAssignments)).append("\n");
+        sb.append("    userRedirectUrl: ").append(toIndentedString(userRedirectUrl)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+    * Convert the given object to string with each line indented by 4 spaces
+    * (except the first line).
+    */
+    private String toIndentedString(java.lang.Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}
+

--- a/components/org.wso2.carbon.identity.api.server.organization.user.invitation.management/org.wso2.carbon.identity.api.server.organization.user.invitation.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/user/invitation/management/v1/model/InvitationsListResponse.java
+++ b/components/org.wso2.carbon.identity.api.server.organization.user.invitation.management/org.wso2.carbon.identity.api.server.organization.user.invitation.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/user/invitation/management/v1/model/InvitationsListResponse.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.organization.user.invitation.management.v1.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import java.util.ArrayList;
+import java.util.List;
+import org.wso2.carbon.identity.api.server.organization.user.invitation.management.v1.model.InvitationResponse;
+import javax.validation.constraints.*;
+
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+import javax.validation.Valid;
+import javax.xml.bind.annotation.*;
+
+public class InvitationsListResponse  {
+  
+    private List<InvitationResponse> invitations = null;
+
+
+    /**
+    **/
+    public InvitationsListResponse invitations(List<InvitationResponse> invitations) {
+
+        this.invitations = invitations;
+        return this;
+    }
+    
+    @ApiModelProperty(value = "")
+    @JsonProperty("invitations")
+    @Valid
+    public List<InvitationResponse> getInvitations() {
+        return invitations;
+    }
+    public void setInvitations(List<InvitationResponse> invitations) {
+        this.invitations = invitations;
+    }
+
+    public InvitationsListResponse addInvitationsItem(InvitationResponse invitationsItem) {
+        if (this.invitations == null) {
+            this.invitations = new ArrayList<>();
+        }
+        this.invitations.add(invitationsItem);
+        return this;
+    }
+
+    
+
+    @Override
+    public boolean equals(java.lang.Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        InvitationsListResponse invitationsListResponse = (InvitationsListResponse) o;
+        return Objects.equals(this.invitations, invitationsListResponse.invitations);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(invitations);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class InvitationsListResponse {\n");
+        
+        sb.append("    invitations: ").append(toIndentedString(invitations)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+    * Convert the given object to string with each line indented by 4 spaces
+    * (except the first line).
+    */
+    private String toIndentedString(java.lang.Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}
+

--- a/components/org.wso2.carbon.identity.api.server.organization.user.invitation.management/org.wso2.carbon.identity.api.server.organization.user.invitation.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/user/invitation/management/v1/model/RoleAssignmentRequestBody.java
+++ b/components/org.wso2.carbon.identity.api.server.organization.user.invitation.management/org.wso2.carbon.identity.api.server.organization.user.invitation.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/user/invitation/management/v1/model/RoleAssignmentRequestBody.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.organization.user.invitation.management.v1.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import java.util.ArrayList;
+import java.util.List;
+import javax.validation.constraints.*;
+
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+import javax.validation.Valid;
+import javax.xml.bind.annotation.*;
+
+public class RoleAssignmentRequestBody  {
+  
+    private String applicationId;
+    private List<String> roles = new ArrayList<>();
+
+
+    /**
+    **/
+    public RoleAssignmentRequestBody applicationId(String applicationId) {
+
+        this.applicationId = applicationId;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "f7594498-5b52-4201-abd5-d7cf72565c73", required = true, value = "")
+    @JsonProperty("applicationId")
+    @Valid
+    @NotNull(message = "Property applicationId cannot be null.")
+
+    public String getApplicationId() {
+        return applicationId;
+    }
+    public void setApplicationId(String applicationId) {
+        this.applicationId = applicationId;
+    }
+
+    /**
+    **/
+    public RoleAssignmentRequestBody roles(List<String> roles) {
+
+        this.roles = roles;
+        return this;
+    }
+    
+    @ApiModelProperty(required = true, value = "")
+    @JsonProperty("roles")
+    @Valid
+    @NotNull(message = "Property roles cannot be null.")
+
+    public List<String> getRoles() {
+        return roles;
+    }
+    public void setRoles(List<String> roles) {
+        this.roles = roles;
+    }
+
+    public RoleAssignmentRequestBody addRolesItem(String rolesItem) {
+        this.roles.add(rolesItem);
+        return this;
+    }
+
+    
+
+    @Override
+    public boolean equals(java.lang.Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        RoleAssignmentRequestBody roleAssignmentRequestBody = (RoleAssignmentRequestBody) o;
+        return Objects.equals(this.applicationId, roleAssignmentRequestBody.applicationId) &&
+            Objects.equals(this.roles, roleAssignmentRequestBody.roles);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(applicationId, roles);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class RoleAssignmentRequestBody {\n");
+        
+        sb.append("    applicationId: ").append(toIndentedString(applicationId)).append("\n");
+        sb.append("    roles: ").append(toIndentedString(roles)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+    * Convert the given object to string with each line indented by 4 spaces
+    * (except the first line).
+    */
+    private String toIndentedString(java.lang.Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}
+

--- a/components/org.wso2.carbon.identity.api.server.organization.user.invitation.management/org.wso2.carbon.identity.api.server.organization.user.invitation.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/user/invitation/management/v1/model/RoleAssignmentResponse.java
+++ b/components/org.wso2.carbon.identity.api.server.organization.user.invitation.management/org.wso2.carbon.identity.api.server.organization.user.invitation.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/user/invitation/management/v1/model/RoleAssignmentResponse.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.organization.user.invitation.management.v1.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import java.util.ArrayList;
+import java.util.List;
+import javax.validation.constraints.*;
+
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+import javax.validation.Valid;
+import javax.xml.bind.annotation.*;
+
+public class RoleAssignmentResponse  {
+  
+    private String applicationId;
+    private String applicationName;
+    private List<String> roles = new ArrayList<>();
+
+
+    /**
+    **/
+    public RoleAssignmentResponse applicationId(String applicationId) {
+
+        this.applicationId = applicationId;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "f7594498-5b52-4201-abd5-d7cf72565c73", required = true, value = "")
+    @JsonProperty("applicationId")
+    @Valid
+    @NotNull(message = "Property applicationId cannot be null.")
+
+    public String getApplicationId() {
+        return applicationId;
+    }
+    public void setApplicationId(String applicationId) {
+        this.applicationId = applicationId;
+    }
+
+    /**
+    **/
+    public RoleAssignmentResponse applicationName(String applicationName) {
+
+        this.applicationName = applicationName;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "b2b_business_sample_application", value = "")
+    @JsonProperty("applicationName")
+    @Valid
+    public String getApplicationName() {
+        return applicationName;
+    }
+    public void setApplicationName(String applicationName) {
+        this.applicationName = applicationName;
+    }
+
+    /**
+    **/
+    public RoleAssignmentResponse roles(List<String> roles) {
+
+        this.roles = roles;
+        return this;
+    }
+    
+    @ApiModelProperty(required = true, value = "")
+    @JsonProperty("roles")
+    @Valid
+    @NotNull(message = "Property roles cannot be null.")
+
+    public List<String> getRoles() {
+        return roles;
+    }
+    public void setRoles(List<String> roles) {
+        this.roles = roles;
+    }
+
+    public RoleAssignmentResponse addRolesItem(String rolesItem) {
+        this.roles.add(rolesItem);
+        return this;
+    }
+
+    
+
+    @Override
+    public boolean equals(java.lang.Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        RoleAssignmentResponse roleAssignmentResponse = (RoleAssignmentResponse) o;
+        return Objects.equals(this.applicationId, roleAssignmentResponse.applicationId) &&
+            Objects.equals(this.applicationName, roleAssignmentResponse.applicationName) &&
+            Objects.equals(this.roles, roleAssignmentResponse.roles);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(applicationId, applicationName, roles);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class RoleAssignmentResponse {\n");
+        
+        sb.append("    applicationId: ").append(toIndentedString(applicationId)).append("\n");
+        sb.append("    applicationName: ").append(toIndentedString(applicationName)).append("\n");
+        sb.append("    roles: ").append(toIndentedString(roles)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+    * Convert the given object to string with each line indented by 4 spaces
+    * (except the first line).
+    */
+    private String toIndentedString(java.lang.Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}
+

--- a/components/org.wso2.carbon.identity.api.server.organization.user.invitation.management/org.wso2.carbon.identity.api.server.organization.user.invitation.management.v1/src/main/java/org/wso2/carbon/identity/api/server/organization/user/invitation/management/v1/core/GuestApiServiceCore.java
+++ b/components/org.wso2.carbon.identity.api.server.organization.user.invitation.management/org.wso2.carbon.identity.api.server.organization.user.invitation.management.v1/src/main/java/org/wso2/carbon/identity/api/server/organization/user/invitation/management/v1/core/GuestApiServiceCore.java
@@ -1,0 +1,294 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.organization.user.invitation.management.v1.core;
+
+import org.apache.commons.lang.StringUtils;
+import org.wso2.carbon.identity.api.server.common.error.APIError;
+import org.wso2.carbon.identity.api.server.common.error.ErrorResponse;
+import org.wso2.carbon.identity.api.server.organization.user.invitation.management.common.UserInvitationMgtConstants;
+import org.wso2.carbon.identity.api.server.organization.user.invitation.management.v1.model.AcceptanceRequestBody;
+import org.wso2.carbon.identity.api.server.organization.user.invitation.management.v1.model.IntrospectSuccessResponse;
+import org.wso2.carbon.identity.api.server.organization.user.invitation.management.v1.model.InvitationRequestBody;
+import org.wso2.carbon.identity.api.server.organization.user.invitation.management.v1.model.InvitationResponse;
+import org.wso2.carbon.identity.api.server.organization.user.invitation.management.v1.model.InvitationSuccessResponse;
+import org.wso2.carbon.identity.api.server.organization.user.invitation.management.v1.model.InvitationsListResponse;
+import org.wso2.carbon.identity.api.server.organization.user.invitation.management.v1.model.RoleAssignmentRequestBody;
+import org.wso2.carbon.identity.api.server.organization.user.invitation.management.v1.model.RoleAssignmentResponse;
+import org.wso2.carbon.identity.organization.user.invitation.management.InvitationCoreServiceImpl;
+import org.wso2.carbon.identity.organization.user.invitation.management.exception.UserInvitationMgtException;
+import org.wso2.carbon.identity.organization.user.invitation.management.models.Invitation;
+import org.wso2.carbon.identity.organization.user.invitation.management.models.RoleAssignments;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import javax.ws.rs.core.Response;
+
+import static org.wso2.carbon.identity.organization.user.invitation.management.constant.UserInvitationMgtConstants.ErrorMessage.ERROR_CODE_ACTIVE_INVITATION_EXISTS;
+import static org.wso2.carbon.identity.organization.user.invitation.management.constant.UserInvitationMgtConstants.ErrorMessage.ERROR_CODE_INVALID_CONFIRMATION_CODE;
+import static org.wso2.carbon.identity.organization.user.invitation.management.constant.UserInvitationMgtConstants.ErrorMessage.ERROR_CODE_INVALID_FILTER;
+import static org.wso2.carbon.identity.organization.user.invitation.management.constant.UserInvitationMgtConstants.ErrorMessage.ERROR_CODE_INVALID_INVITATION_ID;
+import static org.wso2.carbon.identity.organization.user.invitation.management.constant.UserInvitationMgtConstants.ErrorMessage.ERROR_CODE_MULTIPLE_INVITATIONS_FOR_USER;
+import static org.wso2.carbon.identity.organization.user.invitation.management.constant.UserInvitationMgtConstants.ErrorMessage.ERROR_CODE_UNSUPPORTED_FILTER_ATTRIBUTE;
+import static org.wso2.carbon.identity.organization.user.invitation.management.constant.UserInvitationMgtConstants.ErrorMessage.ERROR_CODE_UNSUPPORTED_FILTER_ATTRIBUTE_VALUE;
+import static org.wso2.carbon.identity.organization.user.invitation.management.constant.UserInvitationMgtConstants.ErrorMessage.ERROR_CODE_USER_NOT_FOUND;
+import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
+import static javax.ws.rs.core.Response.Status.INTERNAL_SERVER_ERROR;
+import static javax.ws.rs.core.Response.Status.NOT_IMPLEMENTED;
+
+/**
+ * Service class for the User Invitation Management APIs.
+ */
+public class GuestApiServiceCore {
+
+    private static List<RoleAssignmentResponse> buildRoleAssignmentResponse(Invitation invitationRecord) {
+
+        List<RoleAssignmentResponse> roleAssignmentResponseList = new ArrayList<>();
+        for (RoleAssignments roleAssignment : invitationRecord.getRoleAssignments()) {
+            if (roleAssignment.getRoles() != null) {
+                RoleAssignmentResponse roleAssignmentResponse = new RoleAssignmentResponse();
+                roleAssignmentResponse.setApplicationId(roleAssignment.getApplicationId());
+                roleAssignmentResponse.setRoles(Arrays.asList(roleAssignment.getRoles()));
+                roleAssignmentResponseList.add(roleAssignmentResponse);
+            }
+        }
+        return roleAssignmentResponseList;
+    }
+
+    /**
+     * Creates the invitation to the shared user.
+     *
+     * @param invitationRequestBody Contains the details of the invitation.
+     * @return The details of the created invitation.
+     */
+    public InvitationSuccessResponse createInvitation(InvitationRequestBody invitationRequestBody) {
+
+        InvitationCoreServiceImpl invitationCoreService = new InvitationCoreServiceImpl();
+        Invitation invitation = new Invitation();
+        invitation.setUsername(invitationRequestBody.getUsername());
+        invitation.setUserDomain(invitationRequestBody.getUserDomain());
+        invitation.setUserRedirectUrl(invitationRequestBody.getUserRedirectUrl());
+        if (invitationRequestBody.getRoleAssignments() != null) {
+            List<RoleAssignments> roleAssignments = new ArrayList<>();
+            for (RoleAssignmentRequestBody roleAssignmentRequestBody : invitationRequestBody.getRoleAssignments()) {
+                if (roleAssignmentRequestBody.getRoles() != null) {
+                    RoleAssignments roleAssignment = new RoleAssignments();
+                    roleAssignment.setApplicationId(roleAssignmentRequestBody.getApplicationId());
+                    roleAssignment.setRoles(roleAssignmentRequestBody.getRoles().toArray(new String[0]));
+                    roleAssignments.add(roleAssignment);
+                }
+            }
+            invitation.setRoleAssignments(roleAssignments.toArray(new RoleAssignments[0]));
+        }
+        Invitation invitationResponse;
+        try {
+            invitationResponse = invitationCoreService.createInvitation(invitation);
+        } catch (UserInvitationMgtException e) {
+            if (ERROR_CODE_USER_NOT_FOUND.getCode().equals(e.getErrorCode())) {
+                throw handleException(BAD_REQUEST, UserInvitationMgtConstants.ErrorMessage
+                        .ERROR_CODE_USER_NOT_FOUND, invitation.getUsername());
+            } else if (ERROR_CODE_MULTIPLE_INVITATIONS_FOR_USER.getCode().equals(e.getErrorCode())) {
+                throw handleException(BAD_REQUEST, UserInvitationMgtConstants.ErrorMessage
+                        .ERROR_CODE_MULTIPLE_INVITATIONS_FOR_USER, invitation.getUsername());
+            } else if (ERROR_CODE_ACTIVE_INVITATION_EXISTS.getCode().equals(e.getErrorCode())) {
+                throw handleException(BAD_REQUEST, UserInvitationMgtConstants.ErrorMessage
+                        .ERROR_CODE_ACTIVE_INVITATION_AVAILABLE, invitation.getUsername());
+            }
+            throw handleException(Response.Status.INTERNAL_SERVER_ERROR,
+                    UserInvitationMgtConstants.ErrorMessage.ERROR_CODE_CREATE_INVITATION,
+                    invitation.getUsername());
+        }
+        return createInvitationSuccessResponse(invitationResponse);
+    }
+
+    /**
+     * Gets the invitations for the authenticated user's organization.
+     *
+     * @param filter Contains the filter to be applied to the invitation list. ex : status eq 'PENDING'
+     * @return The list of invitations initiated by the authenticated user's organization.
+     */
+    public InvitationsListResponse getInvitations(String filter, Integer limit, Integer offset, String sortOrder,
+                                                  String sortBy) {
+
+        if (!isUnsupportedParamAvailable(limit, offset, sortOrder, sortBy)) {
+            InvitationCoreServiceImpl invitationCoreService = new InvitationCoreServiceImpl();
+            try {
+                return buildInvitationsListResponse(invitationCoreService.getInvitations(filter));
+            } catch (UserInvitationMgtException e) {
+                if (ERROR_CODE_INVALID_FILTER.getCode().equals(e.getErrorCode())) {
+                    throw handleException(BAD_REQUEST, UserInvitationMgtConstants.ErrorMessage
+                            .ERROR_CODE_INVALID_FILTER, filter);
+                } else if (ERROR_CODE_UNSUPPORTED_FILTER_ATTRIBUTE_VALUE.getCode().equals(e.getErrorCode())) {
+                    throw handleException(BAD_REQUEST, UserInvitationMgtConstants.ErrorMessage
+                            .ERROR_CODE_INVALID_FILTER, filter);
+                } else if (ERROR_CODE_UNSUPPORTED_FILTER_ATTRIBUTE.getCode().equals(e.getErrorCode())) {
+                    throw handleException(BAD_REQUEST, UserInvitationMgtConstants.ErrorMessage
+                            .ERROR_CODE_INVALID_FILTER, filter);
+                }
+                throw handleException(Response.Status.INTERNAL_SERVER_ERROR,
+                        UserInvitationMgtConstants.ErrorMessage.ERROR_CODE_GET_INVITATIONS, StringUtils.EMPTY);
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Gets the validity of the invitation by using the confirmation code.
+     *
+     * @param confirmationCode Contains the confirmation code of the invitation.
+     * @return Very limited details of the invitation including the status.
+     */
+    public IntrospectSuccessResponse introspectInvitation(String confirmationCode) {
+
+        InvitationCoreServiceImpl invitationCoreService = new InvitationCoreServiceImpl();
+        try {
+            return buildValidateResponse(invitationCoreService.introspectInvitation(confirmationCode));
+        } catch (UserInvitationMgtException e) {
+            if (ERROR_CODE_INVALID_CONFIRMATION_CODE.getCode().equals(e.getErrorCode())) {
+                throw handleException(BAD_REQUEST, UserInvitationMgtConstants.ErrorMessage
+                        .ERROR_CODE_INVALID_CONFIRMATION_CODE, confirmationCode);
+            }
+            throw handleException(Response.Status.INTERNAL_SERVER_ERROR,
+                    UserInvitationMgtConstants.ErrorMessage.ERROR_CODE_VALIDATE_INVITATION, confirmationCode);
+        }
+    }
+
+    /**
+     * Deletes an invitation by using the invitation id. This will remove the invitation from the core.
+     *
+     * @param invitationId Contains the invitation id of the invitation to be deleted.
+     * @return True if the invitation is deleted successfully.
+     */
+    public boolean deleteInvitation(String invitationId) {
+
+        InvitationCoreServiceImpl invitationCoreService = new InvitationCoreServiceImpl();
+        try {
+            return invitationCoreService.deleteInvitation(invitationId);
+        } catch (UserInvitationMgtException e) {
+            if (ERROR_CODE_INVALID_INVITATION_ID.getCode().equals(e.getErrorCode())) {
+                throw handleException(BAD_REQUEST,
+                        UserInvitationMgtConstants.ErrorMessage.ERROR_CODE_INVALID_INVITATION, invitationId);
+            }
+            throw handleException(INTERNAL_SERVER_ERROR, UserInvitationMgtConstants.ErrorMessage
+                    .ERROR_CODE_DELETE_INVITATION, invitationId);
+        }
+    }
+
+    /**
+     * Accepts the invitation by sending the confirmation code. This will invalidate the confirmation code and
+     * proceed with the sharing and the role assignments if there are any.
+     * NOTE : NOT IMPLEMENTED
+     *
+     * @param acceptanceRequestBody Contains the confirmation code of the invitation.
+     */
+    public void acceptInvitation(AcceptanceRequestBody acceptanceRequestBody) {
+
+        throw handleException(NOT_IMPLEMENTED, UserInvitationMgtConstants
+                .ErrorMessage.ERROR_CODE_NOT_IMPLEMENTED, null);
+    }
+
+    private APIError handleException(Response.Status status, UserInvitationMgtConstants.ErrorMessage error,
+                                     String data) {
+
+        return new APIError(status, getErrorBuilder(error, data).build());
+    }
+
+    private ErrorResponse.Builder getErrorBuilder(UserInvitationMgtConstants.ErrorMessage errorMsg, String data) {
+
+        return new ErrorResponse.Builder()
+                .withCode(errorMsg.getCode())
+                .withMessage(errorMsg.getMessage())
+                .withDescription(includeData(errorMsg, data));
+    }
+
+    private String includeData(UserInvitationMgtConstants.ErrorMessage error, String data) {
+
+        if (StringUtils.isNotBlank(data)) {
+            return String.format(error.getDescription(), data);
+        }
+        return error.getDescription();
+    }
+
+    private InvitationSuccessResponse createInvitationSuccessResponse(Invitation invitation) {
+
+        InvitationSuccessResponse invitationSuccessResponse = new InvitationSuccessResponse();
+        invitationSuccessResponse.setConfirmationCode(invitation.getConfirmationCode());
+        invitationSuccessResponse.setUsername(invitation.getUsername());
+        invitationSuccessResponse.setEmail(invitation.getEmail());
+        invitationSuccessResponse.setUserRedirectUrl(invitation.getUserRedirectUrl());
+        if (invitation.getRoleAssignments().length > 0) {
+            List<RoleAssignmentResponse> roleAssignmentResponses = buildRoleAssignmentResponse(invitation);
+            invitationSuccessResponse.setRoleAssignments(roleAssignmentResponses);
+        }
+        return invitationSuccessResponse;
+    }
+
+    private InvitationsListResponse buildInvitationsListResponse(List<Invitation> invitationList) {
+
+        InvitationsListResponse invitationsListResponse = new InvitationsListResponse();
+        for (Invitation invitationRecord : invitationList) {
+            InvitationResponse invitationResponse = new InvitationResponse();
+            invitationResponse.setId(invitationRecord.getInvitationId());
+            invitationResponse.setConfirmationCode(invitationRecord.getConfirmationCode());
+            invitationResponse.setUsername(invitationRecord.getUsername());
+            invitationResponse.setEmail(invitationRecord.getEmail());
+            invitationResponse.setStatus(invitationRecord.getStatus());
+            invitationResponse.setExpiredAt(invitationRecord.getExpiredAt().toString());
+            invitationResponse.setUserRedirectUrl(invitationRecord.getUserRedirectUrl());
+            if (invitationRecord.getRoleAssignments().length > 0) {
+                List<RoleAssignmentResponse> roleAssignments = buildRoleAssignmentResponse(invitationRecord);
+                invitationResponse.setRoleAssignments(roleAssignments);
+            }
+            invitationsListResponse.addInvitationsItem(invitationResponse);
+        }
+        return invitationsListResponse;
+    }
+
+    private IntrospectSuccessResponse buildValidateResponse(Invitation invitation) {
+
+        IntrospectSuccessResponse introspectSuccessResponse = new IntrospectSuccessResponse();
+        introspectSuccessResponse.setConfirmationCode(invitation.getConfirmationCode());
+        introspectSuccessResponse.setUsername(invitation.getUsername());
+        introspectSuccessResponse.setUserOrganization(invitation.getUserOrganizationId());
+        introspectSuccessResponse.setInitiatedOrganization(invitation.getInvitedOrganizationId());
+        introspectSuccessResponse.setStatus(invitation.getStatus());
+        return introspectSuccessResponse;
+    }
+
+    private boolean isUnsupportedParamAvailable(Integer limit, Integer offset, String sortOrder, String sortBy) {
+
+        if (limit != null) {
+            throw handleException(BAD_REQUEST, UserInvitationMgtConstants.ErrorMessage
+                    .ERROR_CODE_UNSUPPORTED_LIMIT, String.valueOf(limit));
+        }
+        if (offset != null) {
+            throw handleException(BAD_REQUEST, UserInvitationMgtConstants.ErrorMessage
+                    .ERROR_CODE_UNSUPPORTED_OFFSET, String.valueOf(offset));
+        }
+        if (StringUtils.isNotBlank(sortOrder)) {
+            throw handleException(BAD_REQUEST, UserInvitationMgtConstants.ErrorMessage
+                    .ERROR_CODE_UNSUPPORTED_SORT_ORDER, sortOrder);
+        }
+        if (StringUtils.isNotBlank(sortBy)) {
+            throw handleException(BAD_REQUEST, UserInvitationMgtConstants.ErrorMessage
+                    .ERROR_CODE_UNSUPPORTED_SORT_BY, sortBy);
+        }
+        return false;
+    }
+}

--- a/components/org.wso2.carbon.identity.api.server.organization.user.invitation.management/org.wso2.carbon.identity.api.server.organization.user.invitation.management.v1/src/main/java/org/wso2/carbon/identity/api/server/organization/user/invitation/management/v1/impl/GuestsApiServiceImpl.java
+++ b/components/org.wso2.carbon.identity.api.server.organization.user.invitation.management/org.wso2.carbon.identity.api.server.organization.user.invitation.management.v1/src/main/java/org/wso2/carbon/identity/api/server/organization/user/invitation/management/v1/impl/GuestsApiServiceImpl.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.organization.user.invitation.management.v1.impl;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.wso2.carbon.identity.api.server.organization.user.invitation.management.v1.GuestsApiService;
+import org.wso2.carbon.identity.api.server.organization.user.invitation.management.v1.core.GuestApiServiceCore;
+import org.wso2.carbon.identity.api.server.organization.user.invitation.management.v1.model.AcceptanceRequestBody;
+import org.wso2.carbon.identity.api.server.organization.user.invitation.management.v1.model.IntrospectRequestBody;
+import org.wso2.carbon.identity.api.server.organization.user.invitation.management.v1.model.IntrospectSuccessResponse;
+import org.wso2.carbon.identity.api.server.organization.user.invitation.management.v1.model.InvitationRequestBody;
+import org.wso2.carbon.identity.api.server.organization.user.invitation.management.v1.model.InvitationSuccessResponse;
+import org.wso2.carbon.identity.api.server.organization.user.invitation.management.v1.model.InvitationsListResponse;
+
+import javax.ws.rs.core.Response;
+
+/**
+ * Implementation of the invitation management APIs.
+ */
+public class GuestsApiServiceImpl implements GuestsApiService {
+
+    @Autowired
+    private GuestApiServiceCore guestApiServiceCore;
+
+    @Override
+    public Response invitationAcceptPost(AcceptanceRequestBody acceptanceRequestBody) {
+
+        guestApiServiceCore.acceptInvitation(acceptanceRequestBody);
+        return Response.noContent().build();
+    }
+
+    @Override
+    public Response invitationDelete(String invitationId) {
+
+        guestApiServiceCore.deleteInvitation(invitationId);
+        return Response.noContent().build();
+    }
+
+    @Override
+    public Response invitationIntrospectPost(IntrospectRequestBody introspectRequestBody) {
+
+        IntrospectSuccessResponse introspectSuccessResponse =
+                guestApiServiceCore.introspectInvitation(introspectRequestBody.getConfirmationCode());
+        return Response.ok().entity(introspectSuccessResponse).build();
+    }
+
+    @Override
+    public Response invitationListGet(String filter, Integer limit, Integer offset, String sortOrder, String sortBy) {
+
+        InvitationsListResponse invitationsListResponse = guestApiServiceCore.getInvitations(filter, limit, offset,
+                sortOrder, sortBy);
+        return Response.ok().entity(invitationsListResponse).build();
+    }
+
+    @Override
+    public Response invitationTriggerPost(InvitationRequestBody invitationRequestBody) {
+
+        InvitationSuccessResponse invitationSuccessResponse =
+                guestApiServiceCore.createInvitation(invitationRequestBody);
+        return Response.ok().entity(invitationSuccessResponse).build();
+    }
+}

--- a/components/org.wso2.carbon.identity.api.server.organization.user.invitation.management/org.wso2.carbon.identity.api.server.organization.user.invitation.management.v1/src/main/resources/META-INF/cxf/organization-user-invitation-mgt-v1-cxf.xml
+++ b/components/org.wso2.carbon.identity.api.server.organization.user.invitation.management/org.wso2.carbon.identity.api.server.organization.user.invitation.management.v1/src/main/resources/META-INF/cxf/organization-user-invitation-mgt-v1-cxf.xml
@@ -1,0 +1,33 @@
+<!--
+  ~ Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+  ~
+  ~ WSO2 LLC. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:jaxrs="http://cxf.apache.org/jaxrs" xmlns:context="http://www.springframework.org/schema/context"
+       xsi:schemaLocation=" http://www.springframework.org/schema/beans
+       http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.0.xsd
+       http://cxf.apache.org/jaxrs http://cxf.apache.org/schemas/jaxrs.xsd">
+    <bean class="org.wso2.carbon.identity.api.server.organization.user.invitation.management.v1.core.GuestApiServiceCore"/>
+    <bean class="org.wso2.carbon.identity.api.server.organization.user.invitation.management.v1.impl.GuestsApiServiceImpl"/>
+    <bean id="userInvitationMgtOSGIServiceFactoryBean"
+          class="org.wso2.carbon.identity.api.server.organization.user.invitation.management.common.factory.UserInvitationMgtOSGIServiceFactory"/>
+    <bean id="userInvitationManagerHolderBean"
+          class="org.wso2.carbon.identity.api.server.organization.user.invitation.management.common.UserInvitationMgtServiceHolder">
+        <property name="invitationCoreService" ref="userInvitationMgtOSGIServiceFactoryBean"/>
+    </bean>
+</beans>

--- a/components/org.wso2.carbon.identity.api.server.organization.user.invitation.management/org.wso2.carbon.identity.api.server.organization.user.invitation.management.v1/src/main/resources/organization-user-invitation.yaml
+++ b/components/org.wso2.carbon.identity.api.server.organization.user.invitation.management/org.wso2.carbon.identity.api.server.organization.user.invitation.management.v1/src/main/resources/organization-user-invitation.yaml
@@ -1,0 +1,529 @@
+openapi: 3.0.0
+info:
+  version: 1.0.0
+  title: 'Private CIAM Cloud - Parent User Invitation API Definition'
+  description: |-
+    This is the RESTful API for parent organization user invitation for child organizations in CIAM Cloud. This API 
+    allows administrators to invite users, manage the invitations and invitees are allowed to accept the invitation.
+  contact:
+    name: WSO2
+    url: 'https://wso2.com/ciam-suite/private-ciam-cloud/b2b-ciam'
+    email: iam-dev@wso2.org
+  license:
+    name: Apache 2.0
+    url: 'http://www.apache.org/licenses/LICENSE-2.0.html'
+servers:
+  - url: 'https://localhost:9443/o/{organization-domain}/api/server/v1'
+    variables:
+      organization-domain:
+        default: 10084a8d-113f-4211-a0d5-efe36b082211
+paths:
+  /guests/invite:
+    post:
+      tags:
+        - Parent Organization User Invitation
+      summary: Invite a parent organization user to a child organization
+      description: |
+        Initiates an invitation to a user in the parent organization to onboard to the child organization.
+        This will be initiated from the child organization.
+        
+        <b>Scope required:</b> <br/> 
+        - internal_guest_mgt_invite_add
+      operationId: invitationTriggerPost
+      requestBody:
+        $ref: '#/components/requestBodies/InvitationRequestPayload'
+      responses:
+        '201':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InvitationSuccessResponse'
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '500':
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+  /guests/invitation/introspect:
+    post:
+      tags:
+        - Parent Organization User Invitation
+      summary: introspect an invitation's confirmation code
+      description: |
+        This API can be used to introspect the confirmation code. This will be 
+        invoked from the application with the access token of the user which
+        was logged into the application and switched to the organization where 
+        the user resides in.
+
+        <b>Scope required:</b> <br/> 
+        - none
+      operationId: invitationIntrospectPost
+      requestBody:
+        $ref: '#/components/requestBodies/IntrospectRequestPayload'
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IntrospectSuccessResponse'
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '500':
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+  /guests/invitation/accept:
+    post:
+      tags:
+        - Parent Organization User Invitation
+      summary: Accepts an invitation from a user in the parent organization
+      description: |
+        After user clicks on the link provided, the application should invoke this API.
+        In order to invoke this API a user should be logged in to the application.
+        Then this API can be initiated with the access token issued for that user.
+        This logged in user should be the same user which the invitation was initiated to.
+        
+        <b>Scope required:</b> <br/> 
+        - none
+      operationId: invitationAcceptPost
+      requestBody:
+        $ref: '#/components/requestBodies/AcceptanceRequestPayload'
+      responses:
+        '200':
+          description: Successful Response
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '500':
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+  /guests/invitations:
+    get:
+      tags:
+        - Invitation Management
+      summary: List down the user invitations
+      description: |
+        List down the invitations triggered from the current organization. This should be invoked
+        from an access token issued from an administrator of that organization.
+        
+        <b>Scope required:</b> <br/> 
+        - internal_guest_mgt_invite_list
+      operationId: invitationListGet
+      parameters:
+        - $ref: '#/components/parameters/FilterQueryParam'
+        - $ref: '#/components/parameters/LimitQueryParam'
+        - $ref: '#/components/parameters/OffsetQueryParam'
+        - $ref: '#/components/parameters/sortOrderQueryParam'
+        - $ref: '#/components/parameters/sortByQueryParam'
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InvitationsListResponse'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '500':
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+  /guests/invitations/{invitationId}:
+    delete:
+      tags:
+        - Invitation Management
+      summary: Delete an invitation
+      description: |
+        Based on the requirements the invitations which are initiated by the same organization
+        can be deleted. This should be invoked from an access token issued from an administrator of that organization.
+        
+        <b>Scope required:</b> <br/> 
+        - internal_guest_mgt_invite_delete
+      operationId: invitationDelete
+      parameters:
+        - name: invitationId
+          in: path
+          description: ID of the invitation to delete
+          required: true
+          schema:
+            type: string
+            example: 2d88a90a-3060-46f0-b863-fc481fef8137
+      responses:
+        '204':
+          description: Successful Response and if the resource not found
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '500':
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+components:
+  requestBodies:
+    InvitationRequestPayload:
+      description: Details that need to initiate an invitation
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/InvitationRequestBody'
+      required: true
+    IntrospectRequestPayload:
+      description: Details that need to introspect an invitation
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/IntrospectRequestBody'
+      required: true
+    AcceptanceRequestPayload:
+      description: Details that need to confirm an invitation
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/AcceptanceRequestBody'
+      required: true
+  parameters:
+    FilterQueryParam:
+      in: query
+      name: filter
+      required: false
+      description: Filtering the invitation based on the status. Status can be PENDING or EXPIRED.
+      schema:
+        type: string
+      example: status eq PENDING
+    LimitQueryParam:
+      in: query
+      name: limit
+      required: false
+      description: |
+        Maximum number of records to return
+        _This parameter is not supported yet._
+      schema:
+        type: integer
+      example: 10
+    OffsetQueryParam:
+      in: query
+      name: offset
+      required: false
+      description: |
+        Starting index of the pagination
+        _This parameter is not supported yet._
+      schema:
+        type: integer
+      example: 0
+    sortOrderQueryParam:
+      in: query
+      name: sortOrder
+      required: false
+      description: |
+        Sort order of the returned records. Either ASC or DESC
+        _This parameter is not supported yet._
+      schema:
+        type: string
+        enum:
+          - ASC
+          - DESC
+    sortByQueryParam:
+      in: query
+      name: sortBy
+      required: false
+      description: |
+        Sort by a specific field
+        _This parameter is not supported yet._
+      schema:
+        type: string
+        example: createdTime
+  schemas:
+    InvitationRequestBody:
+      type: object
+      required:
+        - username
+        - applicationId
+        - roles
+      properties:
+        username:
+          type: string
+          description: Username of the user who will be invited to the organization. This can be an
+            email or an alphanumeric username.
+          example: alex@gmail.com/alex
+        userDomain:
+          type: string
+          description: User store domain of the user. If not provided, PRIMARY will be used.
+          example: PRIMARY
+        roleAssignments:
+          type: array
+          description: Role assignments which the user will be assigned to.
+          items:
+            $ref: '#/components/schemas/RoleAssignmentRequestBody'
+        userRedirectUrl:
+          type: string
+          description: URL to which the user should be redirected for authenticate and a place where accepting API
+            can be invoked. This should be able to invoke switch grant and get the token from the organization where
+            the user is existing.
+          example: https://localhost:8080/travel-manager/invitations/accept
+    InvitationSuccessResponse:
+      type: object
+      required:
+        - confirmationCode
+        - username
+        - email
+        - roleAssignments
+        - userRedirectUrl
+      properties:
+        confirmationCode:
+          type: string
+          description: Confirmation code of the invitation which needs to be passed back from the confirmation API
+            to accept the invitation.
+          example: 2663329b-c8c5-4c71-9500-9ea8c4e77d94
+        username:
+          type: string
+          description: Username of the user who will be invited to the organization. This can be an
+            email or an alphanumeric username.
+          example: alex@gmail.com/alex
+        email:
+          type: string
+          description: Email of the user who will be invited to the organization.
+          example: alex@gmail.com
+        roleAssignments:
+          type: array
+          description: Role assignments which the user will be assigned to.
+          items:
+            $ref: '#/components/schemas/RoleAssignmentResponse'
+        userRedirectUrl:
+          type: string
+          description: URL to which the user should be redirected for authenticate before accepting API
+            is invoked.
+          example: https://localhost:8080/travel-manager/login
+    IntrospectRequestBody:
+      type: object
+      required:
+        - confirmationCode
+      properties:
+        confirmationCode:
+          type: string
+          example: 2663329b-c8c5-4c71-9500-9ea8c4e77d94
+    IntrospectSuccessResponse:
+      type: object
+      required:
+        - confirmationCode
+        - username
+        - userOrganization
+        - initiatedOrganization
+        - status
+      properties:
+        confirmationCode:
+          type: string
+          description: Confirmation code of the invitation which needs to be introspected.
+          example: 2663329b-c8c5-4c71-9500-9ea8c4e77d94
+        username:
+          type: string
+          description: Username of the user who will be invited to the organization. This can be an
+            email or an alphanumeric username.
+          example: alex@gmail.com/alex
+        userOrganization:
+          type: string
+          description: Organization which the user is residing.
+          example: 8763329b-c8c5-4c71-9500-9ea8c4e77345
+        initiatedOrganization:
+          type: string
+          description: Organization which the invitation is initiated.
+          example: 1239329b-c8c5-4c71-9500-9ea8c4e70987
+        status:
+          type: string
+          description: Status of the invitation.
+          example: PENDING/EXPIRED
+    AcceptanceRequestBody:
+      type: object
+      required:
+        - confirmationCode
+      properties:
+        confirmationCode:
+          type: string
+          example: 2663329b-c8c5-4c71-9500-9ea8c4e77d94
+    InvitationsListResponse:
+      type: object
+      properties:
+        invitations:
+          type: array
+          items:
+            $ref: '#/components/schemas/InvitationResponse'
+    InvitationResponse:
+      type: object
+      required:
+        - id
+        - confirmationCode
+        - username
+        - email
+        - status
+        - userRedirectUrl
+      properties:
+        id:
+          type: string
+          example: f7594498-5b52-4201-abd5-d7cf72565c73
+        confirmationCode:
+          type: string
+          example: 2663329b-c8c5-4c71-9500-9ea8c4e77d94
+        username:
+          type: string
+          example: alex@gmail.com/alex
+        email:
+          type: string
+          example: alex@gmail.com
+        roleAssignments:
+          type: array
+          items:
+            $ref: '#/components/schemas/RoleAssignmentResponse'
+        status:
+          type: string
+          example: PENDING/EXPIRED
+        expiredAt:
+          type: string
+          example: 2021-08-10T10:15:30.00Z
+        userRedirectUrl:
+          type: string
+          example: https://localhost:8080/travel-manager/login
+    RoleAssignmentResponse:
+      type: object
+      required:
+        - applicationId
+        - roles
+      properties:
+        applicationId:
+          type: string
+          example: f7594498-5b52-4201-abd5-d7cf72565c73
+        applicationName:
+          type: string
+          example: b2b_business_sample_application
+        roles:
+          type: array
+          items:
+            type: string
+            example: editor, manager
+    RoleAssignmentRequestBody:
+      type: object
+      required:
+        - applicationId
+        - roles
+      properties:
+        applicationId:
+          type: string
+          example: f7594498-5b52-4201-abd5-d7cf72565c73
+        roles:
+          type: array
+          items:
+            type: string
+            example: editor, manager
+    Error:
+      type: object
+      required:
+        - code
+        - message
+      properties:
+        code:
+          type: string
+          example: OUI-00000
+          description: An error code.
+        message:
+          type: string
+          example: Some Error Message
+          description: An error message.
+        description:
+          type: string
+          example: Some Error Description
+          description: An error description.
+        traceId:
+          type: string
+          example: e0fbcfeb-3617-43c4-8dd0-7b7d38e13047
+          description: An error trace identifier.
+  #--------------------------------------------------------
+  # Descriptions of error responses.
+  #--------------------------------------------------------
+  responses:
+    NotFound:
+      description: Resource is not found.
+      content:
+        'application/json':
+          schema:
+            $ref: '#/components/schemas/Error'
+    Unauthorized:
+      description: Authentication information is missing or invalid.
+    Forbidden:
+      description: Access forbidden.
+    ServerError:
+      description: Internal server error.
+      content:
+        'application/json':
+          schema:
+            $ref: '#/components/schemas/Error'

--- a/components/org.wso2.carbon.identity.api.server.organization.user.invitation.management/pom.xml
+++ b/components/org.wso2.carbon.identity.api.server.organization.user.invitation.management/pom.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+  ~
+  ~ WSO2 LLC. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <groupId>org.wso2.carbon.identity.server.api</groupId>
+        <artifactId>identity-api-server</artifactId>
+        <version>1.2.69-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>org.wso2.carbon.identity.api.server.organization.user.invitation.management</artifactId>
+    <packaging>pom</packaging>
+
+    <modules>
+        <module>org.wso2.carbon.identity.api.server.organization.user.invitation.management.v1</module>
+        <module>org.wso2.carbon.identity.api.server.organization.user.invitation.management.common</module>
+    </modules>
+
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+  ~ Copyright (c) 2019-2023, WSO2 LLC. (http://www.wso2.com).
   ~
   ~ WSO2 LLC. licenses this file to you under the Apache License,
   ~ Version 2.0 (the "License"); you may not use this file except
@@ -544,6 +544,24 @@
                 <scope>provided</scope>
             </dependency>
             <dependency>
+                <groupId>org.wso2.carbon.identity.server.api</groupId>
+                <artifactId>org.wso2.carbon.identity.api.server.organization.user.invitation.management.common</artifactId>
+                <version>${project.version}</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.wso2.carbon.identity.server.api</groupId>
+                <artifactId>org.wso2.carbon.identity.api.server.organization.user.invitation.management.v1</artifactId>
+                <version>${project.version}</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.wso2.carbon.identity.organization.management</groupId>
+                <artifactId>org.wso2.carbon.identity.organization.user.invitation.management</artifactId>
+                <version>${org.wso2.carbon.identity.organization.management.version}</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
                 <groupId>org.wso2.carbon.extension.identity.verification</groupId>
                 <artifactId>org.wso2.carbon.extension.identity.verification.provider</artifactId>
                 <version>${identity.verification.version}</version>
@@ -697,9 +715,9 @@
         </org.wso2.carbon.identity.organization.management.core.version>
         <org.wso2.carbon.identity.organization.management.core.version.range>[1.0.0, 2.0.0)
         </org.wso2.carbon.identity.organization.management.core.version.range>
-      
+
         <!-- Organization management service Version -->
-        <org.wso2.carbon.identity.organization.management.version>1.3.50
+        <org.wso2.carbon.identity.organization.management.version>1.3.54
         </org.wso2.carbon.identity.organization.management.version>
 
         <!-- Unit test versions -->
@@ -737,6 +755,7 @@
         <module>components/org.wso2.carbon.identity.api.server.organization.management</module>
         <module>components/org.wso2.carbon.identity.api.server.organization.role.management</module>
         <module>components/org.wso2.carbon.identity.api.idle.account.identification</module>
+        <module>components/org.wso2.carbon.identity.api.server.organization.user.invitation.management</module>
     </modules>
 
 </project>


### PR DESCRIPTION
## Purpose
> Adding the API layer for the Organization User invitation management feature.

## Goals
> Facilitate the Organization User invitation management feature.

## Related PRs
> BE service : https://github.com/wso2-extensions/identity-organization-management/pull/221