### PR TITLE
Revert "Migrate security-mgt module from framework to its own group."

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.common/pom.xml
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.common/pom.xml
@@ -57,7 +57,7 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.wso2.carbon.security.mgt</groupId>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
             <artifactId>org.wso2.carbon.security.mgt</artifactId>
             <scope>provided</scope>
         </dependency>

--- a/components/org.wso2.carbon.identity.api.server.keystore.management/org.wso2.carbon.identity.api.server.keystore.management.common/pom.xml
+++ b/components/org.wso2.carbon.identity.api.server.keystore.management/org.wso2.carbon.identity.api.server.keystore.management.common/pom.xml
@@ -49,7 +49,7 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.wso2.carbon.security.mgt</groupId>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
             <artifactId>org.wso2.carbon.security.mgt</artifactId>
             <scope>provided</scope>
         </dependency>

--- a/components/org.wso2.carbon.identity.api.server.keystore.management/org.wso2.carbon.identity.api.server.keystore.management.v1/pom.xml
+++ b/components/org.wso2.carbon.identity.api.server.keystore.management/org.wso2.carbon.identity.api.server.keystore.management.v1/pom.xml
@@ -161,7 +161,7 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.wso2.carbon.security.mgt</groupId>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
             <artifactId>org.wso2.carbon.security.mgt</artifactId>
             <scope>provided</scope>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -287,9 +287,9 @@
                 <version>${identity.inbound.oauth2.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.wso2.carbon.security.mgt</groupId>
+                <groupId>org.wso2.carbon.identity.framework</groupId>
                 <artifactId>org.wso2.carbon.security.mgt</artifactId>
-                <version>${carbon.security.mgt.version}</version>
+                <version>${carbon.identity.framework.version}</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>
@@ -700,7 +700,6 @@
         <mavan.findbugsplugin.exclude.file>findbugs-exclude-filter.xml</mavan.findbugsplugin.exclude.file>
         <carbon.kernel.version>4.9.4</carbon.kernel.version>
         <carbon.multitenancy.version>4.9.10</carbon.multitenancy.version>
-        <carbon.security.mgt.version>1.0.0</carbon.security.mgt.version>
         <org.wso2.carbon.identity.remotefetch.version>0.7.12</org.wso2.carbon.identity.remotefetch.version>
         <org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.version>2.4.21</org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.version>
         <org.wso2.carbon.event.publisher.version>5.2.15</org.wso2.carbon.event.publisher.version>

--- a/pom.xml
+++ b/pom.xml
@@ -689,7 +689,7 @@
         <maven.buildnumber.plugin.version>1.4</maven.buildnumber.plugin.version>
         <org.apache.felix.annotations.version>1.2.4</org.apache.felix.annotations.version>
         <identity.governance.version>1.8.57</identity.governance.version>
-        <carbon.identity.framework.version>5.25.302</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.25.305</carbon.identity.framework.version>
         <maven.findbugsplugin.version>3.0.5</maven.findbugsplugin.version>
         <identity.workflow.impl.bps.version>5.2.0</identity.workflow.impl.bps.version>
         <maven.checkstyleplugin.excludes>**/gen/**/*</maven.checkstyleplugin.excludes>


### PR DESCRIPTION
Reverts wso2/identity-api-server#477

Related issues:
- https://github.com/wso2/product-is/issues/16422