### PR TITLE
Improve organization self-service application creation logic to use Authorized APIs

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.organization.selfservice/org.wso2.carbon.identity.api.server.organization.selfservice.common/pom.xml
+++ b/components/org.wso2.carbon.identity.api.server.organization.selfservice/org.wso2.carbon.identity.api.server.organization.selfservice.common/pom.xml
@@ -59,5 +59,10 @@
             <artifactId>org.wso2.carbon.identity.user.store.configuration</artifactId>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.api.resource.mgt</artifactId>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/components/org.wso2.carbon.identity.api.server.organization.selfservice/org.wso2.carbon.identity.api.server.organization.selfservice.common/src/main/java/org/wso2/carbon/identity/api/server/organization/selfservice/common/SelfServiceMgtServiceHolder.java
+++ b/components/org.wso2.carbon.identity.api.server.organization.selfservice/org.wso2.carbon.identity.api.server.organization.selfservice.common/src/main/java/org/wso2/carbon/identity/api/server/organization/selfservice/common/SelfServiceMgtServiceHolder.java
@@ -18,7 +18,9 @@
 
 package org.wso2.carbon.identity.api.server.organization.selfservice.common;
 
+import org.wso2.carbon.identity.api.resource.mgt.APIResourceManager;
 import org.wso2.carbon.identity.application.mgt.ApplicationManagementService;
+import org.wso2.carbon.identity.application.mgt.AuthorizedAPIManagementService;
 import org.wso2.carbon.identity.governance.IdentityGovernanceService;
 
 /**
@@ -29,6 +31,10 @@ public class SelfServiceMgtServiceHolder {
     private static IdentityGovernanceService identityGovernanceService;
 
     private static ApplicationManagementService applicationManagementService;
+
+    private static APIResourceManager apiResourceManager;
+
+    private static AuthorizedAPIManagementService authorizedAPIManagementService;
 
     /**
      * Get Application Management OSGI service.
@@ -69,5 +75,46 @@ public class SelfServiceMgtServiceHolder {
     public static void setIdentityGovernanceService(IdentityGovernanceService identityGovernanceService) {
 
         SelfServiceMgtServiceHolder.identityGovernanceService = identityGovernanceService;
+    }
+
+    /**
+     * Get APIResourceManager.
+     *
+     * @return APIResourceManager.
+     */
+    public static APIResourceManager getAPIResourceManager() {
+
+        return apiResourceManager;
+    }
+
+    /**
+     * Set APIResourceManager.
+     *
+     * @param apiResourceManager APIResourceManager.
+     */
+    public static void setAPIResourceManager(APIResourceManager apiResourceManager) {
+
+        SelfServiceMgtServiceHolder.apiResourceManager = apiResourceManager;
+    }
+
+    /**
+     * Get AuthorizedAPIManagementService.
+     *
+     * @return AuthorizedAPIManagementService.
+     */
+    public static AuthorizedAPIManagementService getAuthorizedAPIManagementService() {
+
+        return authorizedAPIManagementService;
+    }
+
+    /**
+     * Set AuthorizedAPIManagementService.
+     *
+     * @param authorizedAPIManagementService AuthorizedAPIManagementService.
+     */
+    public static void setAuthorizedAPIManagementService(AuthorizedAPIManagementService
+                                                                 authorizedAPIManagementService) {
+
+        SelfServiceMgtServiceHolder.authorizedAPIManagementService = authorizedAPIManagementService;
     }
 }

