### PR TITLE
Adding Application Tag Management API

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.common/src/main/java/org/wso2/carbon/identity/api/server/application/management/common/ApplicationManagementConstants.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.common/src/main/java/org/wso2/carbon/identity/api/server/application/management/common/ApplicationManagementConstants.java
@@ -51,6 +51,7 @@ public class ApplicationManagementConstants {
     public static final String NAME = "name";
     public static final String CLIENT_ID = "clientId";
     public static final String ISSUER = "issuer";
+    public static final String TAGS = "tags";
 
     public static final String NON_EXISTING_USER_CODE = "30007 - ";
 

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/application/management/v1/ApplicationListItem.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/application/management/v1/ApplicationListItem.java
@@ -23,10 +23,13 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import org.wso2.carbon.identity.api.server.application.management.v1.AdvancedApplicationConfiguration;
+import org.wso2.carbon.identity.api.server.application.management.v1.TagItem;
 import javax.validation.constraints.*;
 
 
 import io.swagger.annotations.*;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
 import javax.validation.Valid;
 import javax.xml.bind.annotation.*;
@@ -77,6 +80,7 @@ public enum AccessEnum {
     private String self;
     private AdvancedApplicationConfiguration advancedConfigurations;
     private String templateId;
+    private List<TagItem> tags = null;
 
     /**
     **/
@@ -276,6 +280,32 @@ public enum AccessEnum {
         this.templateId = templateId;
     }
 
+    /**
+     **/
+    public ApplicationListItem tags(List<TagItem> tags) {
+
+        this.tags = tags;
+        return this;
+    }
+
+    @ApiModelProperty(value = "")
+    @JsonProperty("tags")
+    @Valid
+    public List<TagItem> getTags() {
+        return tags;
+    }
+    public void setTags(List<TagItem> tags) {
+        this.tags = tags;
+    }
+
+    public ApplicationListItem addTagsItem(TagItem tagsItem) {
+        if (this.tags == null) {
+            this.tags = new ArrayList<>();
+        }
+        this.tags.add(tagsItem);
+        return this;
+    }
+
 
 
     @Override
@@ -298,12 +328,13 @@ public enum AccessEnum {
             Objects.equals(this.access, applicationListItem.access) &&
             Objects.equals(this.self, applicationListItem.self) &&
             Objects.equals(this.advancedConfigurations, applicationListItem.advancedConfigurations) &&
-            Objects.equals(this.templateId, applicationListItem.templateId);
+            Objects.equals(this.templateId, applicationListItem.templateId) &&
+            Objects.equals(this.tags, applicationListItem.tags);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, name, description, image, accessUrl, clientId, issuer, access, self, advancedConfigurations, templateId);
+        return Objects.hash(id, name, description, image, accessUrl, clientId, issuer, access, self, advancedConfigurations, templateId, tags);
     }
 
     @Override
@@ -323,6 +354,7 @@ public enum AccessEnum {
         sb.append("    self: ").append(toIndentedString(self)).append("\n");
         sb.append("    advancedConfigurations: ").append(toIndentedString(advancedConfigurations)).append("\n");
         sb.append("    templateId: ").append(toIndentedString(templateId)).append("\n");
+        sb.append("    tags: ").append(toIndentedString(tags)).append("\n");
         sb.append("}");
         return sb.toString();
     }

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/application/management/v1/ApplicationModel.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/application/management/v1/ApplicationModel.java
@@ -27,10 +27,13 @@ import org.wso2.carbon.identity.api.server.application.management.v1.Authenticat
 import org.wso2.carbon.identity.api.server.application.management.v1.ClaimConfiguration;
 import org.wso2.carbon.identity.api.server.application.management.v1.InboundProtocols;
 import org.wso2.carbon.identity.api.server.application.management.v1.ProvisioningConfiguration;
+import org.wso2.carbon.identity.api.server.application.management.v1.ListValue;
 import javax.validation.constraints.*;
 
 
 import io.swagger.annotations.*;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
 import javax.validation.Valid;
 import javax.xml.bind.annotation.*;
@@ -50,6 +53,7 @@ public class ApplicationModel  {
     private AuthenticationSequence authenticationSequence;
     private AdvancedApplicationConfiguration advancedConfigurations;
     private ProvisioningConfiguration provisioningConfigurations;
+    private List<ListValue> tags = null;
 
     /**
     **/
@@ -287,6 +291,32 @@ public class ApplicationModel  {
         this.provisioningConfigurations = provisioningConfigurations;
     }
 
+    /**
+     **/
+    public ApplicationModel tags(List<ListValue> tags) {
+
+        this.tags = tags;
+        return this;
+    }
+
+    @ApiModelProperty(value = "")
+    @JsonProperty("tags")
+    @Valid
+    public List<ListValue> getTags() {
+        return tags;
+    }
+    public void setTags(List<ListValue> tags) {
+        this.tags = tags;
+    }
+
+    public ApplicationModel addTagsItem(ListValue tagsItem) {
+        if (this.tags == null) {
+            this.tags = new ArrayList<>();
+        }
+        this.tags.add(tagsItem);
+        return this;
+    }
+
 
 
     @Override
@@ -311,12 +341,13 @@ public class ApplicationModel  {
             Objects.equals(this.inboundProtocolConfiguration, applicationModel.inboundProtocolConfiguration) &&
             Objects.equals(this.authenticationSequence, applicationModel.authenticationSequence) &&
             Objects.equals(this.advancedConfigurations, applicationModel.advancedConfigurations) &&
-            Objects.equals(this.provisioningConfigurations, applicationModel.provisioningConfigurations);
+            Objects.equals(this.provisioningConfigurations, applicationModel.provisioningConfigurations) &&
+            Objects.equals(this.tags, applicationModel.tags);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, name, description, imageUrl, accessUrl, templateId, isManagementApp, isB2BSelfServiceApp, claimConfiguration, inboundProtocolConfiguration, authenticationSequence, advancedConfigurations, provisioningConfigurations);
+        return Objects.hash(id, name, description, imageUrl, accessUrl, templateId, isManagementApp, isB2BSelfServiceApp, claimConfiguration, inboundProtocolConfiguration, authenticationSequence, advancedConfigurations, provisioningConfigurations, tags);
     }
 
     @Override
@@ -338,6 +369,7 @@ public class ApplicationModel  {
         sb.append("    authenticationSequence: ").append(toIndentedString(authenticationSequence)).append("\n");
         sb.append("    advancedConfigurations: ").append(toIndentedString(advancedConfigurations)).append("\n");
         sb.append("    provisioningConfigurations: ").append(toIndentedString(provisioningConfigurations)).append("\n");
+        sb.append("    tags: ").append(toIndentedString(tags)).append("\n");
         sb.append("}");
         return sb.toString();
     }

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/application/management/v1/ApplicationPatchModel.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/application/management/v1/ApplicationPatchModel.java
@@ -30,6 +30,8 @@ import javax.validation.constraints.*;
 
 
 import io.swagger.annotations.*;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
 import javax.validation.Valid;
 import javax.xml.bind.annotation.*;
@@ -45,6 +47,7 @@ public class ApplicationPatchModel  {
     private AuthenticationSequence authenticationSequence;
     private AdvancedApplicationConfiguration advancedConfigurations;
     private ProvisioningConfiguration provisioningConfigurations;
+    private List<TagsPatchRequest> tags = null;
 
     /**
     **/
@@ -208,6 +211,32 @@ public class ApplicationPatchModel  {
         this.provisioningConfigurations = provisioningConfigurations;
     }
 
+    /**
+     **/
+    public ApplicationPatchModel tags(List<TagsPatchRequest> tags) {
+
+        this.tags = tags;
+        return this;
+    }
+
+    @ApiModelProperty(value = "")
+    @JsonProperty("tags")
+    @Valid
+    public List<TagsPatchRequest> getTags() {
+        return tags;
+    }
+    public void setTags(List<TagsPatchRequest> tags) {
+        this.tags = tags;
+    }
+
+    public ApplicationPatchModel addTagsItem(TagsPatchRequest tagsItem) {
+        if (this.tags == null) {
+            this.tags = new ArrayList<>();
+        }
+        this.tags.add(tagsItem);
+        return this;
+    }
+
 
 
     @Override
@@ -228,12 +257,13 @@ public class ApplicationPatchModel  {
             Objects.equals(this.claimConfiguration, applicationPatchModel.claimConfiguration) &&
             Objects.equals(this.authenticationSequence, applicationPatchModel.authenticationSequence) &&
             Objects.equals(this.advancedConfigurations, applicationPatchModel.advancedConfigurations) &&
-            Objects.equals(this.provisioningConfigurations, applicationPatchModel.provisioningConfigurations);
+            Objects.equals(this.provisioningConfigurations, applicationPatchModel.provisioningConfigurations) &&
+            Objects.equals(this.tags, applicationPatchModel.tags);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(name, description, imageUrl, accessUrl, templateId, claimConfiguration, authenticationSequence, advancedConfigurations, provisioningConfigurations);
+        return Objects.hash(name, description, imageUrl, accessUrl, templateId, claimConfiguration, authenticationSequence, advancedConfigurations, provisioningConfigurations, tags);
     }
 
     @Override
@@ -251,6 +281,7 @@ public class ApplicationPatchModel  {
         sb.append("    authenticationSequence: ").append(toIndentedString(authenticationSequence)).append("\n");
         sb.append("    advancedConfigurations: ").append(toIndentedString(advancedConfigurations)).append("\n");
         sb.append("    provisioningConfigurations: ").append(toIndentedString(provisioningConfigurations)).append("\n");
+        sb.append("    tags: ").append(toIndentedString(tags)).append("\n");
         sb.append("}");
         return sb.toString();
     }

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/application/management/v1/ApplicationResponseModel.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/application/management/v1/ApplicationResponseModel.java
@@ -29,6 +29,7 @@ import org.wso2.carbon.identity.api.server.application.management.v1.Authenticat
 import org.wso2.carbon.identity.api.server.application.management.v1.ClaimConfiguration;
 import org.wso2.carbon.identity.api.server.application.management.v1.InboundProtocolListItem;
 import org.wso2.carbon.identity.api.server.application.management.v1.ProvisioningConfiguration;
+import org.wso2.carbon.identity.api.server.application.management.v1.TagItem;
 import javax.validation.constraints.*;
 
 
@@ -89,6 +90,7 @@ public enum AccessEnum {
 }
 
     private AccessEnum access = AccessEnum.READ;
+    private List<TagItem> tags = null;
 
     /**
     **/
@@ -388,6 +390,32 @@ public enum AccessEnum {
         this.access = access;
     }
 
+    /**
+     **/
+    public ApplicationResponseModel tags(List<TagItem> tags) {
+
+        this.tags = tags;
+        return this;
+    }
+
+    @ApiModelProperty(value = "")
+    @JsonProperty("tags")
+    @Valid
+    public List<TagItem> getTags() {
+        return tags;
+    }
+    public void setTags(List<TagItem> tags) {
+        this.tags = tags;
+    }
+
+    public ApplicationResponseModel addTagsItem(TagItem tagsItem) {
+        if (this.tags == null) {
+            this.tags = new ArrayList<>();
+        }
+        this.tags.add(tagsItem);
+        return this;
+    }
+
 
 
     @Override
@@ -415,12 +443,13 @@ public enum AccessEnum {
             Objects.equals(this.authenticationSequence, applicationResponseModel.authenticationSequence) &&
             Objects.equals(this.advancedConfigurations, applicationResponseModel.advancedConfigurations) &&
             Objects.equals(this.provisioningConfigurations, applicationResponseModel.provisioningConfigurations) &&
-            Objects.equals(this.access, applicationResponseModel.access);
+            Objects.equals(this.access, applicationResponseModel.access) &&
+            Objects.equals(this.tags, applicationResponseModel.tags);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, name, description, imageUrl, accessUrl, clientId, issuer, templateId, isManagementApp, isB2BSelfServiceApp, claimConfiguration, inboundProtocols, authenticationSequence, advancedConfigurations, provisioningConfigurations, access);
+        return Objects.hash(id, name, description, imageUrl, accessUrl, clientId, issuer, templateId, isManagementApp, isB2BSelfServiceApp, claimConfiguration, inboundProtocols, authenticationSequence, advancedConfigurations, provisioningConfigurations, access, tags);
     }
 
     @Override
@@ -445,6 +474,7 @@ public enum AccessEnum {
         sb.append("    advancedConfigurations: ").append(toIndentedString(advancedConfigurations)).append("\n");
         sb.append("    provisioningConfigurations: ").append(toIndentedString(provisioningConfigurations)).append("\n");
         sb.append("    access: ").append(toIndentedString(access)).append("\n");
+        sb.append("    tags: ").append(toIndentedString(tags)).append("\n");
         sb.append("}");
         return sb.toString();
     }

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/application/management/v1/ListValue.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/application/management/v1/ListValue.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.application.management.v1;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import javax.validation.constraints.*;
+
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+import javax.validation.Valid;
+import javax.xml.bind.annotation.*;
+
+public class ListValue  {
+  
+    private String value;
+
+    /**
+    **/
+    public ListValue value(String value) {
+
+        this.value = value;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "e0fbcfeb-3617-43c4-8dd0-7b7d38e13047", value = "")
+    @JsonProperty("value")
+    @Valid
+    public String getValue() {
+        return value;
+    }
+    public void setValue(String value) {
+        this.value = value;
+    }
+
+
+
+    @Override
+    public boolean equals(Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ListValue listValue = (ListValue) o;
+        return Objects.equals(this.value, listValue.value);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(value);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class ListValue {\n");
+        
+        sb.append("    value: ").append(toIndentedString(value)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+    * Convert the given object to string with each line indented by 4 spaces
+    * (except the first line).
+    */
+    private String toIndentedString(Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}
+

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/application/management/v1/TagItem.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/application/management/v1/TagItem.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.application.management.v1;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import javax.validation.constraints.*;
+
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+import javax.validation.Valid;
+import javax.xml.bind.annotation.*;
+
+public class TagItem  {
+  
+    private String id;
+    private String name;
+    private String colour;
+
+    /**
+    **/
+    public TagItem id(String id) {
+
+        this.id = id;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "e0fbcfeb-3617-43c4-8dd0-7b7d38e13047", value = "")
+    @JsonProperty("id")
+    @Valid
+    public String getId() {
+        return id;
+    }
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    /**
+    **/
+    public TagItem name(String name) {
+
+        this.name = name;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "HR", value = "")
+    @JsonProperty("name")
+    @Valid
+    public String getName() {
+        return name;
+    }
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    /**
+    **/
+    public TagItem colour(String colour) {
+
+        this.colour = colour;
+        return this;
+    }
+    
+    @ApiModelProperty(value = "")
+    @JsonProperty("colour")
+    @Valid
+    public String getColour() {
+        return colour;
+    }
+    public void setColour(String colour) {
+        this.colour = colour;
+    }
+
+
+
+    @Override
+    public boolean equals(Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        TagItem tagItem = (TagItem) o;
+        return Objects.equals(this.id, tagItem.id) &&
+            Objects.equals(this.name, tagItem.name) &&
+            Objects.equals(this.colour, tagItem.colour);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, name, colour);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class TagItem {\n");
+        
+        sb.append("    id: ").append(toIndentedString(id)).append("\n");
+        sb.append("    name: ").append(toIndentedString(name)).append("\n");
+        sb.append("    colour: ").append(toIndentedString(colour)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+    * Convert the given object to string with each line indented by 4 spaces
+    * (except the first line).
+    */
+    private String toIndentedString(Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}
+

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/application/management/v1/TagsPatchRequest.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/application/management/v1/TagsPatchRequest.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.application.management.v1;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import java.util.ArrayList;
+import java.util.List;
+import javax.validation.constraints.*;
+
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+import javax.validation.Valid;
+import javax.xml.bind.annotation.*;
+
+public class TagsPatchRequest  {
+
+
+    @XmlType(name="OperationEnum")
+    @XmlEnum(String.class)
+    public enum OperationEnum {
+
+        @XmlEnumValue("ADD") ADD(String.valueOf("ADD")), @XmlEnumValue("REMOVE") REMOVE(String.valueOf("REMOVE"));
+
+
+        private String value;
+
+        OperationEnum(String v) {
+            value = v;
+        }
+
+        public String value() {
+            return value;
+        }
+
+        @Override
+        public String toString() {
+            return String.valueOf(value);
+        }
+
+        public static OperationEnum fromValue(String value) {
+            for (OperationEnum b : OperationEnum.values()) {
+                if (b.value.equals(value)) {
+                    return b;
+                }
+            }
+            throw new IllegalArgumentException("Unexpected value '" + value + "'");
+        }
+    }
+
+    private OperationEnum operation;
+    private List<ListValue> tags = null;
+
+
+    /**
+     **/
+    public TagsPatchRequest operation(OperationEnum operation) {
+
+        this.operation = operation;
+        return this;
+    }
+
+    @ApiModelProperty(value = "")
+    @JsonProperty("operation")
+    @Valid
+    public OperationEnum getOperation() {
+        return operation;
+    }
+    public void setOperation(OperationEnum operation) {
+        this.operation = operation;
+    }
+
+    /**
+     **/
+    public TagsPatchRequest tags(List<ListValue> tags) {
+
+        this.tags = tags;
+        return this;
+    }
+
+    @ApiModelProperty(value = "")
+    @JsonProperty("tags")
+    @Valid
+    public List<ListValue> getTags() {
+        return tags;
+    }
+    public void setTags(List<ListValue> tags) {
+        this.tags = tags;
+    }
+
+    public TagsPatchRequest addTagsItem(ListValue tagsItem) {
+        if (this.tags == null) {
+            this.tags = new ArrayList<>();
+        }
+        this.tags.add(tagsItem);
+        return this;
+    }
+
+
+
+    @Override
+    public boolean equals(java.lang.Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        TagsPatchRequest tagsPatchRequest = (TagsPatchRequest) o;
+        return Objects.equals(this.operation, tagsPatchRequest.operation) &&
+                Objects.equals(this.tags, tagsPatchRequest.tags);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(operation, tags);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class TagsPatchRequest {\n");
+
+        sb.append("    operation: ").append(toIndentedString(operation)).append("\n");
+        sb.append("    tags: ").append(toIndentedString(tags)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(java.lang.Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}
+

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/functions/application/ApiModelToServiceProvider.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/functions/application/ApiModelToServiceProvider.java
@@ -20,11 +20,16 @@ import org.wso2.carbon.identity.api.server.application.management.v1.Application
 import org.wso2.carbon.identity.api.server.application.management.v1.AuthenticationSequence;
 import org.wso2.carbon.identity.api.server.application.management.v1.ClaimConfiguration;
 import org.wso2.carbon.identity.api.server.application.management.v1.InboundProtocols;
+import org.wso2.carbon.identity.api.server.application.management.v1.ListValue;
 import org.wso2.carbon.identity.api.server.application.management.v1.ProvisioningConfiguration;
 import org.wso2.carbon.identity.api.server.application.management.v1.core.functions.application.inbound.UpdateInboundProtocols;
 import org.wso2.carbon.identity.api.server.application.management.v1.core.functions.application.provisioning.UpdateProvisioningConfiguration;
+import org.wso2.carbon.identity.application.common.model.ApplicationTagsItem;
+import org.wso2.carbon.identity.application.common.model.ApplicationTagsItem.ApplicationTagsItemBuilder;
 import org.wso2.carbon.identity.application.common.model.ServiceProvider;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.function.Function;
 
 import static org.wso2.carbon.identity.api.server.application.management.v1.core.functions.Utils.setIfNotNull;
@@ -53,6 +58,7 @@ public class ApiModelToServiceProvider implements Function<ApplicationModel, Ser
         addAuthenticationSequence(application, applicationModel.getAuthenticationSequence());
         addProvisioningConfiguration(application, applicationModel.getProvisioningConfigurations());
         addInboundAuthenticationProtocolsToApplication(application, applicationModel.getInboundProtocolConfiguration());
+        addApplicationTagsToApplication(application, applicationModel.getTags());
 
         return application;
     }
@@ -92,6 +98,17 @@ public class ApiModelToServiceProvider implements Function<ApplicationModel, Ser
 
         if (advancedApplicationConfig != null) {
             new UpdateAdvancedConfigurations().apply(application, advancedApplicationConfig);
+        }
+    }
+
+    private void addApplicationTagsToApplication(ServiceProvider application, List<ListValue> tags) {
+
+        if (tags != null) {
+            List<ApplicationTagsItem> tagsList = new ArrayList<>();
+            for (ListValue tag: tags) {
+                tagsList.add(new ApplicationTagsItemBuilder().id(tag.getValue()).build());
+            }
+            setIfNotNull(tagsList, application::setTags);
         }
     }
 }

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/functions/application/ApiModelToServiceProvider.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/functions/application/ApiModelToServiceProvider.java
@@ -28,9 +28,9 @@ import org.wso2.carbon.identity.application.common.model.ApplicationTagsItem;
 import org.wso2.carbon.identity.application.common.model.ApplicationTagsItem.ApplicationTagsItemBuilder;
 import org.wso2.carbon.identity.application.common.model.ServiceProvider;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import static org.wso2.carbon.identity.api.server.application.management.v1.core.functions.Utils.setIfNotNull;
 
@@ -104,10 +104,9 @@ public class ApiModelToServiceProvider implements Function<ApplicationModel, Ser
     private void addApplicationTagsToApplication(ServiceProvider application, List<ListValue> tags) {
 
         if (tags != null) {
-            List<ApplicationTagsItem> tagsList = new ArrayList<>();
-            for (ListValue tag: tags) {
-                tagsList.add(new ApplicationTagsItemBuilder().id(tag.getValue()).build());
-            }
+            List<ApplicationTagsItem> tagsList = tags.stream()
+                    .map(tag -> new ApplicationTagsItemBuilder().id(tag.getValue()).build())
+                    .collect(Collectors.toList());
             setIfNotNull(tagsList, application::setTags);
         }
     }

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/functions/application/ApplicationInfoWithRequiredPropsToApiModel.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/functions/application/ApplicationInfoWithRequiredPropsToApiModel.java
@@ -54,7 +54,8 @@ public class ApplicationInfoWithRequiredPropsToApiModel implements Function<Appl
                 .issuer(applicationResponseModel.getIssuer())
                 .advancedConfigurations(getAdvancedConfigurations(applicationResponseModel))
                 .templateId(applicationResponseModel.getTemplateId())
-                .self(getApplicationLocation(applicationResponseModel.getId()));
+                .self(getApplicationLocation(applicationResponseModel.getId()))
+                .tags(applicationResponseModel.getTags());
     }
 
     private AdvancedApplicationConfiguration getAdvancedConfigurations(

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/functions/application/ServiceProviderToApiModel.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/functions/application/ServiceProviderToApiModel.java
@@ -34,12 +34,14 @@ import org.wso2.carbon.identity.api.server.application.management.v1.Provisionin
 import org.wso2.carbon.identity.api.server.application.management.v1.RequestedClaimConfiguration;
 import org.wso2.carbon.identity.api.server.application.management.v1.RoleConfig;
 import org.wso2.carbon.identity.api.server.application.management.v1.SubjectConfig;
+import org.wso2.carbon.identity.api.server.application.management.v1.TagItem;
 import org.wso2.carbon.identity.api.server.application.management.v1.core.functions.Utils;
 import org.wso2.carbon.identity.api.server.application.management.v1.core.functions.application.inbound.InboundAuthConfigToApiModel;
 import org.wso2.carbon.identity.api.server.application.management.v1.core.functions.application.provisioning.BuildProvisioningConfiguration;
 import org.wso2.carbon.identity.api.server.common.ContextLoader;
 import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants;
 import org.wso2.carbon.identity.application.common.IdentityApplicationManagementException;
+import org.wso2.carbon.identity.application.common.model.ApplicationTagsItem;
 import org.wso2.carbon.identity.application.common.model.AuthenticationStep;
 import org.wso2.carbon.identity.application.common.model.ClaimMapping;
 import org.wso2.carbon.identity.application.common.model.InboundAuthenticationRequestConfig;
@@ -111,7 +113,8 @@ public class ServiceProviderToApiModel implements Function<ServiceProvider, Appl
                     .advancedConfigurations(buildAdvancedAppConfiguration(application))
                     .provisioningConfigurations(buildProvisioningConfiguration(application))
                     .authenticationSequence(buildAuthenticationSequence(application))
-                    .access(getAccess(application.getApplicationName()));
+                    .access(getAccess(application.getApplicationName()))
+                    .tags(buildTags(application.getTags()));
         }
     }
 
@@ -480,5 +483,18 @@ public class ServiceProviderToApiModel implements Function<ServiceProvider, Appl
         }
 
         return StringUtils.EMPTY;
+    }
+
+    private List<TagItem> buildTags(List<ApplicationTagsItem> tagsList) {
+
+        if (tagsList != null) {
+            return tagsList.stream()
+                    .map(element -> new TagItem()
+                            .id(element.getId())
+                            .name(element.getName())
+                            .colour(element.getColour()))
+                    .collect(Collectors.toList());
+        }
+        return Collections.emptyList();
     }
 }

--- a/components/org.wso2.carbon.identity.api.server.application.tag.management/org.wso2.carbon.identity.api.server.application.tag.management.common/pom.xml
+++ b/components/org.wso2.carbon.identity.api.server.application.tag.management/org.wso2.carbon.identity.api.server.application.tag.management.common/pom.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+  ~
+  ~ WSO2 LLC. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.wso2.carbon.identity.server.api</groupId>
+        <artifactId>org.wso2.carbon.identity.api.server.application.tag.management</artifactId>
+        <version>1.2.81-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>org.wso2.carbon.identity.api.server.application.tag.management.common</artifactId>
+    <version>1.2.81-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-web</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>javax.ws.rs</groupId>
+            <artifactId>javax.ws.rs-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.application.mgt</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.application.tag.mgt</artifactId>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/components/org.wso2.carbon.identity.api.server.application.tag.management/org.wso2.carbon.identity.api.server.application.tag.management.common/pom.xml
+++ b/components/org.wso2.carbon.identity.api.server.application.tag.management/org.wso2.carbon.identity.api.server.application.tag.management.common/pom.xml
@@ -24,12 +24,12 @@
     <parent>
         <groupId>org.wso2.carbon.identity.server.api</groupId>
         <artifactId>org.wso2.carbon.identity.api.server.application.tag.management</artifactId>
-        <version>1.2.81-SNAPSHOT</version>
+        <version>1.2.85-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>org.wso2.carbon.identity.api.server.application.tag.management.common</artifactId>
-    <version>1.2.81-SNAPSHOT</version>
+    <version>1.2.85-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <build>

--- a/components/org.wso2.carbon.identity.api.server.application.tag.management/org.wso2.carbon.identity.api.server.application.tag.management.common/src/main/java/org/wso2/carbon/identity/api/server/application/tag/management/common/ApplicationTagManagementServiceHolder.java
+++ b/components/org.wso2.carbon.identity.api.server.application.tag.management/org.wso2.carbon.identity.api.server.application.tag.management.common/src/main/java/org/wso2/carbon/identity/api/server/application/tag/management/common/ApplicationTagManagementServiceHolder.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.application.tag.management.common;
+
+import org.wso2.carbon.identity.application.tag.mgt.ApplicationTagManager;
+
+/**
+ * Service holder class for Application Tags Management.
+ */
+public class ApplicationTagManagementServiceHolder {
+
+    private static ApplicationTagManager applicationTagManager;
+
+    /**
+     * Get ApplicationTagManager osgi service.
+     *
+     * @return ApplicationTagManager.
+     */
+    public static ApplicationTagManager getApplicationTagManager() {
+
+        return applicationTagManager;
+    }
+
+    /**
+     * Set ApplicationTagManager osgi service.
+     *
+     * @param applicationTagManager ApplicationTagManager.
+     */
+    public static void setApplicationTagManager(ApplicationTagManager applicationTagManager) {
+
+        ApplicationTagManagementServiceHolder.applicationTagManager = applicationTagManager;
+    }
+}

--- a/components/org.wso2.carbon.identity.api.server.application.tag.management/org.wso2.carbon.identity.api.server.application.tag.management.common/src/main/java/org/wso2/carbon/identity/api/server/application/tag/management/common/factory/ApplicationTagMgtOSGiServiceFactory.java
+++ b/components/org.wso2.carbon.identity.api.server.application.tag.management/org.wso2.carbon.identity.api.server.application.tag.management.common/src/main/java/org/wso2/carbon/identity/api/server/application/tag/management/common/factory/ApplicationTagMgtOSGiServiceFactory.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.application.tag.management.common.factory;
+
+import org.springframework.beans.factory.config.AbstractFactoryBean;
+import org.wso2.carbon.context.PrivilegedCarbonContext;
+import org.wso2.carbon.identity.application.tag.mgt.ApplicationTagManager;
+
+/**
+ * Factory class for ApplicationTagMgtOSGiService.
+ */
+public class ApplicationTagMgtOSGiServiceFactory extends AbstractFactoryBean<ApplicationTagManager> {
+
+    private ApplicationTagManager applicationTagManager;
+
+    @Override
+    public Class<?> getObjectType() {
+
+        return Object.class;
+    }
+
+    @Override
+    protected ApplicationTagManager createInstance() throws Exception {
+
+        if (this.applicationTagManager == null) {
+            applicationTagManager = (ApplicationTagManager) PrivilegedCarbonContext.
+                    getThreadLocalCarbonContext().getOSGiService(ApplicationTagManager.class, null);
+            if (applicationTagManager == null) {
+                throw new Exception("Unable to retrieve ApplicationTagManager service.");
+            }
+        }
+        return this.applicationTagManager;
+    }
+}

--- a/components/org.wso2.carbon.identity.api.server.application.tag.management/org.wso2.carbon.identity.api.server.application.tag.management.v1/pom.xml
+++ b/components/org.wso2.carbon.identity.api.server.application.tag.management/org.wso2.carbon.identity.api.server.application.tag.management.v1/pom.xml
@@ -1,0 +1,183 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+  ~
+  ~ WSO2 LLC. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.wso2.carbon.identity.server.api</groupId>
+        <artifactId>org.wso2.carbon.identity.api.server.application.tag.management</artifactId>
+        <version>1.2.81-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <name>WSO2 Identity Server - Applications Tags Rest API</name>
+    <description>WSO2 Identity Server - Application Tags Rest API</description>
+    <artifactId>org.wso2.carbon.identity.api.server.application.tag.management.v1</artifactId>
+    <packaging>jar</packaging>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>${maven.compiler.plugin.version}</version>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+            </plugin>
+<!--            <plugin>-->
+<!--                <groupId>org.openapitools</groupId>-->
+<!--                <artifactId>openapi-generator-maven-plugin</artifactId>-->
+<!--                <version>4.1.2</version>-->
+<!--                <executions>-->
+<!--                    <execution>-->
+<!--                        <goals>-->
+<!--                            <goal>generate</goal>-->
+<!--                        </goals>-->
+<!--                        <configuration>-->
+<!--                            <inputSpec>${project.basedir}/src/main/resources/tags.yaml</inputSpec>-->
+<!--                            <generatorName>org.wso2.carbon.codegen.CxfWso2Generator</generatorName>-->
+<!--                            <configOptions>-->
+<!--                                <sourceFolder>src/gen/java</sourceFolder>-->
+<!--                                <apiPackage>org.wso2.carbon.identity.api.server.application.tag.management.v1</apiPackage>-->
+<!--                                <modelPackage>org.wso2.carbon.identity.api.server.application.tag.management.v1.model</modelPackage>-->
+<!--                                <packageName>org.wso2.carbon.identity.api.server.application.tag.management.v1</packageName>-->
+<!--                                <dateLibrary>java8</dateLibrary>-->
+<!--                                <hideGenerationTimestamp>true</hideGenerationTimestamp>-->
+<!--                            </configOptions>-->
+<!--                            <output>.</output>-->
+<!--                            <skipOverwrite>true</skipOverwrite>-->
+<!--                        </configuration>-->
+<!--                    </execution>-->
+<!--                </executions>-->
+<!--                <dependencies>-->
+<!--                    <dependency>-->
+<!--                        <groupId>org.openapitools</groupId>-->
+<!--                        <artifactId>cxf-wso2-openapi-generator</artifactId>-->
+<!--                        <version>1.0.0</version>-->
+<!--                    </dependency>-->
+<!--                </dependencies>-->
+<!--            </plugin>-->
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <version>1.8</version>
+                <executions>
+                    <execution>
+                        <id>add-source</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>add-source</goal>
+                        </goals>
+                        <configuration>
+                            <sources>
+                                <source>src/gen/java</source>
+                            </sources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.cxf</groupId>
+            <artifactId>cxf-rt-frontend-jaxrs</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.cxf</groupId>
+            <artifactId>cxf-rt-rs-service-description</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-web</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>javax.ws.rs</groupId>
+            <artifactId>javax.ws.rs-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.swagger</groupId>
+            <artifactId>swagger-jaxrs</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-databind</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-annotations</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.dataformat</groupId>
+                    <artifactId>jackson-dataformat-yaml</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>javax.ws.rs</groupId>
+                    <artifactId>jsr311-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.google.guava</groupId>
+                    <artifactId>guava</artifactId>
+                </exclusion>
+            </exclusions>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.jaxrs</groupId>
+            <artifactId>jackson-jaxrs-json-provider</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.application.tag.mgt</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.server.api</groupId>
+            <artifactId>org.wso2.carbon.identity.api.server.common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.cxf</groupId>
+            <artifactId>cxf-rt-rs-extension-search</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.server.api</groupId>
+            <artifactId>org.wso2.carbon.identity.api.server.application.tag.management.common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.application.common</artifactId>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/components/org.wso2.carbon.identity.api.server.application.tag.management/org.wso2.carbon.identity.api.server.application.tag.management.v1/pom.xml
+++ b/components/org.wso2.carbon.identity.api.server.application.tag.management/org.wso2.carbon.identity.api.server.application.tag.management.v1/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.server.api</groupId>
         <artifactId>org.wso2.carbon.identity.api.server.application.tag.management</artifactId>
-        <version>1.2.81-SNAPSHOT</version>
+        <version>1.2.85-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.api.server.application.tag.management/org.wso2.carbon.identity.api.server.application.tag.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/application/tag/management/v1/ApplicationsTagsApi.java
+++ b/components/org.wso2.carbon.identity.api.server.application.tag.management/org.wso2.carbon.identity.api.server.application.tag.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/application/tag/management/v1/ApplicationsTagsApi.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.application.tag.management.v1;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.apache.cxf.jaxrs.ext.multipart.Attachment;
+import org.apache.cxf.jaxrs.ext.multipart.Multipart;
+import java.io.InputStream;
+import java.util.List;
+
+import org.wso2.carbon.identity.api.server.application.tag.management.v1.model.ApplicationTagCreationResponse;
+import org.wso2.carbon.identity.api.server.application.tag.management.v1.model.ApplicationTagModel;
+import org.wso2.carbon.identity.api.server.application.tag.management.v1.model.ApplicationTagResponse;
+import org.wso2.carbon.identity.api.server.application.tag.management.v1.model.ApplicationTagsListResponse;
+import org.wso2.carbon.identity.api.server.application.tag.management.v1.model.Error;
+import org.wso2.carbon.identity.api.server.application.tag.management.v1.ApplicationsTagsApiService;
+
+import javax.validation.Valid;
+import javax.ws.rs.*;
+import javax.ws.rs.core.Response;
+import io.swagger.annotations.*;
+
+import javax.validation.constraints.*;
+
+@Path("/applications-tags")
+@Api(description = "The applications-tags API")
+
+public class ApplicationsTagsApi  {
+
+    @Autowired
+    private ApplicationsTagsApiService delegate;
+
+    @Valid
+    @POST
+    
+    @Consumes({ "application/json" })
+    @Produces({ "application/json" })
+    @ApiOperation(value = "Add a Tag ", notes = "This API provides the capability to store the tag provided by users.<br>   <b>Permission required:</b> <br>       * /permission/admin/manage/identity/tagmgt/add <br>   <b>Scope required:</b> <br>       * internal_tag_mgt_add ", response = ApplicationTagCreationResponse.class, authorizations = {
+        @Authorization(value = "BasicAuth"),
+        @Authorization(value = "OAuth2", scopes = {
+            
+        })
+    }, tags={ "Applications Tags", })
+    @ApiResponses(value = { 
+        @ApiResponse(code = 201, message = "Successful response.", response = ApplicationTagCreationResponse.class),
+        @ApiResponse(code = 400, message = "Bad Request", response = Error.class),
+        @ApiResponse(code = 401, message = "Unauthorized", response = Void.class),
+        @ApiResponse(code = 403, message = "Forbidden", response = Void.class),
+        @ApiResponse(code = 409, message = "Conflict", response = Error.class),
+        @ApiResponse(code = 500, message = "Server Error", response = Error.class),
+        @ApiResponse(code = 501, message = "Not Implemented", response = Error.class)
+    })
+    public Response createApplicationTag(@ApiParam(value = "This represents the application template to be created." ,required=true) @Valid ApplicationTagModel applicationTagModel) {
+
+        return delegate.createApplicationTag(applicationTagModel );
+    }
+
+    @Valid
+    @DELETE
+    @Path("/{tag-id}")
+    
+    @Produces({ "application/json", "application/xml",  })
+    @ApiOperation(value = "Delete a tag by tag ID. ", notes = "This API provides the capability to partially update a tag by ID.<br>   <b>Permission required:</b> <br>       * /permission/admin/manage/identity/tagmgt/delete <br>   <b>Scope required:</b> <br>       * internal_tag_mgt_delete ", response = Void.class, authorizations = {
+        @Authorization(value = "BasicAuth"),
+        @Authorization(value = "OAuth2", scopes = {
+            
+        })
+    }, tags={ "Applications Tags", })
+    @ApiResponses(value = { 
+        @ApiResponse(code = 204, message = "Successfully Deleted", response = Void.class),
+        @ApiResponse(code = 400, message = "Bad Request", response = Error.class),
+        @ApiResponse(code = 401, message = "Unauthorized", response = Void.class),
+        @ApiResponse(code = 403, message = "Forbidden", response = Void.class),
+        @ApiResponse(code = 404, message = "Not Found", response = Error.class),
+        @ApiResponse(code = 500, message = "Server Error", response = Error.class)
+    })
+    public Response deleteApplicationTag(@ApiParam(value = "Application tag ID. ",required=true) @PathParam("tag-id") String tagId) {
+
+        return delegate.deleteApplicationTag(tagId );
+    }
+
+    @Valid
+    @GET
+    
+    
+    @Produces({ "application/json" })
+    @ApiOperation(value = "List all Tags ", notes = "This API provides the capability to retrieve the list of tags available. ", response = ApplicationTagsListResponse.class, authorizations = {
+        @Authorization(value = "BasicAuth"),
+        @Authorization(value = "OAuth2", scopes = {
+            
+        })
+    }, tags={ "Applications Tags", })
+    @ApiResponses(value = { 
+        @ApiResponse(code = 200, message = "OK", response = ApplicationTagsListResponse.class),
+        @ApiResponse(code = 400, message = "Bad Request", response = Error.class),
+        @ApiResponse(code = 401, message = "Unauthorized", response = Void.class),
+        @ApiResponse(code = 403, message = "Forbidden", response = Void.class),
+        @ApiResponse(code = 404, message = "Not Found", response = Error.class),
+        @ApiResponse(code = 500, message = "Server Error", response = Error.class),
+        @ApiResponse(code = 501, message = "Not Implemented", response = Error.class)
+    })
+    public Response getAllApplicationTags(    @Valid@ApiParam(value = "Maximum number of records to return. ")  @QueryParam("limit") Integer limit,     @Valid@ApiParam(value = "Number of records to skip for pagination. ")  @QueryParam("offset") Integer offset,     @Valid@ApiParam(value = "Condition to filter the retrieval of records. Supports 'sw', 'co', 'ew' and 'eq' operations. <br> /applications-tags?filter=name+eq+engineering <br> /applications-tags?filter=name+co+eng ")  @QueryParam("filter") String filter) {
+
+        return delegate.getAllApplicationTags(limit,  offset,  filter );
+    }
+
+    @Valid
+    @GET
+    @Path("/{tag-id}")
+    
+    @Produces({ "application/json", "application/xml",  })
+    @ApiOperation(value = "Retrieve a tag by ID ", notes = "This API provides the capability to retrieve a tag from the tag id. ", response = ApplicationTagResponse.class, authorizations = {
+        @Authorization(value = "BasicAuth"),
+        @Authorization(value = "OAuth2", scopes = {
+            
+        })
+    }, tags={ "Applications Tags", })
+    @ApiResponses(value = { 
+        @ApiResponse(code = 200, message = "OK", response = ApplicationTagResponse.class),
+        @ApiResponse(code = 400, message = "Bad Request", response = Error.class),
+        @ApiResponse(code = 401, message = "Unauthorized", response = Void.class),
+        @ApiResponse(code = 403, message = "Forbidden", response = Void.class),
+        @ApiResponse(code = 404, message = "Not Found", response = Error.class),
+        @ApiResponse(code = 500, message = "Server Error", response = Error.class)
+    })
+    public Response getApplicationTag(@ApiParam(value = "Application tag ID. ",required=true) @PathParam("tag-id") String tagId) {
+
+        return delegate.getApplicationTag(tagId );
+    }
+
+    @Valid
+    @PATCH
+    @Path("/{tag-id}")
+    @Consumes({ "application/json" })
+    @Produces({ "application/json" })
+    @ApiOperation(value = "Partially update a tag by ID ", notes = "This API provides the capability to partially update a tag by ID.<br>   <b>Permission required:</b> <br>       * /permission/admin/manage/identity/tagmgt/update <br>   <b>Scope required:</b> <br>       * internal_tag_mgt_update ", response = Void.class, authorizations = {
+        @Authorization(value = "BasicAuth"),
+        @Authorization(value = "OAuth2", scopes = {
+            
+        })
+    }, tags={ "Applications Tags" })
+    @ApiResponses(value = { 
+        @ApiResponse(code = 200, message = "Successfully Updated", response = Void.class),
+        @ApiResponse(code = 400, message = "Bad Request", response = Error.class),
+        @ApiResponse(code = 401, message = "Unauthorized", response = Void.class),
+        @ApiResponse(code = 403, message = "Forbidden", response = Void.class),
+        @ApiResponse(code = 409, message = "Conflict", response = Error.class),
+        @ApiResponse(code = 500, message = "Server Error", response = Error.class)
+    })
+    public Response patchTag(@ApiParam(value = "Application tag ID. ",required=true) @PathParam("tag-id") String tagId, @ApiParam(value = "This represents the application details to be updated." ,required=true) @Valid ApplicationTagModel applicationTagModel) {
+
+        return delegate.patchTag(tagId,  applicationTagModel );
+    }
+
+}

--- a/components/org.wso2.carbon.identity.api.server.application.tag.management/org.wso2.carbon.identity.api.server.application.tag.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/application/tag/management/v1/ApplicationsTagsApiService.java
+++ b/components/org.wso2.carbon.identity.api.server.application.tag.management/org.wso2.carbon.identity.api.server.application.tag.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/application/tag/management/v1/ApplicationsTagsApiService.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.application.tag.management.v1;
+
+import org.wso2.carbon.identity.api.server.application.tag.management.v1.model.ApplicationTagModel;
+
+import javax.ws.rs.core.Response;
+
+
+public interface ApplicationsTagsApiService {
+
+      public Response createApplicationTag(ApplicationTagModel applicationTagCreationModel);
+
+      public Response deleteApplicationTag(String tagId);
+
+      public Response getAllApplicationTags(Integer offset, Integer limit, String filter);
+
+      public Response getApplicationTag(String tagId);
+
+      public Response patchTag(String tagId, ApplicationTagModel applicationTagPatchModel);
+}

--- a/components/org.wso2.carbon.identity.api.server.application.tag.management/org.wso2.carbon.identity.api.server.application.tag.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/application/tag/management/v1/factories/ApplicationsTagsApiServiceFactory.java
+++ b/components/org.wso2.carbon.identity.api.server.application.tag.management/org.wso2.carbon.identity.api.server.application.tag.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/application/tag/management/v1/factories/ApplicationsTagsApiServiceFactory.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.application.tag.management.v1.factories;
+
+import org.wso2.carbon.identity.api.server.application.tag.management.v1.ApplicationsTagsApiService;
+import org.wso2.carbon.identity.api.server.application.tag.management.v1.impl.ApplicationsTagsApiServiceImpl;
+
+public class ApplicationsTagsApiServiceFactory {
+
+   private final static ApplicationsTagsApiService service = new ApplicationsTagsApiServiceImpl();
+
+   public static ApplicationsTagsApiService getApplicationsTagsApi()
+   {
+      return service;
+   }
+}

--- a/components/org.wso2.carbon.identity.api.server.application.tag.management/org.wso2.carbon.identity.api.server.application.tag.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/application/tag/management/v1/model/ApplicationTagCreationResponse.java
+++ b/components/org.wso2.carbon.identity.api.server.application.tag.management/org.wso2.carbon.identity.api.server.application.tag.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/application/tag/management/v1/model/ApplicationTagCreationResponse.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.application.tag.management.v1.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import javax.validation.constraints.*;
+
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+import javax.validation.Valid;
+import javax.xml.bind.annotation.*;
+
+public class ApplicationTagCreationResponse  {
+  
+    private String id;
+    private String name;
+    private String colour;
+
+    /**
+    **/
+    public ApplicationTagCreationResponse id(String id) {
+
+        this.id = id;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "85e3f4b8-0d22-4181-b1e3-1651f71b88bd", value = "")
+    @JsonProperty("id")
+    @Valid
+    public String getId() {
+        return id;
+    }
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    /**
+    **/
+    public ApplicationTagCreationResponse name(String name) {
+
+        this.name = name;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "HR", value = "")
+    @JsonProperty("name")
+    @Valid
+    public String getName() {
+        return name;
+    }
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    /**
+    **/
+    public ApplicationTagCreationResponse colour(String colour) {
+
+        this.colour = colour;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "#677b66", value = "")
+    @JsonProperty("colour")
+    @Valid
+    public String getColour() {
+        return colour;
+    }
+    public void setColour(String colour) {
+        this.colour = colour;
+    }
+
+
+
+    @Override
+    public boolean equals(java.lang.Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ApplicationTagCreationResponse applicationTagCreationResponse = (ApplicationTagCreationResponse) o;
+        return Objects.equals(this.id, applicationTagCreationResponse.id) &&
+            Objects.equals(this.name, applicationTagCreationResponse.name) &&
+            Objects.equals(this.colour, applicationTagCreationResponse.colour);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, name, colour);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class ApplicationTagCreationResponse {\n");
+        
+        sb.append("    id: ").append(toIndentedString(id)).append("\n");
+        sb.append("    name: ").append(toIndentedString(name)).append("\n");
+        sb.append("    colour: ").append(toIndentedString(colour)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+    * Convert the given object to string with each line indented by 4 spaces
+    * (except the first line).
+    */
+    private String toIndentedString(java.lang.Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}
+

--- a/components/org.wso2.carbon.identity.api.server.application.tag.management/org.wso2.carbon.identity.api.server.application.tag.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/application/tag/management/v1/model/ApplicationTagModel.java
+++ b/components/org.wso2.carbon.identity.api.server.application.tag.management/org.wso2.carbon.identity.api.server.application.tag.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/application/tag/management/v1/model/ApplicationTagModel.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.application.tag.management.v1.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import javax.validation.constraints.*;
+
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+import javax.validation.Valid;
+import javax.xml.bind.annotation.*;
+
+public class ApplicationTagModel  {
+  
+    private String name;
+    private String colour;
+
+    /**
+    **/
+    public ApplicationTagModel name(String name) {
+
+        this.name = name;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "HR", required = true, value = "")
+    @JsonProperty("name")
+    @Valid
+    @NotNull(message = "Property name cannot be null.")
+
+    public String getName() {
+        return name;
+    }
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    /**
+    **/
+    public ApplicationTagModel colour(String colour) {
+
+        this.colour = colour;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "#677b66", required = true, value = "")
+    @JsonProperty("colour")
+    @Valid
+    @NotNull(message = "Property colour cannot be null.")
+
+    public String getColour() {
+        return colour;
+    }
+    public void setColour(String colour) {
+        this.colour = colour;
+    }
+
+
+
+    @Override
+    public boolean equals(java.lang.Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ApplicationTagModel applicationTagModel = (ApplicationTagModel) o;
+        return Objects.equals(this.name, applicationTagModel.name) &&
+            Objects.equals(this.colour, applicationTagModel.colour);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, colour);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class ApplicationTagModel {\n");
+        
+        sb.append("    name: ").append(toIndentedString(name)).append("\n");
+        sb.append("    colour: ").append(toIndentedString(colour)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+    * Convert the given object to string with each line indented by 4 spaces
+    * (except the first line).
+    */
+    private String toIndentedString(java.lang.Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}
+

--- a/components/org.wso2.carbon.identity.api.server.application.tag.management/org.wso2.carbon.identity.api.server.application.tag.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/application/tag/management/v1/model/ApplicationTagPatchModel.java
+++ b/components/org.wso2.carbon.identity.api.server.application.tag.management/org.wso2.carbon.identity.api.server.application.tag.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/application/tag/management/v1/model/ApplicationTagPatchModel.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.application.tag.management.v1.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import javax.validation.constraints.*;
+
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+import javax.validation.Valid;
+import javax.xml.bind.annotation.*;
+
+public class ApplicationTagPatchModel  {
+  
+    private String name;
+    private String colour;
+
+    /**
+    **/
+    public ApplicationTagPatchModel name(String name) {
+
+        this.name = name;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "HR", value = "")
+    @JsonProperty("name")
+    @Valid
+    public String getName() {
+        return name;
+    }
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    /**
+    **/
+    public ApplicationTagPatchModel colour(String colour) {
+
+        this.colour = colour;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "#677b66", value = "")
+    @JsonProperty("colour")
+    @Valid
+    public String getColour() {
+        return colour;
+    }
+    public void setColour(String colour) {
+        this.colour = colour;
+    }
+
+
+
+    @Override
+    public boolean equals(java.lang.Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ApplicationTagPatchModel applicationTagPatchModel = (ApplicationTagPatchModel) o;
+        return Objects.equals(this.name, applicationTagPatchModel.name) &&
+            Objects.equals(this.colour, applicationTagPatchModel.colour);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, colour);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class ApplicationTagPatchModel {\n");
+        
+        sb.append("    name: ").append(toIndentedString(name)).append("\n");
+        sb.append("    colour: ").append(toIndentedString(colour)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+    * Convert the given object to string with each line indented by 4 spaces
+    * (except the first line).
+    */
+    private String toIndentedString(java.lang.Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}
+

--- a/components/org.wso2.carbon.identity.api.server.application.tag.management/org.wso2.carbon.identity.api.server.application.tag.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/application/tag/management/v1/model/ApplicationTagResponse.java
+++ b/components/org.wso2.carbon.identity.api.server.application.tag.management/org.wso2.carbon.identity.api.server.application.tag.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/application/tag/management/v1/model/ApplicationTagResponse.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.application.tag.management.v1.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import javax.validation.constraints.*;
+
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+import javax.validation.Valid;
+import javax.xml.bind.annotation.*;
+
+public class ApplicationTagResponse  {
+  
+    private String id;
+    private String name;
+    private String colour;
+    private Integer associatedAppsCount;
+
+    /**
+    **/
+    public ApplicationTagResponse id(String id) {
+
+        this.id = id;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "85e3f4b8-0d22-4181-b1e3-1651f71b88bd", value = "")
+    @JsonProperty("id")
+    @Valid
+    public String getId() {
+        return id;
+    }
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    /**
+    **/
+    public ApplicationTagResponse name(String name) {
+
+        this.name = name;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "HR", value = "")
+    @JsonProperty("name")
+    @Valid
+    public String getName() {
+        return name;
+    }
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    /**
+    **/
+    public ApplicationTagResponse colour(String colour) {
+
+        this.colour = colour;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "#677b66", value = "")
+    @JsonProperty("colour")
+    @Valid
+    public String getColour() {
+        return colour;
+    }
+    public void setColour(String colour) {
+        this.colour = colour;
+    }
+
+    /**
+     **/
+    public ApplicationTagResponse associatedAppsCount(Integer associatedAppsCount) {
+
+        this.associatedAppsCount = associatedAppsCount;
+        return this;
+    }
+
+    @ApiModelProperty(example = "2", value = "")
+    @JsonProperty("associatedAppsCount")
+    @Valid
+    public Integer getAssociatedAppsCount() {
+        return associatedAppsCount;
+    }
+    public void setAssociatedAppsCount(Integer associatedAppsCount) {
+        this.associatedAppsCount = associatedAppsCount;
+    }
+
+    @Override
+    public boolean equals(java.lang.Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ApplicationTagResponse applicationTagResponse = (ApplicationTagResponse) o;
+        return Objects.equals(this.id, applicationTagResponse.id) &&
+            Objects.equals(this.name, applicationTagResponse.name) &&
+            Objects.equals(this.colour, applicationTagResponse.colour) &&
+            Objects.equals(this.associatedAppsCount, applicationTagResponse.associatedAppsCount);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, name, colour, associatedAppsCount);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class ApplicationTagResponse {\n");
+        
+        sb.append("    id: ").append(toIndentedString(id)).append("\n");
+        sb.append("    name: ").append(toIndentedString(name)).append("\n");
+        sb.append("    colour: ").append(toIndentedString(colour)).append("\n");
+        sb.append("    associatedAppsCount: ").append(toIndentedString(associatedAppsCount)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+    * Convert the given object to string with each line indented by 4 spaces
+    * (except the first line).
+    */
+    private String toIndentedString(java.lang.Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}
+

--- a/components/org.wso2.carbon.identity.api.server.application.tag.management/org.wso2.carbon.identity.api.server.application.tag.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/application/tag/management/v1/model/ApplicationTagsListItem.java
+++ b/components/org.wso2.carbon.identity.api.server.application.tag.management/org.wso2.carbon.identity.api.server.application.tag.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/application/tag/management/v1/model/ApplicationTagsListItem.java
@@ -1,0 +1,182 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.application.tag.management.v1.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import javax.validation.constraints.*;
+
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+import javax.validation.Valid;
+import javax.xml.bind.annotation.*;
+
+public class ApplicationTagsListItem  {
+  
+    private String id;
+    private String name;
+    private String colour;
+    private Integer associatedAppsCount;
+    private String self;
+
+    /**
+    **/
+    public ApplicationTagsListItem id(String id) {
+
+        this.id = id;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "85e3f4b8-0d22-4181-b1e3-1651f71b88bd", value = "")
+    @JsonProperty("id")
+    @Valid
+    public String getId() {
+        return id;
+    }
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    /**
+    **/
+    public ApplicationTagsListItem name(String name) {
+
+        this.name = name;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "HR", value = "")
+    @JsonProperty("name")
+    @Valid
+    public String getName() {
+        return name;
+    }
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    /**
+    **/
+    public ApplicationTagsListItem colour(String colour) {
+
+        this.colour = colour;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "#677b66", value = "")
+    @JsonProperty("colour")
+    @Valid
+    public String getColour() {
+        return colour;
+    }
+    public void setColour(String colour) {
+        this.colour = colour;
+    }
+
+    /**
+    **/
+    public ApplicationTagsListItem associatedAppsCount(Integer associatedAppsCount) {
+
+        this.associatedAppsCount = associatedAppsCount;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "2", value = "")
+    @JsonProperty("associatedAppsCount")
+    @Valid
+    public Integer getAssociatedAppsCount() {
+        return associatedAppsCount;
+    }
+    public void setAssociatedAppsCount(Integer associatedAppsCount) {
+        this.associatedAppsCount = associatedAppsCount;
+    }
+
+    /**
+    **/
+    public ApplicationTagsListItem self(String self) {
+
+        this.self = self;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "/t/wso2.com/api/server/v1/applications-tags/85e3f4b8-0d22-4181-b1e3-1651f71b88bd", value = "")
+    @JsonProperty("self")
+    @Valid
+    public String getSelf() {
+        return self;
+    }
+    public void setSelf(String self) {
+        this.self = self;
+    }
+
+
+
+    @Override
+    public boolean equals(java.lang.Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ApplicationTagsListItem applicationTagsListItem = (ApplicationTagsListItem) o;
+        return Objects.equals(this.id, applicationTagsListItem.id) &&
+            Objects.equals(this.name, applicationTagsListItem.name) &&
+            Objects.equals(this.colour, applicationTagsListItem.colour) &&
+            Objects.equals(this.associatedAppsCount, applicationTagsListItem.associatedAppsCount) &&
+            Objects.equals(this.self, applicationTagsListItem.self);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, name, colour, associatedAppsCount, self);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class ApplicationTagsListItem {\n");
+        
+        sb.append("    id: ").append(toIndentedString(id)).append("\n");
+        sb.append("    name: ").append(toIndentedString(name)).append("\n");
+        sb.append("    colour: ").append(toIndentedString(colour)).append("\n");
+        sb.append("    associatedAppsCount: ").append(toIndentedString(associatedAppsCount)).append("\n");
+        sb.append("    self: ").append(toIndentedString(self)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+    * Convert the given object to string with each line indented by 4 spaces
+    * (except the first line).
+    */
+    private String toIndentedString(java.lang.Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}
+

--- a/components/org.wso2.carbon.identity.api.server.application.tag.management/org.wso2.carbon.identity.api.server.application.tag.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/application/tag/management/v1/model/ApplicationTagsListResponse.java
+++ b/components/org.wso2.carbon.identity.api.server.application.tag.management/org.wso2.carbon.identity.api.server.application.tag.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/application/tag/management/v1/model/ApplicationTagsListResponse.java
@@ -1,0 +1,207 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.application.tag.management.v1.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import java.util.ArrayList;
+import java.util.List;
+import org.wso2.carbon.identity.api.server.application.tag.management.v1.model.ApplicationTagsListItem;
+import org.wso2.carbon.identity.api.server.application.tag.management.v1.model.Link;
+import javax.validation.constraints.*;
+
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+import javax.validation.Valid;
+import javax.xml.bind.annotation.*;
+
+public class ApplicationTagsListResponse  {
+  
+    private Integer totalResults;
+    private Integer startIndex;
+    private Integer count;
+    private List<ApplicationTagsListItem> applicationTags = null;
+
+    private List<Link> links = null;
+
+
+    /**
+    * Number of results that match the listing operation.
+    **/
+    public ApplicationTagsListResponse totalResults(Integer totalResults) {
+
+        this.totalResults = totalResults;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "1", value = "Number of results that match the listing operation.")
+    @JsonProperty("totalResults")
+    @Valid
+    public Integer getTotalResults() {
+        return totalResults;
+    }
+    public void setTotalResults(Integer totalResults) {
+        this.totalResults = totalResults;
+    }
+
+    /**
+    * Index of the first element of the page, which will be equal to offset + 1.
+    **/
+    public ApplicationTagsListResponse startIndex(Integer startIndex) {
+
+        this.startIndex = startIndex;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "1", value = "Index of the first element of the page, which will be equal to offset + 1.")
+    @JsonProperty("startIndex")
+    @Valid
+    public Integer getStartIndex() {
+        return startIndex;
+    }
+    public void setStartIndex(Integer startIndex) {
+        this.startIndex = startIndex;
+    }
+
+    /**
+    * Number of elements in the returned page.
+    **/
+    public ApplicationTagsListResponse count(Integer count) {
+
+        this.count = count;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "10", value = "Number of elements in the returned page.")
+    @JsonProperty("count")
+    @Valid
+    public Integer getCount() {
+        return count;
+    }
+    public void setCount(Integer count) {
+        this.count = count;
+    }
+
+    /**
+    **/
+    public ApplicationTagsListResponse applicationTags(List<ApplicationTagsListItem> applicationTags) {
+
+        this.applicationTags = applicationTags;
+        return this;
+    }
+    
+    @ApiModelProperty(value = "")
+    @JsonProperty("applicationTags")
+    @Valid
+    public List<ApplicationTagsListItem> getApplicationTags() {
+        return applicationTags;
+    }
+    public void setApplicationTags(List<ApplicationTagsListItem> applicationTags) {
+        this.applicationTags = applicationTags;
+    }
+
+    public ApplicationTagsListResponse addApplicationTagsItem(ApplicationTagsListItem applicationTagsItem) {
+        if (this.applicationTags == null) {
+            this.applicationTags = new ArrayList<>();
+        }
+        this.applicationTags.add(applicationTagsItem);
+        return this;
+    }
+
+        /**
+    **/
+    public ApplicationTagsListResponse links(List<Link> links) {
+
+        this.links = links;
+        return this;
+    }
+    
+    @ApiModelProperty(value = "")
+    @JsonProperty("links")
+    @Valid
+    public List<Link> getLinks() {
+        return links;
+    }
+    public void setLinks(List<Link> links) {
+        this.links = links;
+    }
+
+    public ApplicationTagsListResponse addLinksItem(Link linksItem) {
+        if (this.links == null) {
+            this.links = new ArrayList<>();
+        }
+        this.links.add(linksItem);
+        return this;
+    }
+
+    
+
+    @Override
+    public boolean equals(java.lang.Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ApplicationTagsListResponse applicationTagsListResponse = (ApplicationTagsListResponse) o;
+        return Objects.equals(this.totalResults, applicationTagsListResponse.totalResults) &&
+            Objects.equals(this.startIndex, applicationTagsListResponse.startIndex) &&
+            Objects.equals(this.count, applicationTagsListResponse.count) &&
+            Objects.equals(this.applicationTags, applicationTagsListResponse.applicationTags) &&
+            Objects.equals(this.links, applicationTagsListResponse.links);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(totalResults, startIndex, count, applicationTags, links);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class ApplicationTagsListResponse {\n");
+        
+        sb.append("    totalResults: ").append(toIndentedString(totalResults)).append("\n");
+        sb.append("    startIndex: ").append(toIndentedString(startIndex)).append("\n");
+        sb.append("    count: ").append(toIndentedString(count)).append("\n");
+        sb.append("    applicationTags: ").append(toIndentedString(applicationTags)).append("\n");
+        sb.append("    links: ").append(toIndentedString(links)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+    * Convert the given object to string with each line indented by 4 spaces
+    * (except the first line).
+    */
+    private String toIndentedString(java.lang.Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}
+

--- a/components/org.wso2.carbon.identity.api.server.application.tag.management/org.wso2.carbon.identity.api.server.application.tag.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/application/tag/management/v1/model/Error.java
+++ b/components/org.wso2.carbon.identity.api.server.application.tag.management/org.wso2.carbon.identity.api.server.application.tag.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/application/tag/management/v1/model/Error.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.application.tag.management.v1.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import javax.validation.constraints.*;
+
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+import javax.validation.Valid;
+import javax.xml.bind.annotation.*;
+
+public class Error  {
+  
+    private String code;
+    private String message;
+    private String description;
+    private String traceId;
+
+    /**
+    **/
+    public Error code(String code) {
+
+        this.code = code;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "AAA-00000", value = "")
+    @JsonProperty("code")
+    @Valid
+    public String getCode() {
+        return code;
+    }
+    public void setCode(String code) {
+        this.code = code;
+    }
+
+    /**
+    **/
+    public Error message(String message) {
+
+        this.message = message;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "Some error message.", value = "")
+    @JsonProperty("message")
+    @Valid
+    public String getMessage() {
+        return message;
+    }
+    public void setMessage(String message) {
+        this.message = message;
+    }
+
+    /**
+    **/
+    public Error description(String description) {
+
+        this.description = description;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "Some error description.", value = "")
+    @JsonProperty("description")
+    @Valid
+    public String getDescription() {
+        return description;
+    }
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    /**
+    **/
+    public Error traceId(String traceId) {
+
+        this.traceId = traceId;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "e0fbcfeb-3617-43c4-8dd0-7b7d38e13047", value = "")
+    @JsonProperty("traceId")
+    @Valid
+    public String getTraceId() {
+        return traceId;
+    }
+    public void setTraceId(String traceId) {
+        this.traceId = traceId;
+    }
+
+
+
+    @Override
+    public boolean equals(java.lang.Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Error error = (Error) o;
+        return Objects.equals(this.code, error.code) &&
+            Objects.equals(this.message, error.message) &&
+            Objects.equals(this.description, error.description) &&
+            Objects.equals(this.traceId, error.traceId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(code, message, description, traceId);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class Error {\n");
+        
+        sb.append("    code: ").append(toIndentedString(code)).append("\n");
+        sb.append("    message: ").append(toIndentedString(message)).append("\n");
+        sb.append("    description: ").append(toIndentedString(description)).append("\n");
+        sb.append("    traceId: ").append(toIndentedString(traceId)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+    * Convert the given object to string with each line indented by 4 spaces
+    * (except the first line).
+    */
+    private String toIndentedString(java.lang.Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}
+

--- a/components/org.wso2.carbon.identity.api.server.application.tag.management/org.wso2.carbon.identity.api.server.application.tag.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/application/tag/management/v1/model/Link.java
+++ b/components/org.wso2.carbon.identity.api.server.application.tag.management/org.wso2.carbon.identity.api.server.application.tag.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/application/tag/management/v1/model/Link.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.application.tag.management.v1.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import javax.validation.constraints.*;
+
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+import javax.validation.Valid;
+import javax.xml.bind.annotation.*;
+
+public class Link  {
+  
+    private String href;
+    private String rel;
+
+    /**
+    **/
+    public Link href(String href) {
+
+        this.href = href;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "applications-tags?offset=10&limit=10", value = "")
+    @JsonProperty("href")
+    @Valid
+    public String getHref() {
+        return href;
+    }
+    public void setHref(String href) {
+        this.href = href;
+    }
+
+    /**
+    **/
+    public Link rel(String rel) {
+
+        this.rel = rel;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "next", value = "")
+    @JsonProperty("rel")
+    @Valid
+    public String getRel() {
+        return rel;
+    }
+    public void setRel(String rel) {
+        this.rel = rel;
+    }
+
+
+
+    @Override
+    public boolean equals(java.lang.Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Link link = (Link) o;
+        return Objects.equals(this.href, link.href) &&
+            Objects.equals(this.rel, link.rel);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(href, rel);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class Link {\n");
+        
+        sb.append("    href: ").append(toIndentedString(href)).append("\n");
+        sb.append("    rel: ").append(toIndentedString(rel)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+    * Convert the given object to string with each line indented by 4 spaces
+    * (except the first line).
+    */
+    private String toIndentedString(java.lang.Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}
+

--- a/components/org.wso2.carbon.identity.api.server.application.tag.management/org.wso2.carbon.identity.api.server.application.tag.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/tag/management/v1/constants/ApplicationTagMgtEndpointConstants.java
+++ b/components/org.wso2.carbon.identity.api.server.application.tag.management/org.wso2.carbon.identity.api.server.application.tag.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/tag/management/v1/constants/ApplicationTagMgtEndpointConstants.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.application.tag.management.v1.constants;
+
+/**
+ * Constants related to Application Tag management.
+ */
+public class ApplicationTagMgtEndpointConstants {
+
+    private ApplicationTagMgtEndpointConstants() {
+    }
+
+    public static final String APPLICATION_TAG_MANAGEMENT_PREFIX = "APPLICATION-TAG-";
+    public static final String APPLICATION_TAG_PATH_COMPONENT = "/applications-tags";
+
+    /**
+     * Enum for error messages.
+     */
+    public enum ErrorMessage {
+
+        // Client errors.
+        ERROR_CODE_APPLICATION_TAG_NOT_FOUND("60001", "Unable to find the Application Tag.",
+                "Unable to find the Application Tag with the id: %s in the tenant domain."),
+        ERROR_CODE_INVALID_APPLICATION_TAG_NAME("60002",
+                "Invalid Application Tag name provided.", "Application Tag name is required."),
+        ERROR_CODE_INVALID_APPLICATION_TAG_COLOUR("60003",
+                "Invalid Application Tag colour provided.", "Application Tag colour is required."),
+        ERROR_CODE_INVALID_SEARCH_ATTRIBUTE("60007", "Invalid search attribute.",
+                "Invalid search attribute: %s."),
+        ERROR_CODE_INVALID_LIMIT("60004", "Invalid limit provided.",
+                "Limit should be a positive integer."),
+
+        // Server errors.
+        ERROR_CODE_ADD_APPLICATION_TAG("65001", "Error while adding application tag.",
+                "Server encountered an error while adding the application tag.");
+
+        private final String code;
+        private final String message;
+        private final String description;
+
+        ErrorMessage(String code, String message, String description) {
+
+            this.code = code;
+            this.message = message;
+            this.description = description;
+        }
+
+        public String getCode() {
+
+            return APPLICATION_TAG_MANAGEMENT_PREFIX + code;
+        }
+
+        public String getMessage() {
+
+            return message;
+        }
+
+        public String getDescription() {
+
+            return description;
+        }
+
+        @Override
+        public String toString() {
+
+            return code + " | " + message;
+        }
+    }
+}

--- a/components/org.wso2.carbon.identity.api.server.application.tag.management/org.wso2.carbon.identity.api.server.application.tag.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/tag/management/v1/core/ServerApplicationTagManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.application.tag.management/org.wso2.carbon.identity.api.server.application.tag.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/tag/management/v1/core/ServerApplicationTagManagementService.java
@@ -1,0 +1,304 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.application.tag.management.v1.core;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.context.CarbonContext;
+import org.wso2.carbon.identity.api.server.application.tag.management.common.ApplicationTagManagementServiceHolder;
+import org.wso2.carbon.identity.api.server.application.tag.management.v1.constants.ApplicationTagMgtEndpointConstants;
+import org.wso2.carbon.identity.api.server.application.tag.management.v1.constants.ApplicationTagMgtEndpointConstants.ErrorMessage;
+import org.wso2.carbon.identity.api.server.application.tag.management.v1.model.ApplicationTagCreationResponse;
+import org.wso2.carbon.identity.api.server.application.tag.management.v1.model.ApplicationTagModel;
+import org.wso2.carbon.identity.api.server.application.tag.management.v1.model.ApplicationTagResponse;
+import org.wso2.carbon.identity.api.server.application.tag.management.v1.model.ApplicationTagsListItem;
+import org.wso2.carbon.identity.api.server.application.tag.management.v1.model.ApplicationTagsListResponse;
+import org.wso2.carbon.identity.api.server.application.tag.management.v1.model.Link;
+import org.wso2.carbon.identity.api.server.application.tag.management.v1.util.ApplicationTagMgtEndpointUtil;
+import org.wso2.carbon.identity.api.server.common.ContextLoader;
+import org.wso2.carbon.identity.api.server.common.Util;
+import org.wso2.carbon.identity.application.common.model.ApplicationTag;
+import org.wso2.carbon.identity.application.common.model.ApplicationTag.ApplicationTagBuilder;
+import org.wso2.carbon.identity.application.common.model.ApplicationTagsItem;
+import org.wso2.carbon.identity.application.tag.mgt.ApplicationTagMgtException;
+import org.wso2.carbon.identity.core.util.IdentityUtil;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import javax.ws.rs.core.Response;
+
+import static org.wso2.carbon.identity.api.server.application.tag.management.v1.constants.ApplicationTagMgtEndpointConstants.APPLICATION_TAG_PATH_COMPONENT;
+import static org.wso2.carbon.identity.api.server.common.Constants.V1_API_PATH_COMPONENT;
+
+/**
+ * Server Application Tag Management Service.
+ */
+public class ServerApplicationTagManagementService {
+
+    private static final int DEFAULT_OFFSET = 0;
+    private static final ServerApplicationTagManagementService instance = new ServerApplicationTagManagementService();
+    private static final Log LOG = LogFactory.getLog(ServerApplicationTagManagementService.class);
+
+    private ServerApplicationTagManagementService() {
+
+    }
+
+    public static ServerApplicationTagManagementService getInstance() {
+
+        return instance;
+    }
+
+    /**
+     * Add Application Tag.
+     *
+     * @param applicationTagCreationModel Application Tag creation model.
+     * @return Created Application Tag ID.
+     */
+    public ApplicationTagCreationResponse addApplicationTag(ApplicationTagModel applicationTagCreationModel) {
+
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Adding Application Tag: " + applicationTagCreationModel.getName());
+        }
+
+        String tenantDomain = ContextLoader.getTenantDomainFromContext();
+        ApplicationTagsItem createdTag = null;
+        try {
+            ApplicationTag applicationTag = createApplicationTag(applicationTagCreationModel);
+            createdTag = ApplicationTagManagementServiceHolder.getApplicationTagManager()
+                    .createApplicationTag(applicationTag, tenantDomain);
+            if (createdTag == null) {
+                LOG.error(ErrorMessage.ERROR_CODE_ADD_APPLICATION_TAG.getDescription());
+                throw ApplicationTagMgtEndpointUtil.handleException(Response.Status.INTERNAL_SERVER_ERROR,
+                        ErrorMessage.ERROR_CODE_ADD_APPLICATION_TAG);
+            }
+            return buildApplicationTagCreationResponse(createdTag);
+        } catch (ApplicationTagMgtException e) {
+            throw ApplicationTagMgtEndpointUtil.handleApplicationTagMgtException(e);
+        }
+    }
+
+    /**
+     * Delete Application Tag.
+     *
+     * @param tagId     Application Tag ID.
+     */
+    public void deleteApplicationTag(String tagId) {
+
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Deleting Application Tag with ID: " + tagId);
+        }
+        try {
+            ApplicationTagManagementServiceHolder.getApplicationTagManager().deleteApplicationTagById(tagId,
+                    CarbonContext.getThreadLocalCarbonContext().getTenantDomain());
+        } catch (ApplicationTagMgtException e) {
+            throw ApplicationTagMgtEndpointUtil.handleApplicationTagMgtException(e);
+        }
+    }
+
+    /**
+     * Get all Application Tags.
+     *
+     * @param offset    Offset for pagination.
+     * @param limit     Limit for pagination.
+     * @param filter    Filter String.
+     * @return ApplicationTagsListResponse.
+     */
+    public ApplicationTagsListResponse getAllApplicationTags(Integer offset, Integer limit, String filter) {
+
+        limit = validateAndGetLimit(limit);
+        offset = validateAndGetOffset(offset);
+        String tenantDomain = CarbonContext.getThreadLocalCarbonContext().getTenantDomain();
+
+        try {
+            int totalResults = ApplicationTagManagementServiceHolder.getApplicationTagManager()
+                    .getCountOfApplicationTags(filter, tenantDomain);
+
+            List<org.wso2.carbon.identity.application.common.model.ApplicationTagsListItem> filteredApplicationTags =
+                    ApplicationTagManagementServiceHolder.getApplicationTagManager()
+                    .getAllApplicationTags(tenantDomain, offset, limit, filter);
+            int resultsInCurrentPage = filteredApplicationTags.size();
+
+            return new ApplicationTagsListResponse()
+                    .totalResults(totalResults)
+                    .startIndex(offset + 1)
+                    .count(resultsInCurrentPage)
+                    .applicationTags(buildApplicationTagsList(filteredApplicationTags))
+                    .links(Util.buildPaginationLinks(limit, offset, totalResults,
+                                    APPLICATION_TAG_PATH_COMPONENT)
+                            .entrySet()
+                            .stream()
+                            .map(link -> new Link().rel(link.getKey()).href(link.getValue()))
+                            .collect(Collectors.toList()));
+        } catch (ApplicationTagMgtException e) {
+            throw ApplicationTagMgtEndpointUtil.handleApplicationTagMgtException(e);
+        }
+    }
+
+    /**
+     * Get an Application Tag.
+     *
+     * @param tagId    Application Tag ID.
+     * @return ApplicationTagResponse.
+     */
+    public ApplicationTagResponse getApplicationTagById(String tagId) {
+
+        try {
+            ApplicationTagsItem applicationTag = ApplicationTagManagementServiceHolder.getApplicationTagManager()
+                    .getApplicationTagById(tagId, CarbonContext.getThreadLocalCarbonContext().getTenantDomain());
+            if (applicationTag == null) {
+                throw ApplicationTagMgtEndpointUtil.handleException(Response.Status.NOT_FOUND,
+                        ApplicationTagMgtEndpointConstants.ErrorMessage.ERROR_CODE_APPLICATION_TAG_NOT_FOUND, tagId);
+            }
+            return buildApplicationTagResponse(applicationTag);
+        } catch (ApplicationTagMgtException e) {
+            throw ApplicationTagMgtEndpointUtil.handleApplicationTagMgtException(e);
+        }
+    }
+
+    /**
+     * Update an existing Application Tag.
+     *
+     * @param tagId                     Application Tag ID.
+     * @param applicationTagPatch       Application Tag Patch Model.
+     */
+    public void patchApplicationTag(String tagId, ApplicationTagModel applicationTagPatch) {
+
+        try {
+            ApplicationTagResponse currentApplicationTag = getApplicationTagById(tagId);
+
+            String tagName = applicationTagPatch.getName() == null ? currentApplicationTag.getName() :
+                    applicationTagPatch.getName();
+            String tagColour = applicationTagPatch.getColour() == null ? currentApplicationTag.getColour() :
+                    applicationTagPatch.getColour();
+
+            ApplicationTagBuilder appTagBuilder = new ApplicationTagBuilder()
+                    .name(tagName)
+                    .colour(tagColour);
+            ApplicationTag applicationTag = appTagBuilder.build();
+            ApplicationTagManagementServiceHolder.getApplicationTagManager().updateApplicationTag(applicationTag, tagId,
+                    CarbonContext.getThreadLocalCarbonContext().getTenantDomain());
+        } catch (ApplicationTagMgtException e) {
+            throw ApplicationTagMgtEndpointUtil.handleApplicationTagMgtException(e);
+        }
+    }
+
+    /**
+     * Create Application Tag from the ApplicationTag.
+     *
+     * @param applicationTag Application Tag creation model.
+     * @return Application Tag.
+     */
+    private ApplicationTag createApplicationTag(ApplicationTagModel applicationTag) {
+
+        ApplicationTagMgtEndpointUtil.validateApplicationTag(applicationTag);
+        ApplicationTagBuilder applicationTagBuilder = new ApplicationTagBuilder()
+                .name(applicationTag.getName())
+                .colour(applicationTag.getColour());
+        return applicationTagBuilder.build();
+    }
+
+    /**
+     * Build ApplicationTagsListItem from the ApplicationTagsItem.
+     *
+     * @param applicationTag Application Tag Item.
+     * @return ApplicationTagsListItem.
+     */
+    private ApplicationTagResponse buildApplicationTagResponse(ApplicationTagsItem applicationTag) {
+
+       return new ApplicationTagResponse()
+                    .id(applicationTag.getId())
+                    .name(applicationTag.getName())
+                    .colour(applicationTag.getColour())
+                    .associatedAppsCount(0);
+    }
+
+    /**
+     * Build Application Tags List from the List<ApplicationTagsItem>.
+     *
+     * @param applicationTags Application Tags List.
+     * @return List<ApplicationTagsListItem>.
+     */
+    private List<ApplicationTagsListItem> buildApplicationTagsList(
+            List<org.wso2.carbon.identity.application.common.model.ApplicationTagsListItem> applicationTags) {
+
+        List<ApplicationTagsListItem> applicationTagsList = new ArrayList<>();
+        for (org.wso2.carbon.identity.application.common.model.ApplicationTagsListItem appTag: applicationTags) {
+            applicationTagsList.add(new ApplicationTagsListItem()
+                    .id(appTag.getId())
+                    .name(appTag.getName())
+                    .colour(appTag.getColour())
+                    .associatedAppsCount(appTag.getAssociatedAppsCount())
+                    .self(ContextLoader.buildURIForBody(V1_API_PATH_COMPONENT + APPLICATION_TAG_PATH_COMPONENT
+                            + "/" + appTag.getId()).toString()));
+        }
+        return applicationTagsList;
+    }
+
+    /**
+     * Build ApplicationTag Response from the ApplicationTagsItem.
+     *
+     * @param createdTag Created Application Tag.
+     * @return ApplicationTagResponse.
+     */
+    private ApplicationTagCreationResponse buildApplicationTagCreationResponse(ApplicationTagsItem createdTag) {
+
+        return new ApplicationTagCreationResponse()
+                .id(createdTag.getId())
+                .name(createdTag.getName())
+                .colour(createdTag.getColour());
+    }
+
+    /**
+     * Validate the value of the limit.
+     *
+     * @param limit Value of the limit.
+     * @return Limit value after validation.
+     */
+    private int validateAndGetLimit(Integer limit) {
+
+        final int maximumItemPerPage = IdentityUtil.getMaximumItemPerPage();
+        if (limit != null && limit > 0 && limit <= maximumItemPerPage) {
+            return limit;
+        } else if (limit != null && limit > maximumItemPerPage) {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Given limit exceeds the maximum limit. Therefore the configured default limit: "
+                        + maximumItemPerPage + " is set as the limit.");
+            }
+            return maximumItemPerPage;
+        } else {
+            return IdentityUtil.getDefaultItemsPerPage();
+        }
+    }
+
+    /**
+     * Validate the value of the offset.
+     *
+     * @param offset Value of the offset.
+     * @return Offset value after validation.
+     */
+    private int validateAndGetOffset(Integer offset) {
+
+        if (offset != null && offset >= 0) {
+            return offset;
+        } else {
+            return DEFAULT_OFFSET;
+        }
+    }
+}

--- a/components/org.wso2.carbon.identity.api.server.application.tag.management/org.wso2.carbon.identity.api.server.application.tag.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/tag/management/v1/core/ServerApplicationTagManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.application.tag.management/org.wso2.carbon.identity.api.server.application.tag.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/tag/management/v1/core/ServerApplicationTagManagementService.java
@@ -160,7 +160,8 @@ public class ServerApplicationTagManagementService {
     public ApplicationTagResponse getApplicationTagById(String tagId) {
 
         try {
-            ApplicationTagsItem applicationTag = ApplicationTagManagementServiceHolder.getApplicationTagManager()
+            org.wso2.carbon.identity.application.common.model.ApplicationTagsListItem applicationTag =
+                    ApplicationTagManagementServiceHolder.getApplicationTagManager()
                     .getApplicationTagById(tagId, CarbonContext.getThreadLocalCarbonContext().getTenantDomain());
             if (applicationTag == null) {
                 throw ApplicationTagMgtEndpointUtil.handleException(Response.Status.NOT_FOUND,
@@ -215,18 +216,19 @@ public class ServerApplicationTagManagementService {
     }
 
     /**
-     * Build ApplicationTagsListItem from the ApplicationTagsItem.
+     * Build ApplicationTagResponse from the ApplicationTagsListItem.
      *
      * @param applicationTag Application Tag Item.
      * @return ApplicationTagsListItem.
      */
-    private ApplicationTagResponse buildApplicationTagResponse(ApplicationTagsItem applicationTag) {
+    private ApplicationTagResponse buildApplicationTagResponse(
+            org.wso2.carbon.identity.application.common.model.ApplicationTagsListItem applicationTag) {
 
        return new ApplicationTagResponse()
                     .id(applicationTag.getId())
                     .name(applicationTag.getName())
                     .colour(applicationTag.getColour())
-                    .associatedAppsCount(0);
+                    .associatedAppsCount(applicationTag.getAssociatedAppsCount());
     }
 
     /**

--- a/components/org.wso2.carbon.identity.api.server.application.tag.management/org.wso2.carbon.identity.api.server.application.tag.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/tag/management/v1/exception/ApplicationTagMgtEndpointException.java
+++ b/components/org.wso2.carbon.identity.api.server.application.tag.management/org.wso2.carbon.identity.api.server.application.tag.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/tag/management/v1/exception/ApplicationTagMgtEndpointException.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.application.tag.management.v1.exception;
+
+import org.wso2.carbon.identity.api.server.application.tag.management.v1.model.Error;
+
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+/**
+ * Exception class for Application Tag management endpoint.
+ */
+public class ApplicationTagMgtEndpointException extends WebApplicationException {
+
+    public ApplicationTagMgtEndpointException(Response.Status status, Error error) {
+
+        super(Response.status(status).entity(error).header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON)
+                .build());
+    }
+}

--- a/components/org.wso2.carbon.identity.api.server.application.tag.management/org.wso2.carbon.identity.api.server.application.tag.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/tag/management/v1/impl/ApplicationsTagsApiServiceImpl.java
+++ b/components/org.wso2.carbon.identity.api.server.application.tag.management/org.wso2.carbon.identity.api.server.application.tag.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/tag/management/v1/impl/ApplicationsTagsApiServiceImpl.java
@@ -57,7 +57,7 @@ public class ApplicationsTagsApiServiceImpl implements ApplicationsTagsApiServic
     }
 
     @Override
-    public Response getAllApplicationTags(Integer offset, Integer limit, String filter) {
+    public Response getAllApplicationTags(Integer limit, Integer offset, String filter) {
 
         return Response.ok().entity(serverApplicationTagManagementService.getAllApplicationTags(offset, limit,
                 filter)).build();

--- a/components/org.wso2.carbon.identity.api.server.application.tag.management/org.wso2.carbon.identity.api.server.application.tag.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/tag/management/v1/impl/ApplicationsTagsApiServiceImpl.java
+++ b/components/org.wso2.carbon.identity.api.server.application.tag.management/org.wso2.carbon.identity.api.server.application.tag.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/tag/management/v1/impl/ApplicationsTagsApiServiceImpl.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.application.tag.management.v1.impl;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.wso2.carbon.identity.api.server.application.tag.management.v1.ApplicationsTagsApiService;
+import org.wso2.carbon.identity.api.server.application.tag.management.v1.constants.ApplicationTagMgtEndpointConstants;
+import org.wso2.carbon.identity.api.server.application.tag.management.v1.core.ServerApplicationTagManagementService;
+import org.wso2.carbon.identity.api.server.application.tag.management.v1.model.ApplicationTagCreationResponse;
+import org.wso2.carbon.identity.api.server.application.tag.management.v1.model.ApplicationTagModel;
+import org.wso2.carbon.identity.api.server.common.ContextLoader;
+
+import java.net.URI;
+import javax.ws.rs.core.Response;
+
+import static org.wso2.carbon.identity.api.server.common.Constants.V1_API_PATH_COMPONENT;
+
+/**
+ * Implementation of the Application Tags REST Api.
+ */
+public class ApplicationsTagsApiServiceImpl implements ApplicationsTagsApiService {
+
+    @Autowired
+    private ServerApplicationTagManagementService serverApplicationTagManagementService;
+
+    @Override
+    public Response createApplicationTag(ApplicationTagModel applicationTagCreationModel) {
+
+        ApplicationTagCreationResponse applicationTag = serverApplicationTagManagementService
+                .addApplicationTag(applicationTagCreationModel);
+        URI location = ContextLoader.buildURIForHeader(V1_API_PATH_COMPONENT +
+                ApplicationTagMgtEndpointConstants.APPLICATION_TAG_PATH_COMPONENT + "/" + applicationTag.getId());
+        return Response.created(location).entity(applicationTag).build();
+    }
+
+    @Override
+    public Response deleteApplicationTag(String tagId) {
+
+        serverApplicationTagManagementService.deleteApplicationTag(tagId);
+        return Response.noContent().build();
+    }
+
+    @Override
+    public Response getAllApplicationTags(Integer offset, Integer limit, String filter) {
+
+        return Response.ok().entity(serverApplicationTagManagementService.getAllApplicationTags(offset, limit,
+                filter)).build();
+    }
+
+    @Override
+    public Response getApplicationTag(String tagId) {
+
+        return Response.ok().entity(serverApplicationTagManagementService.getApplicationTagById(tagId)).build();
+    }
+
+    @Override
+    public Response patchTag(String tagId, ApplicationTagModel applicationTagPatchModel) {
+
+        serverApplicationTagManagementService.patchApplicationTag(tagId, applicationTagPatchModel);
+        return Response.ok().build();
+    }
+}

--- a/components/org.wso2.carbon.identity.api.server.application.tag.management/org.wso2.carbon.identity.api.server.application.tag.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/tag/management/v1/util/ApplicationTagMgtEndpointUtil.java
+++ b/components/org.wso2.carbon.identity.api.server.application.tag.management/org.wso2.carbon.identity.api.server.application.tag.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/tag/management/v1/util/ApplicationTagMgtEndpointUtil.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.application.tag.management.v1.util;
+
+import org.apache.commons.lang.StringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.identity.api.server.application.tag.management.v1.constants.ApplicationTagMgtEndpointConstants;
+import org.wso2.carbon.identity.api.server.application.tag.management.v1.exception.ApplicationTagMgtEndpointException;
+import org.wso2.carbon.identity.api.server.application.tag.management.v1.model.ApplicationTagModel;
+import org.wso2.carbon.identity.api.server.application.tag.management.v1.model.Error;
+import org.wso2.carbon.identity.application.tag.mgt.ApplicationTagMgtClientException;
+import org.wso2.carbon.identity.application.tag.mgt.ApplicationTagMgtException;
+
+import javax.ws.rs.core.Response;
+
+import static org.wso2.carbon.identity.api.server.application.tag.management.v1.constants.ApplicationTagMgtEndpointConstants.ErrorMessage.ERROR_CODE_INVALID_APPLICATION_TAG_COLOUR;
+import static org.wso2.carbon.identity.api.server.application.tag.management.v1.constants.ApplicationTagMgtEndpointConstants.ErrorMessage.ERROR_CODE_INVALID_APPLICATION_TAG_NAME;
+import static org.wso2.carbon.identity.api.server.common.Constants.ERROR_CODE_DELIMITER;
+import static org.wso2.carbon.identity.application.tag.mgt.constant.ApplicationTagManagementConstants.ErrorMessages.ERROR_CODE_APP_TAG_ALREADY_EXISTS;
+
+/**
+ * Utility class for Application Tag management endpoint.
+ */
+public class ApplicationTagMgtEndpointUtil {
+
+    private static final Log LOG = LogFactory.getLog(ApplicationTagMgtEndpointUtil.class);
+
+    public static void validateApplicationTag(ApplicationTagModel applicationTagCreationModel) {
+
+        if (StringUtils.isBlank(applicationTagCreationModel.getName())) {
+            throw handleException(Response.Status.BAD_REQUEST, ERROR_CODE_INVALID_APPLICATION_TAG_NAME);
+        }
+        if (StringUtils.isBlank(applicationTagCreationModel.getColour())) {
+            throw handleException(Response.Status.BAD_REQUEST, ERROR_CODE_INVALID_APPLICATION_TAG_COLOUR);
+        }
+    }
+
+    public static ApplicationTagMgtEndpointException handleException(Response.Status status,
+         ApplicationTagMgtEndpointConstants.ErrorMessage error) {
+
+        return new ApplicationTagMgtEndpointException(status, getError(error.getCode(), error.getMessage(),
+                error.getDescription()));
+    }
+
+    public static ApplicationTagMgtEndpointException handleException(Response.Status status,
+         ApplicationTagMgtEndpointConstants.ErrorMessage error, String data) {
+
+        return new ApplicationTagMgtEndpointException(status, getError(error.getCode(), error.getMessage(),
+                String.format(error.getDescription(), data)));
+    }
+
+    public static ApplicationTagMgtEndpointException handleException(Response.Status status, String errorCode,
+                                                                  String message, String description) {
+
+        return new ApplicationTagMgtEndpointException(status, getError(errorCode, message, description));
+    }
+
+    public static ApplicationTagMgtEndpointException handleApplicationTagMgtException(ApplicationTagMgtException e) {
+
+        Response.Status status = Response.Status.INTERNAL_SERVER_ERROR;
+        if (e instanceof ApplicationTagMgtClientException) {
+            LOG.debug(e.getMessage(), e);
+            if (ERROR_CODE_APP_TAG_ALREADY_EXISTS.getCode().equals(e.getErrorCode())) {
+                status = Response.Status.CONFLICT;
+            } else {
+                status = Response.Status.BAD_REQUEST;
+            }
+        } else {
+            LOG.error(e.getMessage(), e);
+        }
+        String errorCode = e.getErrorCode();
+        errorCode = errorCode.contains(ERROR_CODE_DELIMITER) ? errorCode :
+                ApplicationTagMgtEndpointConstants.APPLICATION_TAG_MANAGEMENT_PREFIX + errorCode;
+        return handleException(status, errorCode, e.getMessage(), e.getDescription());
+    }
+
+    /**
+     * Returns a generic error object.
+     *
+     * @param errorCode        Error code.
+     * @param errorMessage     Error message.
+     * @param errorDescription Error description.
+     * @return A generic error with the specified details.
+     */
+    public static Error getError(String errorCode, String errorMessage, String errorDescription) {
+
+        Error error = new Error();
+        error.setCode(errorCode);
+        error.setMessage(errorMessage);
+        error.setDescription(errorDescription);
+        return error;
+    }
+}

--- a/components/org.wso2.carbon.identity.api.server.application.tag.management/org.wso2.carbon.identity.api.server.application.tag.management.v1/src/main/resources/META-INF/cxf/application-tag-server-v1-cxf.xml
+++ b/components/org.wso2.carbon.identity.api.server.application.tag.management/org.wso2.carbon.identity.api.server.application.tag.management.v1/src/main/resources/META-INF/cxf/application-tag-server-v1-cxf.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+  ~
+  ~ WSO2 LLC. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans  http://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
+
+    <bean class="org.wso2.carbon.identity.api.server.application.tag.management.v1.core.ServerApplicationTagManagementService"/>
+    <bean class="org.wso2.carbon.identity.api.server.application.tag.management.v1.impl.ApplicationsTagsApiServiceImpl"/>
+
+    <bean id="applicationTagManagementServiceHolderBean"
+          class="org.wso2.carbon.identity.api.server.application.tag.management.common.ApplicationTagManagementServiceHolder">
+        <property name="applicationTagManager" ref="applicationTagManagementServiceFactoryBean"/>
+    </bean>
+
+    <bean id="applicationTagManagementServiceFactoryBean"
+          class="org.wso2.carbon.identity.api.server.application.tag.management.common.factory.ApplicationTagMgtOSGiServiceFactory"/>
+</beans>

--- a/components/org.wso2.carbon.identity.api.server.application.tag.management/org.wso2.carbon.identity.api.server.application.tag.management.v1/src/main/resources/tags.yaml
+++ b/components/org.wso2.carbon.identity.api.server.application.tag.management/org.wso2.carbon.identity.api.server.application.tag.management.v1/src/main/resources/tags.yaml
@@ -1,0 +1,438 @@
+openapi: 3.0.0
+info:
+  description: >-
+    This is the **RESTful API** for Applications Tag management in **WSO2 Identity Server**
+  version: "v1"
+  title: WSO2 Identity Server - Applications Tag Management
+  termsOfService: 'http://swagger.io/terms/'
+  contact:
+    name: WSO2 Identity Server
+    url: 'https://wso2.com/identity-and-access-management'
+    email: architecture@wso2.org
+  license:
+    name: Apache 2.0
+    url: 'http://www.apache.org/licenses/LICENSE-2.0.html'
+
+security:
+  - OAuth2: []
+  - BasicAuth: []
+paths:
+  /applications-tags:
+    get:
+      tags:
+        - Applications Tags
+      operationId: getAllApplicationTags
+      summary: |
+        List all Tags
+      description: |
+        This API provides the capability to retrieve the list of tags available.
+      parameters:
+        - $ref: '#/components/parameters/limitWithoutDefaultQueryParam'
+        - $ref: '#/components/parameters/offsetWithoutDefaultQueryParam'
+        - $ref: '#/components/parameters/filterQueryParam'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApplicationTagsListResponse'
+        '400':
+          description: "Bad Request"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '401':
+          description: "Unauthorized"
+        '403':
+          description: "Forbidden"
+        '404':
+          description: "Not Found"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '500':
+          description: "Server Error"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '501':
+          description: "Not Implemented"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+    post:
+      tags:
+        - Applications Tags
+      summary: |
+        Add a Tag
+      operationId: createApplicationTag
+      description: |
+        This API provides the capability to store the tag provided by users.<br>
+          <b>Permission required:</b> <br>
+              * /permission/admin/manage/identity/tagmgt/add <br>
+          <b>Scope required:</b> <br>
+              * internal_tag_mgt_add
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ApplicationTagModel'
+        description: "This represents the application template to be created."
+        required: true
+      responses:
+        '201':
+          description: "Successful response."
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApplicationTagCreationResponse'
+          headers:
+            Location:
+              description: "Location of the newly created tag."
+              schema:
+                type: string
+                example: "/t/wso2.com/api/server/v1/applications-tags/85e3f4b8-0d22-4181-b1e3-1651f71b88bd"
+        '400':
+          description: "Bad Request"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '401':
+          description: "Unauthorized"
+        '403':
+          description: "Forbidden"
+        '409':
+          description: "Conflict"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '500':
+          description: "Server Error"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '501':
+          description: "Not Implemented"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
+  /applications-tags/{tag-id}:
+    get:
+      tags:
+        - Applications Tags
+      summary: |
+        Retrieve a tag by ID
+      operationId: getApplicationTag
+      description: >
+        This API provides the capability to retrieve a tag from the tag id.
+      parameters:
+        - $ref: '#/components/parameters/tagIdPathParam'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApplicationTagResponse'
+        '400':
+          description: "Bad Request"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+            application/xml:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '401':
+          description: "Unauthorized"
+        '403':
+          description: "Forbidden"
+        '404':
+          description: "Not Found"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+            application/xml:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '500':
+          description: "Server Error"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+            application/xml:
+              schema:
+                $ref: '#/components/schemas/Error'
+
+    patch:
+      tags:
+        - Applications Tags
+      summary: |
+        Partially update a tag by ID
+      operationId: patchTag
+      description: |
+        This API provides the capability to partially update a tag by ID.<br>
+          <b>Permission required:</b> <br>
+              * /permission/admin/manage/identity/tagmgt/update <br>
+          <b>Scope required:</b> <br>
+              * internal_tag_mgt_update
+      parameters:
+        - $ref: '#/components/parameters/tagIdPathParam'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ApplicationTagModel'
+        description: This represents the application details to be updated.
+        required: true
+      responses:
+        '200':
+          description: Successfully Updated
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '409':
+          description: Conflict
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '500':
+          description: Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
+    delete:
+      tags:
+        - Applications Tags
+      summary: |
+        Delete a tag by tag ID.
+      operationId: deleteApplicationTag
+      description: |
+        This API provides the capability to partially update a tag by ID.<br>
+          <b>Permission required:</b> <br>
+              * /permission/admin/manage/identity/tagmgt/delete <br>
+          <b>Scope required:</b> <br>
+              * internal_tag_mgt_delete
+      parameters:
+        - $ref: '#/components/parameters/tagIdPathParam'
+      responses:
+        '204':
+          description: "Successfully Deleted"
+        '400':
+          description: "Bad Request"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '401':
+          description: "Unauthorized"
+        '403':
+          description: "Forbidden"
+        '404':
+          description: "Not Found"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+            application/xml:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '500':
+          description: "Server Error"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
+components:
+  parameters:
+    limitWithoutDefaultQueryParam:
+      in: query
+      name: limit
+      required: false
+      description: |
+        Maximum number of records to return.
+      schema:
+        type: integer
+    offsetWithoutDefaultQueryParam:
+      in: query
+      name: offset
+      required: false
+      description: |
+        Number of records to skip for pagination.
+      schema:
+        type: integer
+    filterQueryParam:
+      name: filter
+      in: query
+      required: false
+      description: |
+        Condition to filter the retrieval of records. Supports 'sw', 'co', 'ew' and 'eq' operations.
+        <br>
+        /applications-tags?filter=name+eq+engineering
+        <br>
+        /applications-tags?filter=name+co+eng
+      schema:
+        type: string
+    tagIdPathParam:
+      in: path
+      name: tag-id
+      required: true
+      description: |
+        Application tag ID.
+      schema:
+        type: string
+  securitySchemes:
+    BasicAuth:
+      type: http
+      scheme: basic
+    OAuth2:
+      type: oauth2
+      flows:
+        authorizationCode:
+          authorizationUrl: 'https://localhost:9443/oauth2/authorize'
+          tokenUrl: 'http://localhost:9763/oauth2/token'
+          scopes: {}
+  schemas:
+    ApplicationTagsListResponse:
+      type: object
+      properties:
+        totalResults:
+          type: integer
+          description: "Number of results that match the listing operation."
+          example: 1
+        startIndex:
+          type: integer
+          description: "Index of the first element of the page, which will be equal to offset + 1."
+          example: 1
+        count:
+          type: integer
+          description: "Number of elements in the returned page."
+          example: 10
+        applicationTags:
+          type: array
+          items:
+            $ref: '#/components/schemas/ApplicationTagsListItem'
+        links:
+          type: array
+          items:
+            $ref: '#/components/schemas/Link'
+
+    ApplicationTagsListItem:
+      type: object
+      properties:
+        id:
+          type: string
+          example: "85e3f4b8-0d22-4181-b1e3-1651f71b88bd"
+        name:
+          type: string
+          example: "HR"
+        colour:
+          type: string
+          example: "#677b66"
+        associatedAppsCount:
+          type: integer
+          example: "2"
+        self:
+          type: string
+          example: "/t/wso2.com/api/server/v1/applications-tags/85e3f4b8-0d22-4181-b1e3-1651f71b88bd"
+
+    ApplicationTagModel:
+      type: object
+      properties:
+        name:
+          type: string
+          example: "HR"
+        colour:
+          type: string
+          example: "#677b66"
+      required:
+        - name
+        - colour
+
+    ApplicationTagCreationResponse:
+      type: object
+      properties:
+        id:
+          type: string
+          example: "85e3f4b8-0d22-4181-b1e3-1651f71b88bd"
+        name:
+          type: string
+          example: "HR"
+        colour:
+          type: string
+          example: "#677b66"
+
+    ApplicationTagResponse:
+      type: object
+      properties:
+        id:
+          type: string
+          example: "85e3f4b8-0d22-4181-b1e3-1651f71b88bd"
+        name:
+          type: string
+          example: "HR"
+        colour:
+          type: string
+          example: "#677b66"
+        associatedAppsCount:
+          type: integer
+          example: "2"
+
+    Error:
+      type: object
+      properties:
+        code:
+          type: string
+          example: AAA-00000
+        message:
+          type: string
+          example: Some error message.
+        description:
+          type: string
+          example: Some error description.
+        traceId:
+          type: string
+          example: e0fbcfeb-3617-43c4-8dd0-7b7d38e13047
+
+    Link:
+      type: object
+      properties:
+        href:
+          type: string
+          example: "applications-tags?offset=10&limit=10"
+        rel:
+          type: string
+          example: "next"
+servers:
+  # Added by API Auto Mocking Plugin
+  - description: SwaggerHub API Auto Mocking
+    url: https://virtserver.swaggerhub.com/ATPALIHAKKARA/applications-tags/v1
+  - url: 'https://{server-url}/t/{tenant-domain}/api/server/v1'
+    variables:
+      tenant-domain:
+        default: "carbon.super"
+      server-url:
+        default: "localhost:9443"

--- a/components/org.wso2.carbon.identity.api.server.application.tag.management/pom.xml
+++ b/components/org.wso2.carbon.identity.api.server.application.tag.management/pom.xml
@@ -23,12 +23,12 @@
     <parent>
         <artifactId>identity-api-server</artifactId>
         <groupId>org.wso2.carbon.identity.server.api</groupId>
-        <version>1.2.81-SNAPSHOT</version>
+        <version>1.2.85-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>org.wso2.carbon.identity.api.server.application.tag.management</artifactId>
-    <version>1.2.81-SNAPSHOT</version>
+    <version>1.2.85-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <modules>

--- a/components/org.wso2.carbon.identity.api.server.application.tag.management/pom.xml
+++ b/components/org.wso2.carbon.identity.api.server.application.tag.management/pom.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+  ~
+  ~ WSO2 LLC. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>identity-api-server</artifactId>
+        <groupId>org.wso2.carbon.identity.server.api</groupId>
+        <version>1.2.81-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>org.wso2.carbon.identity.api.server.application.tag.management</artifactId>
+    <version>1.2.81-SNAPSHOT</version>
+    <packaging>pom</packaging>
+
+    <modules>
+        <module>org.wso2.carbon.identity.api.server.application.tag.management.common</module>
+        <module>org.wso2.carbon.identity.api.server.application.tag.management.v1</module>
+    </modules>
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -193,6 +193,12 @@
             </dependency>
             <dependency>
                 <groupId>org.wso2.carbon.identity.framework</groupId>
+                <artifactId>org.wso2.carbon.identity.application.tag.mgt</artifactId>
+                <version>${carbon.identity.framework.version}</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.wso2.carbon.identity.framework</groupId>
                 <artifactId>org.wso2.carbon.identity.application.mgt</artifactId>
                 <version>${carbon.identity.framework.version}</version>
                 <scope>provided</scope>
@@ -391,6 +397,12 @@
             <dependency>
                 <groupId>org.wso2.carbon.identity.server.api</groupId>
                 <artifactId>org.wso2.carbon.identity.api.server.tenant.management.common</artifactId>
+                <version>${project.version}</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.wso2.carbon.identity.server.api</groupId>
+                <artifactId>org.wso2.carbon.identity.api.server.application.tag.management.common</artifactId>
                 <version>${project.version}</version>
                 <scope>provided</scope>
             </dependency>
@@ -706,7 +718,7 @@
         <maven.buildnumber.plugin.version>1.4</maven.buildnumber.plugin.version>
         <org.apache.felix.annotations.version>1.2.4</org.apache.felix.annotations.version>
         <identity.governance.version>1.8.62</identity.governance.version>
-        <carbon.identity.framework.version>5.25.305</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.25.358-SNAPSHOT</carbon.identity.framework.version>
         <maven.findbugsplugin.version>3.0.5</maven.findbugsplugin.version>
         <identity.workflow.impl.bps.version>5.2.0</identity.workflow.impl.bps.version>
         <maven.checkstyleplugin.excludes>**/gen/**/*</maven.checkstyleplugin.excludes>
@@ -775,6 +787,8 @@
         <module>components/org.wso2.carbon.identity.api.idle.account.identification</module>
         <module>components/org.wso2.carbon.identity.api.expired.password.identification</module>
         <module>components/org.wso2.carbon.identity.api.server.organization.user.invitation.management</module>
+        <module>components/org.wso2.carbon.identity.api.server.application.tag.management</module>
+        <module>components/AAAXtra</module>
     </modules>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -408,7 +408,13 @@
             </dependency>
             <dependency>
                 <groupId>org.wso2.carbon.identity.server.api</groupId>
-
+                <artifactId>org.wso2.carbon.identity.api.server.api.resource.common</artifactId>
+                <version>${project.version}</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.wso2.carbon.identity.server.api</groupId>
+                <artifactId>org.wso2.carbon.identity.api.server.application.tag.management.common</artifactId>
                 <version>${project.version}</version>
                 <scope>provided</scope>
             </dependency>


### PR DESCRIPTION
## Purpose
Add Application Tagging feature in both Console and MyAccount

## Goals
Add Application Tag Management API. Allows managing Application Tags in the identity server.

## Automation tests
 - Unit tests 
 - Integration tests

## Issue
- https://github.com/wso2/product-is/issues/12999

## Related PRs
- https://github.com/wso2/carbon-identity-framework/pull/4904