### PR TITLE
Removing hardcoded display names of the client authentication methods

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/resources/applications.yaml
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/resources/applications.yaml
@@ -3377,7 +3377,7 @@ components:
         tokenEndpointAuthSigningAlg:
           type: string
           example: 'PS256'
-        tlsClientAuthSubjectDnUpdated:
+        tlsClientAuthSubjectDn:
           type: string
           example: 'CN=John Doe,OU=OrgUnit,O=Organization,L=Colombo,ST=Western,C=LK'
     RequestObjectConfiguration:

--- a/pom.xml
+++ b/pom.xml
@@ -765,7 +765,7 @@
         <identity.workflow.impl.bps.version>5.2.0</identity.workflow.impl.bps.version>
         <maven.checkstyleplugin.excludes>**/gen/**/*</maven.checkstyleplugin.excludes>
         <identity.event.handler.version>1.4.4</identity.event.handler.version>
-        <identity.inbound.oauth2.version>6.11.165</identity.inbound.oauth2.version>
+        <identity.inbound.oauth2.version>6.11.188</identity.inbound.oauth2.version>
         <identity.inbound.saml2.version>5.11.16</identity.inbound.saml2.version>
         <commons.beanutils.version>1.9.4</commons.beanutils.version>
         <mavan.findbugsplugin.exclude.file>findbugs-exclude-filter.xml</mavan.findbugsplugin.exclude.file>


### PR DESCRIPTION
## Purpose
> This PR updates the current usage of the getSupportedClientAuthenticationMethods() method of the OAuthClientAuthenticator to adapt to the new changes made in that method. Therefore the hardcoded values for the authentication method display names have been removed and they are being obtained by the method itself.