--- a/components/org.wso2.carbon.identity.api.server.organization.selfservice/org.wso2.carbon.identity.api.server.organization.selfservice.common/src/main/java/org/wso2/carbon/identity/api/server/organization/selfservice/common/factory/APIResourceManagementOSGiServiceFactory.java
+++ b/components/org.wso2.carbon.identity.api.server.organization.selfservice/org.wso2.carbon.identity.api.server.organization.selfservice.common/src/main/java/org/wso2/carbon/identity/api/server/organization/selfservice/common/factory/APIResourceManagementOSGiServiceFactory.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.organization.selfservice.common.factory;
+
+import org.springframework.beans.factory.config.AbstractFactoryBean;
+import org.wso2.carbon.context.PrivilegedCarbonContext;
+import org.wso2.carbon.identity.api.resource.mgt.APIResourceManager;
+
+/**
+ * Factory class for APIResourceManagementOSGiService.
+ */
+public class APIResourceManagementOSGiServiceFactory extends AbstractFactoryBean<APIResourceManager> {
+
+    private APIResourceManager apiResourceManager;
+
+    @Override
+    public Class<?> getObjectType() {
+
+        return Object.class;
+    }
+
+    @Override
+    protected APIResourceManager createInstance() throws Exception {
+
+        if (this.apiResourceManager == null) {
+            apiResourceManager = (APIResourceManager) PrivilegedCarbonContext.
+                    getThreadLocalCarbonContext().getOSGiService(APIResourceManager.class, null);
+            if (apiResourceManager == null) {
+                throw new Exception("Unable to retrieve APIResourceManager service.");
+            }
+        }
+        return this.apiResourceManager;
+    }
+}

--- a/components/org.wso2.carbon.identity.api.server.organization.selfservice/org.wso2.carbon.identity.api.server.organization.selfservice.common/src/main/java/org/wso2/carbon/identity/api/server/organization/selfservice/common/factory/AuthorizedAPIManagementOSGiServiceFactory.java
+++ b/components/org.wso2.carbon.identity.api.server.organization.selfservice/org.wso2.carbon.identity.api.server.organization.selfservice.common/src/main/java/org/wso2/carbon/identity/api/server/organization/selfservice/common/factory/AuthorizedAPIManagementOSGiServiceFactory.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.organization.selfservice.common.factory;
+
+import org.springframework.beans.factory.config.AbstractFactoryBean;
+import org.wso2.carbon.context.PrivilegedCarbonContext;
+import org.wso2.carbon.identity.application.mgt.AuthorizedAPIManagementService;
+
+/**
+ * Factory Beans serves as a factory for creating other beans within the IOC container. This factory bean is used to
+ * instantiate the AuthorizedAPIManagementService type of object inside the container.
+ */
+public class AuthorizedAPIManagementOSGiServiceFactory extends AbstractFactoryBean<AuthorizedAPIManagementService> {
+
+    private AuthorizedAPIManagementService authorizedAPIManagementService;
+
+    @Override
+    public Class<?> getObjectType() {
+
+        return Object.class;
+    }
+
+    @Override
+    protected AuthorizedAPIManagementService createInstance() throws Exception {
+
+        if (this.authorizedAPIManagementService == null) {
+            authorizedAPIManagementService = (AuthorizedAPIManagementService)
+                    PrivilegedCarbonContext.getThreadLocalCarbonContext()
+                            .getOSGiService(AuthorizedAPIManagementService.class, null);
+            if (authorizedAPIManagementService == null) {
+                throw new Exception("Unable to retrieve AuthorizedAPIManagement service.");
+            }
+        }
+        return this.authorizedAPIManagementService;
+    }
+}

--- a/components/org.wso2.carbon.identity.api.server.organization.selfservice/org.wso2.carbon.identity.api.server.organization.selfservice.v1/pom.xml
+++ b/components/org.wso2.carbon.identity.api.server.organization.selfservice/org.wso2.carbon.identity.api.server.organization.selfservice.v1/pom.xml
@@ -159,6 +159,11 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.api.resource.mgt</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>

--- a/components/org.wso2.carbon.identity.api.server.organization.selfservice/org.wso2.carbon.identity.api.server.organization.selfservice.v1/src/main/java/org/wso2/carbon/identity/api/server/organization/selfservice/v1/core/SelfServiceMgtService.java
+++ b/components/org.wso2.carbon.identity.api.server.organization.selfservice/org.wso2.carbon.identity.api.server.organization.selfservice.v1/src/main/java/org/wso2/carbon/identity/api/server/organization/selfservice/v1/core/SelfServiceMgtService.java
@@ -27,7 +27,11 @@ import org.apache.commons.logging.LogFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.ResourceLoader;
+import org.wso2.carbon.CarbonConstants;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
+import org.wso2.carbon.identity.api.resource.mgt.APIResourceManager;
+import org.wso2.carbon.identity.api.resource.mgt.APIResourceMgtException;
+import org.wso2.carbon.identity.api.resource.mgt.constant.APIResourceManagementConstants;
 import org.wso2.carbon.identity.api.server.application.management.v1.ApplicationModel;
 import org.wso2.carbon.identity.api.server.application.management.v1.core.ServerApplicationManagementService;
 import org.wso2.carbon.identity.api.server.organization.selfservice.common.SelfServiceMgtServiceHolder;
