### PR TITLE
Improve Branding API to delete all the custom texts in a organization

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.branding.preference.management/org.wso2.carbon.identity.api.server.branding.preference.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/branding/preference/management/v1/BrandingPreferenceApi.java
+++ b/components/org.wso2.carbon.identity.api.server.branding.preference.management/org.wso2.carbon.identity.api.server.branding.preference.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/branding/preference/management/v1/BrandingPreferenceApi.java
@@ -113,7 +113,7 @@ public class BrandingPreferenceApi  {
         @ApiResponse(code = 404, message = "Requested resource is not found.", response = Error.class),
         @ApiResponse(code = 500, message = "Internal server error.", response = Error.class)
     })
-    public Response deleteBrandingPreference(    @Valid@ApiParam(value = "Type to filter the retrieval of customizations.", allowableValues="ORG, APP, CUSTOM", defaultValue="ORG") @DefaultValue("ORG")  @QueryParam("type") String type,     @Valid@ApiParam(value = "Tenant/Application name to filter the retrieval of customizations.")  @QueryParam("name") String name,     @Valid@ApiParam(value = "Locale to filter the retrieval of customizations.", defaultValue="en-US") @DefaultValue("en-US")  @QueryParam("locale") String locale) {
+    public Response deleteBrandingPreference(    @Valid@ApiParam(value = "Type to filter the retrieval of customizations.", allowableValues="ORG, APP, CUSTOM")  @QueryParam("type") String type,     @Valid@ApiParam(value = "Tenant/Application name to filter the retrieval of customizations.")  @QueryParam("name") String name,     @Valid@ApiParam(value = "Locale to filter the retrieval of customizations.")  @QueryParam("locale") String locale) {
 
         return delegate.deleteBrandingPreference(type,  name,  locale );
     }
@@ -123,7 +123,7 @@ public class BrandingPreferenceApi  {
     @Path("/text")
     
     @Produces({ "application/json" })
-    @ApiOperation(value = "Deletes custom text.", notes = "This API provides the capability to delete the custom texts for the specified screen & locale of a tenant.<br>   <b>Permission required:</b> <br>     * /permission/admin/manage/identity/applicationmgt/update <br>   <b>Scope required:</b> <br>     * internal_application_mgt_update ", response = Void.class, authorizations = {
+    @ApiOperation(value = "Deletes custom text.", notes = "This API provides the capability to delete the custom texts for the specified screen & locale of a tenant.<br> If no query parameter was specified in the delete request, all the custom texts configured in the tenant will be deleted.<br>   <b>Permission required:</b> <br>     * /permission/admin/manage/identity/applicationmgt/update <br>   <b>Scope required:</b> <br>     * internal_application_mgt_update ", response = Void.class, authorizations = {
         @Authorization(value = "BasicAuth"),
         @Authorization(value = "OAuth2", scopes = {
             
@@ -136,7 +136,7 @@ public class BrandingPreferenceApi  {
         @ApiResponse(code = 403, message = "Access forbidden.", response = Void.class),
         @ApiResponse(code = 500, message = "Internal server error.", response = Error.class)
     })
-    public Response deleteCustomText(    @Valid@ApiParam(value = "Type to filter the retrieval of customizations.", allowableValues="ORG, APP, CUSTOM", defaultValue="ORG") @DefaultValue("ORG")  @QueryParam("type") String type,     @Valid@ApiParam(value = "Tenant/Application name to filter the retrieval of customizations.")  @QueryParam("name") String name,     @Valid@ApiParam(value = "Locale to filter the retrieval of customizations.", defaultValue="en-US") @DefaultValue("en-US")  @QueryParam("locale") String locale,     @Valid@ApiParam(value = "Screen to filter the retrieval of customizations.")  @QueryParam("screen") String screen) {
+    public Response deleteCustomText(    @Valid@ApiParam(value = "Type to filter the retrieval of customizations.", allowableValues="ORG, APP, CUSTOM")  @QueryParam("type") String type,     @Valid@ApiParam(value = "Tenant/Application name to filter the retrieval of customizations.")  @QueryParam("name") String name,     @Valid@ApiParam(value = "Locale to filter the retrieval of customizations.")  @QueryParam("locale") String locale,     @Valid@ApiParam(value = "Screen to filter the retrieval of customizations.")  @QueryParam("screen") String screen) {
 
         return delegate.deleteCustomText(type,  name,  locale,  screen );
     }
@@ -160,7 +160,7 @@ public class BrandingPreferenceApi  {
         @ApiResponse(code = 404, message = "Requested resource is not found.", response = Error.class),
         @ApiResponse(code = 500, message = "Internal server error.", response = Error.class)
     })
-    public Response getBrandingPreference(    @Valid@ApiParam(value = "Type to filter the retrieval of customizations.", allowableValues="ORG, APP, CUSTOM", defaultValue="ORG") @DefaultValue("ORG")  @QueryParam("type") String type,     @Valid@ApiParam(value = "Tenant/Application name to filter the retrieval of customizations.")  @QueryParam("name") String name,     @Valid@ApiParam(value = "Locale to filter the retrieval of customizations.", defaultValue="en-US") @DefaultValue("en-US")  @QueryParam("locale") String locale) {
+    public Response getBrandingPreference(    @Valid@ApiParam(value = "Type to filter the retrieval of customizations.", allowableValues="ORG, APP, CUSTOM")  @QueryParam("type") String type,     @Valid@ApiParam(value = "Tenant/Application name to filter the retrieval of customizations.")  @QueryParam("name") String name,     @Valid@ApiParam(value = "Locale to filter the retrieval of customizations.")  @QueryParam("locale") String locale) {
 
         return delegate.getBrandingPreference(type,  name,  locale );
     }
@@ -182,7 +182,7 @@ public class BrandingPreferenceApi  {
         @ApiResponse(code = 404, message = "Requested resource is not found.", response = Error.class),
         @ApiResponse(code = 500, message = "Internal server error.", response = Error.class)
     })
-    public Response getCustomText(    @Valid@ApiParam(value = "Type to filter the retrieval of customizations.", allowableValues="ORG, APP, CUSTOM", defaultValue="ORG") @DefaultValue("ORG")  @QueryParam("type") String type,     @Valid@ApiParam(value = "Tenant/Application name to filter the retrieval of customizations.")  @QueryParam("name") String name,     @Valid@ApiParam(value = "Locale to filter the retrieval of customizations.", defaultValue="en-US") @DefaultValue("en-US")  @QueryParam("locale") String locale,     @Valid@ApiParam(value = "Screen to filter the retrieval of customizations.")  @QueryParam("screen") String screen) {
+    public Response getCustomText(    @Valid@ApiParam(value = "Type to filter the retrieval of customizations.", allowableValues="ORG, APP, CUSTOM")  @QueryParam("type") String type,     @Valid@ApiParam(value = "Tenant/Application name to filter the retrieval of customizations.")  @QueryParam("name") String name,     @Valid@ApiParam(value = "Locale to filter the retrieval of customizations.")  @QueryParam("locale") String locale,     @Valid@ApiParam(value = "Screen to filter the retrieval of customizations.")  @QueryParam("screen") String screen) {
 
         return delegate.getCustomText(type,  name,  locale,  screen );
     }
@@ -206,7 +206,7 @@ public class BrandingPreferenceApi  {
         @ApiResponse(code = 404, message = "Requested resource is not found.", response = Error.class),
         @ApiResponse(code = 500, message = "Internal server error.", response = Error.class)
     })
-    public Response resolveBrandingPreference(    @Valid@ApiParam(value = "Type to filter the retrieval of customizations.", allowableValues="ORG, APP, CUSTOM", defaultValue="ORG") @DefaultValue("ORG")  @QueryParam("type") String type,     @Valid@ApiParam(value = "Tenant/Application name to filter the retrieval of customizations.")  @QueryParam("name") String name,     @Valid@ApiParam(value = "Locale to filter the retrieval of customizations.", defaultValue="en-US") @DefaultValue("en-US")  @QueryParam("locale") String locale) {
+    public Response resolveBrandingPreference(    @Valid@ApiParam(value = "Type to filter the retrieval of customizations.", allowableValues="ORG, APP, CUSTOM")  @QueryParam("type") String type,     @Valid@ApiParam(value = "Tenant/Application name to filter the retrieval of customizations.")  @QueryParam("name") String name,     @Valid@ApiParam(value = "Locale to filter the retrieval of customizations.")  @QueryParam("locale") String locale) {
 
         return delegate.resolveBrandingPreference(type,  name,  locale );
     }
@@ -228,7 +228,7 @@ public class BrandingPreferenceApi  {
         @ApiResponse(code = 404, message = "Requested resource is not found.", response = Error.class),
         @ApiResponse(code = 500, message = "Internal server error.", response = Error.class)
     })
-    public Response resolveCustomText(    @Valid@ApiParam(value = "Type to filter the retrieval of customizations.", allowableValues="ORG, APP, CUSTOM", defaultValue="ORG") @DefaultValue("ORG")  @QueryParam("type") String type,     @Valid@ApiParam(value = "Tenant/Application name to filter the retrieval of customizations.")  @QueryParam("name") String name,     @Valid@ApiParam(value = "Locale to filter the retrieval of customizations.", defaultValue="en-US") @DefaultValue("en-US")  @QueryParam("locale") String locale,     @Valid@ApiParam(value = "Screen to filter the retrieval of customizations.")  @QueryParam("screen") String screen) {
+    public Response resolveCustomText(    @Valid@ApiParam(value = "Type to filter the retrieval of customizations.", allowableValues="ORG, APP, CUSTOM")  @QueryParam("type") String type,     @Valid@ApiParam(value = "Tenant/Application name to filter the retrieval of customizations.")  @QueryParam("name") String name,     @Valid@ApiParam(value = "Locale to filter the retrieval of customizations.")  @QueryParam("locale") String locale,     @Valid@ApiParam(value = "Screen to filter the retrieval of customizations.")  @QueryParam("screen") String screen) {
 
         return delegate.resolveCustomText(type,  name,  locale,  screen );
     }

--- a/components/org.wso2.carbon.identity.api.server.branding.preference.management/org.wso2.carbon.identity.api.server.branding.preference.management.v1/src/main/java/org/wso2/carbon/identity/api/server/branding/preference/management/v1/core/BrandingPreferenceManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.branding.preference.management/org.wso2.carbon.identity.api.server.branding.preference.management.v1/src/main/java/org/wso2/carbon/identity/api/server/branding/preference/management/v1/core/BrandingPreferenceManagementService.java
@@ -310,6 +310,26 @@ public class BrandingPreferenceManagementService {
     }
 
     /**
+     * Delete all the custom text preference resources of the current tenant.
+     */
+    public void deleteAllCustomTextPreferences() {
+
+        String tenantDomain = getTenantDomainFromContext();
+        try {
+            BrandingPreferenceServiceHolder.getBrandingPreferenceManager().deleteAllCustomText();
+        } catch (BrandingPreferenceMgtException e) {
+            if (CUSTOM_TEXT_PREFERENCE_NOT_EXISTS_ERROR_CODE.equals(e.getErrorCode())) {
+                if (log.isDebugEnabled()) {
+                    log.debug("Can not find a custom text preferences to delete for tenant: " + tenantDomain, e);
+                }
+                return;
+            }
+            throw handleBrandingPreferenceMgtException(e, ERROR_CODE_ERROR_DELETING_CUSTOM_TEXT_PREFERENCE,
+                    tenantDomain);
+        }
+    }
+
+    /**
      * Retrieve the requested branding preferences.
      *
      * @param type   Resource Type.

--- a/components/org.wso2.carbon.identity.api.server.branding.preference.management/org.wso2.carbon.identity.api.server.branding.preference.management.v1/src/main/java/org/wso2/carbon/identity/api/server/branding/preference/management/v1/impl/BrandingPreferenceApiServiceImpl.java
+++ b/components/org.wso2.carbon.identity.api.server.branding.preference.management/org.wso2.carbon.identity.api.server.branding.preference.management.v1/src/main/java/org/wso2/carbon/identity/api/server/branding/preference/management/v1/impl/BrandingPreferenceApiServiceImpl.java
@@ -145,6 +145,13 @@ public class BrandingPreferenceApiServiceImpl implements BrandingPreferenceApiSe
     @Override
     public Response deleteCustomText(String type, String name, String locale, String screen) {
 
+        if (StringUtils.isBlank(type) && StringUtils.isBlank(screen) && StringUtils.isBlank(name) &&
+                StringUtils.isBlank(locale)) {
+            // Delete all custom text preferences if no query parameter was specified.
+            brandingPreferenceManagementService.deleteAllCustomTextPreferences();
+            return Response.noContent().build();
+        }
+
         if (StringUtils.isBlank(type)) {
             type = ORGANIZATION_TYPE;
         } else if (!(ORGANIZATION_TYPE.equals(type) || APPLICATION_TYPE.equals(type) || CUSTOM_TYPE.equals(type))) {

--- a/components/org.wso2.carbon.identity.api.server.branding.preference.management/org.wso2.carbon.identity.api.server.branding.preference.management.v1/src/main/resources/branding-preference.yaml
+++ b/components/org.wso2.carbon.identity.api.server.branding.preference.management/org.wso2.carbon.identity.api.server.branding.preference.management.v1/src/main/resources/branding-preference.yaml
@@ -312,6 +312,7 @@ paths:
       summary: Deletes custom text.
       description: |
         This API provides the capability to delete the custom texts for the specified screen & locale of a tenant.<br>
+        If no query parameter was specified in the delete request, all the custom texts configured in the tenant will be deleted.<br>
           <b>Permission required:</b> <br>
             * /permission/admin/manage/identity/applicationmgt/update <br>
           <b>Scope required:</b> <br>
@@ -378,7 +379,6 @@ components:
           - ORG
           - APP
           - CUSTOM
-        default: "ORG"
       example: "ORG"
     nameQueryParam:
       in: query
@@ -395,7 +395,6 @@ components:
       description: Locale to filter the retrieval of customizations.
       schema:
         type: string
-        default: "en-US"
       example: "en-US"
     screenQueryParam:
       in: query

--- a/pom.xml
+++ b/pom.xml
@@ -751,7 +751,7 @@
         <org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.version>2.4.21</org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.version>
         <org.wso2.carbon.logging.service.version>4.10.7</org.wso2.carbon.logging.service.version>
         <org.wso2.carbon.event.publisher.version>5.2.15</org.wso2.carbon.event.publisher.version>
-        <identity.branding.preference.management.version>1.0.7</identity.branding.preference.management.version>
+        <identity.branding.preference.management.version>1.0.9-SNAPSHOT</identity.branding.preference.management.version>
         <apache.felix.scr.ds.annotations.version>1.2.4</apache.felix.scr.ds.annotations.version>
         <!--<maven.checkstyleplugin.excludes>**/gen/**/*</maven.checkstyleplugin.excludes>-->
 

--- a/pom.xml
+++ b/pom.xml
@@ -751,7 +751,7 @@
         <org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.version>2.4.21</org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.version>
         <org.wso2.carbon.logging.service.version>4.10.7</org.wso2.carbon.logging.service.version>
         <org.wso2.carbon.event.publisher.version>5.2.15</org.wso2.carbon.event.publisher.version>
-        <identity.branding.preference.management.version>1.0.9-SNAPSHOT</identity.branding.preference.management.version>
+        <identity.branding.preference.management.version>1.0.12</identity.branding.preference.management.version>
         <apache.felix.scr.ds.annotations.version>1.2.4</apache.felix.scr.ds.annotations.version>
         <!--<maven.checkstyleplugin.excludes>**/gen/**/*</maven.checkstyleplugin.excludes>-->
 


### PR DESCRIPTION
## Purpose

- Improve Branding API to delete all the custom texts in a organization

## TODO

- [ ] Bump branding preference management version

## Related PRs
- https://github.com/wso2/carbon-identity-framework/pull/5030
- https://github.com/wso2-extensions/identity-branding-preference-management/pull/20
