### PR TITLE
Add deprecate tag to organization self service API

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.organization.selfservice/org.wso2.carbon.identity.api.server.organization.selfservice.v1/src/main/resources/self.service.yaml
+++ b/components/org.wso2.carbon.identity.api.server.organization.selfservice/org.wso2.carbon.identity.api.server.organization.selfservice.v1/src/main/resources/self.service.yaml
@@ -23,6 +23,7 @@ security:
 paths:
   /self-service/preferences:
     patch:
+      deprecated: true
       description:
         This API provides the capability to update properties related to self service for an organization<br>
         <b>Permission required:</b> <br>
@@ -54,6 +55,7 @@ paths:
       tags:
         - SelfService
     get:
+      deprecated: true
       description:
         This API provides the capability to retrieve properties related to self service <br>
         <b>Permission required:</b> <br>


### PR DESCRIPTION
## Purpose

- Add deprecate tag to organization self service API since the API.

### Related Issue
- https://github.com/wso2/product-is/issues/19071