### PR TITLE
Fix null pointer exceptions when no scopes are assigned to authorized APIs

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/ServerApplicationManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/ServerApplicationManagementService.java
@@ -1453,8 +1453,10 @@ public class ServerApplicationManagementService {
             if (currentAuthorizedAPI == null) {
                 throw buildClientError(ErrorMessage.AUTHORIZED_API_NOT_FOUND, apiId, applicationId);
             }
-            addedScopes.removeIf(scopeName -> currentAuthorizedAPI.getScopes().stream().anyMatch(scope ->
-                    scope.getName().equals(scopeName)));
+            if (currentAuthorizedAPI.getScopes() != null) {
+                addedScopes.removeIf(scopeName -> currentAuthorizedAPI.getScopes().stream().anyMatch(scope ->
+                        scope.getName().equals(scopeName)));
+            }
 
             getAuthorizedAPIManagementService().patchAuthorizedAPI(applicationId, apiId, addedScopes, removedScopes,
                     tenantDomain);


### PR DESCRIPTION
## Purpose
Fix null pointer exceptions when no scopes are assigned to authorized APIs

## Related Issues
- https://github.com/wso2/product-is/issues/18704

## Related PRs
- https://github.com/wso2/carbon-identity-framework/pull/5332
