### PR TITLE
Add support for logout wreply validation in WS-Federation (Passive) Configuration

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/application/management/v1/PassiveStsConfiguration.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/application/management/v1/PassiveStsConfiguration.java
@@ -34,6 +34,7 @@ public class PassiveStsConfiguration  {
   
     private String realm;
     private String replyTo;
+    private String replyToLogout;
 
     /**
     **/
@@ -75,6 +76,26 @@ public class PassiveStsConfiguration  {
         this.replyTo = replyTo;
     }
 
+    /**
+    **/
+    public PassiveStsConfiguration replyToLogout(String replyToLogout) {
+
+        this.replyToLogout = replyToLogout;
+        return this;
+    }
+    
+    @ApiModelProperty(required = true, value = "")
+    @JsonProperty("replyToLogout")
+    @Valid
+    @NotNull(message = "Property replyToLogout cannot be null.")
+
+    public String getReplyToLogout() {
+        return replyToLogout;
+    }
+    public void setReplyToLogout(String replyToLogout) {
+        this.replyToLogout = replyToLogout;
+    }
+
 
 
     @Override
@@ -88,12 +109,13 @@ public class PassiveStsConfiguration  {
         }
         PassiveStsConfiguration passiveStsConfiguration = (PassiveStsConfiguration) o;
         return Objects.equals(this.realm, passiveStsConfiguration.realm) &&
-            Objects.equals(this.replyTo, passiveStsConfiguration.replyTo);
+            Objects.equals(this.replyTo, passiveStsConfiguration.replyTo) &&
+            Objects.equals(this.replyToLogout, passiveStsConfiguration.replyToLogout);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(realm, replyTo);
+        return Objects.hash(realm, replyTo, replyToLogout);
     }
 
     @Override
@@ -104,6 +126,7 @@ public class PassiveStsConfiguration  {
         
         sb.append("    realm: ").append(toIndentedString(realm)).append("\n");
         sb.append("    replyTo: ").append(toIndentedString(replyTo)).append("\n");
+        sb.append("    replyToLogout: ").append(toIndentedString(replyToLogout)).append("\n");
         sb.append("}");
         return sb.toString();
     }

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/application/management/v1/PassiveStsConfiguration.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/application/management/v1/PassiveStsConfiguration.java
@@ -84,11 +84,9 @@ public class PassiveStsConfiguration  {
         return this;
     }
     
-    @ApiModelProperty(required = true, value = "")
+    @ApiModelProperty(value = "")
     @JsonProperty("replyToLogout")
     @Valid
-    @NotNull(message = "Property replyToLogout cannot be null.")
-
     public String getReplyToLogout() {
         return replyToLogout;
     }

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/functions/application/inbound/PassiveSTSInboundFunctions.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/functions/application/inbound/PassiveSTSInboundFunctions.java
@@ -26,6 +26,7 @@ import org.wso2.carbon.identity.application.common.util.IdentityApplicationConst
 import static org.wso2.carbon.identity.api.server.application.management.v1.core.functions.Utils.arrayToStream;
 import static org.wso2.carbon.identity.api.server.application.management.v1.core.functions.Utils.buildBadRequestError;
 import static org.wso2.carbon.identity.application.common.util.IdentityApplicationConstants.PassiveSTS.PASSIVE_STS_REPLY_URL;
