### PR TITLE
Modify SMS sender notification API to support config update without provider URL

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.notification.sender/org.wso2.carbon.identity.api.server.notification.sender.v1/src/gen/java/org/wso2/carbon/identity/api/server/notification/sender/v1/model/SMSSenderAdd.java
+++ b/components/org.wso2.carbon.identity.api.server.notification.sender/org.wso2.carbon.identity.api.server.notification.sender.v1/src/gen/java/org/wso2/carbon/identity/api/server/notification/sender/v1/model/SMSSenderAdd.java
@@ -122,11 +122,9 @@ public class SMSSenderAdd  {
         return this;
     }
     
-    @ApiModelProperty(example = "https://rest.nexmo.com/sms/json", required = true, value = "")
+    @ApiModelProperty(example = "https://rest.nexmo.com/sms/json", value = "")
     @JsonProperty("providerURL")
     @Valid
-    @NotNull(message = "Property providerURL cannot be null.")
-
     public String getProviderURL() {
         return providerURL;
     }

--- a/components/org.wso2.carbon.identity.api.server.notification.sender/org.wso2.carbon.identity.api.server.notification.sender.v1/src/gen/java/org/wso2/carbon/identity/api/server/notification/sender/v1/model/SMSSenderUpdateRequest.java
+++ b/components/org.wso2.carbon.identity.api.server.notification.sender/org.wso2.carbon.identity.api.server.notification.sender.v1/src/gen/java/org/wso2/carbon/identity/api/server/notification/sender/v1/model/SMSSenderUpdateRequest.java
@@ -48,13 +48,13 @@ public class SMSSenderUpdateRequest  {
 
         private String value;
 
-        ContentTypeEnum(String v) {
-            value = v;
-        }
+    ContentTypeEnum(String v) {
+        value = v;
+    }
 
-        public String value() {
-            return value;
-        }
+    public String value() {
+        return value;
+    }
 
         @Override
         public String toString() {
@@ -103,11 +103,9 @@ public class SMSSenderUpdateRequest  {
         return this;
     }
     
-    @ApiModelProperty(example = "https://rest.nexmo.com/sms/json", required = true, value = "")
+    @ApiModelProperty(example = "https://rest.nexmo.com/sms/json", value = "")
     @JsonProperty("providerURL")
     @Valid
-    @NotNull(message = "Property providerURL cannot be null.")
-
     public String getProviderURL() {
         return providerURL;
     }

--- a/components/org.wso2.carbon.identity.api.server.notification.sender/org.wso2.carbon.identity.api.server.notification.sender.v1/src/main/java/org/wso2/carbon/identity/api/server/notification/sender/v1/impl/NotificationSendersApiServiceImpl.java
+++ b/components/org.wso2.carbon.identity.api.server.notification.sender/org.wso2.carbon.identity.api.server.notification.sender.v1/src/main/java/org/wso2/carbon/identity/api/server/notification/sender/v1/impl/NotificationSendersApiServiceImpl.java
@@ -81,9 +81,6 @@ public class NotificationSendersApiServiceImpl implements NotificationSendersApi
     @Override
     public Response createSMSSender(SMSSenderAdd smSSenderAdd) {
 
-        if (StringUtils.equals(getTenantDomainFromContext(), MultitenantConstants.SUPER_TENANT_DOMAIN_NAME)) {
-            return Response.status(Response.Status.METHOD_NOT_ALLOWED).build();
-        }
         SMSSender smsSender = notificationSenderManagementService.addSMSSender(smSSenderAdd);
         URI location = null;
         try {
@@ -112,9 +109,6 @@ public class NotificationSendersApiServiceImpl implements NotificationSendersApi
     @Override
     public Response deleteSMSSender(String senderName) {
 
-        if (StringUtils.equals(getTenantDomainFromContext(), MultitenantConstants.SUPER_TENANT_DOMAIN_NAME)) {
-            return Response.status(Response.Status.METHOD_NOT_ALLOWED).build();
-        }
         notificationSenderManagementService.deleteNotificationSender(senderName);
         return Response.noContent().build();
     }
@@ -140,18 +134,12 @@ public class NotificationSendersApiServiceImpl implements NotificationSendersApi
     @Override
     public Response getSMSSender(String senderName) {
 
-        if (StringUtils.equals(getTenantDomainFromContext(), MultitenantConstants.SUPER_TENANT_DOMAIN_NAME)) {
-            return Response.status(Response.Status.METHOD_NOT_ALLOWED).build();
-        }
         return Response.ok().entity(notificationSenderManagementService.getSMSSender(senderName)).build();
     }
 
     @Override
     public Response getSMSSenders() {
 
-        if (StringUtils.equals(getTenantDomainFromContext(), MultitenantConstants.SUPER_TENANT_DOMAIN_NAME)) {
-            return Response.status(Response.Status.METHOD_NOT_ALLOWED).build();
-        }
         return Response.ok().entity(notificationSenderManagementService.getSMSSenders()).build();
     }
 
@@ -169,9 +157,6 @@ public class NotificationSendersApiServiceImpl implements NotificationSendersApi
     @Override
     public Response updateSMSSender(String senderName, SMSSenderUpdateRequest smSSenderUpdateRequest) {
 
-        if (StringUtils.equals(getTenantDomainFromContext(), MultitenantConstants.SUPER_TENANT_DOMAIN_NAME)) {
-            return Response.status(Response.Status.METHOD_NOT_ALLOWED).build();
-        }
         return Response.ok()
                 .entity(notificationSenderManagementService.updateSMSSender(senderName, smSSenderUpdateRequest))
                 .build();

--- a/components/org.wso2.carbon.identity.api.server.notification.sender/org.wso2.carbon.identity.api.server.notification.sender.v1/src/main/resources/notification-sender.yaml
+++ b/components/org.wso2.carbon.identity.api.server.notification.sender/org.wso2.carbon.identity.api.server.notification.sender.v1/src/main/resources/notification-sender.yaml
@@ -656,7 +656,6 @@ components:
             $ref: '#/components/schemas/Properties'
     SMSSenderAdd:
       required:
-        - providerURL
         - provider
         - contentType
       type: object
@@ -793,7 +792,6 @@ components:
             $ref: '#/components/schemas/Properties'
     SMSSenderUpdateRequest:
       required:
-        - providerURL
         - provider
         - contentType
       type: object


### PR DESCRIPTION
## Purpose
- Provide API capability to create / Update SMS Notification provider configurations without provider URLs by making it optional
- Provide support for this API for super tenant

## Related Issues
- https://github.com/wso2/product-is/issues/16362

## Related PRs
- https://github.com/wso2-extensions/identity-event-handler-notification/pull/205