### PR TITLE
Add trusted tags to yaml loader options

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/ServerApplicationManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/ServerApplicationManagementService.java
@@ -125,6 +125,8 @@ import org.yaml.snakeyaml.TypeDescription;
 import org.yaml.snakeyaml.Yaml;
 import org.yaml.snakeyaml.constructor.Constructor;
 import org.yaml.snakeyaml.error.YAMLException;
+import org.yaml.snakeyaml.inspector.TagInspector;
+import org.yaml.snakeyaml.inspector.TrustedPrefixesTagInspector;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -686,7 +688,16 @@ public class ServerApplicationManagementService {
             throws IdentityApplicationManagementException {
 
         try {
-            Yaml yaml = new Yaml(new Constructor(ServiceProvider.class, new LoaderOptions()));
+            // Add trusted tags included in the SP YAML file.
+            List<String> trustedTagList = new ArrayList<>();
+            trustedTagList.add(ServiceProvider.class.getName());
+            trustedTagList.add(OAuthAppDO.class.getName());
+            trustedTagList.add(SAMLSSOServiceProviderDTO.class.getName());
+
+            LoaderOptions loaderOptions = new LoaderOptions();
+            TagInspector tagInspector = new TrustedPrefixesTagInspector(trustedTagList);
+            loaderOptions.setTagInspector(tagInspector);
+            Yaml yaml = new Yaml(new Constructor(ServiceProvider.class, loaderOptions));
             return yaml.loadAs(spFileContent.getContent(), ServiceProvider.class);
         } catch (YAMLException e) {
             throw new IdentityApplicationManagementException(String.format("Error in reading YAML Service Provider " +

--- a/components/org.wso2.carbon.identity.api.server.claim.management/org.wso2.carbon.identity.rest.api.server.claim.management.v1/src/main/java/org/wso2/carbon/identity/rest/api/server/claim/management/v1/core/ServerClaimManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.claim.management/org.wso2.carbon.identity.rest.api.server.claim.management.v1/src/main/java/org/wso2/carbon/identity/rest/api/server/claim/management/v1/core/ServerClaimManagementService.java
@@ -62,6 +62,8 @@ import org.yaml.snakeyaml.LoaderOptions;
 import org.yaml.snakeyaml.Yaml;
 import org.yaml.snakeyaml.constructor.Constructor;
 import org.yaml.snakeyaml.error.YAMLException;
+import org.yaml.snakeyaml.inspector.TagInspector;
+import org.yaml.snakeyaml.inspector.TrustedPrefixesTagInspector;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -1155,7 +1157,16 @@ public class ServerClaimManagementService {
     private ClaimDialectConfiguration parseClaimDialectFromYaml(FileContent fileContent) throws ClaimMetadataException {
 
         try {
-            Yaml yaml = new Yaml(new Constructor(ClaimDialectConfiguration.class, new LoaderOptions()));
+            // Add trusted tags included in the Claims YAML files.
+            List<String> trustedTagList = new ArrayList<>();
+            trustedTagList.add(ClaimDialectConfiguration.class.getName());
+            trustedTagList.add(ExternalClaimResDTO.class.getName());
+            trustedTagList.add(LocalClaimResDTO.class.getName());
+
+            LoaderOptions loaderOptions = new LoaderOptions();
+            TagInspector tagInspector = new TrustedPrefixesTagInspector(trustedTagList);
+            loaderOptions.setTagInspector(tagInspector);
+            Yaml yaml = new Yaml(new Constructor(ClaimDialectConfiguration.class, loaderOptions));
             return yaml.loadAs(fileContent.getContent(), ClaimDialectConfiguration.class);
         } catch (YAMLException e) {
             throw new ClaimMetadataException(String.format(

--- a/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/main/java/org/wso2/carbon/identity/api/server/idp/v1/core/ServerIdpManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/main/java/org/wso2/carbon/identity/api/server/idp/v1/core/ServerIdpManagementService.java
@@ -118,6 +118,8 @@ import org.yaml.snakeyaml.TypeDescription;
 import org.yaml.snakeyaml.Yaml;
 import org.yaml.snakeyaml.constructor.Constructor;
 import org.yaml.snakeyaml.error.YAMLException;
+import org.yaml.snakeyaml.inspector.TagInspector;
+import org.yaml.snakeyaml.inspector.TrustedPrefixesTagInspector;
 import org.yaml.snakeyaml.representer.Representer;
 
 import java.io.IOException;
@@ -3696,7 +3698,14 @@ public class ServerIdpManagementService {
             throws IdentityProviderManagementClientException {
 
         try {
-            Yaml yaml = new Yaml(new Constructor(IdentityProvider.class, new LoaderOptions()));
+            // Add trusted tags included in the IDP YAML files.
+            List<String> trustedTagList = new ArrayList<>();
+            trustedTagList.add(IdentityProvider.class.getName());
+
+            LoaderOptions loaderOptions = new LoaderOptions();
+            TagInspector tagInspector = new TrustedPrefixesTagInspector(trustedTagList);
+            loaderOptions.setTagInspector(tagInspector);
+            Yaml yaml = new Yaml(new Constructor(IdentityProvider.class, loaderOptions));
             return yaml.loadAs(fileContent.getContent(), IdentityProvider.class);
         } catch (YAMLException e) {
             throw new IdentityProviderManagementClientException(String.format("Error in reading YAML file " +

--- a/components/org.wso2.carbon.identity.api.server.userstore/org.wso2.carbon.identity.api.server.userstore.v1/src/main/java/org/wso2/carbon/identity/api/server/userstore/v1/core/ServerUserStoreService.java
+++ b/components/org.wso2.carbon.identity.api.server.userstore/org.wso2.carbon.identity.api.server.userstore.v1/src/main/java/org/wso2/carbon/identity/api/server/userstore/v1/core/ServerUserStoreService.java
@@ -80,6 +80,8 @@ import org.yaml.snakeyaml.LoaderOptions;
 import org.yaml.snakeyaml.Yaml;
 import org.yaml.snakeyaml.constructor.Constructor;
 import org.yaml.snakeyaml.error.YAMLException;
+import org.yaml.snakeyaml.inspector.TagInspector;
+import org.yaml.snakeyaml.inspector.TrustedPrefixesTagInspector;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -1661,7 +1663,14 @@ public class ServerUserStoreService {
     private UserStoreConfigurations parseUserStoreFromYaml(FileContent fileContent) throws UserStoreException {
 
         try {
-            Yaml yaml = new Yaml(new Constructor(UserStoreConfigurations.class, new LoaderOptions()));
+            // Add trusted tags included in the Userstore YAML files.
+            List<String> trustedTagList = new ArrayList<>();
+            trustedTagList.add(UserStoreConfigurations.class.getName());
+
+            LoaderOptions loaderOptions = new LoaderOptions();
+            TagInspector tagInspector = new TrustedPrefixesTagInspector(trustedTagList);
+            loaderOptions.setTagInspector(tagInspector);
+            Yaml yaml = new Yaml(new Constructor(UserStoreConfigurations.class, loaderOptions));
             return yaml.loadAs(fileContent.getContent(), UserStoreConfigurations.class);
         } catch (YAMLException e) {
             throw new UserStoreException(String.format("Error in reading YAML file " +


### PR DESCRIPTION
With Snakeyaml 2.0 upgrade, global tags are not allowed by default and will throw errors of there is a tag in the YAML file during parsing. This PR will allow trusted tags that are available in the Application, IDP, userstore and claim objects.

Related issue: https://github.com/wso2/product-is/issues/16679