+import static org.wso2.carbon.identity.application.common.util.IdentityApplicationConstants.PassiveSTS.PASSIVE_STS_REPLY_URL_LOGOUT;
 
 /**
  * Helper functions for Passive STS inbound management.
@@ -63,7 +64,11 @@ public class PassiveSTSInboundFunctions {
         passiveStsReplyUrl.setName(IdentityApplicationConstants.PassiveSTS.PASSIVE_STS_REPLY_URL);
         passiveStsReplyUrl.setValue(config.getReplyTo());
 
-        passiveStsInbound.setProperties(new Property[]{passiveStsReplyUrl});
+        Property passiveStsReplyUrlLogout = new Property();
+        passiveStsReplyUrlLogout.setName(PASSIVE_STS_REPLY_URL_LOGOUT);
+        passiveStsReplyUrlLogout.setValue(config.getReplyToLogout());
+
+        passiveStsInbound.setProperties(new Property[]{passiveStsReplyUrl, passiveStsReplyUrlLogout});
         return passiveStsInbound;
     }
 
@@ -74,6 +79,12 @@ public class PassiveSTSInboundFunctions {
                 .findAny()
                 .map(Property::getValue).orElse(null);
 
-        return new PassiveStsConfiguration().realm(inboundAuth.getInboundAuthKey()).replyTo(replyTo);
+        String replyToLogout = arrayToStream(inboundAuth.getProperties())
+                .filter(property -> StringUtils.equals(property.getName(), PASSIVE_STS_REPLY_URL_LOGOUT))
+                .findAny()
+                .map(Property::getValue).orElse(null);
+
+        return new PassiveStsConfiguration().realm(inboundAuth.getInboundAuthKey()).replyTo(replyTo)
+                .replyToLogout(replyToLogout);
     }
 }

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/functions/application/inbound/PassiveSTSInboundFunctions.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/functions/application/inbound/PassiveSTSInboundFunctions.java
@@ -64,11 +64,15 @@ public class PassiveSTSInboundFunctions {
         passiveStsReplyUrl.setName(IdentityApplicationConstants.PassiveSTS.PASSIVE_STS_REPLY_URL);
         passiveStsReplyUrl.setValue(config.getReplyTo());
 
-        Property passiveStsReplyUrlLogout = new Property();
-        passiveStsReplyUrlLogout.setName(PASSIVE_STS_REPLY_URL_LOGOUT);
-        passiveStsReplyUrlLogout.setValue(config.getReplyToLogout());
+        if (StringUtils.isNotBlank(config.getReplyToLogout())) {
+            Property passiveStsReplyUrlLogout = new Property();
+            passiveStsReplyUrlLogout.setName(PASSIVE_STS_REPLY_URL_LOGOUT);
+            passiveStsReplyUrlLogout.setValue(config.getReplyToLogout());
+            passiveStsInbound.setProperties(new Property[]{passiveStsReplyUrl, passiveStsReplyUrlLogout});
+        } else {
+            passiveStsInbound.setProperties(new Property[]{passiveStsReplyUrl});
+        }
 
-        passiveStsInbound.setProperties(new Property[]{passiveStsReplyUrl, passiveStsReplyUrlLogout});
         return passiveStsInbound;
     }
 

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/resources/applications.yaml
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/resources/applications.yaml
@@ -3429,10 +3429,13 @@ components:
       required:
         - realm
         - replyTo
+        - replyToLogout
       properties:
         realm:
           type: string
         replyTo:
+          type: string
+        replyToLogout:
           type: string
     WSTrustConfiguration:
       type: object

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/resources/applications.yaml
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/resources/applications.yaml
@@ -3429,7 +3429,6 @@ components:
       required:
         - realm
         - replyTo
-        - replyToLogout
       properties:
         realm:
           type: string

--- a/pom.xml
+++ b/pom.xml
@@ -760,7 +760,7 @@
         <maven.buildnumber.plugin.version>1.4</maven.buildnumber.plugin.version>
         <org.apache.felix.annotations.version>1.2.4</org.apache.felix.annotations.version>
         <identity.governance.version>1.8.62</identity.governance.version>
-        <carbon.identity.framework.version>5.25.481</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.25.492</carbon.identity.framework.version>
         <maven.findbugsplugin.version>3.0.5</maven.findbugsplugin.version>
         <identity.workflow.impl.bps.version>5.2.0</identity.workflow.impl.bps.version>
         <maven.checkstyleplugin.excludes>**/gen/**/*</maven.checkstyleplugin.excludes>


### PR DESCRIPTION
## Purpose
The api endpoint now allows configuring the wreply logout url and also retrieves the logout url in the get request.
This is to add support for logout wreply validation.
The wreply logout configuration is already available in the carbon management console, and this update allows the IS console to retrieve and update this value.

## Related PRs

- https://github.com/wso2/carbon-identity-framework/pull/5129
- https://github.com/wso2-extensions/identity-inbound-auth-sts/pull/144