### PR TITLE
Remove Empty check for IDP issuer name to support update function in console IDP page.

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/main/java/org/wso2/carbon/identity/api/server/idp/v1/core/ServerIdpManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/main/java/org/wso2/carbon/identity/api/server/idp/v1/core/ServerIdpManagementService.java
@@ -2124,12 +2124,11 @@ public class ServerIdpManagementService {
             jwksProperty.setValue(idpJWKSUri);
             idpProperties.add(jwksProperty);
         }
-        if (StringUtils.isNotEmpty(identityProviderPOSTRequest.getIdpIssuerName())) {
-            IdentityProviderProperty idpIssuerProperty = new IdentityProviderProperty();
-            idpIssuerProperty.setName(Constants.IDP_ISSUER_NAME);
-            idpIssuerProperty.setValue(identityProviderPOSTRequest.getIdpIssuerName());
-            idpProperties.add(idpIssuerProperty);
-        }
+        // IDP issuer name can be empty. Hence, no need to check for blank value.
+        IdentityProviderProperty idpIssuerProperty = new IdentityProviderProperty();
+        idpIssuerProperty.setName(Constants.IDP_ISSUER_NAME);
+        idpIssuerProperty.setValue(identityProviderPOSTRequest.getIdpIssuerName());
+        idpProperties.add(idpIssuerProperty);
         idp.setIdpProperties(idpProperties.toArray(new IdentityProviderProperty[0]));
         return idp;
     }


### PR DESCRIPTION
This PR will remove the empty check added for IDP issuer name when being added as an IDP property into the IDP object because, the issuer name can be empty for an IDP if it is not explicitly provided.

Related issue:
- https://github.com/wso2/product-is/issues/19013