### PR TITLE
Introduce mappedLocalSubjectMandatory service provider configuration

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.common/src/main/java/org/wso2/carbon/identity/api/server/application/management/common/ApplicationManagementConstants.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.common/src/main/java/org/wso2/carbon/identity/api/server/application/management/common/ApplicationManagementConstants.java
@@ -134,7 +134,7 @@ public class ApplicationManagementConstants {
 
         ERROR_ASSERT_LOCAL_SUBJECT_IDENTIFIER_DISABLED("60513",
                 "Invalid configuration.",
-                "useMappedLocalSubject cannot be disabled when mappedLocalSubjectMandatory is enabled."),
+                "'useMappedLocalSubject' cannot be disabled when 'mappedLocalSubjectMandatory' is enabled."),
         // Server Errors.
         ERROR_RETRIEVING_SAML_METADATA("65001",
                 "Error occurred while retrieving SAML Metadata.",

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.common/src/main/java/org/wso2/carbon/identity/api/server/application/management/common/ApplicationManagementConstants.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.common/src/main/java/org/wso2/carbon/identity/api/server/application/management/common/ApplicationManagementConstants.java
@@ -132,6 +132,9 @@ public class ApplicationManagementConstants {
         INVALID_POLICY_TYPE_FOR_API_RESOURCE("60512", "Invalid policy type provided for the API " +
                 "resource.", "API resource with id: %s doesn't allow the provided policy type: %s."),
 
+        ERROR_ASSERT_LOCAL_SUBJECT_IDENTIFIER_DISABLED("60513",
+                "Invalid configuration.",
+                "useMappedLocalSubject cannot be disabled when mappedLocalSubjectMandatory is enabled."),
         // Server Errors.
         ERROR_RETRIEVING_SAML_METADATA("65001",
                 "Error occurred while retrieving SAML Metadata.",

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/application/management/v1/SubjectConfig.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/application/management/v1/SubjectConfig.java
@@ -37,6 +37,7 @@ public class SubjectConfig  {
     private Boolean includeUserDomain;
     private Boolean includeTenantDomain;
     private Boolean useMappedLocalSubject;
+    private Boolean mappedLocalSubjectMandatory;
 
     /**
     **/
@@ -110,6 +111,24 @@ public class SubjectConfig  {
         this.useMappedLocalSubject = useMappedLocalSubject;
     }
 
+    /**
+    **/
+    public SubjectConfig mappedLocalSubjectMandatory(Boolean mappedLocalSubjectMandatory) {
+
+        this.mappedLocalSubjectMandatory = mappedLocalSubjectMandatory;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "false", value = "")
+    @JsonProperty("mappedLocalSubjectMandatory")
+    @Valid
+    public Boolean getMappedLocalSubjectMandatory() {
+        return mappedLocalSubjectMandatory;
+    }
+    public void setMappedLocalSubjectMandatory(Boolean mappedLocalSubjectMandatory) {
+        this.mappedLocalSubjectMandatory = mappedLocalSubjectMandatory;
+    }
+
 
 
     @Override
@@ -125,12 +144,13 @@ public class SubjectConfig  {
         return Objects.equals(this.claim, subjectConfig.claim) &&
             Objects.equals(this.includeUserDomain, subjectConfig.includeUserDomain) &&
             Objects.equals(this.includeTenantDomain, subjectConfig.includeTenantDomain) &&
-            Objects.equals(this.useMappedLocalSubject, subjectConfig.useMappedLocalSubject);
+            Objects.equals(this.useMappedLocalSubject, subjectConfig.useMappedLocalSubject) &&
+            Objects.equals(this.mappedLocalSubjectMandatory, subjectConfig.mappedLocalSubjectMandatory);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(claim, includeUserDomain, includeTenantDomain, useMappedLocalSubject);
+        return Objects.hash(claim, includeUserDomain, includeTenantDomain, useMappedLocalSubject, mappedLocalSubjectMandatory);
     }
 
     @Override
@@ -143,6 +163,7 @@ public class SubjectConfig  {
         sb.append("    includeUserDomain: ").append(toIndentedString(includeUserDomain)).append("\n");
         sb.append("    includeTenantDomain: ").append(toIndentedString(includeTenantDomain)).append("\n");
         sb.append("    useMappedLocalSubject: ").append(toIndentedString(useMappedLocalSubject)).append("\n");
+        sb.append("    mappedLocalSubjectMandatory: ").append(toIndentedString(mappedLocalSubjectMandatory)).append("\n");
         sb.append("}");
         return sb.toString();
     }

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/functions/application/ServiceProviderToApiModel.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/functions/application/ServiceProviderToApiModel.java
@@ -306,6 +306,7 @@ public class ServiceProviderToApiModel implements Function<ServiceProvider, Appl
 
         if (application.getClaimConfig() != null) {
             subjectConfig.useMappedLocalSubject(application.getClaimConfig().isAlwaysSendMappedLocalSubjectId());
+            subjectConfig.mappedLocalSubjectMandatory(application.getClaimConfig().isMappedLocalSubjectMandatory());
         }
 
         LocalAndOutboundAuthenticationConfig localAndOutboundAuthConfig =

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/functions/application/UpdateClaimConfiguration.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/functions/application/UpdateClaimConfiguration.java
@@ -133,10 +133,8 @@ public class UpdateClaimConfiguration implements UpdateFunction<ServiceProvider,
 
         if (subjectApiModel != null) {
 
-            if (subjectApiModel.getMappedLocalSubjectMandatory() != null &&
-                    subjectApiModel.getMappedLocalSubjectMandatory() &&
-                    subjectApiModel.getUseMappedLocalSubject() != null &&
-                    !subjectApiModel.getUseMappedLocalSubject()) {
+            if (Boolean.TRUE.equals(subjectApiModel.getMappedLocalSubjectMandatory()) &&
+                    Boolean.FALSE.equals(subjectApiModel.getUseMappedLocalSubject())) {
                 throw buildBadRequestError(ERROR_ASSERT_LOCAL_SUBJECT_IDENTIFIER_DISABLED.getCode(),
                         ERROR_ASSERT_LOCAL_SUBJECT_IDENTIFIER_DISABLED.getDescription());
             }

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/functions/application/UpdateClaimConfiguration.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/functions/application/UpdateClaimConfiguration.java
@@ -35,6 +35,8 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+import static org.wso2.carbon.identity.api.server.application.management.common.ApplicationManagementConstants.ErrorMessage.ERROR_ASSERT_LOCAL_SUBJECT_IDENTIFIER_DISABLED;
+import static org.wso2.carbon.identity.api.server.application.management.v1.core.functions.Utils.buildBadRequestError;
 import static org.wso2.carbon.identity.api.server.application.management.v1.core.functions.Utils.setIfNotNull;
 
 /**
@@ -131,6 +133,14 @@ public class UpdateClaimConfiguration implements UpdateFunction<ServiceProvider,
 
         if (subjectApiModel != null) {
 
+            if (subjectApiModel.getMappedLocalSubjectMandatory() != null &&
+                    subjectApiModel.getMappedLocalSubjectMandatory() &&
+                    subjectApiModel.getUseMappedLocalSubject() != null &&
+                    !subjectApiModel.getUseMappedLocalSubject()) {
+                throw buildBadRequestError(ERROR_ASSERT_LOCAL_SUBJECT_IDENTIFIER_DISABLED.getCode(),
+                        ERROR_ASSERT_LOCAL_SUBJECT_IDENTIFIER_DISABLED.getDescription());
+            }
+
             LocalAndOutboundAuthenticationConfig authConfig = getLocalAndOutboundConfig(application);
             if (subjectApiModel.getClaim() != null) {
                 setIfNotNull(subjectApiModel.getClaim().getUri(), authConfig::setSubjectClaimUri);
@@ -142,6 +152,7 @@ public class UpdateClaimConfiguration implements UpdateFunction<ServiceProvider,
 
             ClaimConfig claimConfig = getClaimConfig(application);
             setIfNotNull(subjectApiModel.getUseMappedLocalSubject(), claimConfig::setAlwaysSendMappedLocalSubjectId);
+            setIfNotNull(subjectApiModel.getMappedLocalSubjectMandatory(), claimConfig::setMappedLocalSubjectMandatory);
         }
     }
 

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/resources/applications.yaml
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/resources/applications.yaml
@@ -2934,6 +2934,9 @@ components:
         useMappedLocalSubject:
           type: boolean
           example: false
+        mappedLocalSubjectMandatory:
+          type: boolean
+          example: false
     RoleConfig:
       type: object
       properties:

--- a/pom.xml
+++ b/pom.xml
@@ -760,7 +760,7 @@
         <maven.buildnumber.plugin.version>1.4</maven.buildnumber.plugin.version>
         <org.apache.felix.annotations.version>1.2.4</org.apache.felix.annotations.version>
         <identity.governance.version>1.8.62</identity.governance.version>
-        <carbon.identity.framework.version>5.25.430</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.25.481</carbon.identity.framework.version>
         <maven.findbugsplugin.version>3.0.5</maven.findbugsplugin.version>
         <identity.workflow.impl.bps.version>5.2.0</identity.workflow.impl.bps.version>
         <maven.checkstyleplugin.excludes>**/gen/**/*</maven.checkstyleplugin.excludes>


### PR DESCRIPTION
## Purpose
This PR adds the API support for the newly introduced `mappedLocalSubjectMandatory` service provider configuration

### Related carbon-identity-framework PR
- https://github.com/wso2/carbon-identity-framework/pull/5110