### PR TITLE
Update scopes of APIs related to API resources in applications

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/resources/applications.yaml
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/resources/applications.yaml
@@ -762,9 +762,9 @@ paths:
       description: |
         This API provides the capability to delete an authorized API of the application.<br>
           <b>Permission required:</b> <br>
-              * /permission/admin/manage/identity/applicationmgt/delete <br>
+              * /permission/admin/manage/identity/applicationmgt/update <br>
           <b>Scope required:</b> <br>
-              * internal_application_mgt_delete
+              * internal_application_mgt_update
       parameters:
         - name: applicationId
           in: path


### PR DESCRIPTION
$subject

Related issue:
- https://github.com/wso2/product-is/issues/19240

Note:
The scope of API to add API authorization to an app has already defined as `internal_application_mgt_update`. Hence, no changes were done to that.