### PR TITLE
Introduce implicit association identity provider configuration

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.common/src/main/java/org/wso2/carbon/identity/api/server/idp/common/Constants.java
+++ b/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.common/src/main/java/org/wso2/carbon/identity/api/server/idp/common/Constants.java
@@ -202,6 +202,9 @@ public class Constants {
                 "Server encountered an error while retrieving the identity provider JIT config for identifier %s."),
         ERROR_CODE_ERROR_RETRIEVING_IDP_GROUPS("65033", "Unable to retrieve identity provider group config.",
                 "Server encountered an error while retrieving the identity provider group config for identifier %s."),
+        ERROR_CODE_ERROR_RETRIEVING_IDP_ASSOCIATION("65034", "Unable to retrieve identity provider federated " +
+                "association config.", "Server encountered an error while retrieving the identity provider " +
+                "federated association config for identifier %s."),
         ERROR_CODE_ERROR_RETRIEVING_IDP_CONNECTED_APPS("65042",
                 "Unable to retrieve identity provider connected applications.",
                 "Server encountered an error while retrieving the identity provider connected applications %s."),
@@ -244,6 +247,9 @@ public class Constants {
                 "Unable to update identity provider groups.",
                 "Server encountered an error while updating the identity provider " +
                         "group config for identifier %s."),
