### PR TITLE
Set BLOB as the property type of Google Outbound Provisioning Private Key

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.common/src/main/java/org/wso2/carbon/identity/api/server/idp/common/Constants.java
+++ b/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.common/src/main/java/org/wso2/carbon/identity/api/server/idp/common/Constants.java
@@ -72,6 +72,7 @@ public class Constants {
     public static final String GROUPS = "groups";
     public static final String FEDERATED_AUTHENTICATORS = "federatedAuthenticators";
     public static final String PROVISIONING = "provisioning";
+    public static final String GOOGLE_PRIVATE_KEY = "google_prov_private_key";
 
     // IdP template property keys
     public static final String PROP_CATEGORY = "category";

--- a/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/main/java/org/wso2/carbon/identity/api/server/idp/v1/core/ServerIdpManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/main/java/org/wso2/carbon/identity/api/server/idp/v1/core/ServerIdpManagementService.java
@@ -161,6 +161,7 @@ import static org.wso2.carbon.identity.api.server.common.Constants.YAML_FILE_EXT
 import static org.wso2.carbon.identity.api.server.common.Util.base64URLDecode;
 import static org.wso2.carbon.identity.api.server.common.Util.base64URLEncode;
 import static org.wso2.carbon.identity.api.server.idp.common.Constants.ErrorMessage.ERROR_CODE_IDP_LIMIT_REACHED;
+import static org.wso2.carbon.identity.api.server.idp.common.Constants.GOOGLE_PRIVATE_KEY;
 import static org.wso2.carbon.identity.api.server.idp.common.Constants.IDP_PATH_COMPONENT;
 import static org.wso2.carbon.identity.api.server.idp.common.Constants.IDP_TEMPLATE_PATH_COMPONENT;
 import static org.wso2.carbon.identity.api.server.idp.common.Constants.PROP_CATEGORY;
@@ -2053,6 +2054,9 @@ public class ServerIdpManagementService {
         Property property = new Property();
         property.setName(apiProperty.getKey());
         property.setValue(apiProperty.getValue());
+        if (StringUtils.equals(GOOGLE_PRIVATE_KEY, apiProperty.getKey())) {
+            property.setType(IdentityApplicationConstants.ConfigElements.PROPERTY_TYPE_BLOB);
+        }
         return property;
     };
 


### PR DESCRIPTION
## Purpose
Resolves https://github.com/wso2/product-is/issues/19049

## Approach
- When creating/updating the IDP via managemnt console, from the SOAP requests we are setting the property type of `google_prov_private_key` as a BLOB and due to that we are saving it as a BLOB.[1]

- But when we creating/updating the IDP via new console, form the API server we didn't set the property type for the `google_prov_private_key` and due to that we are getting below error 
    `Value too long for column "PROPERTY_VALUE CHARACTER VARYING(2048)`

- So set BLOB as the property type of Google Outbound Provisioning Private Key.


[1] https://github.com/wso2/carbon-identity-framework/blob/610b6a595cb865320720b3884b188507dcc5587b/components/idp-mgt/org.wso2.carbon.idp.mgt.ui/src/main/java/org/wso2/carbon/idp/mgt/ui/util/IdPManagementUIUtil.java#L483-L488