@@ -40,9 +44,15 @@ import org.wso2.carbon.identity.api.server.organization.selfservice.v1.util.Self
 import org.wso2.carbon.identity.api.server.userstore.v1.core.ServerUserStoreService;
 import org.wso2.carbon.identity.api.server.userstore.v1.model.UserStoreReq;
 import org.wso2.carbon.identity.application.common.IdentityApplicationManagementException;
+import org.wso2.carbon.identity.application.common.model.APIResource;
 import org.wso2.carbon.identity.application.common.model.ApplicationBasicInfo;
+import org.wso2.carbon.identity.application.common.model.AuthorizedAPI;
 import org.wso2.carbon.identity.application.common.model.Property;
+import org.wso2.carbon.identity.application.common.model.Scope;
+import org.wso2.carbon.identity.application.common.model.ServiceProvider;
+import org.wso2.carbon.identity.application.common.model.ServiceProviderProperty;
 import org.wso2.carbon.identity.application.mgt.ApplicationManagementService;
+import org.wso2.carbon.identity.application.mgt.AuthorizedAPIManagementService;
 import org.wso2.carbon.identity.governance.IdentityGovernanceException;
 import org.wso2.carbon.identity.governance.IdentityGovernanceService;
 import org.wso2.carbon.identity.governance.bean.ConnectorConfig;
