### PR TITLE
Fix email template type retrieval bug

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.email.template/org.wso2.carbon.identity.rest.api.server.email.template.v2/src/main/java/org/wso2/carbon/identity/rest/api/server/email/template/v2/core/ServerEmailTemplatesService.java
+++ b/components/org.wso2.carbon.identity.api.server.email.template/org.wso2.carbon.identity.rest.api.server.email.template.v2/src/main/java/org/wso2/carbon/identity/rest/api/server/email/template/v2/core/ServerEmailTemplatesService.java
@@ -124,6 +124,15 @@ public class ServerEmailTemplatesService {
         EmailTemplateTypeWithID emailTemplateTypeWithID = new EmailTemplateTypeWithID();
         String decodedTemplateTypeId = decodeTemplateTypeId(templateTypeId);
 
+        try {
+            if (!EmailTemplatesServiceHolder.getEmailTemplateManager()
+                    .isEmailTemplateTypeExists(decodedTemplateTypeId, getTenantDomainFromContext())) {
+                throw handleError(Constants.ErrorMessage.ERROR_EMAIL_TEMPLATE_TYPE_NOT_FOUND);
+            }
+        } catch (I18nEmailMgtException e) {
+            throw handleI18nEmailMgtException(e, Constants.ErrorMessage.ERROR_RETRIEVING_EMAIL_TEMPLATE_TYPE);
+        }
+
         emailTemplateTypeWithID.setId(templateTypeId);
         emailTemplateTypeWithID.setDisplayName(decodedTemplateTypeId);
         emailTemplateTypeWithID.setSelf(getTemplateTypeLocation(templateTypeId));


### PR DESCRIPTION
### Description
Email template type retrieval should check if the template type exists as a resource before returning.

### Related issue
- https://github.com/wso2/product-is/issues/20045