### PR TITLE
Add passivests realm attribute to the application response

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/application/management/v1/ApplicationListItem.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/application/management/v1/ApplicationListItem.java
@@ -41,6 +41,7 @@ public class ApplicationListItem  {
     private String accessUrl;
     private String clientId;
     private String issuer;
+    private String realm;
 
 @XmlType(name="AccessEnum")
 @XmlEnum(String.class)
@@ -208,6 +209,24 @@ public enum AccessEnum {
 
     /**
     **/
+    public ApplicationListItem realm(String realm) {
+
+        this.realm = realm;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "PassiveSTSSampleApp", value = "")
+    @JsonProperty("realm")
+    @Valid
+    public String getRealm() {
+        return realm;
+    }
+    public void setRealm(String realm) {
+        this.realm = realm;
+    }
+
+    /**
+    **/
     public ApplicationListItem access(AccessEnum access) {
 
         this.access = access;
@@ -315,6 +334,7 @@ public enum AccessEnum {
             Objects.equals(this.accessUrl, applicationListItem.accessUrl) &&
             Objects.equals(this.clientId, applicationListItem.clientId) &&
             Objects.equals(this.issuer, applicationListItem.issuer) &&
+            Objects.equals(this.realm, applicationListItem.realm) &&
             Objects.equals(this.access, applicationListItem.access) &&
             Objects.equals(this.self, applicationListItem.self) &&
             Objects.equals(this.advancedConfigurations, applicationListItem.advancedConfigurations) &&
@@ -324,7 +344,7 @@ public enum AccessEnum {
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, name, description, image, accessUrl, clientId, issuer, access, self, advancedConfigurations, templateId, associatedRoles);
+        return Objects.hash(id, name, description, image, accessUrl, clientId, issuer, realm, access, self, advancedConfigurations, templateId, associatedRoles);
     }
 
     @Override
@@ -340,6 +360,7 @@ public enum AccessEnum {
         sb.append("    accessUrl: ").append(toIndentedString(accessUrl)).append("\n");
         sb.append("    clientId: ").append(toIndentedString(clientId)).append("\n");
         sb.append("    issuer: ").append(toIndentedString(issuer)).append("\n");
+        sb.append("    realm: ").append(toIndentedString(realm)).append("\n");
         sb.append("    access: ").append(toIndentedString(access)).append("\n");
         sb.append("    self: ").append(toIndentedString(self)).append("\n");
         sb.append("    advancedConfigurations: ").append(toIndentedString(advancedConfigurations)).append("\n");

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/application/management/v1/ApplicationResponseModel.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/application/management/v1/ApplicationResponseModel.java
@@ -47,6 +47,7 @@ public class ApplicationResponseModel  {
     private String accessUrl;
     private String clientId;
     private String issuer;
+    private String realm;
     private String templateId;
     private Boolean isManagementApp;
     private Boolean isB2BSelfServiceApp;
@@ -222,6 +223,24 @@ public enum AccessEnum {
 
     /**
     **/
+    public ApplicationResponseModel realm(String realm) {
+
+        this.realm = realm;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "PassiveSTSSampleApp", value = "")
+    @JsonProperty("realm")
+    @Valid
+    public String getRealm() {
+        return realm;
+    }
+    public void setRealm(String realm) {
+        this.realm = realm;
+    }
+
+    /**
+    **/
     public ApplicationResponseModel templateId(String templateId) {
 
         this.templateId = templateId;
@@ -265,12 +284,11 @@ public enum AccessEnum {
         this.isB2BSelfServiceApp = isB2BSelfServiceApp;
         return this;
     }
-
+    
     @ApiModelProperty(example = "false", value = "Decides whether the application used to for B2B self service")
     @JsonProperty("isB2BSelfServiceApp")
     @Valid
     public Boolean getIsB2BSelfServiceApp() {
-
         return isB2BSelfServiceApp;
     }
     public void setIsB2BSelfServiceApp(Boolean isB2BSelfServiceApp) {
@@ -430,6 +448,7 @@ public enum AccessEnum {
             Objects.equals(this.accessUrl, applicationResponseModel.accessUrl) &&
             Objects.equals(this.clientId, applicationResponseModel.clientId) &&
             Objects.equals(this.issuer, applicationResponseModel.issuer) &&
+            Objects.equals(this.realm, applicationResponseModel.realm) &&
             Objects.equals(this.templateId, applicationResponseModel.templateId) &&
             Objects.equals(this.isManagementApp, applicationResponseModel.isManagementApp) &&
             Objects.equals(this.isB2BSelfServiceApp, applicationResponseModel.isB2BSelfServiceApp) &&
@@ -444,7 +463,7 @@ public enum AccessEnum {
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, name, description, imageUrl, accessUrl, clientId, issuer, templateId, isManagementApp, isB2BSelfServiceApp, associatedRoles, claimConfiguration, inboundProtocols, authenticationSequence, advancedConfigurations, provisioningConfigurations, access);
+        return Objects.hash(id, name, description, imageUrl, accessUrl, clientId, issuer, realm, templateId, isManagementApp, isB2BSelfServiceApp, associatedRoles, claimConfiguration, inboundProtocols, authenticationSequence, advancedConfigurations, provisioningConfigurations, access);
     }
 
     @Override
@@ -460,6 +479,7 @@ public enum AccessEnum {
         sb.append("    accessUrl: ").append(toIndentedString(accessUrl)).append("\n");
         sb.append("    clientId: ").append(toIndentedString(clientId)).append("\n");
         sb.append("    issuer: ").append(toIndentedString(issuer)).append("\n");
+        sb.append("    realm: ").append(toIndentedString(realm)).append("\n");
         sb.append("    templateId: ").append(toIndentedString(templateId)).append("\n");
         sb.append("    isManagementApp: ").append(toIndentedString(isManagementApp)).append("\n");
         sb.append("    isB2BSelfServiceApp: ").append(toIndentedString(isB2BSelfServiceApp)).append("\n");

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/functions/application/ApplicationInfoWithRequiredPropsToApiModel.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/functions/application/ApplicationInfoWithRequiredPropsToApiModel.java
@@ -54,6 +54,7 @@ public class ApplicationInfoWithRequiredPropsToApiModel implements Function<Appl
                 .access(getAccessForApplicationListItems(applicationResponseModel.getName()))
                 .clientId(applicationResponseModel.getClientId())
                 .issuer(applicationResponseModel.getIssuer())
+                .realm(applicationResponseModel.getRealm())
                 .advancedConfigurations(getAdvancedConfigurations(applicationResponseModel))
                 .templateId(applicationResponseModel.getTemplateId())
                 .self(getApplicationLocation(applicationResponseModel.getId()))

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/functions/application/ServiceProviderToApiModel.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/functions/application/ServiceProviderToApiModel.java
@@ -122,6 +122,7 @@ public class ServiceProviderToApiModel implements Function<ServiceProvider, Appl
                     .accessUrl(application.getAccessUrl())
                     .clientId(getInboundKey(application, "oauth2"))
                     .issuer(getInboundKey(application, "samlsso"))
+                    .realm(getInboundKey(application, "passivests"))
                     .templateId(application.getTemplateId())
                     .isManagementApp(application.isManagementApp())
                     .associatedRoles(buildAssociatedRoles(application))
@@ -564,8 +565,10 @@ public class ServiceProviderToApiModel implements Function<ServiceProvider, Appl
                     .getInboundAuthenticationRequestConfigs();
 
             if (authRequestConfigs != null && authRequestConfigs.length > 0) {
-                if (authRequestConfigs[0].getInboundAuthType().equals(authType)) {
-                    return authRequestConfigs[0].getInboundAuthKey();
+                for (InboundAuthenticationRequestConfig authRequestConfig: authRequestConfigs) {
+                    if (authRequestConfig.getInboundAuthType().equals(authType)) {
+                        return authRequestConfig.getInboundAuthKey();
+                    }
                 }
             }
         }

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/resources/applications.yaml
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/resources/applications.yaml
@@ -2813,6 +2813,9 @@ components:
         issuer:
           type: string
           example: 'http://idp.example.com/metadata.php'
+        realm:
+          type: string
+          example: 'PassiveSTSSampleApp'
         access:
           type: string
           enum:
@@ -2828,8 +2831,8 @@ components:
           type: string
           example: "980b8tester24c64a8a09a0d80abf8c337bd2555"
         associatedRoles:
-           type: object
-           $ref: '#/components/schemas/AssociatedRolesConfig'
+          type: object
+          $ref: '#/components/schemas/AssociatedRolesConfig'
     ApplicationModel:
       type: object
       required:
@@ -2903,6 +2906,9 @@ components:
         issuer:
           type: string
           example: 'http://idp.example.com/metadata.php'
+        realm:
+          type: string
+          example: 'PassiveSTSSampleApp'
         templateId:
           type: string
           example: "adwefi2429asdfdf94444rraf44"


### PR DESCRIPTION
## Purpose
> $subject
> This PR will help to identify legacy applications(Which has multiple inbound authenticators configured) where the application response will show the configured inbound auth type respective attributes(clinetid, issuer, realm).

## Related Issue
- https://github.com/wso2/product-is/issues/14950

## Related PR
- https://github.com/wso2/identity-apps/pull/5195
