### PR TITLE
Change `AUDIT` `CARBON` uri endpoints to `audit` and `carbon`

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.common/src/main/java/org/wso2/carbon/identity/api/server/configs/common/Constants.java
+++ b/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.common/src/main/java/org/wso2/carbon/identity/api/server/configs/common/Constants.java
@@ -50,6 +50,8 @@ public class Constants {
 
     public static final String AUDIT = "AUDIT";
     public static final String CARBON = "CARBON";
+    public static final String AUDIT_LOWER_CASE = "audit";
+    public static final String CARBON_LOWER_CASE = "carbon";
 
     /**
      * PATCH operation path for Private Key JWT Validation configuration.
@@ -137,7 +139,7 @@ public class Constants {
 
         ERROR_CODE_INVALID_LOG_TYPE_FOR_REMOTE_LOGGING_CONFIG("60507",
                 "Invalid log type provided remote logging config service",
-                "Remote logging configuration service only supports AUDIT or CARBON."),
+                "Remote logging configuration service only supports audit or carbon."),
         ERROR_CODE_REMOTE_LOGGING_CONFIG_NOT_FOUND("60508",
                 "Resource not found.",
                 "Unable to find a resource matching the provided log type %s."),

--- a/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.common/src/main/java/org/wso2/carbon/identity/api/server/configs/common/Constants.java
+++ b/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.common/src/main/java/org/wso2/carbon/identity/api/server/configs/common/Constants.java
@@ -50,8 +50,6 @@ public class Constants {
 
     public static final String AUDIT = "AUDIT";
     public static final String CARBON = "CARBON";
-    public static final String AUDIT_LOWER_CASE = "audit";
-    public static final String CARBON_LOWER_CASE = "carbon";
 
     /**
      * PATCH operation path for Private Key JWT Validation configuration.
@@ -139,7 +137,7 @@ public class Constants {
 
         ERROR_CODE_INVALID_LOG_TYPE_FOR_REMOTE_LOGGING_CONFIG("60507",
                 "Invalid log type provided remote logging config service",
-                "Remote logging configuration service only supports audit or carbon."),
+                "Remote logging configuration service only supports AUDIT or CARBON."),
         ERROR_CODE_REMOTE_LOGGING_CONFIG_NOT_FOUND("60508",
                 "Resource not found.",
                 "Unable to find a resource matching the provided log type %s."),

--- a/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.common/src/main/java/org/wso2/carbon/identity/api/server/configs/common/Constants.java
+++ b/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.common/src/main/java/org/wso2/carbon/identity/api/server/configs/common/Constants.java
@@ -48,8 +48,8 @@ public class Constants {
     public static final String CORS_CONFIG_SUPPORTS_CREDENTIALS_PATH_REGEX = "^/supportsCredentials$";
     public static final String CORS_CONFIG_MAX_AGE_PATH_REGEX = "^/maxAge$";
 
-    public static final String AUDIT = "AUDIT";
-    public static final String CARBON = "CARBON";
+    public static final String AUDIT = "audit";
+    public static final String CARBON = "carbon";
 
     /**
      * PATCH operation path for Private Key JWT Validation configuration.
@@ -137,7 +137,7 @@ public class Constants {
 
         ERROR_CODE_INVALID_LOG_TYPE_FOR_REMOTE_LOGGING_CONFIG("60507",
                 "Invalid log type provided remote logging config service",
-                "Remote logging configuration service only supports AUDIT or CARBON."),
+                "Remote logging configuration service only supports audit or carbon."),
         ERROR_CODE_REMOTE_LOGGING_CONFIG_NOT_FOUND("60508",
                 "Resource not found.",
                 "Unable to find a resource matching the provided log type %s."),

--- a/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.common/src/main/java/org/wso2/carbon/identity/api/server/configs/common/Constants.java
+++ b/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.common/src/main/java/org/wso2/carbon/identity/api/server/configs/common/Constants.java
@@ -48,8 +48,8 @@ public class Constants {
     public static final String CORS_CONFIG_SUPPORTS_CREDENTIALS_PATH_REGEX = "^/supportsCredentials$";
     public static final String CORS_CONFIG_MAX_AGE_PATH_REGEX = "^/maxAge$";
 
-    public static final String AUDIT = "audit";
-    public static final String CARBON = "carbon";
+    public static final String AUDIT = "AUDIT";
+    public static final String CARBON = "CARBON";
 
     /**
      * PATCH operation path for Private Key JWT Validation configuration.
@@ -137,7 +137,7 @@ public class Constants {
 
         ERROR_CODE_INVALID_LOG_TYPE_FOR_REMOTE_LOGGING_CONFIG("60507",
                 "Invalid log type provided remote logging config service",
-                "Remote logging configuration service only supports audit or carbon."),
+                "Remote logging configuration service only supports AUDIT or CARBON."),
         ERROR_CODE_REMOTE_LOGGING_CONFIG_NOT_FOUND("60508",
                 "Resource not found.",
                 "Unable to find a resource matching the provided log type %s."),

--- a/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/main/java/org/wso2/carbon/identity/api/server/configs/v1/core/ServerConfigManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/main/java/org/wso2/carbon/identity/api/server/configs/v1/core/ServerConfigManagementService.java
@@ -482,7 +482,6 @@ public class ServerConfigManagementService {
 
         RemoteServerLoggerData remoteServerLoggerData = new RemoteServerLoggerData();
 
-        logType = logType.toUpperCase();
         validateLogType(logType);
         remoteServerLoggerData.setLogType(logType);
 
@@ -566,7 +565,6 @@ public class ServerConfigManagementService {
         validateTenantDomain(tenantDomain, "Resetting remote server configuration service is not available for %s");
 
         RemoteServerLoggerData remoteServerLoggerData = getRemoteServerLoggerData(remoteLoggingConfig);
-        logType = logType.toUpperCase();
         validateLogType(logType);
         remoteServerLoggerData.setLogType(logType);
 
@@ -1180,8 +1178,7 @@ public class ServerConfigManagementService {
         String tenantDomain = ContextLoader.getTenantDomainFromContext();
         validateTenantDomain(tenantDomain, "Getting remote server configuration service is not available for %s");
         try {
-            return ConfigsServiceHolder.getInstance().getRemoteLoggingConfigService().getRemoteServerConfig(
-                    logType.toUpperCase());
+            return ConfigsServiceHolder.getInstance().getRemoteLoggingConfigService().getRemoteServerConfig(logType);
         } catch (ConfigurationException e) {
             throw handleException(Response.Status.INTERNAL_SERVER_ERROR,
                     Constants.ErrorMessage.ERROR_CODE_ERROR_GETTING_REMOTE_LOGGING_CONFIGS, null);

--- a/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/main/java/org/wso2/carbon/identity/api/server/configs/v1/core/ServerConfigManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/main/java/org/wso2/carbon/identity/api/server/configs/v1/core/ServerConfigManagementService.java
@@ -92,6 +92,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -482,6 +483,7 @@ public class ServerConfigManagementService {
 
         RemoteServerLoggerData remoteServerLoggerData = new RemoteServerLoggerData();
 
+        logType = logType.toUpperCase(Locale.ENGLISH);
         validateLogType(logType);
         remoteServerLoggerData.setLogType(logType);
 
@@ -565,6 +567,7 @@ public class ServerConfigManagementService {
         validateTenantDomain(tenantDomain, "Resetting remote server configuration service is not available for %s");
 
         RemoteServerLoggerData remoteServerLoggerData = getRemoteServerLoggerData(remoteLoggingConfig);
+        logType = logType.toUpperCase(Locale.ENGLISH);
         validateLogType(logType);
         remoteServerLoggerData.setLogType(logType);
 
@@ -1178,7 +1181,8 @@ public class ServerConfigManagementService {
         String tenantDomain = ContextLoader.getTenantDomainFromContext();
         validateTenantDomain(tenantDomain, "Getting remote server configuration service is not available for %s");
         try {
-            return ConfigsServiceHolder.getInstance().getRemoteLoggingConfigService().getRemoteServerConfig(logType);
+            return ConfigsServiceHolder.getInstance().getRemoteLoggingConfigService().getRemoteServerConfig(
+                    logType.toUpperCase(Locale.ENGLISH));
         } catch (ConfigurationException e) {
             throw handleException(Response.Status.INTERNAL_SERVER_ERROR,
                     Constants.ErrorMessage.ERROR_CODE_ERROR_GETTING_REMOTE_LOGGING_CONFIGS, null);

--- a/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/main/java/org/wso2/carbon/identity/api/server/configs/v1/core/ServerConfigManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/main/java/org/wso2/carbon/identity/api/server/configs/v1/core/ServerConfigManagementService.java
@@ -484,7 +484,7 @@ public class ServerConfigManagementService {
         RemoteServerLoggerData remoteServerLoggerData = new RemoteServerLoggerData();
 
         validateLogType(logType);
-        // Backend logic supports logType in Uppercase.
+        // Backend logic only supports logType in Uppercase.
         remoteServerLoggerData.setLogType(logType.toUpperCase(Locale.ENGLISH));
 
         try {
@@ -568,7 +568,7 @@ public class ServerConfigManagementService {
 
         RemoteServerLoggerData remoteServerLoggerData = getRemoteServerLoggerData(remoteLoggingConfig);
         validateLogType(logType);
-        // Backend logic supports logType in Uppercase.
+        // Backend logic only supports logType in Uppercase.
         remoteServerLoggerData.setLogType(logType.toUpperCase(Locale.ENGLISH));
 
         try {
@@ -1182,7 +1182,7 @@ public class ServerConfigManagementService {
         validateTenantDomain(tenantDomain, "Getting remote server configuration service is not available for %s");
         validateLogType(logType);
         try {
-            // Backend logic supports logType in Uppercase.
+            // Backend logic only supports logType in Uppercase.
             return ConfigsServiceHolder.getInstance().getRemoteLoggingConfigService().getRemoteServerConfig(
                     logType.toUpperCase(Locale.ENGLISH));
         } catch (ConfigurationException e) {

--- a/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/main/java/org/wso2/carbon/identity/api/server/configs/v1/core/ServerConfigManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/main/java/org/wso2/carbon/identity/api/server/configs/v1/core/ServerConfigManagementService.java
@@ -482,6 +482,7 @@ public class ServerConfigManagementService {
 
         RemoteServerLoggerData remoteServerLoggerData = new RemoteServerLoggerData();
 
+        logType = logType.toUpperCase();
         validateLogType(logType);
         remoteServerLoggerData.setLogType(logType);
 
@@ -565,6 +566,7 @@ public class ServerConfigManagementService {
         validateTenantDomain(tenantDomain, "Resetting remote server configuration service is not available for %s");
 
         RemoteServerLoggerData remoteServerLoggerData = getRemoteServerLoggerData(remoteLoggingConfig);
+        logType = logType.toUpperCase();
         validateLogType(logType);
         remoteServerLoggerData.setLogType(logType);
 
@@ -1178,7 +1180,8 @@ public class ServerConfigManagementService {
         String tenantDomain = ContextLoader.getTenantDomainFromContext();
         validateTenantDomain(tenantDomain, "Getting remote server configuration service is not available for %s");
         try {
-            return ConfigsServiceHolder.getInstance().getRemoteLoggingConfigService().getRemoteServerConfig(logType);
+            return ConfigsServiceHolder.getInstance().getRemoteLoggingConfigService().getRemoteServerConfig(
+                    logType.toUpperCase());
         } catch (ConfigurationException e) {
             throw handleException(Response.Status.INTERNAL_SERVER_ERROR,
                     Constants.ErrorMessage.ERROR_CODE_ERROR_GETTING_REMOTE_LOGGING_CONFIGS, null);

--- a/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/main/java/org/wso2/carbon/identity/api/server/configs/v1/core/ServerConfigManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/main/java/org/wso2/carbon/identity/api/server/configs/v1/core/ServerConfigManagementService.java
@@ -466,8 +466,8 @@ public class ServerConfigManagementService {
      */
     public void resetRemoteServerConfig() {
 
-        resetRemoteServerConfig(Constants.AUDIT_LOWER_CASE);
-        resetRemoteServerConfig(Constants.CARBON_LOWER_CASE);
+        resetRemoteServerConfig(Constants.AUDIT);
+        resetRemoteServerConfig(Constants.CARBON);
     }
 
     /**
@@ -483,7 +483,7 @@ public class ServerConfigManagementService {
         RemoteServerLoggerData remoteServerLoggerData = new RemoteServerLoggerData();
 
         validateLogType(logType);
-        remoteServerLoggerData.setLogType(resolveLogType(logType));
+        remoteServerLoggerData.setLogType(logType);
 
         try {
             ConfigsServiceHolder.getInstance().getRemoteLoggingConfigService()
@@ -509,22 +509,10 @@ public class ServerConfigManagementService {
 
     private void validateLogType(String logType) {
 
-        if (!Constants.AUDIT_LOWER_CASE.equals(logType) && !Constants.CARBON_LOWER_CASE.equals(logType)) {
+        if (!Constants.AUDIT.equals(logType) && !Constants.CARBON.equals(logType)) {
             throw handleException(Response.Status.BAD_REQUEST, Constants.ErrorMessage
                     .ERROR_CODE_INVALID_LOG_TYPE_FOR_REMOTE_LOGGING_CONFIG, null);
         }
-    }
-
-    private String resolveLogType(String logType) {
-
-        switch (logType) {
-            case Constants.AUDIT_LOWER_CASE:
-                return Constants.AUDIT;
-            case Constants.CARBON_LOWER_CASE:
-                return Constants.CARBON;
-        }
-        throw handleException(Response.Status.BAD_REQUEST, Constants.ErrorMessage
-                .ERROR_CODE_INVALID_LOG_TYPE_FOR_REMOTE_LOGGING_CONFIG, null);
     }
 
     /**
@@ -578,7 +566,7 @@ public class ServerConfigManagementService {
 
         RemoteServerLoggerData remoteServerLoggerData = getRemoteServerLoggerData(remoteLoggingConfig);
         validateLogType(logType);
-        remoteServerLoggerData.setLogType(resolveLogType(logType));
+        remoteServerLoggerData.setLogType(logType);
 
         try {
             ConfigsServiceHolder.getInstance().getRemoteLoggingConfigService()
@@ -1190,8 +1178,7 @@ public class ServerConfigManagementService {
         String tenantDomain = ContextLoader.getTenantDomainFromContext();
         validateTenantDomain(tenantDomain, "Getting remote server configuration service is not available for %s");
         try {
-            return ConfigsServiceHolder.getInstance().getRemoteLoggingConfigService()
-                    .getRemoteServerConfig(resolveLogType(logType));
+            return ConfigsServiceHolder.getInstance().getRemoteLoggingConfigService().getRemoteServerConfig(logType);
         } catch (ConfigurationException e) {
             throw handleException(Response.Status.INTERNAL_SERVER_ERROR,
                     Constants.ErrorMessage.ERROR_CODE_ERROR_GETTING_REMOTE_LOGGING_CONFIGS, null);

--- a/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/main/java/org/wso2/carbon/identity/api/server/configs/v1/core/ServerConfigManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/main/java/org/wso2/carbon/identity/api/server/configs/v1/core/ServerConfigManagementService.java
@@ -466,8 +466,8 @@ public class ServerConfigManagementService {
      */
     public void resetRemoteServerConfig() {
 
-        resetRemoteServerConfig(Constants.AUDIT);
-        resetRemoteServerConfig(Constants.CARBON);
+        resetRemoteServerConfig(Constants.AUDIT_LOWER_CASE);
+        resetRemoteServerConfig(Constants.CARBON_LOWER_CASE);
     }
 
     /**
@@ -483,7 +483,7 @@ public class ServerConfigManagementService {
         RemoteServerLoggerData remoteServerLoggerData = new RemoteServerLoggerData();
 
         validateLogType(logType);
-        remoteServerLoggerData.setLogType(logType);
+        remoteServerLoggerData.setLogType(resolveLogType(logType));
 
         try {
             ConfigsServiceHolder.getInstance().getRemoteLoggingConfigService()
@@ -509,10 +509,22 @@ public class ServerConfigManagementService {
 
     private void validateLogType(String logType) {
 
-        if (!Constants.AUDIT.equals(logType) && !Constants.CARBON.equals(logType)) {
+        if (!Constants.AUDIT_LOWER_CASE.equals(logType) && !Constants.CARBON_LOWER_CASE.equals(logType)) {
             throw handleException(Response.Status.BAD_REQUEST, Constants.ErrorMessage
                     .ERROR_CODE_INVALID_LOG_TYPE_FOR_REMOTE_LOGGING_CONFIG, null);
         }
+    }
+
+    private String resolveLogType(String logType) {
+
+        switch (logType) {
+            case Constants.AUDIT_LOWER_CASE:
+                return Constants.AUDIT;
+            case Constants.CARBON_LOWER_CASE:
+                return Constants.CARBON;
+        }
+        throw handleException(Response.Status.BAD_REQUEST, Constants.ErrorMessage
+                .ERROR_CODE_INVALID_LOG_TYPE_FOR_REMOTE_LOGGING_CONFIG, null);
     }
 
     /**
@@ -566,7 +578,7 @@ public class ServerConfigManagementService {
 
         RemoteServerLoggerData remoteServerLoggerData = getRemoteServerLoggerData(remoteLoggingConfig);
         validateLogType(logType);
-        remoteServerLoggerData.setLogType(logType);
+        remoteServerLoggerData.setLogType(resolveLogType(logType));
 
         try {
             ConfigsServiceHolder.getInstance().getRemoteLoggingConfigService()
@@ -1178,7 +1190,8 @@ public class ServerConfigManagementService {
         String tenantDomain = ContextLoader.getTenantDomainFromContext();
         validateTenantDomain(tenantDomain, "Getting remote server configuration service is not available for %s");
         try {
-            return ConfigsServiceHolder.getInstance().getRemoteLoggingConfigService().getRemoteServerConfig(logType);
+            return ConfigsServiceHolder.getInstance().getRemoteLoggingConfigService()
+                    .getRemoteServerConfig(resolveLogType(logType));
         } catch (ConfigurationException e) {
             throw handleException(Response.Status.INTERNAL_SERVER_ERROR,
                     Constants.ErrorMessage.ERROR_CODE_ERROR_GETTING_REMOTE_LOGGING_CONFIGS, null);

--- a/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/main/java/org/wso2/carbon/identity/api/server/configs/v1/core/ServerConfigManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/main/java/org/wso2/carbon/identity/api/server/configs/v1/core/ServerConfigManagementService.java
@@ -483,9 +483,9 @@ public class ServerConfigManagementService {
 
         RemoteServerLoggerData remoteServerLoggerData = new RemoteServerLoggerData();
 
-        logType = logType.toUpperCase(Locale.ENGLISH);
         validateLogType(logType);
-        remoteServerLoggerData.setLogType(logType);
+        // Backend logic supports logType in Uppercase.
+        remoteServerLoggerData.setLogType(logType.toUpperCase(Locale.ENGLISH));
 
         try {
             ConfigsServiceHolder.getInstance().getRemoteLoggingConfigService()
@@ -567,9 +567,9 @@ public class ServerConfigManagementService {
         validateTenantDomain(tenantDomain, "Resetting remote server configuration service is not available for %s");
 
         RemoteServerLoggerData remoteServerLoggerData = getRemoteServerLoggerData(remoteLoggingConfig);
-        logType = logType.toUpperCase(Locale.ENGLISH);
         validateLogType(logType);
-        remoteServerLoggerData.setLogType(logType);
+        // Backend logic supports logType in Uppercase.
+        remoteServerLoggerData.setLogType(logType.toUpperCase(Locale.ENGLISH));
 
         try {
             ConfigsServiceHolder.getInstance().getRemoteLoggingConfigService()
@@ -1180,7 +1180,9 @@ public class ServerConfigManagementService {
 
         String tenantDomain = ContextLoader.getTenantDomainFromContext();
         validateTenantDomain(tenantDomain, "Getting remote server configuration service is not available for %s");
+        validateLogType(logType);
         try {
+            // Backend logic supports logType in Uppercase.
             return ConfigsServiceHolder.getInstance().getRemoteLoggingConfigService().getRemoteServerConfig(
                     logType.toUpperCase(Locale.ENGLISH));
         } catch (ConfigurationException e) {

--- a/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/main/java/org/wso2/carbon/identity/api/server/configs/v1/impl/ConfigsApiServiceImpl.java
+++ b/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/main/java/org/wso2/carbon/identity/api/server/configs/v1/impl/ConfigsApiServiceImpl.java
@@ -19,6 +19,7 @@
 package org.wso2.carbon.identity.api.server.configs.v1.impl;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.wso2.carbon.identity.api.server.configs.common.Constants;
 import org.wso2.carbon.identity.api.server.configs.v1.ConfigsApiService;
 import org.wso2.carbon.identity.api.server.configs.v1.core.ServerConfigManagementService;
 import org.wso2.carbon.identity.api.server.configs.v1.model.CORSPatch;
@@ -28,6 +29,7 @@ import org.wso2.carbon.identity.api.server.configs.v1.model.JWTKeyValidatorPatch
 import org.wso2.carbon.identity.api.server.configs.v1.model.Patch;
 import org.wso2.carbon.identity.api.server.configs.v1.model.RemoteLoggingConfig;
 import org.wso2.carbon.identity.api.server.configs.v1.model.RemoteLoggingConfigListItem;
+import org.wso2.carbon.identity.api.server.configs.v1.model.RemoteLoggingConfigListItem.LogTypeEnum;
 import org.wso2.carbon.identity.api.server.configs.v1.model.ScimConfig;
 import org.wso2.carbon.logging.service.data.RemoteServerLoggerData;
 
@@ -216,9 +218,19 @@ public class ConfigsApiServiceImpl implements ConfigsApiService {
         remoteLoggingConfigListItem.setKeystorePassword(remoteServerLoggerData.getKeystorePassword());
         remoteLoggingConfigListItem.setTruststoreLocation(remoteServerLoggerData.getTruststoreLocation());
         remoteLoggingConfigListItem.setTruststorePassword(remoteServerLoggerData.getTruststorePassword());
-        remoteLoggingConfigListItem.setLogType(
-                RemoteLoggingConfigListItem.LogTypeEnum.valueOf(remoteServerLoggerData.getLogType()));
+        remoteLoggingConfigListItem.setLogType(getLogType(remoteServerLoggerData));
         return remoteLoggingConfigListItem;
+    }
+
+    private RemoteLoggingConfigListItem.LogTypeEnum getLogType(RemoteServerLoggerData remoteServerLoggerData) {
+
+        switch (remoteServerLoggerData.getLogType()) {
+            case Constants.AUDIT:
+                return LogTypeEnum.AUDIT;
+            case Constants.CARBON:
+                return LogTypeEnum.CARBON;
+        }
+        return null;
     }
 
     private RemoteLoggingConfig createRemoteLoggingConfig(

--- a/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/main/java/org/wso2/carbon/identity/api/server/configs/v1/impl/ConfigsApiServiceImpl.java
+++ b/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/main/java/org/wso2/carbon/identity/api/server/configs/v1/impl/ConfigsApiServiceImpl.java
@@ -19,7 +19,6 @@
 package org.wso2.carbon.identity.api.server.configs.v1.impl;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.wso2.carbon.identity.api.server.configs.common.Constants;
 import org.wso2.carbon.identity.api.server.configs.v1.ConfigsApiService;
 import org.wso2.carbon.identity.api.server.configs.v1.core.ServerConfigManagementService;
 import org.wso2.carbon.identity.api.server.configs.v1.model.CORSPatch;
@@ -29,7 +28,6 @@ import org.wso2.carbon.identity.api.server.configs.v1.model.JWTKeyValidatorPatch
 import org.wso2.carbon.identity.api.server.configs.v1.model.Patch;
 import org.wso2.carbon.identity.api.server.configs.v1.model.RemoteLoggingConfig;
 import org.wso2.carbon.identity.api.server.configs.v1.model.RemoteLoggingConfigListItem;
-import org.wso2.carbon.identity.api.server.configs.v1.model.RemoteLoggingConfigListItem.LogTypeEnum;
 import org.wso2.carbon.identity.api.server.configs.v1.model.ScimConfig;
 import org.wso2.carbon.logging.service.data.RemoteServerLoggerData;
 
@@ -218,19 +216,9 @@ public class ConfigsApiServiceImpl implements ConfigsApiService {
         remoteLoggingConfigListItem.setKeystorePassword(remoteServerLoggerData.getKeystorePassword());
         remoteLoggingConfigListItem.setTruststoreLocation(remoteServerLoggerData.getTruststoreLocation());
         remoteLoggingConfigListItem.setTruststorePassword(remoteServerLoggerData.getTruststorePassword());
-        remoteLoggingConfigListItem.setLogType(getLogType(remoteServerLoggerData));
+        remoteLoggingConfigListItem.setLogType(
+                RemoteLoggingConfigListItem.LogTypeEnum.valueOf(remoteServerLoggerData.getLogType()));
         return remoteLoggingConfigListItem;
-    }
-
-    private RemoteLoggingConfigListItem.LogTypeEnum getLogType(RemoteServerLoggerData remoteServerLoggerData) {
-
-        switch (remoteServerLoggerData.getLogType()) {
-            case Constants.AUDIT:
-                return LogTypeEnum.AUDIT;
-            case Constants.CARBON:
-                return LogTypeEnum.CARBON;
-        }
-        return null;
     }
 
     private RemoteLoggingConfig createRemoteLoggingConfig(


### PR DESCRIPTION
## Purpose
> Add changes suggested in https://github.com/wso2/product-is/issues/18853#issuecomment-1884616761

After this, 
https://localhost:9443/t/carbon.super/api/server/v1/configs/remote-logging/AUDIT can only be accessible by https://localhost:9443/t/carbon.super/api/server/v1/configs/remote-logging/audit 

https://localhost:9443/t/carbon.super/api/server/v1/configs/remote-logging/CARBON can only be accessible by https://localhost:9443/t/carbon.super/api/server/v1/configs/remote-logging/carbon

## Related PRs
- https://github.com/wso2/identity-apps/pull/5244