### PR TITLE
Return super tenant's email sender configurations

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.notification.sender/org.wso2.carbon.identity.api.server.notification.sender.v1/src/main/java/org/wso2/carbon/identity/api/server/notification/sender/v1/core/EventAdapterUtil.java
+++ b/components/org.wso2.carbon.identity.api.server.notification.sender/org.wso2.carbon.identity.api.server.notification.sender.v1/src/main/java/org/wso2/carbon/identity/api/server/notification/sender/v1/core/EventAdapterUtil.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2023, WSO2 Inc. (http://www.wso2.com).
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.notification.sender.v1.core;
+
+import org.apache.commons.logging.Log;
+
+/**
+ * Created on 3/2/15.
+ */
+public class EventAdapterUtil {
+
+    public static void logAndDrop(String adapterName, Object event, String message, Throwable e, Log log,
+                                  int tenantId) {
+        if (message != null) {
+            message = message + ", ";
+        } else {
+            message = "";
+        }
+        log.error("Event dropped at Output Adapter '" + adapterName + "' for tenant id '" + tenantId + "', "
+                + message + e
+                .getMessage(), e);
+        if (log.isDebugEnabled()) {
+            log.debug("Error at Output Adapter '" + adapterName + "' for tenant id '" + tenantId
+                    + "', dropping event: \n" + event, e);
+        }
+    }
+
+}

--- a/components/org.wso2.carbon.identity.api.server.notification.sender/org.wso2.carbon.identity.api.server.notification.sender.v1/src/main/java/org/wso2/carbon/identity/api/server/notification/sender/v1/core/OutputEventAdapter.java
+++ b/components/org.wso2.carbon.identity.api.server.notification.sender/org.wso2.carbon.identity.api.server.notification.sender.v1/src/main/java/org/wso2/carbon/identity/api/server/notification/sender/v1/core/OutputEventAdapter.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2023, WSO2 Inc. (http://www.wso2.com).
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.notification.sender.v1.core;
+
+import org.wso2.carbon.identity.api.server.notification.sender.v1.core.exception.ConnectionUnavailableException;
+import org.wso2.carbon.identity.api.server.notification.sender.v1.core.exception.OutputEventAdapterException;
+import org.wso2.carbon.identity.api.server.notification.sender.v1.core.exception.TestConnectionNotSupportedException;
+
+import java.util.Map;
+
+/**
+ * This is a EventAdapter type. these interface let users to publish subscribe messages according to
+ * some type. this type can either be local, jms or ws
+ */
+public interface OutputEventAdapter {
+
+    /**
+     * The init of the adapter, this will be called only once be for connect() and testConnect().
+     * @throws OutputEventAdapterException if there are any configuration errors
+     */
+    void init() throws OutputEventAdapterException;
+
+    /**
+     * Used to test the connection.
+     * @throws TestConnectionNotSupportedException if test connection is not supported by the adapter
+     * @throws ConnectionUnavailableException if it cannot connect to the backend
+     */
+    void testConnect() throws TestConnectionNotSupportedException, ConnectionUnavailableException;
+
+    /**
+     * Will be called to connect to the backend before events are published.
+     * @throws ConnectionUnavailableException if it cannot connect to the backend
+     */
+    void connect() throws ConnectionUnavailableException;
+
+    /**
+     * To publish the events.
+     * @param message event to be published, it can be Map,OMElement or String
+     * @param dynamicProperties  the dynamic properties of the event
+     * @throws ConnectionUnavailableException if it cannot connect to the backend
+     */
+    void publish(Object message, Map<String, String> dynamicProperties) throws ConnectionUnavailableException;
+
+    /**
+     * Will be called after all publishing is done, or when ConnectionUnavailableException is thrown.
+     */
+    void disconnect();
+
+    /**
+     * Will be called at the end to clean all the resources consumed.
+     */
+    void destroy();
+
+    /**
+     * Whether events get accumulated at the adopter and clients connect to it to collect events.
+     * @return is polled
+     */
+    boolean isPolled();
+
+}

--- a/components/org.wso2.carbon.identity.api.server.notification.sender/org.wso2.carbon.identity.api.server.notification.sender.v1/src/main/java/org/wso2/carbon/identity/api/server/notification/sender/v1/core/OutputEventAdapterConfiguration.java
+++ b/components/org.wso2.carbon.identity.api.server.notification.sender/org.wso2.carbon.identity.api.server.notification.sender.v1/src/main/java/org/wso2/carbon/identity/api/server/notification/sender/v1/core/OutputEventAdapterConfiguration.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2023, WSO2 Inc. (http://www.wso2.com).
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.notification.sender.v1.core;
+
+
+import java.util.Map;
+
+/**
+ * This class contain the configuration details of the event.
+ */
+
+public class OutputEventAdapterConfiguration {
+
+    private String name;
+    private String type;
+    private String messageFormat;
+    private String outputStreamIdOfWso2eventMessageFormat;
+    private Map<String, String> staticProperties;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    public String getMessageFormat() {
+        return messageFormat;
+    }
+
+    public void setMessageFormat(String messageFormat) {
+        this.messageFormat = messageFormat;
+    }
+
+    public Map<String, String> getStaticProperties() {
+        return staticProperties;
+    }
+
+    public void setStaticProperties(Map<String, String> staticProperties) {
+        this.staticProperties = staticProperties;
+    }
+
+    public String getOutputStreamIdOfWso2eventMessageFormat() {
+        return outputStreamIdOfWso2eventMessageFormat;
+    }
+
+    public void setOutputStreamIdOfWso2eventMessageFormat(String outputStreamIdOfWso2eventMessageFormat) {
+        this.outputStreamIdOfWso2eventMessageFormat = outputStreamIdOfWso2eventMessageFormat;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof OutputEventAdapterConfiguration)) {
+            return false;
+        }
+
+        OutputEventAdapterConfiguration that = (OutputEventAdapterConfiguration) o;
+
+        if (messageFormat != null ? !messageFormat.equals(that.messageFormat) : that.messageFormat != null) {
+            return false;
+        }
+        if (name != null ? !name.equals(that.name) : that.name != null) {
+            return false;
+        }
+        if (outputStreamIdOfWso2eventMessageFormat != null ? !outputStreamIdOfWso2eventMessageFormat
+                .equals(that.outputStreamIdOfWso2eventMessageFormat) :
+                that.outputStreamIdOfWso2eventMessageFormat != null)  {
+            return false;
+        }
+        if (staticProperties != null ? !staticProperties.equals(that.staticProperties) :
+                that.staticProperties != null)  {
+            return false;
+        }
+        if (type != null ? !type.equals(that.type) : that.type != null) {
+            return false;
+        }
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = name != null ? name.hashCode() : 0;
+        result = 31 * result + (type != null ? type.hashCode() : 0);
+        result = 31 * result + (messageFormat != null ? messageFormat.hashCode() : 0);
+        result = 31 * result + (outputStreamIdOfWso2eventMessageFormat != null ?
+                outputStreamIdOfWso2eventMessageFormat.hashCode() : 0);
+        result = 31 * result + (staticProperties != null ? staticProperties.hashCode() : 0);
+        return result;
+    }
+}

--- a/components/org.wso2.carbon.identity.api.server.notification.sender/org.wso2.carbon.identity.api.server.notification.sender.v1/src/main/java/org/wso2/carbon/identity/api/server/notification/sender/v1/core/OutputEventAdapterFactory.java
+++ b/components/org.wso2.carbon.identity.api.server.notification.sender/org.wso2.carbon.identity.api.server.notification.sender.v1/src/main/java/org/wso2/carbon/identity/api/server/notification/sender/v1/core/OutputEventAdapterFactory.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2023, WSO2 Inc. (http://www.wso2.com).
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.notification.sender.v1.core;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * This class is used to create the event adapter.
+ */
+public abstract class OutputEventAdapterFactory {
+
+    private OutputEventAdapterSchema outputEventAdapterSchema;
+
+    public abstract String getType();
+
+    public abstract List<String> getSupportedMessageFormats();
+
+    public abstract List<Property> getStaticPropertyList();
+
+    public abstract List<Property> getDynamicPropertyList();
+
+    public abstract String getUsageTips();
+
+    public abstract OutputEventAdapter createEventAdapter
+            (OutputEventAdapterConfiguration eventAdapterConfiguration, Map<String, String> globalProperties);
+
+    public OutputEventAdapterSchema getOutputEventAdapterSchema() {
+        if (outputEventAdapterSchema == null) {
+            outputEventAdapterSchema = new OutputEventAdapterSchema(getType(), getUsageTips(),
+                    getSupportedMessageFormats(), getStaticPropertyList(), getDynamicPropertyList());
+        }
+        return outputEventAdapterSchema;
+    }
+
+}

--- a/components/org.wso2.carbon.identity.api.server.notification.sender/org.wso2.carbon.identity.api.server.notification.sender.v1/src/main/java/org/wso2/carbon/identity/api/server/notification/sender/v1/core/OutputEventAdapterSchema.java
+++ b/components/org.wso2.carbon.identity.api.server.notification.sender/org.wso2.carbon.identity.api.server.notification.sender.v1/src/main/java/org/wso2/carbon/identity/api/server/notification/sender/v1/core/OutputEventAdapterSchema.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2023, WSO2 Inc. (http://www.wso2.com).
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.notification.sender.v1.core;
+
+
+import java.util.List;
+
+/**
+ * this class is used to transfer the event adapter type details to the UI. UI renders the
+ * properties according to the properties specified here.
+ */
+public class OutputEventAdapterSchema {
+
+    private final String type;
+    private String usageTips;
+    private final List<String> supportedMessageFormats;
+    private final List<Property> staticPropertyList;
+    private final List<Property> dynamicPropertyList;
+
+    public OutputEventAdapterSchema(String type, String usageTips, List<String> supportedMessageFormats,
+                                    List<Property> staticPropertyList,
+                                    List<Property> dynamicPropertyList) {
+        this.type = type;
+        this.usageTips = usageTips;
+        this.supportedMessageFormats = supportedMessageFormats;
+        this.staticPropertyList = staticPropertyList;
+        this.dynamicPropertyList = dynamicPropertyList;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public String getUsageTips() {
+        return usageTips;
+    }
+
+    public List<String> getSupportedMessageFormats() {
+        return supportedMessageFormats;
+    }
+
+    public List<Property> getStaticPropertyList() {
+        return staticPropertyList;
+    }
+
+    public List<Property> getDynamicPropertyList() {
+
+        return dynamicPropertyList;
+    }
+
+}

--- a/components/org.wso2.carbon.identity.api.server.notification.sender/org.wso2.carbon.identity.api.server.notification.sender.v1/src/main/java/org/wso2/carbon/identity/api/server/notification/sender/v1/core/OutputEventAdapterService.java
+++ b/components/org.wso2.carbon.identity.api.server.notification.sender/org.wso2.carbon.identity.api.server.notification.sender.v1/src/main/java/org/wso2/carbon/identity/api/server/notification/sender/v1/core/OutputEventAdapterService.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2023, WSO2 Inc. (http://www.wso2.com).
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.notification.sender.v1.core;
+
+import org.wso2.carbon.identity.api.server.notification.sender.v1.core.exception.OutputEventAdapterException;
+import org.wso2.carbon.identity.api.server.notification.sender.v1.core.exception.TestConnectionNotSupportedException;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * OSGI interface for the EventAdapter Service.
+ */
+
+public interface OutputEventAdapterService {
+
+
+    /**
+     * this method returns all the available event adapter types. UI use this details to
+     * show the types and the properties to be set to the user when creating the
+     * event adapter objects.
+     *
+     * @return list of available types
+     */
+    List<String> getOutputEventAdapterTypes();
+
+    /**
+     * This method returns the event adapter dto for a specific event adapter type.
+     *
+     * @param eventAdapterType
+     * @return
+     */
+    OutputEventAdapterSchema getOutputEventAdapterSchema(String eventAdapterType);
+
+
+    void create(OutputEventAdapterConfiguration outputEventAdapterConfiguration)
+            throws OutputEventAdapterException;
+
+    /**
+     * publishes the message using the given event adapter to the given topic.
+     *  @param name              - name of the event adapter
+     * @param dynamicProperties
+     */
+    void publish(String name, Map<String, String> dynamicProperties, Object message);
+
+    /**
+     * publish testConnect message using the given event adapter.
+     *
+     * @param outputEventAdapterConfiguration - Configuration Details of the event adapter
+     */
+    void testConnection(OutputEventAdapterConfiguration outputEventAdapterConfiguration)
+            throws OutputEventAdapterException, TestConnectionNotSupportedException;
+
+    void destroy(String name);
+
+    boolean isPolled(String outputAdapterName) throws OutputEventAdapterException;
+}

--- a/components/org.wso2.carbon.identity.api.server.notification.sender/org.wso2.carbon.identity.api.server.notification.sender.v1/src/main/java/org/wso2/carbon/identity/api/server/notification/sender/v1/core/Property.java
+++ b/components/org.wso2.carbon.identity.api.server.notification.sender/org.wso2.carbon.identity.api.server.notification.sender.v1/src/main/java/org/wso2/carbon/identity/api/server/notification/sender/v1/core/Property.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2023, WSO2 Inc. (http://www.wso2.com).
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.notification.sender.v1.core;
+
+/**
+ * Event Adapter property details are stored.
+ */
+public class Property {
+
+    private final String propertyName;
+    // property is a required field or not
+    private boolean isRequired = false;
+    // property is a password field or not
+    private boolean isSecured = false;
+    // property needs encryption
+    private boolean isEncrypted = false;
+    // display name in ui
+    private String displayName;
+    // default value of the property
+    private String defaultValue;
+    // in out type of the property
+    private String[] options;
+    // hint for the property
+    private String hint;
+
+    public String[] getOptions() {
+        return options;
+    }
+
+    public void setOptions(String[] options) {
+        this.options = options;
+    }
+
+    public String getHint() {
+        return hint;
+    }
+
+    public void setHint(String hint) {
+        this.hint = hint;
+    }
+
+    public String getDefaultValue() {
+        return defaultValue;
+    }
+
+    public void setDefaultValue(String defaultValue) {
+        this.defaultValue = defaultValue;
+    }
+
+    public Property(String propertyName) {
+        this.propertyName = propertyName;
+    }
+
+    public void setRequired(boolean required) {
+        isRequired = required;
+    }
+
+    public void setSecured(boolean secured) {
+        isSecured = secured;
+        if (secured) {
+            //By default if property is secured then it also set as encrypted
+            setEncrypted(true);
+        }
+    }
+
+    public String getPropertyName() {
+        return propertyName;
+    }
+
+    public boolean isRequired() {
+        return isRequired;
+    }
+
+    public boolean isSecured() {
+        return isSecured;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    public void setDisplayName(String displayName) {
+        this.displayName = displayName;
+    }
+
+    public boolean isEncrypted() {
+        return isEncrypted;
+    }
+
+    public void setEncrypted(boolean encrypted) {
+        this.isEncrypted = encrypted;
+    }
+}

--- a/components/org.wso2.carbon.identity.api.server.notification.sender/org.wso2.carbon.identity.api.server.notification.sender.v1/src/main/java/org/wso2/carbon/identity/api/server/notification/sender/v1/core/exception/ConnectionUnavailableException.java
+++ b/components/org.wso2.carbon.identity.api.server.notification.sender/org.wso2.carbon.identity.api.server.notification.sender.v1/src/main/java/org/wso2/carbon/identity/api/server/notification/sender/v1/core/exception/ConnectionUnavailableException.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2023, WSO2 Inc. (http://www.wso2.com).
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.notification.sender.v1.core.exception;
+
+/**
+ * This class represents the message processing time issues.
+ */
+public class ConnectionUnavailableException extends RuntimeException {
+    public ConnectionUnavailableException() {
+    }
+
+    public ConnectionUnavailableException(String message) {
+        super(message);
+    }
+
+    public ConnectionUnavailableException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public ConnectionUnavailableException(Throwable cause) {
+        super(cause);
+    }
+
+}

--- a/components/org.wso2.carbon.identity.api.server.notification.sender/org.wso2.carbon.identity.api.server.notification.sender.v1/src/main/java/org/wso2/carbon/identity/api/server/notification/sender/v1/core/exception/OutputEventAdapterException.java
+++ b/components/org.wso2.carbon.identity.api.server.notification.sender/org.wso2.carbon.identity.api.server.notification.sender.v1/src/main/java/org/wso2/carbon/identity/api/server/notification/sender/v1/core/exception/OutputEventAdapterException.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2023, WSO2 Inc. (http://www.wso2.com).
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.notification.sender.v1.core.exception;
+
+/**
+ * This class represents the message processing time issues.
+ */
+public class OutputEventAdapterException extends Exception {
+    public OutputEventAdapterException() {
+    }
+
+    public OutputEventAdapterException(String message) {
+        super(message);
+    }
+
+    public OutputEventAdapterException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public OutputEventAdapterException(Throwable cause) {
+        super(cause);
+    }
+
+}

--- a/components/org.wso2.carbon.identity.api.server.notification.sender/org.wso2.carbon.identity.api.server.notification.sender.v1/src/main/java/org/wso2/carbon/identity/api/server/notification/sender/v1/core/exception/OutputEventAdapterRuntimeException.java
+++ b/components/org.wso2.carbon.identity.api.server.notification.sender/org.wso2.carbon.identity.api.server.notification.sender.v1/src/main/java/org/wso2/carbon/identity/api/server/notification/sender/v1/core/exception/OutputEventAdapterRuntimeException.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2023, WSO2 Inc. (http://www.wso2.com).
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.notification.sender.v1.core.exception;
+
+/**
+ * This class represents the message processing time issues.
+ */
+public class OutputEventAdapterRuntimeException extends RuntimeException {
+    public OutputEventAdapterRuntimeException() {
+    }
+
+    public OutputEventAdapterRuntimeException(String message) {
+        super(message);
+    }
+
+    public OutputEventAdapterRuntimeException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public OutputEventAdapterRuntimeException(Throwable cause) {
+        super(cause);
+    }
+
+}

--- a/components/org.wso2.carbon.identity.api.server.notification.sender/org.wso2.carbon.identity.api.server.notification.sender.v1/src/main/java/org/wso2/carbon/identity/api/server/notification/sender/v1/core/exception/TestConnectionNotSupportedException.java
+++ b/components/org.wso2.carbon.identity.api.server.notification.sender/org.wso2.carbon.identity.api.server.notification.sender.v1/src/main/java/org/wso2/carbon/identity/api/server/notification/sender/v1/core/exception/TestConnectionNotSupportedException.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2023, WSO2 Inc. (http://www.wso2.com).
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.notification.sender.v1.core.exception;
+
+/**
+ * This class represents the message processing time issues.
+ */
+public class TestConnectionNotSupportedException extends Exception {
+
+    public TestConnectionNotSupportedException() {
+    }
+
+    public TestConnectionNotSupportedException(String message) {
+        super(message);
+    }
+
+    public TestConnectionNotSupportedException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public TestConnectionNotSupportedException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/components/org.wso2.carbon.identity.api.server.notification.sender/org.wso2.carbon.identity.api.server.notification.sender.v1/src/main/java/org/wso2/carbon/identity/api/server/notification/sender/v1/core/internal/CarbonOutputEventAdapterService.java
+++ b/components/org.wso2.carbon.identity.api.server.notification.sender/org.wso2.carbon.identity.api.server.notification.sender.v1/src/main/java/org/wso2/carbon/identity/api/server/notification/sender/v1/core/internal/CarbonOutputEventAdapterService.java
@@ -1,0 +1,225 @@
+/*
+ * Copyright (c) 2023, WSO2 Inc. (http://www.wso2.com).
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.notification.sender.v1.core.internal;
+
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.context.PrivilegedCarbonContext;
+import org.wso2.carbon.identity.api.server.notification.sender.v1.core.OutputEventAdapter;
+import org.wso2.carbon.identity.api.server.notification.sender.v1.core.OutputEventAdapterConfiguration;
+import org.wso2.carbon.identity.api.server.notification.sender.v1.core.OutputEventAdapterFactory;
+import org.wso2.carbon.identity.api.server.notification.sender.v1.core.OutputEventAdapterSchema;
+import org.wso2.carbon.identity.api.server.notification.sender.v1.core.OutputEventAdapterService;
+import org.wso2.carbon.identity.api.server.notification.sender.v1.core.Property;
+import org.wso2.carbon.identity.api.server.notification.sender.v1.core.exception.OutputEventAdapterException;
+import org.wso2.carbon.identity.api.server.notification.sender.v1.core.exception.OutputEventAdapterRuntimeException;
+import org.wso2.carbon.identity.api.server.notification.sender.v1.core.exception.TestConnectionNotSupportedException;
+import org.wso2.carbon.identity.api.server.notification.sender.v1.core.internal.ds.OutputEventAdapterServiceValueHolder;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * EventAdapter service implementation.
+ */
+public class CarbonOutputEventAdapterService implements OutputEventAdapterService {
+
+    private static Log log = LogFactory.getLog(CarbonOutputEventAdapterService.class);
+
+    private final Map<String, OutputEventAdapterFactory> eventAdapterFactoryMap;
+    private final ConcurrentHashMap<Integer, ConcurrentHashMap<String, OutputAdapterRuntime>>
+            tenantSpecificEventAdapters;
+
+
+    public CarbonOutputEventAdapterService() {
+        this.eventAdapterFactoryMap = new ConcurrentHashMap<String, OutputEventAdapterFactory>();
+        this.tenantSpecificEventAdapters =
+                new ConcurrentHashMap<Integer, ConcurrentHashMap<String, OutputAdapterRuntime>>();
+    }
+
+    public void registerEventAdapterFactory(OutputEventAdapterFactory outputEventAdapterFactory) {
+        OutputEventAdapterSchema outputEventAdapterSchema = outputEventAdapterFactory.getOutputEventAdapterSchema();
+        this.eventAdapterFactoryMap.put(outputEventAdapterSchema.getType(), outputEventAdapterFactory);
+    }
+
+    public void unRegisterEventAdapterFactory(OutputEventAdapterFactory outputEventAdapterFactory) {
+        OutputEventAdapterSchema outputEventAdapterSchema = outputEventAdapterFactory.getOutputEventAdapterSchema();
+        this.eventAdapterFactoryMap.remove(outputEventAdapterSchema.getType());
+    }
+
+
+    @Override
+    public List<String> getOutputEventAdapterTypes() {
+        return new ArrayList<String>(eventAdapterFactoryMap.keySet());
+    }
+
+    /**
+     * This method returns the event adapter dto for a specific event adapter type.
+     *
+     * @param eventAdapterType
+     * @return
+     */
+    @Override
+    public OutputEventAdapterSchema getOutputEventAdapterSchema(String eventAdapterType) {
+        OutputEventAdapterFactory outputEventAdapterFactory = eventAdapterFactoryMap.get(eventAdapterType);
+        if (outputEventAdapterFactory != null) {
+            return outputEventAdapterFactory.getOutputEventAdapterSchema();
+        }
+        return null;
+    }
+
+    @Override
+    public void create(OutputEventAdapterConfiguration outputEventAdapterConfiguration)
+            throws OutputEventAdapterException {
+        int tenantId = PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantId();
+        ConcurrentHashMap<String, OutputAdapterRuntime> eventAdapters = tenantSpecificEventAdapters.get(tenantId);
+        if (eventAdapters == null) {
+            tenantSpecificEventAdapters.putIfAbsent(tenantId, new ConcurrentHashMap<String, OutputAdapterRuntime>());
+            eventAdapters = tenantSpecificEventAdapters.get(tenantId);
+        }
+        OutputEventAdapterFactory adapterFactory = eventAdapterFactoryMap
+                .get(outputEventAdapterConfiguration.getType());
+        if (adapterFactory == null) {
+            throw new OutputEventAdapterException("Output Event Adapter not created as no " +
+                    "adapter factory is registered with type " + outputEventAdapterConfiguration.getType());
+        }
+        if (outputEventAdapterConfiguration.getName() == null) {
+            throw new OutputEventAdapterException("Output Event Adapter name cannot by null, for the adapter type " +
+                    outputEventAdapterConfiguration.getType());
+        }
+        if (eventAdapters.get(outputEventAdapterConfiguration.getName()) != null) {
+            throw new OutputEventAdapterException("Output Event Adapter not created as another adapter with same name '"
+                    + outputEventAdapterConfiguration.getName() + "' already exist for tenant " + tenantId);
+        }
+        //check if all the required properties are given here
+        List<Property> staticPropertyList = adapterFactory.getStaticPropertyList();
+        if (staticPropertyList != null) {
+            Map<String, String> staticPropertyMap = outputEventAdapterConfiguration.getStaticProperties();
+            for (Property property: staticPropertyList) {
+                if (property.isRequired()) {
+                    if (staticPropertyMap == null) {
+                        throw new OutputEventAdapterException("Output Event Adapter not created as " +
+                                "the 'staticProperties' are null, which means, the required property "
+                                + property.getPropertyName() + " is not  being set, for the adapter type " +
+                                outputEventAdapterConfiguration.getType());
+                    }
+                    if (staticPropertyMap.get(property.getPropertyName()) == null) {
+                        throw new OutputEventAdapterException("Output Event Adapter not created as the " +
+                                "required property: " + property.getPropertyName() +
+                                " is not set, for the adapter type " + outputEventAdapterConfiguration.getType());
+                    }
+                }
+            }
+        }
+        Map<String, String> globalProperties = OutputEventAdapterServiceValueHolder.getGlobalAdapterConfigs().
+                getAdapterConfig(outputEventAdapterConfiguration.getType()).getGlobalPropertiesAsMap();
+        eventAdapters.put(outputEventAdapterConfiguration.getName(), new OutputAdapterRuntime(adapterFactory.
+                createEventAdapter(outputEventAdapterConfiguration, globalProperties),
+                outputEventAdapterConfiguration.getName()));
+    }
+
+    /**
+     * publishes the message using the given event adapter to the given topic.
+     *  @param name              - name of the event adapter
+     * @param dynamicProperties
+     * @param message
+     */
+    @Override
+    public void publish(String name, Map<String, String> dynamicProperties, Object message) {
+        int tenantId = PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantId();
+        ConcurrentHashMap<String, OutputAdapterRuntime> eventAdapters = tenantSpecificEventAdapters.get(tenantId);
+        if (eventAdapters == null) {
+            throw new OutputEventAdapterRuntimeException("Event not published as no Output Event Adapter found with " +
+                    "for tenant id " + tenantId);
+        }
+        OutputAdapterRuntime outputAdapterRuntime = eventAdapters.get(name);
+        if (outputAdapterRuntime == null) {
+            throw new OutputEventAdapterRuntimeException("Event not published as no Output Event Adapter found " +
+                    "with name '" + name + "' for tenant id " + tenantId);
+        }
+        outputAdapterRuntime.publish(message, dynamicProperties);
+    }
+
+    /**
+     * publish testConnect message using the given event adapter.
+     *
+     * @param outputEventAdapterConfiguration - Configuration Details of the event adapter
+     */
+    @Override
+    public void testConnection(OutputEventAdapterConfiguration outputEventAdapterConfiguration)
+            throws OutputEventAdapterException, TestConnectionNotSupportedException {
+        OutputEventAdapter outputEventAdapter = null;
+        try {
+            OutputEventAdapterFactory outputEventAdapterFactory =
+                    this.eventAdapterFactoryMap.get(outputEventAdapterConfiguration.getType());
+            OutputEventAdapterFactory adapterFactory
+                    = eventAdapterFactoryMap.get(outputEventAdapterConfiguration.getType());
+            if (adapterFactory == null) {
+                throw new OutputEventAdapterException("Output Event Adapter not created as no adapter factory is " +
+                        "registered with type " + outputEventAdapterConfiguration.getType());
+            }
+            if (outputEventAdapterConfiguration.getName() == null) {
+                throw new OutputEventAdapterException("Output Event Adapter name cannot by null, for the adapter type "
+                        + outputEventAdapterConfiguration.getType());
+            }
+            Map<String, String> globalProperties = OutputEventAdapterServiceValueHolder.getGlobalAdapterConfigs().
+                    getAdapterConfig(outputEventAdapterConfiguration.getType()).getGlobalPropertiesAsMap();
+            outputEventAdapter =
+                    outputEventAdapterFactory.createEventAdapter(outputEventAdapterConfiguration, globalProperties);
+            outputEventAdapter.init();
+            outputEventAdapter.testConnect();
+            outputEventAdapter.disconnect();
+            outputEventAdapter.destroy();
+        } finally {
+            if (outputEventAdapter != null) {
+                outputEventAdapter.destroy();
+            }
+        }
+    }
+
+    @Override
+    public void destroy(String name) {
+        int tenantId = PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantId();
+        ConcurrentHashMap<String, OutputAdapterRuntime> eventAdapters = tenantSpecificEventAdapters.get(tenantId);
+        if (eventAdapters == null) {
+            return;
+        }
+        OutputAdapterRuntime outputAdapterRuntime = eventAdapters.remove(name);
+        if (outputAdapterRuntime != null) {
+            outputAdapterRuntime.destroy();
+        }
+    }
+
+    @Override
+    public boolean isPolled(String outputAdapterName) throws OutputEventAdapterException {
+            int tenantId = PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantId();
+            ConcurrentHashMap<String, OutputAdapterRuntime> inputRuntimeMap = tenantSpecificEventAdapters.get(tenantId);
+            if (inputRuntimeMap != null) {
+                OutputAdapterRuntime outputAdapterRuntime = inputRuntimeMap.get(outputAdapterName);
+                if (outputAdapterRuntime != null) {
+                    return outputAdapterRuntime.isPolled();
+                }
+            }
+            throw new OutputEventAdapterException("Adopter with name'" + outputAdapterName + "' not found");
+    }
+
+}

--- a/components/org.wso2.carbon.identity.api.server.notification.sender/org.wso2.carbon.identity.api.server.notification.sender.v1/src/main/java/org/wso2/carbon/identity/api/server/notification/sender/v1/core/internal/DecayTimer.java
+++ b/components/org.wso2.carbon.identity.api.server.notification.sender/org.wso2.carbon.identity.api.server.notification.sender.v1/src/main/java/org/wso2/carbon/identity/api/server/notification/sender/v1/core/internal/DecayTimer.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2023, WSO2 Inc. (http://www.wso2.com).
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.notification.sender.v1.core.internal;
+
+/**
+ * Gracefully append time for reconnection.
+ */
+public class DecayTimer {
+
+    private final long waitTimeSequenceSeconds[] = new long[]{0, 0, 1, 5, 15, 30, 60, 300, 900, 1800, 3600};
+    private volatile int position = 0;
+
+
+    public void reset() {
+        position = 0;
+    }
+
+    public synchronized void incrementPosition() {
+
+        if (position != (waitTimeSequenceSeconds.length - 1)) {
+            position++;
+        }
+    }
+
+    public long returnTimeToWait() {
+
+        return waitTimeSequenceSeconds[position] * 1000; //milliseconds
+    }
+
+}

--- a/components/org.wso2.carbon.identity.api.server.notification.sender/org.wso2.carbon.identity.api.server.notification.sender.v1/src/main/java/org/wso2/carbon/identity/api/server/notification/sender/v1/core/internal/EventAdapterConstants.java
+++ b/components/org.wso2.carbon.identity.api.server.notification.sender/org.wso2.carbon.identity.api.server.notification.sender.v1/src/main/java/org/wso2/carbon/identity/api/server/notification/sender/v1/core/internal/EventAdapterConstants.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2023, WSO2 Inc. (http://www.wso2.com).
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.notification.sender.v1.core.internal;
+
+/**
+ * Constants for the Event Adapter.
+ */
+public final class EventAdapterConstants {
+
+    private EventAdapterConstants() {
+    }
+
+    public static final String GLOBAL_CONFIG_FILE_NAME = "output-event-adapters.xml";
+
+    public static final String SECURE_VAULT_NS = "http://org.wso2.securevault/configuration";
+
+    public static final String SECRET_ALIAS_ATTR_NAME = "secretAlias";
+
+}

--- a/components/org.wso2.carbon.identity.api.server.notification.sender/org.wso2.carbon.identity.api.server.notification.sender.v1/src/main/java/org/wso2/carbon/identity/api/server/notification/sender/v1/core/internal/OutputAdapterRuntime.java
+++ b/components/org.wso2.carbon.identity.api.server.notification.sender/org.wso2.carbon.identity.api.server.notification.sender.v1/src/main/java/org/wso2/carbon/identity/api/server/notification/sender/v1/core/internal/OutputAdapterRuntime.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) 2023, WSO2 Inc. (http://www.wso2.com).
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.notification.sender.v1.core.internal;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.context.PrivilegedCarbonContext;
+import org.wso2.carbon.identity.api.server.notification.sender.v1.core.EventAdapterUtil;
+import org.wso2.carbon.identity.api.server.notification.sender.v1.core.OutputEventAdapter;
+import org.wso2.carbon.identity.api.server.notification.sender.v1.core.exception.ConnectionUnavailableException;
+import org.wso2.carbon.identity.api.server.notification.sender.v1.core.exception.OutputEventAdapterException;
+
+import java.util.Map;
+
+/**
+ * This class represents the Output Adapter Runtime.
+ */
+public class OutputAdapterRuntime {
+    private static final Log log = LogFactory.getLog(OutputAdapterRuntime.class);
+    private final OutputEventAdapter outputEventAdapter;
+    private final String name;
+    private volatile boolean connected = false;
+    private final DecayTimer timer = new DecayTimer();
+    private volatile long nextConnectionTime;
+
+
+    public OutputAdapterRuntime(OutputEventAdapter outputEventAdapter, String name) throws OutputEventAdapterException {
+        this.outputEventAdapter = outputEventAdapter;
+        this.name = name;
+        synchronized (this) {
+            outputEventAdapter.init();
+//            try {
+//                outputEventAdapter.connect();
+//                connected = true;
+//            } catch (ConnectionUnavailableException e) {
+//                connected = false;
+//                outputEventAdapter.disconnect();
+//                log.error("Error initializing connecting on " + this.name + ",
+//                reconnection will be tried on next event arrival.", e);
+//            } catch (OutputEventAdapterRuntimeException e) {
+//                connected = false;
+//                outputEventAdapter.disconnect();
+//                log.error("Error initializing connecting on " + this.name + ",
+//                reconnection will be tried on next event arrival.", e);
+//            }
+        }
+    }
+
+    public void publish(Object message, Map<String, String> dynamicProperties) {
+        try {
+            try {
+                if (connected) {
+                    outputEventAdapter.publish(message, dynamicProperties);
+                } else {
+                    if (nextConnectionTime <= System.currentTimeMillis()) {
+                        synchronized (this) {
+                            if (!connected) {
+                                if (nextConnectionTime <= System.currentTimeMillis()) {
+                                    outputEventAdapter.connect();
+                                    outputEventAdapter.publish(message, dynamicProperties);
+                                    connected = true;
+                                    timer.reset();
+                                } else {
+                                    logAndDrop(message);
+                                }
+                            } else {
+                                outputEventAdapter.publish(message, dynamicProperties);
+                            }
+                        }
+                    } else {
+                        logAndDrop(message);
+                    }
+                }
+            } catch (ConnectionUnavailableException e) {
+                connected = false;
+                if (nextConnectionTime <= System.currentTimeMillis()) {
+                    synchronized (this) {
+                        if (nextConnectionTime <= System.currentTimeMillis()) {
+                            outputEventAdapter.disconnect();
+                            timer.incrementPosition();
+                            nextConnectionTime = System.currentTimeMillis() + timer.returnTimeToWait();
+                            if (timer.returnTimeToWait() == 0) {
+                                log.error("Connection unavailable for Output Adopter '" + name
+                                        + "' reconnecting.", e);
+                                publish(message, dynamicProperties);
+                            } else {
+                                log.error("Connection unavailable for Output Adopter '" + name
+                                        + "' reconnection will be retried in " + (timer.returnTimeToWait())
+                                        + " milliseconds.", e);
+                            }
+                        } else {
+                            logAndDrop(message);
+                        }
+                    }
+                } else {
+                    logAndDrop(message);
+                }
+            }
+        } catch (Throwable e) {
+            EventAdapterUtil.logAndDrop(name, message, null, e, log, PrivilegedCarbonContext
+                    .getThreadLocalCarbonContext().getTenantId());
+        }
+    }
+
+    private void logAndDrop(Object message) {
+        log.error("Event dropped, Output Adapter '" + name + "' suspended, Adapter will be active after "
+                + (nextConnectionTime - System.currentTimeMillis()) + " milliseconds.");
+        if (log.isDebugEnabled()) {
+            log.debug("Output Adapter '" + name + "' suspended, dropping event: /n" + message + "/n");
+        }
+    }
+
+    public void destroy() {
+        try {
+            outputEventAdapter.disconnect();
+        } finally {
+            outputEventAdapter.destroy();
+        }
+    }
+
+    public boolean isPolled() {
+        return outputEventAdapter.isPolled();
+    }
+}

--- a/components/org.wso2.carbon.identity.api.server.notification.sender/org.wso2.carbon.identity.api.server.notification.sender.v1/src/main/java/org/wso2/carbon/identity/api/server/notification/sender/v1/core/internal/config/AdapterConfig.java
+++ b/components/org.wso2.carbon.identity.api.server.notification.sender/org.wso2.carbon.identity.api.server.notification.sender.v1/src/main/java/org/wso2/carbon/identity/api/server/notification/sender/v1/core/internal/config/AdapterConfig.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2023, WSO2 Inc. (http://www.wso2.com).
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.notification.sender.v1.core.internal.config;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+
+
+/**
+ * Created on 3/2/15.
+ */
+public class AdapterConfig {
+
+    private String type;
+    private List<Property> globalProperties = new ArrayList<Property>();
+
+    public String getType() {
+        return type;
+    }
+
+    @XmlAttribute
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    public List<Property> getGlobalProperties() {
+        return globalProperties;
+    }
+
+    @XmlElement(name = "property")
+    public void setGlobalProperties(List<Property> globalProperties) {
+        this.globalProperties = globalProperties;
+    }
+
+    public Property getProperty(String key) {
+        Property matchedProperty = null;
+        for (Property property : globalProperties) {
+            if (property.getKey().equals(key)) {
+                matchedProperty = property;
+                break;
+            }
+        }
+        return matchedProperty;
+    }
+
+    public Map<String, String> getGlobalPropertiesAsMap() {
+        Map<String, String> properties = new HashMap<String, String>();
+        for (Property property : globalProperties) {
+            properties.put(property.getKey(), property.getValue());
+        }
+        return properties;
+    }
+}

--- a/components/org.wso2.carbon.identity.api.server.notification.sender/org.wso2.carbon.identity.api.server.notification.sender.v1/src/main/java/org/wso2/carbon/identity/api/server/notification/sender/v1/core/internal/config/AdapterConfigs.java
+++ b/components/org.wso2.carbon.identity.api.server.notification.sender/org.wso2.carbon.identity.api.server.notification.sender.v1/src/main/java/org/wso2/carbon/identity/api/server/notification/sender/v1/core/internal/config/AdapterConfigs.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2023, WSO2 Inc. (http://www.wso2.com).
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.notification.sender.v1.core.internal.config;
+
+import java.util.ArrayList;
+import java.util.List;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+
+
+/**
+ * Created on 3/2/15.
+ */
+@XmlRootElement(name = "outputEventAdaptersConfig")
+public class AdapterConfigs {
+
+    private List<AdapterConfig> adapterConfigs = new ArrayList<AdapterConfig>();
+
+    public List<AdapterConfig> getAdapterConfigs() {
+        return adapterConfigs;
+    }
+
+    @XmlElement(name = "adapterConfig")
+    public void setAdapterConfigs(List<AdapterConfig>
+                                              adapterConfigs) {
+        this.adapterConfigs = adapterConfigs;
+    }
+
+    public AdapterConfig getAdapterConfig(String type) {
+        AdapterConfig matchedAdapterConfig = new AdapterConfig();
+        for (AdapterConfig adapterConfig : adapterConfigs) {
+            if (adapterConfig.getType().equals(type)) {
+                matchedAdapterConfig = adapterConfig;
+                break;
+            }
+        }
+        return matchedAdapterConfig;
+    }
+}

--- a/components/org.wso2.carbon.identity.api.server.notification.sender/org.wso2.carbon.identity.api.server.notification.sender.v1/src/main/java/org/wso2/carbon/identity/api/server/notification/sender/v1/core/internal/config/Property.java
+++ b/components/org.wso2.carbon.identity.api.server.notification.sender/org.wso2.carbon.identity.api.server.notification.sender.v1/src/main/java/org/wso2/carbon/identity/api/server/notification/sender/v1/core/internal/config/Property.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2023, WSO2 Inc. (http://www.wso2.com).
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.notification.sender.v1.core.internal.config;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlValue;
+
+/**
+ * Created on 3/2/15.
+ */
+@XmlAccessorType(XmlAccessType.NONE)
+public class Property {
+    private String key;
+    private String value;
+
+
+    public String getKey() {
+        return key;
+    }
+
+    @XmlAttribute
+    public void setKey(String key) {
+        this.key = key;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    @XmlValue
+    public void setValue(String value) {
+        this.value = value;
+    }
+}

--- a/components/org.wso2.carbon.identity.api.server.notification.sender/org.wso2.carbon.identity.api.server.notification.sender.v1/src/main/java/org/wso2/carbon/identity/api/server/notification/sender/v1/core/internal/ds/OutputEventAdapterServiceValueHolder.java
+++ b/components/org.wso2.carbon.identity.api.server.notification.sender/org.wso2.carbon.identity.api.server.notification.sender.v1/src/main/java/org/wso2/carbon/identity/api/server/notification/sender/v1/core/internal/ds/OutputEventAdapterServiceValueHolder.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2023, WSO2 Inc. (http://www.wso2.com).
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.notification.sender.v1.core.internal.ds;
+
+import org.wso2.carbon.identity.api.server.notification.sender.v1.core.internal.CarbonOutputEventAdapterService;
+import org.wso2.carbon.identity.api.server.notification.sender.v1.core.internal.config.AdapterConfigs;
+import org.wso2.carbon.registry.core.service.RegistryService;
+import org.wso2.carbon.securevault.SecretCallbackHandlerService;
+import org.wso2.carbon.utils.ConfigurationContextService;
+
+/**
+ * Service holder class for Output Event Adapter Service.
+ */
+public class OutputEventAdapterServiceValueHolder {
+
+    private static CarbonOutputEventAdapterService carbonOutputEventAdapterService;
+    private static RegistryService registryService;
+    private static AdapterConfigs globalAdapterConfigs;
+    private static ConfigurationContextService configurationContextService;
+    private static SecretCallbackHandlerService secretCallbackHandlerService;
+
+    private OutputEventAdapterServiceValueHolder() {
+
+    }
+
+    public static CarbonOutputEventAdapterService getCarbonOutputEventAdapterService() {
+        return carbonOutputEventAdapterService;
+    }
+
+    public static void setCarbonOutputEventAdapterService
+            (CarbonOutputEventAdapterService carbonOutputEventAdapterService) {
+        OutputEventAdapterServiceValueHolder.carbonOutputEventAdapterService = carbonOutputEventAdapterService;
+    }
+
+    public static RegistryService getRegistryService() {
+        return registryService;
+    }
+
+    public static void setRegistryService(RegistryService registryService) {
+        OutputEventAdapterServiceValueHolder.registryService = registryService;
+    }
+
+    public static void setGlobalAdapterConfigs(AdapterConfigs globalAdapterConfigs) {
+        OutputEventAdapterServiceValueHolder.globalAdapterConfigs = globalAdapterConfigs;
+    }
+
+    public static AdapterConfigs getGlobalAdapterConfigs() {
+        return globalAdapterConfigs;
+    }
+
+    public static void setConfigurationContextService(ConfigurationContextService configurationContextService) {
+        OutputEventAdapterServiceValueHolder.configurationContextService = configurationContextService;
+    }
+
+    public static ConfigurationContextService getConfigurationContextService() {
+        return configurationContextService;
+    }
+
+    public static void setSecretCallbackHandlerService(SecretCallbackHandlerService secretCallbackHandlerService) {
+        OutputEventAdapterServiceValueHolder.secretCallbackHandlerService = secretCallbackHandlerService;
+    }
+
+    public static SecretCallbackHandlerService getSecretCallbackHandlerService() {
+        return secretCallbackHandlerService;
+    }
+}

--- a/components/org.wso2.carbon.identity.api.server.notification.sender/org.wso2.carbon.identity.api.server.notification.sender.v1/src/main/java/org/wso2/carbon/identity/api/server/notification/sender/v1/core/internal/util/EventAdapterConfigHelper.java
+++ b/components/org.wso2.carbon.identity.api.server.notification.sender/org.wso2.carbon.identity.api.server.notification.sender.v1/src/main/java/org/wso2/carbon/identity/api/server/notification/sender/v1/core/internal/util/EventAdapterConfigHelper.java
@@ -1,0 +1,214 @@
+/*
+ * Copyright (c) 2023, WSO2 Inc. (http://www.wso2.com).
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.notification.sender.v1.core.internal.util;
+
+
+import org.apache.axiom.om.OMAttribute;
+import org.apache.axiom.om.OMElement;
+import org.apache.axiom.om.impl.builder.StAXOMBuilder;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.xerces.impl.Constants;
+import org.apache.xerces.util.SecurityManager;
+import org.w3c.dom.Attr;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+import org.wso2.carbon.core.util.CryptoException;
+import org.wso2.carbon.identity.api.server.notification.sender.v1.core.exception.OutputEventAdapterException;
+import org.wso2.carbon.identity.api.server.notification.sender.v1.core.internal.EventAdapterConstants;
+import org.wso2.carbon.identity.api.server.notification.sender.v1.core.internal.config.AdapterConfigs;
+import org.wso2.carbon.identity.api.server.notification.sender.v1.core.internal.ds.OutputEventAdapterServiceValueHolder;
+import org.wso2.carbon.utils.CarbonUtils;
+import org.wso2.securevault.SecretResolver;
+import org.wso2.securevault.SecretResolverFactory;
+import org.wso2.securevault.commons.MiscellaneousUtil;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.util.Iterator;
+import javax.xml.bind.JAXBContext;
+import javax.xml.bind.JAXBException;
+import javax.xml.bind.Unmarshaller;
+import javax.xml.namespace.QName;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+
+/**
+ * This class contains utility methods used for event adapter configuration.
+ */
+public class EventAdapterConfigHelper {
+
+    private static final Log log = LogFactory.getLog(EventAdapterConfigHelper.class);
+    private static SecretResolver secretResolver;
+    private static final int ENTITY_EXPANSION_LIMIT = 0;
+
+    public static void secureResolveDocument(Document doc)
+            throws OutputEventAdapterException {
+        Element element = doc.getDocumentElement();
+        if (element != null) {
+            try {
+                secureLoadElement(element);
+            } catch (CryptoException e) {
+                throw new OutputEventAdapterException("Error in secure load of global output " +
+                        "event adapter properties: " + e.getMessage(), e);
+            }
+        }
+    }
+
+    public static void secureResolveOmElement(OMElement doc) throws OutputEventAdapterException {
+
+        if (doc != null) {
+            try {
+                secretResolver = SecretResolverFactory.create(doc, true);
+                secureLoadOMElement(doc);
+            } catch (CryptoException e) {
+                throw new OutputEventAdapterException("Error in secure load of global output event " +
+                        "adapter properties: " + e.getMessage(), e);
+            }
+        }
+    }
+
+    private static void secureLoadOMElement(OMElement element) throws CryptoException {
+
+        String alias = MiscellaneousUtil.getProtectedToken(element.getText());
+        if (alias != null && !alias.isEmpty()) {
+            element.setText(loadFromSecureVault(alias));
+        } else {
+            OMAttribute secureAttr = element.getAttribute(new QName(EventAdapterConstants.SECURE_VAULT_NS,
+                    EventAdapterConstants.SECRET_ALIAS_ATTR_NAME));
+            if (secureAttr != null) {
+                element.setText(loadFromSecureVault(secureAttr.getAttributeValue()));
+                element.removeAttribute(secureAttr);
+            }
+        }
+        Iterator<OMElement> childNodes = element.getChildElements();
+        while (childNodes.hasNext()) {
+            OMElement tmpNode = childNodes.next();
+            secureLoadOMElement(tmpNode);
+        }
+    }
+
+
+
+    public static Document convertToDocument(File file) throws OutputEventAdapterException {
+        DocumentBuilderFactory fac = getSecuredDocumentBuilder();
+        fac.setNamespaceAware(true);
+        try {
+            return fac.newDocumentBuilder().parse(file);
+        } catch (Exception e) {
+            throw new OutputEventAdapterException("Error in creating an XML document from file: " +
+                    e.getMessage(), e);
+        }
+    }
+
+    public static OMElement convertToOmElement(File file) throws OutputEventAdapterException {
+
+        try {
+            StAXOMBuilder builder = new StAXOMBuilder(new FileInputStream(file));
+            return builder.getDocumentElement();
+        } catch (Exception e) {
+            throw new OutputEventAdapterException("Error in creating an XML document from file: " +
+                    e.getMessage(), e);
+        }
+    }
+
+    private static DocumentBuilderFactory getSecuredDocumentBuilder() {
+
+                        DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+                dbf.setNamespaceAware(true);
+                dbf.setXIncludeAware(false);
+                dbf.setExpandEntityReferences(false);
+                try {
+                        dbf.setFeature(Constants.SAX_FEATURE_PREFIX +
+                                Constants.EXTERNAL_GENERAL_ENTITIES_FEATURE, false);
+                        dbf.setFeature(Constants.SAX_FEATURE_PREFIX +
+                                Constants.EXTERNAL_PARAMETER_ENTITIES_FEATURE, false);
+                        dbf.setFeature(Constants.XERCES_FEATURE_PREFIX +
+                                Constants.LOAD_EXTERNAL_DTD_FEATURE, false);
+                    } catch (ParserConfigurationException e) {
+                        log.error("Failed to load XML Processor Feature " + Constants.EXTERNAL_GENERAL_ENTITIES_FEATURE
+                                + " or " + Constants.EXTERNAL_PARAMETER_ENTITIES_FEATURE + " or "
+                                + Constants.LOAD_EXTERNAL_DTD_FEATURE);
+                    }
+
+                        SecurityManager securityManager = new SecurityManager();
+                securityManager.setEntityExpansionLimit(ENTITY_EXPANSION_LIMIT);
+                dbf.setAttribute(Constants.XERCES_PROPERTY_PREFIX + Constants.SECURITY_MANAGER_PROPERTY,
+                        securityManager);
+
+                        return dbf;
+            }
+
+    private static void secureLoadElement(Element element)
+            throws CryptoException {
+
+        Attr secureAttr = element.getAttributeNodeNS(EventAdapterConstants.SECURE_VAULT_NS,
+                EventAdapterConstants.SECRET_ALIAS_ATTR_NAME);
+        if (secureAttr != null) {
+            element.setTextContent(loadFromSecureVault(secureAttr.getValue()));
+            element.removeAttributeNode(secureAttr);
+        }
+        NodeList childNodes = element.getChildNodes();
+        int count = childNodes.getLength();
+        Node tmpNode;
+        for (int i = 0; i < count; i++) {
+            tmpNode = childNodes.item(i);
+            if (tmpNode instanceof Element) {
+                secureLoadElement((Element) tmpNode);
+            }
+        }
+    }
+
+    private static synchronized String loadFromSecureVault(String alias) {
+        if (secretResolver == null) {
+            secretResolver = SecretResolverFactory.create((OMElement) null, false);
+            secretResolver.init(OutputEventAdapterServiceValueHolder.
+                    getSecretCallbackHandlerService().getSecretCallbackHandler());
+        }
+        return secretResolver.resolve(alias);
+    }
+
+    public static AdapterConfigs loadGlobalConfigs() {
+
+        String path = CarbonUtils.getCarbonConfigDirPath() + File.separator
+                + EventAdapterConstants.GLOBAL_CONFIG_FILE_NAME;
+        try {
+            JAXBContext jaxbContext = JAXBContext.newInstance(AdapterConfigs.class);
+            Unmarshaller unmarshaller = jaxbContext.createUnmarshaller();
+
+            File configFile = new File(path);
+            if (!configFile.exists()) {
+                log.warn(EventAdapterConstants.GLOBAL_CONFIG_FILE_NAME + " can not found in " + path + "," +
+                        " hence Output Event Adapters will be running with default global configs.");
+            }
+            OMElement globalConfigDoc = convertToOmElement(configFile);
+            secureResolveOmElement(globalConfigDoc);
+            return (AdapterConfigs) unmarshaller.unmarshal(globalConfigDoc.getXMLStreamReader());
+        } catch (JAXBException e) {
+            log.error("Error in loading " + EventAdapterConstants.GLOBAL_CONFIG_FILE_NAME + " from " + path + "," +
+                    " hence Output Event Adapters will be running with default global configs.");
+        } catch (OutputEventAdapterException e) {
+            log.error("Error in converting " + EventAdapterConstants.GLOBAL_CONFIG_FILE_NAME + " to parsed document," +
+                    " hence Output Event Adapters will be running with default global configs.");
+        }
+        return new AdapterConfigs();
+    }
+}

--- a/components/org.wso2.carbon.identity.api.server.notification.sender/org.wso2.carbon.identity.api.server.notification.sender.v1/src/main/java/org/wso2/carbon/identity/api/server/notification/sender/v1/impl/NotificationSendersApiServiceImpl.java
+++ b/components/org.wso2.carbon.identity.api.server.notification.sender/org.wso2.carbon.identity.api.server.notification.sender.v1/src/main/java/org/wso2/carbon/identity/api/server/notification/sender/v1/impl/NotificationSendersApiServiceImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2023, WSO2 Inc. (http://www.wso2.com).
  *
  * WSO2 Inc. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -125,9 +125,6 @@ public class NotificationSendersApiServiceImpl implements NotificationSendersApi
     @Override
     public Response getEmailSenders() {
 
-        if (StringUtils.equals(getTenantDomainFromContext(), MultitenantConstants.SUPER_TENANT_DOMAIN_NAME)) {
-            return Response.status(Response.Status.METHOD_NOT_ALLOWED).build();
-        }
         return Response.ok().entity(notificationSenderManagementService.getEmailSenders()).build();
     }
 


### PR DESCRIPTION
Super tenant email sender configurations could be only added through deployment.toml. Hence that was not viewed in the console UI, and the get api was not allowed to process if the request is for carbon.super. With this update, we enable the get api and return the email sender configurations of super tenant and will be viewed in the console with a read only view.

Issue : https://github.com/wso2/product-is/issues/17488