+        ERROR_CODE_ERROR_UPDATING_IDP_ASSOCIATION("65037", "Unable to update identity provider federated " +
+                "association config.", "Server encountered an error while updating the identity provider " +
+                "federated association config for identifier %s."),
         ERROR_CODE_ERROR_LISTING_IDP_TEMPLATES("65050", "Unable to list existing identity provider " +
                 "templates.", "Error occured while listing identity provider templates."),
         ERROR_CODE_ERROR_ADDING_IDP_TEMPLATE("65051", "Unable to add IDP template.",

--- a/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/gen/java/org/wso2/carbon/identity/api/server/idp/v1/IdentityProvidersApi.java
+++ b/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/gen/java/org/wso2/carbon/identity/api/server/idp/v1/IdentityProvidersApi.java
@@ -241,7 +241,7 @@ public class IdentityProvidersApi  {
 
     @Valid
     @GET
-    @Path("/{identity-provider-id}/association")
+    @Path("/{identity-provider-id}/implicit-association")
     
     @Produces({ "application/json" })
     @ApiOperation(value = "Federated association config of an identity provider ", notes = "This API provides the federated association config of an identity provider. <br> <b>Permission required:</b> <br>     * /permission/admin/manage/identity/idpmgt/view <br> <b>Scope required:</b> <br>     * internal_idp_view ", response = AssociationResponse.class, authorizations = {
@@ -724,7 +724,7 @@ public class IdentityProvidersApi  {
 
     @Valid
     @PUT
-    @Path("/{identity-provider-id}/association")
+    @Path("/{identity-provider-id}/implicit-association")
     @Consumes({ "application/json" })
     @Produces({ "application/json" })
     @ApiOperation(value = "Update the federated association config of an identity provider ", notes = "This API provides the capability to update the federated association config of an identity provider by specifying the identity provider ID. <br> <b>Permission required:</b> <br>     * /permission/admin/manage/identity/idpmgt/update <br> <b>Scope required:</b> <br>     * internal_idp_update ", response = AssociationResponse.class, authorizations = {

--- a/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/gen/java/org/wso2/carbon/identity/api/server/idp/v1/IdentityProvidersApi.java
+++ b/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/gen/java/org/wso2/carbon/identity/api/server/idp/v1/IdentityProvidersApi.java
@@ -1,18 +1,20 @@
 /*
-* Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-* http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 
 package org.wso2.carbon.identity.api.server.idp.v1;
 
@@ -23,6 +25,8 @@ import org.apache.cxf.jaxrs.ext.multipart.Multipart;
 import java.io.InputStream;
 import java.util.List;
 
+import org.wso2.carbon.identity.api.server.idp.v1.model.AssociationRequest;
+import org.wso2.carbon.identity.api.server.idp.v1.model.AssociationResponse;
 import org.wso2.carbon.identity.api.server.idp.v1.model.Claims;
 import org.wso2.carbon.identity.api.server.idp.v1.model.ConnectedApps;
 import org.wso2.carbon.identity.api.server.idp.v1.model.Error;
@@ -233,6 +237,30 @@ public class IdentityProvidersApi  {
     public Response getConnectedApps(@ApiParam(value = "ID of the identity provider.",required=true) @PathParam("identity-provider-id") String identityProviderId,     @Valid@ApiParam(value = "Maximum number of records to return. ")  @QueryParam("limit") Integer limit,     @Valid@ApiParam(value = "Number of records to skip for pagination. ")  @QueryParam("offset") Integer offset) {
 
         return delegate.getConnectedApps(identityProviderId,  limit,  offset );
+    }
+
+    @Valid
+    @GET
+    @Path("/{identity-provider-id}/association")
+    
+    @Produces({ "application/json" })
+    @ApiOperation(value = "Federated association config of an identity provider ", notes = "This API provides the federated association config of an identity provider. <br> <b>Permission required:</b> <br>     * /permission/admin/manage/identity/idpmgt/view <br> <b>Scope required:</b> <br>     * internal_idp_view ", response = AssociationResponse.class, authorizations = {
+        @Authorization(value = "BasicAuth"),
+        @Authorization(value = "OAuth2", scopes = {
+            
+        })
+    }, tags={ "Association", })
+    @ApiResponses(value = { 
+        @ApiResponse(code = 200, message = "Successful response", response = AssociationResponse.class),
+        @ApiResponse(code = 400, message = "Bad Request", response = Error.class),
+        @ApiResponse(code = 401, message = "Unauthorized", response = Void.class),
+        @ApiResponse(code = 403, message = "Forbidden", response = Void.class),
+        @ApiResponse(code = 404, message = "Not Found", response = Error.class),
+        @ApiResponse(code = 500, message = "Server Error", response = Error.class)
+    })
+    public Response getFederatedAssociationConfig(@ApiParam(value = "ID of the identity provider.",required=true) @PathParam("identity-provider-id") String identityProviderId) {
+
+        return delegate.getFederatedAssociationConfig(identityProviderId );
     }
 
     @Valid
@@ -692,6 +720,30 @@ public class IdentityProvidersApi  {
     public Response updateClaimConfig(@ApiParam(value = "ID of the identity provider.",required=true) @PathParam("identity-provider-id") String identityProviderId, @ApiParam(value = "This represents the claim config to be updated" ,required=true) @Valid Claims claims) {
 
         return delegate.updateClaimConfig(identityProviderId,  claims );
+    }
+
+    @Valid
+    @PUT
+    @Path("/{identity-provider-id}/association")
+    @Consumes({ "application/json" })
+    @Produces({ "application/json" })
+    @ApiOperation(value = "Update the federated association config of an identity provider ", notes = "This API provides the capability to update the federated association config of an identity provider by specifying the identity provider ID. <br> <b>Permission required:</b> <br>     * /permission/admin/manage/identity/idpmgt/update <br> <b>Scope required:</b> <br>     * internal_idp_update ", response = AssociationResponse.class, authorizations = {
+        @Authorization(value = "BasicAuth"),
+        @Authorization(value = "OAuth2", scopes = {
+            
+        })
+    }, tags={ "Association", })
+    @ApiResponses(value = { 
+        @ApiResponse(code = 200, message = "Successful response", response = AssociationResponse.class),
+        @ApiResponse(code = 400, message = "Bad Request", response = Error.class),
+        @ApiResponse(code = 401, message = "Unauthorized", response = Void.class),
+        @ApiResponse(code = 403, message = "Forbidden", response = Void.class),
+        @ApiResponse(code = 404, message = "Not Found", response = Error.class),
+        @ApiResponse(code = 500, message = "Server Error", response = Error.class)
+    })
+    public Response updateFederatedAssociationConfig(@ApiParam(value = "ID of the identity provider.",required=true) @PathParam("identity-provider-id") String identityProviderId, @ApiParam(value = "This represents the federated association config to be updated." ,required=true) @Valid AssociationRequest associationRequest) {
+
+        return delegate.updateFederatedAssociationConfig(identityProviderId,  associationRequest );
     }
 
     @Valid

--- a/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/gen/java/org/wso2/carbon/identity/api/server/idp/v1/IdentityProvidersApiService.java
+++ b/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/gen/java/org/wso2/carbon/identity/api/server/idp/v1/IdentityProvidersApiService.java
@@ -1,18 +1,20 @@
 /*
-* Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-* http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 
 package org.wso2.carbon.identity.api.server.idp.v1;
 
@@ -23,6 +25,8 @@ import org.apache.cxf.jaxrs.ext.multipart.Attachment;
 import org.apache.cxf.jaxrs.ext.multipart.Multipart;
 import java.io.InputStream;
 import java.util.List;
+import org.wso2.carbon.identity.api.server.idp.v1.model.AssociationRequest;
+import org.wso2.carbon.identity.api.server.idp.v1.model.AssociationResponse;
 import org.wso2.carbon.identity.api.server.idp.v1.model.Claims;
 import org.wso2.carbon.identity.api.server.idp.v1.model.ConnectedApps;
 import org.wso2.carbon.identity.api.server.idp.v1.model.Error;
@@ -68,6 +72,8 @@ public interface IdentityProvidersApiService {
 
       public Response getConnectedApps(String identityProviderId, Integer limit, Integer offset);
 
+      public Response getFederatedAssociationConfig(String identityProviderId);
+
       public Response getFederatedAuthenticator(String identityProviderId, String federatedAuthenticatorId);
 
       public Response getFederatedAuthenticators(String identityProviderId);
@@ -105,6 +111,8 @@ public interface IdentityProvidersApiService {
       public Response patchIDP(String identityProviderId, List<Patch> patch);
 
       public Response updateClaimConfig(String identityProviderId, Claims claims);
+
+      public Response updateFederatedAssociationConfig(String identityProviderId, AssociationRequest associationRequest);
 
       public Response updateFederatedAuthenticator(String identityProviderId, String federatedAuthenticatorId, FederatedAuthenticatorPUTRequest federatedAuthenticatorPUTRequest);
 

--- a/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/gen/java/org/wso2/carbon/identity/api/server/idp/v1/model/AssociationRequest.java
+++ b/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/gen/java/org/wso2/carbon/identity/api/server/idp/v1/model/AssociationRequest.java
@@ -22,6 +22,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import java.util.ArrayList;
+import java.util.List;
 import javax.validation.constraints.*;
 
 
@@ -33,8 +35,8 @@ import javax.xml.bind.annotation.*;
 public class AssociationRequest  {
   
     private Boolean isEnabled;
-    private String federatedAttribute;
-    private String mappedLocalAttribute;
+    private List<String> lookupAttribute = null;
+
 
     /**
     **/
@@ -56,41 +58,31 @@ public class AssociationRequest  {
 
     /**
     **/
-    public AssociationRequest federatedAttribute(String federatedAttribute) {
+    public AssociationRequest lookupAttribute(List<String> lookupAttribute) {
 
-        this.federatedAttribute = federatedAttribute;
+        this.lookupAttribute = lookupAttribute;
         return this;
     }
     
-    @ApiModelProperty(example = "email", value = "")
-    @JsonProperty("federatedAttribute")
+    @ApiModelProperty(example = "[\"email\"]", value = "")
+    @JsonProperty("lookupAttribute")
     @Valid
-    public String getFederatedAttribute() {
-        return federatedAttribute;
+    public List<String> getLookupAttribute() {
+        return lookupAttribute;
     }
-    public void setFederatedAttribute(String federatedAttribute) {
-        this.federatedAttribute = federatedAttribute;
+    public void setLookupAttribute(List<String> lookupAttribute) {
+        this.lookupAttribute = lookupAttribute;
     }
 
-    /**
-    **/
-    public AssociationRequest mappedLocalAttribute(String mappedLocalAttribute) {
-
-        this.mappedLocalAttribute = mappedLocalAttribute;
+    public AssociationRequest addLookupAttributeItem(String lookupAttributeItem) {
+        if (this.lookupAttribute == null) {
+            this.lookupAttribute = new ArrayList<>();
+        }
+        this.lookupAttribute.add(lookupAttributeItem);
         return this;
     }
+
     
-    @ApiModelProperty(example = "username", value = "")
-    @JsonProperty("mappedLocalAttribute")
-    @Valid
-    public String getMappedLocalAttribute() {
-        return mappedLocalAttribute;
-    }
-    public void setMappedLocalAttribute(String mappedLocalAttribute) {
-        this.mappedLocalAttribute = mappedLocalAttribute;
-    }
-
-
 
     @Override
     public boolean equals(java.lang.Object o) {
@@ -103,13 +95,12 @@ public class AssociationRequest  {
         }
         AssociationRequest associationRequest = (AssociationRequest) o;
         return Objects.equals(this.isEnabled, associationRequest.isEnabled) &&
-            Objects.equals(this.federatedAttribute, associationRequest.federatedAttribute) &&
-            Objects.equals(this.mappedLocalAttribute, associationRequest.mappedLocalAttribute);
+            Objects.equals(this.lookupAttribute, associationRequest.lookupAttribute);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(isEnabled, federatedAttribute, mappedLocalAttribute);
+        return Objects.hash(isEnabled, lookupAttribute);
     }
 
     @Override
@@ -119,8 +110,7 @@ public class AssociationRequest  {
         sb.append("class AssociationRequest {\n");
         
         sb.append("    isEnabled: ").append(toIndentedString(isEnabled)).append("\n");
-        sb.append("    federatedAttribute: ").append(toIndentedString(federatedAttribute)).append("\n");
-        sb.append("    mappedLocalAttribute: ").append(toIndentedString(mappedLocalAttribute)).append("\n");
+        sb.append("    lookupAttribute: ").append(toIndentedString(lookupAttribute)).append("\n");
         sb.append("}");
         return sb.toString();
     }

--- a/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/gen/java/org/wso2/carbon/identity/api/server/idp/v1/model/AssociationRequest.java
+++ b/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/gen/java/org/wso2/carbon/identity/api/server/idp/v1/model/AssociationRequest.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.idp.v1.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import javax.validation.constraints.*;
+
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+import javax.validation.Valid;
+import javax.xml.bind.annotation.*;
+
+public class AssociationRequest  {
+  
+    private Boolean isEnabled;
+    private String federatedAttribute;
+    private String mappedLocalAttribute;
+
+    /**
+    **/
+    public AssociationRequest isEnabled(Boolean isEnabled) {
+
+        this.isEnabled = isEnabled;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "false", value = "")
+    @JsonProperty("isEnabled")
+    @Valid
+    public Boolean getIsEnabled() {
+        return isEnabled;
+    }
+    public void setIsEnabled(Boolean isEnabled) {
+        this.isEnabled = isEnabled;
+    }
+
+    /**
+    **/
+    public AssociationRequest federatedAttribute(String federatedAttribute) {
+
+        this.federatedAttribute = federatedAttribute;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "email", value = "")
+    @JsonProperty("federatedAttribute")
+    @Valid
+    public String getFederatedAttribute() {
+        return federatedAttribute;
+    }
+    public void setFederatedAttribute(String federatedAttribute) {
+        this.federatedAttribute = federatedAttribute;
+    }
+
+    /**
+    **/
+    public AssociationRequest mappedLocalAttribute(String mappedLocalAttribute) {
+
+        this.mappedLocalAttribute = mappedLocalAttribute;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "username", value = "")
+    @JsonProperty("mappedLocalAttribute")
+    @Valid
+    public String getMappedLocalAttribute() {
+        return mappedLocalAttribute;
+    }
+    public void setMappedLocalAttribute(String mappedLocalAttribute) {
+        this.mappedLocalAttribute = mappedLocalAttribute;
+    }
+
+
+
+    @Override
+    public boolean equals(java.lang.Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        AssociationRequest associationRequest = (AssociationRequest) o;
+        return Objects.equals(this.isEnabled, associationRequest.isEnabled) &&
+            Objects.equals(this.federatedAttribute, associationRequest.federatedAttribute) &&
+            Objects.equals(this.mappedLocalAttribute, associationRequest.mappedLocalAttribute);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(isEnabled, federatedAttribute, mappedLocalAttribute);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class AssociationRequest {\n");
+        
+        sb.append("    isEnabled: ").append(toIndentedString(isEnabled)).append("\n");
+        sb.append("    federatedAttribute: ").append(toIndentedString(federatedAttribute)).append("\n");
+        sb.append("    mappedLocalAttribute: ").append(toIndentedString(mappedLocalAttribute)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+    * Convert the given object to string with each line indented by 4 spaces
+    * (except the first line).
+    */
+    private String toIndentedString(java.lang.Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}
+

--- a/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/gen/java/org/wso2/carbon/identity/api/server/idp/v1/model/AssociationResponse.java
+++ b/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/gen/java/org/wso2/carbon/identity/api/server/idp/v1/model/AssociationResponse.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.idp.v1.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import javax.validation.constraints.*;
+
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+import javax.validation.Valid;
+import javax.xml.bind.annotation.*;
+
+public class AssociationResponse  {
+  
+    private Boolean isEnabled;
+    private String federatedAttribute;
+    private String mappedLocalAttribute;
+
+    /**
+    **/
+    public AssociationResponse isEnabled(Boolean isEnabled) {
+
+        this.isEnabled = isEnabled;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "false", value = "")
+    @JsonProperty("isEnabled")
+    @Valid
+    public Boolean getIsEnabled() {
+        return isEnabled;
+    }
+    public void setIsEnabled(Boolean isEnabled) {
+        this.isEnabled = isEnabled;
+    }
+
+    /**
+    **/
+    public AssociationResponse federatedAttribute(String federatedAttribute) {
+
+        this.federatedAttribute = federatedAttribute;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "sub", value = "")
+    @JsonProperty("federatedAttribute")
+    @Valid
+    public String getFederatedAttribute() {
+        return federatedAttribute;
+    }
+    public void setFederatedAttribute(String federatedAttribute) {
+        this.federatedAttribute = federatedAttribute;
+    }
+
+    /**
+    **/
+    public AssociationResponse mappedLocalAttribute(String mappedLocalAttribute) {
+
+        this.mappedLocalAttribute = mappedLocalAttribute;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "http://wso2.org/claims/username", value = "")
+    @JsonProperty("mappedLocalAttribute")
+    @Valid
+    public String getMappedLocalAttribute() {
+        return mappedLocalAttribute;
+    }
+    public void setMappedLocalAttribute(String mappedLocalAttribute) {
+        this.mappedLocalAttribute = mappedLocalAttribute;
+    }
+
+
+
+    @Override
+    public boolean equals(java.lang.Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        AssociationResponse associationResponse = (AssociationResponse) o;
+        return Objects.equals(this.isEnabled, associationResponse.isEnabled) &&
+            Objects.equals(this.federatedAttribute, associationResponse.federatedAttribute) &&
+            Objects.equals(this.mappedLocalAttribute, associationResponse.mappedLocalAttribute);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(isEnabled, federatedAttribute, mappedLocalAttribute);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class AssociationResponse {\n");
+        
+        sb.append("    isEnabled: ").append(toIndentedString(isEnabled)).append("\n");
+        sb.append("    federatedAttribute: ").append(toIndentedString(federatedAttribute)).append("\n");
+        sb.append("    mappedLocalAttribute: ").append(toIndentedString(mappedLocalAttribute)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+    * Convert the given object to string with each line indented by 4 spaces
+    * (except the first line).
+    */
+    private String toIndentedString(java.lang.Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}
+

--- a/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/gen/java/org/wso2/carbon/identity/api/server/idp/v1/model/AssociationResponse.java
+++ b/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/gen/java/org/wso2/carbon/identity/api/server/idp/v1/model/AssociationResponse.java
@@ -22,6 +22,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import java.util.ArrayList;
+import java.util.List;
 import javax.validation.constraints.*;
 
 
@@ -33,8 +35,8 @@ import javax.xml.bind.annotation.*;
 public class AssociationResponse  {
   
     private Boolean isEnabled;
-    private String federatedAttribute;
-    private String mappedLocalAttribute;
+    private List<String> lookupAttribute = null;
+
 
     /**
     **/
@@ -56,41 +58,31 @@ public class AssociationResponse  {
 
     /**
     **/
-    public AssociationResponse federatedAttribute(String federatedAttribute) {
+    public AssociationResponse lookupAttribute(List<String> lookupAttribute) {
 
-        this.federatedAttribute = federatedAttribute;
+        this.lookupAttribute = lookupAttribute;
         return this;
     }
     
-    @ApiModelProperty(example = "sub", value = "")
-    @JsonProperty("federatedAttribute")
+    @ApiModelProperty(example = "[\"email\"]", value = "")
+    @JsonProperty("lookupAttribute")
     @Valid
-    public String getFederatedAttribute() {
-        return federatedAttribute;
+    public List<String> getLookupAttribute() {
+        return lookupAttribute;
     }
-    public void setFederatedAttribute(String federatedAttribute) {
-        this.federatedAttribute = federatedAttribute;
+    public void setLookupAttribute(List<String> lookupAttribute) {
+        this.lookupAttribute = lookupAttribute;
     }
 
-    /**
-    **/
-    public AssociationResponse mappedLocalAttribute(String mappedLocalAttribute) {
-
-        this.mappedLocalAttribute = mappedLocalAttribute;
+    public AssociationResponse addLookupAttributeItem(String lookupAttributeItem) {
+        if (this.lookupAttribute == null) {
+            this.lookupAttribute = new ArrayList<>();
+        }
+        this.lookupAttribute.add(lookupAttributeItem);
         return this;
     }
+
     
-    @ApiModelProperty(example = "http://wso2.org/claims/username", value = "")
-    @JsonProperty("mappedLocalAttribute")
-    @Valid
-    public String getMappedLocalAttribute() {
-        return mappedLocalAttribute;
-    }
-    public void setMappedLocalAttribute(String mappedLocalAttribute) {
-        this.mappedLocalAttribute = mappedLocalAttribute;
-    }
-
-
 
     @Override
     public boolean equals(java.lang.Object o) {
@@ -103,13 +95,12 @@ public class AssociationResponse  {
         }
         AssociationResponse associationResponse = (AssociationResponse) o;
         return Objects.equals(this.isEnabled, associationResponse.isEnabled) &&
-            Objects.equals(this.federatedAttribute, associationResponse.federatedAttribute) &&
-            Objects.equals(this.mappedLocalAttribute, associationResponse.mappedLocalAttribute);
+            Objects.equals(this.lookupAttribute, associationResponse.lookupAttribute);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(isEnabled, federatedAttribute, mappedLocalAttribute);
+        return Objects.hash(isEnabled, lookupAttribute);
     }
 
     @Override
@@ -119,8 +110,7 @@ public class AssociationResponse  {
         sb.append("class AssociationResponse {\n");
         
         sb.append("    isEnabled: ").append(toIndentedString(isEnabled)).append("\n");
-        sb.append("    federatedAttribute: ").append(toIndentedString(federatedAttribute)).append("\n");
-        sb.append("    mappedLocalAttribute: ").append(toIndentedString(mappedLocalAttribute)).append("\n");
+        sb.append("    lookupAttribute: ").append(toIndentedString(lookupAttribute)).append("\n");
         sb.append("}");
         return sb.toString();
     }

--- a/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/gen/java/org/wso2/carbon/identity/api/server/idp/v1/model/IdentityProviderPOSTRequest.java
+++ b/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/gen/java/org/wso2/carbon/identity/api/server/idp/v1/model/IdentityProviderPOSTRequest.java
@@ -24,6 +24,7 @@ import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import java.util.ArrayList;
 import java.util.List;
+import org.wso2.carbon.identity.api.server.idp.v1.model.AssociationRequest;
 import org.wso2.carbon.identity.api.server.idp.v1.model.Certificate;
 import org.wso2.carbon.identity.api.server.idp.v1.model.Claims;
 import org.wso2.carbon.identity.api.server.idp.v1.model.FederatedAuthenticatorRequest;
@@ -56,6 +57,7 @@ public class IdentityProviderPOSTRequest  {
 
     private FederatedAuthenticatorRequest federatedAuthenticators;
     private ProvisioningRequest provisioning;
+    private AssociationRequest association;
 
     /**
     **/
@@ -338,6 +340,24 @@ public class IdentityProviderPOSTRequest  {
         this.provisioning = provisioning;
     }
 
+    /**
+    **/
+    public IdentityProviderPOSTRequest association(AssociationRequest association) {
+
+        this.association = association;
+        return this;
+    }
+    
+    @ApiModelProperty(value = "")
+    @JsonProperty("association")
+    @Valid
+    public AssociationRequest getAssociation() {
+        return association;
+    }
+    public void setAssociation(AssociationRequest association) {
+        this.association = association;
+    }
+
 
 
     @Override
@@ -364,12 +384,13 @@ public class IdentityProviderPOSTRequest  {
             Objects.equals(this.roles, identityProviderPOSTRequest.roles) &&
             Objects.equals(this.groups, identityProviderPOSTRequest.groups) &&
             Objects.equals(this.federatedAuthenticators, identityProviderPOSTRequest.federatedAuthenticators) &&
-            Objects.equals(this.provisioning, identityProviderPOSTRequest.provisioning);
+            Objects.equals(this.provisioning, identityProviderPOSTRequest.provisioning) &&
+            Objects.equals(this.association, identityProviderPOSTRequest.association);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(name, description, image, templateId, isPrimary, isFederationHub, homeRealmIdentifier, certificate, alias, idpIssuerName, claims, roles, groups, federatedAuthenticators, provisioning);
+        return Objects.hash(name, description, image, templateId, isPrimary, isFederationHub, homeRealmIdentifier, certificate, alias, idpIssuerName, claims, roles, groups, federatedAuthenticators, provisioning, association);
     }
 
     @Override
@@ -393,6 +414,7 @@ public class IdentityProviderPOSTRequest  {
         sb.append("    groups: ").append(toIndentedString(groups)).append("\n");
         sb.append("    federatedAuthenticators: ").append(toIndentedString(federatedAuthenticators)).append("\n");
         sb.append("    provisioning: ").append(toIndentedString(provisioning)).append("\n");
+        sb.append("    association: ").append(toIndentedString(association)).append("\n");
         sb.append("}");
         return sb.toString();
     }

--- a/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/gen/java/org/wso2/carbon/identity/api/server/idp/v1/model/IdentityProviderPOSTRequest.java
+++ b/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/gen/java/org/wso2/carbon/identity/api/server/idp/v1/model/IdentityProviderPOSTRequest.java
@@ -57,7 +57,7 @@ public class IdentityProviderPOSTRequest  {
 
     private FederatedAuthenticatorRequest federatedAuthenticators;
     private ProvisioningRequest provisioning;
-    private AssociationRequest association;
+    private AssociationRequest implicitAssociation;
 
     /**
     **/
@@ -342,20 +342,20 @@ public class IdentityProviderPOSTRequest  {
 
     /**
     **/
-    public IdentityProviderPOSTRequest association(AssociationRequest association) {
+    public IdentityProviderPOSTRequest implicitAssociation(AssociationRequest implicitAssociation) {
 
-        this.association = association;
+        this.implicitAssociation = implicitAssociation;
         return this;
     }
     
     @ApiModelProperty(value = "")
-    @JsonProperty("association")
+    @JsonProperty("implicitAssociation")
     @Valid
-    public AssociationRequest getAssociation() {
-        return association;
+    public AssociationRequest getImplicitAssociation() {
+        return implicitAssociation;
     }
-    public void setAssociation(AssociationRequest association) {
-        this.association = association;
+    public void setImplicitAssociation(AssociationRequest implicitAssociation) {
+        this.implicitAssociation = implicitAssociation;
     }
 
 
@@ -385,12 +385,12 @@ public class IdentityProviderPOSTRequest  {
             Objects.equals(this.groups, identityProviderPOSTRequest.groups) &&
             Objects.equals(this.federatedAuthenticators, identityProviderPOSTRequest.federatedAuthenticators) &&
             Objects.equals(this.provisioning, identityProviderPOSTRequest.provisioning) &&
-            Objects.equals(this.association, identityProviderPOSTRequest.association);
+            Objects.equals(this.implicitAssociation, identityProviderPOSTRequest.implicitAssociation);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(name, description, image, templateId, isPrimary, isFederationHub, homeRealmIdentifier, certificate, alias, idpIssuerName, claims, roles, groups, federatedAuthenticators, provisioning, association);
+        return Objects.hash(name, description, image, templateId, isPrimary, isFederationHub, homeRealmIdentifier, certificate, alias, idpIssuerName, claims, roles, groups, federatedAuthenticators, provisioning, implicitAssociation);
     }
 
     @Override
@@ -414,7 +414,7 @@ public class IdentityProviderPOSTRequest  {
         sb.append("    groups: ").append(toIndentedString(groups)).append("\n");
         sb.append("    federatedAuthenticators: ").append(toIndentedString(federatedAuthenticators)).append("\n");
         sb.append("    provisioning: ").append(toIndentedString(provisioning)).append("\n");
-        sb.append("    association: ").append(toIndentedString(association)).append("\n");
+        sb.append("    implicitAssociation: ").append(toIndentedString(implicitAssociation)).append("\n");
         sb.append("}");
         return sb.toString();
     }

--- a/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/gen/java/org/wso2/carbon/identity/api/server/idp/v1/model/IdentityProviderResponse.java
+++ b/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/gen/java/org/wso2/carbon/identity/api/server/idp/v1/model/IdentityProviderResponse.java
@@ -24,6 +24,7 @@ import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import java.util.ArrayList;
 import java.util.List;
+import org.wso2.carbon.identity.api.server.idp.v1.model.AssociationResponse;
 import org.wso2.carbon.identity.api.server.idp.v1.model.Certificate;
 import org.wso2.carbon.identity.api.server.idp.v1.model.Claims;
 import org.wso2.carbon.identity.api.server.idp.v1.model.FederatedAuthenticatorListResponse;
@@ -58,6 +59,7 @@ public class IdentityProviderResponse  {
 
     private FederatedAuthenticatorListResponse federatedAuthenticators;
     private ProvisioningResponse provisioning;
+    private AssociationResponse association;
 
     /**
     **/
@@ -374,6 +376,24 @@ public class IdentityProviderResponse  {
         this.provisioning = provisioning;
     }
 
+    /**
+    **/
+    public IdentityProviderResponse association(AssociationResponse association) {
+
+        this.association = association;
+        return this;
+    }
+    
+    @ApiModelProperty(value = "")
+    @JsonProperty("association")
+    @Valid
+    public AssociationResponse getAssociation() {
+        return association;
+    }
+    public void setAssociation(AssociationResponse association) {
+        this.association = association;
+    }
+
 
 
     @Override
@@ -402,12 +422,13 @@ public class IdentityProviderResponse  {
             Objects.equals(this.roles, identityProviderResponse.roles) &&
             Objects.equals(this.groups, identityProviderResponse.groups) &&
             Objects.equals(this.federatedAuthenticators, identityProviderResponse.federatedAuthenticators) &&
-            Objects.equals(this.provisioning, identityProviderResponse.provisioning);
+            Objects.equals(this.provisioning, identityProviderResponse.provisioning) &&
+            Objects.equals(this.association, identityProviderResponse.association);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, name, description, templateId, isEnabled, isPrimary, image, isFederationHub, homeRealmIdentifier, certificate, alias, idpIssuerName, claims, roles, groups, federatedAuthenticators, provisioning);
+        return Objects.hash(id, name, description, templateId, isEnabled, isPrimary, image, isFederationHub, homeRealmIdentifier, certificate, alias, idpIssuerName, claims, roles, groups, federatedAuthenticators, provisioning, association);
     }
 
     @Override
@@ -433,6 +454,7 @@ public class IdentityProviderResponse  {
         sb.append("    groups: ").append(toIndentedString(groups)).append("\n");
         sb.append("    federatedAuthenticators: ").append(toIndentedString(federatedAuthenticators)).append("\n");
         sb.append("    provisioning: ").append(toIndentedString(provisioning)).append("\n");
+        sb.append("    association: ").append(toIndentedString(association)).append("\n");
         sb.append("}");
         return sb.toString();
     }

--- a/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/gen/java/org/wso2/carbon/identity/api/server/idp/v1/model/IdentityProviderResponse.java
+++ b/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/gen/java/org/wso2/carbon/identity/api/server/idp/v1/model/IdentityProviderResponse.java
@@ -59,7 +59,7 @@ public class IdentityProviderResponse  {
 
     private FederatedAuthenticatorListResponse federatedAuthenticators;
     private ProvisioningResponse provisioning;
-    private AssociationResponse association;
+    private AssociationResponse implicitAssociation;
 
     /**
     **/
@@ -378,20 +378,20 @@ public class IdentityProviderResponse  {
 
     /**
     **/
-    public IdentityProviderResponse association(AssociationResponse association) {
+    public IdentityProviderResponse implicitAssociation(AssociationResponse implicitAssociation) {
 
-        this.association = association;
+        this.implicitAssociation = implicitAssociation;
         return this;
     }
     
     @ApiModelProperty(value = "")
-    @JsonProperty("association")
+    @JsonProperty("implicitAssociation")
     @Valid
-    public AssociationResponse getAssociation() {
-        return association;
+    public AssociationResponse getImplicitAssociation() {
+        return implicitAssociation;
     }
-    public void setAssociation(AssociationResponse association) {
-        this.association = association;
+    public void setImplicitAssociation(AssociationResponse implicitAssociation) {
+        this.implicitAssociation = implicitAssociation;
     }
 
 
@@ -423,12 +423,12 @@ public class IdentityProviderResponse  {
             Objects.equals(this.groups, identityProviderResponse.groups) &&
             Objects.equals(this.federatedAuthenticators, identityProviderResponse.federatedAuthenticators) &&
             Objects.equals(this.provisioning, identityProviderResponse.provisioning) &&
-            Objects.equals(this.association, identityProviderResponse.association);
+            Objects.equals(this.implicitAssociation, identityProviderResponse.implicitAssociation);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, name, description, templateId, isEnabled, isPrimary, image, isFederationHub, homeRealmIdentifier, certificate, alias, idpIssuerName, claims, roles, groups, federatedAuthenticators, provisioning, association);
+        return Objects.hash(id, name, description, templateId, isEnabled, isPrimary, image, isFederationHub, homeRealmIdentifier, certificate, alias, idpIssuerName, claims, roles, groups, federatedAuthenticators, provisioning, implicitAssociation);
     }
 
     @Override
@@ -454,7 +454,7 @@ public class IdentityProviderResponse  {
         sb.append("    groups: ").append(toIndentedString(groups)).append("\n");
         sb.append("    federatedAuthenticators: ").append(toIndentedString(federatedAuthenticators)).append("\n");
         sb.append("    provisioning: ").append(toIndentedString(provisioning)).append("\n");
-        sb.append("    association: ").append(toIndentedString(association)).append("\n");
+        sb.append("    implicitAssociation: ").append(toIndentedString(implicitAssociation)).append("\n");
         sb.append("}");
         return sb.toString();
     }

--- a/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/main/java/org/wso2/carbon/identity/api/server/idp/v1/core/ServerIdpManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/main/java/org/wso2/carbon/identity/api/server/idp/v1/core/ServerIdpManagementService.java
@@ -1908,8 +1908,7 @@ public class ServerIdpManagementService {
         if (associationRequest != null) {
 
             if (associationRequest.getIsEnabled() == null ||
-                    StringUtils.isBlank(associationRequest.getFederatedAttribute()) ||
-                    StringUtils.isBlank(associationRequest.getMappedLocalAttribute())) {
+                    associationRequest.getLookupAttribute().isEmpty()) {
                 throw handleException(Response.Status.BAD_REQUEST,
                         Constants.ErrorMessage.ERROR_CODE_INVALID_INPUT,
                         "Provided request body content is not in the expected format.");
@@ -1917,8 +1916,7 @@ public class ServerIdpManagementService {
 
             FederatedAssociationConfig associationConfig = new FederatedAssociationConfig();
             associationConfig.setEnabled(associationRequest.getIsEnabled());
-            associationConfig.setFederatedAttribute(associationRequest.getFederatedAttribute());
-            associationConfig.setMappedLocalAttribute(associationRequest.getMappedLocalAttribute());
+            associationConfig.setLookupAttributes(associationRequest.getLookupAttribute().toArray(new String[0]));
             identityProvider.setFederatedAssociationConfig(associationConfig);
         }
     }
@@ -2110,8 +2108,8 @@ public class ServerIdpManagementService {
             updateJIT(idp, identityProviderPOSTRequest.getProvisioning().getJit());
         }
 
-        if (identityProviderPOSTRequest.getAssociation() != null) {
-            updateFederatedAssociation(idp, identityProviderPOSTRequest.getAssociation());
+        if (identityProviderPOSTRequest.getImplicitAssociation() != null) {
+            updateFederatedAssociation(idp, identityProviderPOSTRequest.getImplicitAssociation());
         }
         updateClaims(idp, identityProviderPOSTRequest.getClaims());
         updateRoles(idp, identityProviderPOSTRequest.getRoles());
@@ -2279,7 +2277,7 @@ public class ServerIdpManagementService {
         idpResponse.setGroups(createGroupResponse(identityProvider));
         idpResponse.setFederatedAuthenticators(createFederatedAuthenticatorResponse(identityProvider));
         idpResponse.setProvisioning(createProvisioningResponse(identityProvider));
-        idpResponse.setAssociation(createAssociationResponse(identityProvider));
+        idpResponse.setImplicitAssociation(createAssociationResponse(identityProvider));
         return idpResponse;
     }
 
@@ -2485,8 +2483,8 @@ public class ServerIdpManagementService {
 
         AssociationResponse associationResponse = new AssociationResponse();
         associationResponse.setIsEnabled(idp.getFederatedAssociationConfig().isEnabled());
-        associationResponse.setFederatedAttribute(idp.getFederatedAssociationConfig().getFederatedAttribute());
-        associationResponse.setMappedLocalAttribute(idp.getFederatedAssociationConfig().getMappedLocalAttribute());
+        associationResponse.setLookupAttribute(
+                Arrays.asList(idp.getFederatedAssociationConfig().getLookupAttributes()));;
         return associationResponse;
     }
 

--- a/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/main/java/org/wso2/carbon/identity/api/server/idp/v1/impl/IdentityProvidersApiServiceImpl.java
+++ b/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/main/java/org/wso2/carbon/identity/api/server/idp/v1/impl/IdentityProvidersApiServiceImpl.java
@@ -26,6 +26,7 @@ import org.wso2.carbon.identity.api.server.common.ContextLoader;
 import org.wso2.carbon.identity.api.server.common.FileContent;
 import org.wso2.carbon.identity.api.server.idp.v1.IdentityProvidersApiService;
 import org.wso2.carbon.identity.api.server.idp.v1.core.ServerIdpManagementService;
+import org.wso2.carbon.identity.api.server.idp.v1.model.AssociationRequest;
 import org.wso2.carbon.identity.api.server.idp.v1.model.Claims;
 import org.wso2.carbon.identity.api.server.idp.v1.model.FederatedAuthenticatorPUTRequest;
 import org.wso2.carbon.identity.api.server.idp.v1.model.FederatedAuthenticatorRequest;
@@ -141,6 +142,12 @@ public class IdentityProvidersApiServiceImpl implements IdentityProvidersApiServ
     public Response getGroupConfig(String identityProviderId) {
 
         return Response.ok().entity(idpManagementService.getGroupConfig(identityProviderId)).build();
+    }
+
+    @Override
+    public Response getFederatedAssociationConfig(String identityProviderId) {
+
+        return Response.ok().entity(idpManagementService.getFederatedAssociationConfig(identityProviderId)).build();
     }
 
     @Override
@@ -276,6 +283,13 @@ public class IdentityProvidersApiServiceImpl implements IdentityProvidersApiServ
     public Response updateGroupConfig(String identityProviderId, List<IdPGroup> idPGroup) {
 
         return Response.ok().entity(idpManagementService.updateGroupConfig(identityProviderId, idPGroup)).build();
+    }
+
+    @Override
+    public Response updateFederatedAssociationConfig(String identityProviderId, AssociationRequest associationRequest) {
+
+        return Response.ok().entity(idpManagementService.updateFederatedAssociationConfig(identityProviderId,
+                associationRequest)).build();
     }
 
     @Override

--- a/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/main/resources/idp.yaml
+++ b/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/main/resources/idp.yaml
@@ -1529,6 +1529,116 @@ paths:
               $ref: '#/components/schemas/IdPGroupsConfig'
         description: This represents the group config to be updated.
         required: true
+  '/identity-providers/{identity-provider-id}/association':
+    get:
+      tags:
+        - Association
+      summary: |
+        Federated association config of an identity provider
+      description: >
+        This API provides the federated association config of an identity provider. <br>
+        <b>Permission required:</b> <br>
+            * /permission/admin/manage/identity/idpmgt/view <br>
+        <b>Scope required:</b> <br>
+            * internal_idp_view
+      operationId: getFederatedAssociationConfig
+      parameters:
+        - name: identity-provider-id
+          in: path
+          description: ID of the identity provider.
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AssociationResponse'
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '500':
+          description: Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+    put:
+      tags:
+        - Association
+      summary: |
+        Update the federated association config of an identity provider
+      description: >
+        This API provides the capability to update the federated association config of an
+        identity provider by specifying the identity provider ID. <br>
+        <b>Permission required:</b> <br>
+            * /permission/admin/manage/identity/idpmgt/update <br>
+        <b>Scope required:</b> <br>
+            * internal_idp_update
+      operationId: updateFederatedAssociationConfig
+      parameters:
+        - name: identity-provider-id
+          in: path
+          description: ID of the identity provider.
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Successful response
+          headers:
+            Location:
+              description: Location of the updated federated association config.
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AssociationResponse'
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '500':
+          description: Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AssociationRequest'
+        description: This represents the federated association config to be updated.
+        required: true
   '/identity-providers/{identity-provider-id}/provisioning/jit':
     get:
       tags:
@@ -2536,6 +2646,8 @@ components:
           $ref: '#/components/schemas/FederatedAuthenticatorRequest'
         provisioning:
           $ref: '#/components/schemas/ProvisioningRequest'
+        association:
+          $ref: '#/components/schemas/AssociationRequest'
     IdentityProviderResponse:
       type: object
       properties:
@@ -2584,6 +2696,8 @@ components:
           $ref: '#/components/schemas/FederatedAuthenticatorListResponse'
         provisioning:
           $ref: '#/components/schemas/ProvisioningResponse'
+        association:
+          $ref: '#/components/schemas/AssociationResponse'
     IdentityProviderListResponse:
       type: object
       properties:
@@ -2837,6 +2951,30 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/MetaProperty'
+    AssociationRequest:
+      type: object
+      properties:
+        isEnabled:
+          type: boolean
+          example: false
+        federatedAttribute:
+          type: string
+          example: email
+        mappedLocalAttribute:
+          type: string
+          example: http://wso2.org/claims/username
+    AssociationResponse:
+      type: object
+      properties:
+        isEnabled:
+          type: boolean
+          example: false
+        federatedAttribute:
+          type: string
+          example: sub
+        mappedLocalAttribute:
+          type: string
+          example: http://wso2.org/claims/username
     ProvisioningRequest:
       type: object
       properties:

--- a/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/main/resources/idp.yaml
+++ b/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/main/resources/idp.yaml
@@ -1529,7 +1529,7 @@ paths:
               $ref: '#/components/schemas/IdPGroupsConfig'
         description: This represents the group config to be updated.
         required: true
-  '/identity-providers/{identity-provider-id}/association':
+  '/identity-providers/{identity-provider-id}/implicit-association':
     get:
       tags:
         - Association
@@ -2646,7 +2646,7 @@ components:
           $ref: '#/components/schemas/FederatedAuthenticatorRequest'
         provisioning:
           $ref: '#/components/schemas/ProvisioningRequest'
-        association:
+        implicitAssociation:
           $ref: '#/components/schemas/AssociationRequest'
     IdentityProviderResponse:
       type: object
@@ -2696,7 +2696,7 @@ components:
           $ref: '#/components/schemas/FederatedAuthenticatorListResponse'
         provisioning:
           $ref: '#/components/schemas/ProvisioningResponse'
-        association:
+        implicitAssociation:
           $ref: '#/components/schemas/AssociationResponse'
     IdentityProviderListResponse:
       type: object
@@ -2957,24 +2957,22 @@ components:
         isEnabled:
           type: boolean
           example: false
-        federatedAttribute:
-          type: string
-          example: email
-        mappedLocalAttribute:
-          type: string
-          example: http://wso2.org/claims/username
+        lookupAttribute:
+          type: array
+          items:
+            type: string
+          example: [ 'email' ]
     AssociationResponse:
       type: object
       properties:
         isEnabled:
           type: boolean
           example: false
-        federatedAttribute:
-          type: string
-          example: sub
-        mappedLocalAttribute:
-          type: string
-          example: http://wso2.org/claims/username
+        lookupAttribute:
+          type: array
+          items:
+            type: string
+          example: [ 'email' ]
     ProvisioningRequest:
       type: object
       properties:

--- a/pom.xml
+++ b/pom.xml
@@ -760,7 +760,7 @@
         <maven.buildnumber.plugin.version>1.4</maven.buildnumber.plugin.version>
         <org.apache.felix.annotations.version>1.2.4</org.apache.felix.annotations.version>
         <identity.governance.version>1.8.62</identity.governance.version>
-        <carbon.identity.framework.version>5.25.383</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.25.407</carbon.identity.framework.version>
         <maven.findbugsplugin.version>3.0.5</maven.findbugsplugin.version>
         <identity.workflow.impl.bps.version>5.2.0</identity.workflow.impl.bps.version>
         <maven.checkstyleplugin.excludes>**/gen/**/*</maven.checkstyleplugin.excludes>


### PR DESCRIPTION
## Purpose
With this PR, a new identity provider configuration will be introduced that can be used to configure the implicit association behaviour during federated login. 

```
"implicitAssociation": {
        "isEnabled": true,
        "lookupAttribute": [
            "username",
            "mobile"
        ]
}
```

Identity provider API will be improved with the following new endpoints

- `GET api/server/v1/identity-providers/IDP-ID/implicit-association`
- `PUT api/server/v1/identity-providers/IDP-ID/implicit-association`
- `POST api/server/v1/identity-providers` will be improved to provide the ability to set the new configs when creating an idp

### Dependent PRs
- https://github.com/wso2/carbon-identity-framework/pull/5017

### Related Issues
- https://github.com/wso2-enterprise/asgardeo-product/issues/20046