@@ -51,7 +61,9 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Base64;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -73,6 +85,8 @@ public class SelfServiceMgtService {
 
     @Autowired
     private ServerUserStoreService serverUserStoreService;
+
+    public static final String SHARE_WITH_ALL_CHILDREN = "shareWithAllChildren";
 
     /**
      * Get organization governance configs.
@@ -275,6 +289,40 @@ public class SelfServiceMgtService {
 
             // Create the application using the Application Management Service.
             applicationManagementService.createApplication(model, null);
+
+            // If legacy authorization runtime is enabled, skip subscribing to APIs.
+            if (isLegacyAuthzRuntime()) {
+                return;
+            }
+
+            // Subscribe to APIs required for Organization Management Self Service.
+            ApplicationBasicInfo sSApplicationBasicInfo = getApplicationManagementService()
+                    .getApplicationBasicInfoByName(appName, tenantDomain);
+
+            if (sSApplicationBasicInfo == null) {
+                LOG.error(SelfServiceMgtConstants.ErrorMessage.ERROR_CREATING_SYSTEM_APP.getDescription());
+                throw new SelfServiceMgtEndpointException(Response.Status.INTERNAL_SERVER_ERROR,
+                        getError(SelfServiceMgtConstants.ErrorMessage.ERROR_CREATING_SYSTEM_APP.getCode(),
+                                SelfServiceMgtConstants.ErrorMessage.ERROR_CREATING_SYSTEM_APP.getMessage(),
+                                SelfServiceMgtConstants.ErrorMessage.ERROR_CREATING_SYSTEM_APP.getDescription()));
+            }
+            String sSApplicationId = sSApplicationBasicInfo.getApplicationResourceId();
+
+            Map<String, List<String>> authorizedAPIAndScopeNames = getAuthorizedAPIsAndScopeNamesForSSApp();
+
+            // Loop through the APIs and subscribe to them.
+            for (Map.Entry<String, List<String>> entry : authorizedAPIAndScopeNames.entrySet()) {
+                String apiId = entry.getKey();
+                List<String> scopeNames = entry.getValue();
+                authorizeAPItoSelfServiceApp(apiId, scopeNames, tenantDomain, sSApplicationId);
+            }
+
+            // Share the self-service app with all the child organizations.
+            ServiceProvider serviceProvider = getApplicationManagementService()
+                    .getServiceProvider(sSApplicationBasicInfo.getApplicationId());
+            shareWithOrganizations(serviceProvider);
+            getApplicationManagementService().updateApplication(serviceProvider, tenantDomain, userName);
+
         } catch (IOException | IdentityApplicationManagementException e) {
             LOG.error(SelfServiceMgtConstants.ErrorMessage.ERROR_CREATING_SYSTEM_APP.getDescription(), e);
             throw new SelfServiceMgtEndpointException(Response.Status.INTERNAL_SERVER_ERROR,
@@ -414,6 +462,16 @@ public class SelfServiceMgtService {
         return SelfServiceMgtServiceHolder.getApplicationManagementService();
     }
 
+    private APIResourceManager getAPIResourcesManager() {
+
+        return SelfServiceMgtServiceHolder.getAPIResourceManager();
+    }
+
+    private AuthorizedAPIManagementService getAuthorizedAPIManagementService() {
+
+        return SelfServiceMgtServiceHolder.getAuthorizedAPIManagementService();
+    }
+
     private Error getError(String errorCode, String errorMessage, String errorDescription) {
 
         Error error = new Error();
@@ -421,5 +479,83 @@ public class SelfServiceMgtService {
         error.setMessage(errorMessage);
         error.setDescription(errorDescription);
         return error;
+    }
+
+    private Map<String, List<String>> getAuthorizedAPIsAndScopeNamesForSSApp() {
+
+        Map<String, List<String>> authorizedAPIMap = new HashMap<>();
+
+        // Authorize Organization Management API.
+        authorizedAPIMap.put("/api/server/v1/organizations",
+                new ArrayList<>(Arrays.asList("internal_organization_view", "internal_organization_create")));
+
+        // Authorize Scim User API.
+        authorizedAPIMap.put("/scim2/Users",
+                new ArrayList<>(Arrays.asList("internal_user_mgt_view", "internal_user_mgt_create")));
+
+        // Authorize Scim Organization User API.
+        authorizedAPIMap.put("/o/scim2/Users",
+                new ArrayList<>(Collections.singletonList("internal_org_user_mgt_create")));
+
+        // Authorize Scim Organization Roles API.
+        authorizedAPIMap.put("/o/scim2/Roles",
+                new ArrayList<>(Arrays.asList("internal_org_role_mgt_view", "internal_org_role_mgt_update")));
+
+        return authorizedAPIMap;
+    }
+
+    private void authorizeAPItoSelfServiceApp(String aPIIResourceIdentifier, List<String> scopeNames,
+                                              String tenantDomain, String sSApplicationId) {
+
+        String aPIFilter = "identifier eq " + aPIIResourceIdentifier;
+        try {
+            List<APIResource> apiResources = getAPIResourcesManager().getAPIResources(null, null, 1,
+                    aPIFilter, APIResourceManagementConstants.ASC,
+                    tenantDomain).getAPIResources();
+            if (apiResources != null && !apiResources.isEmpty()) {
+
+                APIResource apiResource = apiResources.get(0);
+
+                String policyId = APIResourceManagementConstants.RBAC_AUTHORIZATION;
+                List<Scope> scopes = getAPIResourcesManager().getAPIScopesById(apiResource.getId(), tenantDomain);
+
+                List<Scope> authorizedScopes = new ArrayList<>();
+                for (Scope scope : scopes) {
+                    if (scopeNames.contains(scope.getName())) {
+                        authorizedScopes.add(scope);
+                    }
+                }
+
+                AuthorizedAPI authorizedAPI = new AuthorizedAPI.AuthorizedAPIBuilder()
+                        .apiId(apiResource.getId())
+                        .appId(sSApplicationId)
+                        .scopes(authorizedScopes)
+                        .policyId(policyId)
+                        .build();
+                getAuthorizedAPIManagementService().addAuthorizedAPI(sSApplicationId,
+                        authorizedAPI, tenantDomain);
+            }
+
+        } catch (APIResourceMgtException | IdentityApplicationManagementException e) {
+            LOG.error("Error while authorizing APIs to the Organization Self Service application.", e);
+        }
+    }
+
+    private void shareWithOrganizations(ServiceProvider serviceProvider) {
+
+        ServiceProviderProperty[] spProperties = serviceProvider.getSpProperties();
+        ServiceProviderProperty[] newSpProperties = new ServiceProviderProperty[spProperties.length + 1];
+        System.arraycopy(spProperties, 0, newSpProperties, 0, spProperties.length);
+
+        ServiceProviderProperty shareWithAllChildrenProperty = new ServiceProviderProperty();
+        shareWithAllChildrenProperty.setName(SHARE_WITH_ALL_CHILDREN);
+        shareWithAllChildrenProperty.setValue(Boolean.TRUE.toString());
+        newSpProperties[spProperties.length] = shareWithAllChildrenProperty;
+        serviceProvider.setSpProperties(newSpProperties);
+    }
+
+    public static boolean isLegacyAuthzRuntime() {
+
+        return CarbonConstants.ENABLE_LEGACY_AUTHZ_RUNTIME;
     }
 }

--- a/components/org.wso2.carbon.identity.api.server.organization.selfservice/org.wso2.carbon.identity.api.server.organization.selfservice.v1/src/main/java/org/wso2/carbon/identity/api/server/organization/selfservice/v1/core/SelfServiceMgtService.java
+++ b/components/org.wso2.carbon.identity.api.server.organization.selfservice/org.wso2.carbon.identity.api.server.organization.selfservice.v1/src/main/java/org/wso2/carbon/identity/api/server/organization/selfservice/v1/core/SelfServiceMgtService.java
@@ -56,6 +56,7 @@ import org.wso2.carbon.identity.application.mgt.AuthorizedAPIManagementService;
 import org.wso2.carbon.identity.governance.IdentityGovernanceException;
 import org.wso2.carbon.identity.governance.IdentityGovernanceService;
 import org.wso2.carbon.identity.governance.bean.ConnectorConfig;
+import org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -85,8 +86,6 @@ public class SelfServiceMgtService {
 
     @Autowired
     private ServerUserStoreService serverUserStoreService;
-
-    public static final String SHARE_WITH_ALL_CHILDREN = "shareWithAllChildren";
 
     /**
      * Get organization governance configs.
@@ -548,7 +547,7 @@ public class SelfServiceMgtService {
         System.arraycopy(spProperties, 0, newSpProperties, 0, spProperties.length);
 
         ServiceProviderProperty shareWithAllChildrenProperty = new ServiceProviderProperty();
-        shareWithAllChildrenProperty.setName(SHARE_WITH_ALL_CHILDREN);
+        shareWithAllChildrenProperty.setName(OrganizationManagementConstants.SHARE_WITH_ALL_CHILDREN);
         shareWithAllChildrenProperty.setValue(Boolean.TRUE.toString());
         newSpProperties[spProperties.length] = shareWithAllChildrenProperty;
         serviceProvider.setSpProperties(newSpProperties);

--- a/components/org.wso2.carbon.identity.api.server.organization.selfservice/org.wso2.carbon.identity.api.server.organization.selfservice.v1/src/main/resources/META-INF/cxf/self-service-mgt-v1-cxf.xml
+++ b/components/org.wso2.carbon.identity.api.server.organization.selfservice/org.wso2.carbon.identity.api.server.organization.selfservice.v1/src/main/resources/META-INF/cxf/self-service-mgt-v1-cxf.xml
@@ -26,10 +26,16 @@
           class="org.wso2.carbon.identity.api.server.organization.selfservice.common.factory.GovernanceOSGIServiceFactory"/>
     <bean id="ApplicationManagementServiceFactoryBean"
           class="org.wso2.carbon.identity.api.server.organization.selfservice.common.factory.ApplicationManagementOSGiServiceFactory"/>
+    <bean id="APIResourceManagementServiceFactoryBean"
+          class="org.wso2.carbon.identity.api.server.organization.selfservice.common.factory.APIResourceManagementOSGiServiceFactory"/>
+    <bean id="AuthorizedAPIManagementServiceFactoryBean"
+          class="org.wso2.carbon.identity.api.server.organization.selfservice.common.factory.AuthorizedAPIManagementOSGiServiceFactory"/>
 
     <bean id="SelfServiceMgtServiceHolderBean"
           class="org.wso2.carbon.identity.api.server.organization.selfservice.common.SelfServiceMgtServiceHolder">
         <property name="IdentityGovernanceService" ref="GovernanceConnectorServiceFactoryBean"/>
         <property name="ApplicationManagementService" ref="ApplicationManagementServiceFactoryBean"/>
+        <property name="APIResourceManager" ref="APIResourceManagementServiceFactoryBean"/>
+        <property name="AuthorizedAPIManagementService" ref="AuthorizedAPIManagementServiceFactoryBean"/>
     </bean>
 </beans>

--- a/components/org.wso2.carbon.identity.api.server.organization.selfservice/org.wso2.carbon.identity.api.server.organization.selfservice.v1/src/main/resources/create-app-request.json
+++ b/components/org.wso2.carbon.identity.api.server.organization.selfservice/org.wso2.carbon.identity.api.server.organization.selfservice.v1/src/main/resources/create-app-request.json
@@ -7,7 +7,7 @@
     "oidc": {
       "grantTypes": [
         "client_credentials",
-        "organization_switch"
+        "organization_switch_cc"
       ],
       "accessToken": {
         "applicationAccessTokenExpiryInSeconds": 7200,

--- a/components/org.wso2.carbon.identity.api.server.organization.selfservice/org.wso2.carbon.identity.api.server.organization.selfservice.v1/src/main/resources/create-app-request.json
+++ b/components/org.wso2.carbon.identity.api.server.organization.selfservice/org.wso2.carbon.identity.api.server.organization.selfservice.v1/src/main/resources/create-app-request.json
@@ -1,6 +1,6 @@
 {
   "name": "b2b-self-service-app",
-  "templateId": "custom-application-oidc",
+  "templateId": "m2m-application",
   "isManagementApp": true,
   "isB2BSelfServiceApp": true,
   "inboundProtocolConfiguration": {

--- a/pom.xml
+++ b/pom.xml
@@ -769,7 +769,7 @@
         <identity.inbound.saml2.version>5.11.16</identity.inbound.saml2.version>
         <commons.beanutils.version>1.9.4</commons.beanutils.version>
         <mavan.findbugsplugin.exclude.file>findbugs-exclude-filter.xml</mavan.findbugsplugin.exclude.file>
-        <carbon.kernel.version>4.9.4</carbon.kernel.version>
+        <carbon.kernel.version>4.9.17</carbon.kernel.version>
         <carbon.multitenancy.version>4.9.10</carbon.multitenancy.version>
         <org.wso2.carbon.identity.remotefetch.version>0.7.12</org.wso2.carbon.identity.remotefetch.version>
         <org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.version>2.4.21</org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.version>

--- a/pom.xml
+++ b/pom.xml
@@ -783,7 +783,7 @@
         <identity.verification.version>1.0.3</identity.verification.version>
 
         <!-- Organization management core Version -->
-        <org.wso2.carbon.identity.organization.management.core.version>1.0.85
+        <org.wso2.carbon.identity.organization.management.core.version>1.0.89
         </org.wso2.carbon.identity.organization.management.core.version>
         <org.wso2.carbon.identity.organization.management.core.version.range>[1.0.0, 2.0.0)
         </org.wso2.carbon.identity.organization.management.core.version.range>


### PR DESCRIPTION
### Purpose
- Use new API authorization feature in Organization Self Service (SS) Application

### Changes
- Subsribe the Organization SS application to required APIs for self service upon creation when Authz Legacy Runtime is not enabled
- Change application template to M2M application
- Enable sharing with organizations created after the SS application creatition


### Related Issue
- https://github.com/wso2/product-is/issues/17693
