### PR TITLE
Add application config for impersonation

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/application/management/v1/OpenIDConnectConfiguration.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/application/management/v1/OpenIDConnectConfiguration.java
@@ -85,6 +85,7 @@ public enum StateEnum {
     private OAuth2PKCEConfiguration pkce;
     private AccessTokenConfiguration accessToken;
     private RefreshTokenConfiguration refreshToken;
+    private SubjectTokenConfiguration subjectToken;
     private IdTokenConfiguration idToken;
     private OIDCLogoutConfiguration logout;
     private Boolean validateRequestObjectSignature = false;
@@ -304,6 +305,24 @@ public enum StateEnum {
 
     /**
     **/
+    public OpenIDConnectConfiguration subjectToken(SubjectTokenConfiguration subjectToken) {
+
+        this.subjectToken = subjectToken;
+        return this;
+    }
+
+    @ApiModelProperty(value = "")
+    @JsonProperty("subjectToken")
+    @Valid
+    public SubjectTokenConfiguration getSubjectToken() {
+        return subjectToken;
+    }
+    public void setSubjectToken(SubjectTokenConfiguration subjectToken) {
+        this.subjectToken = subjectToken;
+    }
+
+    /**
+    **/
     public OpenIDConnectConfiguration idToken(IdTokenConfiguration idToken) {
 
         this.idToken = idToken;
@@ -511,6 +530,7 @@ public enum StateEnum {
             Objects.equals(this.pkce, openIDConnectConfiguration.pkce) &&
             Objects.equals(this.accessToken, openIDConnectConfiguration.accessToken) &&
             Objects.equals(this.refreshToken, openIDConnectConfiguration.refreshToken) &&
+            Objects.equals(this.subjectToken, openIDConnectConfiguration.subjectToken) &&
             Objects.equals(this.idToken, openIDConnectConfiguration.idToken) &&
             Objects.equals(this.logout, openIDConnectConfiguration.logout) &&
             Objects.equals(this.validateRequestObjectSignature, openIDConnectConfiguration.validateRequestObjectSignature) &&
@@ -525,7 +545,7 @@ public enum StateEnum {
 
     @Override
     public int hashCode() {
-        return Objects.hash(clientId, clientSecret, state, grantTypes, callbackURLs, allowedOrigins, publicClient, pkce, accessToken, refreshToken, idToken, logout, validateRequestObjectSignature, scopeValidators, clientAuthentication, requestObject, pushAuthorizationRequest, subject, isFAPIApplication, fapiMetadata);
+        return Objects.hash(clientId, clientSecret, state, grantTypes, callbackURLs, allowedOrigins, publicClient, pkce, accessToken, refreshToken, subjectToken, idToken, logout, validateRequestObjectSignature, scopeValidators, clientAuthentication, requestObject, pushAuthorizationRequest, subject, isFAPIApplication, fapiMetadata);
     }
 
     @Override
@@ -544,6 +564,7 @@ public enum StateEnum {
         sb.append("    pkce: ").append(toIndentedString(pkce)).append("\n");
         sb.append("    accessToken: ").append(toIndentedString(accessToken)).append("\n");
         sb.append("    refreshToken: ").append(toIndentedString(refreshToken)).append("\n");
+        sb.append("    subjectToken: ").append(toIndentedString(subjectToken)).append("\n");
         sb.append("    idToken: ").append(toIndentedString(idToken)).append("\n");
         sb.append("    logout: ").append(toIndentedString(logout)).append("\n");
         sb.append("    validateRequestObjectSignature: ").append(toIndentedString(validateRequestObjectSignature)).append("\n");

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/application/management/v1/SubjectTokenConfiguration.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/application/management/v1/SubjectTokenConfiguration.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.application.management.v1;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import javax.validation.constraints.*;
+
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+import javax.validation.Valid;
+import javax.xml.bind.annotation.*;
+
+public class SubjectTokenConfiguration  {
+  
+    private Boolean enable;
+    private Integer applicationSubjectTokenExpiryInSeconds;
+
+    /**
+    * If enabled, subject token can be issued for token exchange grant type.
+    **/
+    public SubjectTokenConfiguration enable(Boolean enable) {
+
+        this.enable = enable;
+        return this;
+    }
+    
+    @ApiModelProperty(value = "If enabled, subject token can be issued for token exchange grant type.")
+    @JsonProperty("enable")
+    @Valid
+    public Boolean getEnable() {
+        return enable;
+    }
+    public void setEnable(Boolean enable) {
+        this.enable = enable;
+    }
+
+    /**
+    **/
+    public SubjectTokenConfiguration applicationSubjectTokenExpiryInSeconds(Integer applicationSubjectTokenExpiryInSeconds) {
+
+        this.applicationSubjectTokenExpiryInSeconds = applicationSubjectTokenExpiryInSeconds;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "3600", value = "")
+    @JsonProperty("applicationSubjectTokenExpiryInSeconds")
+    @Valid
+    public Integer getApplicationSubjectTokenExpiryInSeconds() {
+        return applicationSubjectTokenExpiryInSeconds;
+    }
+    public void setApplicationSubjectTokenExpiryInSeconds(Integer applicationSubjectTokenExpiryInSeconds) {
+        this.applicationSubjectTokenExpiryInSeconds = applicationSubjectTokenExpiryInSeconds;
+    }
+
+
+
+    @Override
+    public boolean equals(java.lang.Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        SubjectTokenConfiguration subjectTokenConfiguration = (SubjectTokenConfiguration) o;
+        return Objects.equals(this.enable, subjectTokenConfiguration.enable) &&
+            Objects.equals(this.applicationSubjectTokenExpiryInSeconds, subjectTokenConfiguration.applicationSubjectTokenExpiryInSeconds);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(enable, applicationSubjectTokenExpiryInSeconds);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class SubjectTokenConfiguration {\n");
+        
+        sb.append("    enable: ").append(toIndentedString(enable)).append("\n");
+        sb.append("    applicationSubjectTokenExpiryInSeconds: ").append(toIndentedString(applicationSubjectTokenExpiryInSeconds)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+    * Convert the given object to string with each line indented by 4 spaces
+    * (except the first line).
+    */
+    private String toIndentedString(java.lang.Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}
+

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/functions/application/inbound/oauth2/ApiModelToOAuthConsumerApp.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/functions/application/inbound/oauth2/ApiModelToOAuthConsumerApp.java
@@ -27,6 +27,7 @@ import org.wso2.carbon.identity.api.server.application.management.v1.PushAuthori
 import org.wso2.carbon.identity.api.server.application.management.v1.RefreshTokenConfiguration;
 import org.wso2.carbon.identity.api.server.application.management.v1.RequestObjectConfiguration;
 import org.wso2.carbon.identity.api.server.application.management.v1.SubjectConfiguration;
+import org.wso2.carbon.identity.api.server.application.management.v1.SubjectTokenConfiguration;
 import org.wso2.carbon.identity.api.server.application.management.v1.core.functions.Utils;
 import org.wso2.carbon.identity.oauth.common.OAuthConstants;
 import org.wso2.carbon.identity.oauth.dto.OAuthConsumerAppDTO;
@@ -72,6 +73,7 @@ public class ApiModelToOAuthConsumerApp implements ApiModelToOAuthConsumerAppFun
         updatePARConfigurations(consumerAppDTO, oidcModel.getPushAuthorizationRequest());
         updateSubjectConfigurations(consumerAppDTO, oidcModel.getSubject());
         consumerAppDTO.setFapiConformanceEnabled(oidcModel.getIsFAPIApplication());
+        updateSubjectTokenConfigurations(consumerAppDTO, oidcModel.getSubjectToken());
 
         return consumerAppDTO;
     }
@@ -231,6 +233,15 @@ public class ApiModelToOAuthConsumerApp implements ApiModelToOAuthConsumerAppFun
         if (subject != null) {
             consumerAppDTO.setSubjectType(subject.getSubjectType());
             consumerAppDTO.setSectorIdentifierURI(subject.getSectorIdentifierUri());
+        }
+    }
+
+    private void updateSubjectTokenConfigurations(OAuthConsumerAppDTO consumerAppDTO,
+                                                  SubjectTokenConfiguration subjectToken) {
+
+        if (subjectToken != null) {
+            consumerAppDTO.setSubjectTokenEnabled(subjectToken.getEnable());
+            consumerAppDTO.setSubjectTokenExpiryTime(subjectToken.getApplicationSubjectTokenExpiryInSeconds());
         }
     }
 }

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/functions/application/inbound/oauth2/OAuthConsumerAppToApiModel.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/functions/application/inbound/oauth2/OAuthConsumerAppToApiModel.java
@@ -28,6 +28,7 @@ import org.wso2.carbon.identity.api.server.application.management.v1.RefreshToke
 import org.wso2.carbon.identity.api.server.application.management.v1.RequestObjectConfiguration;
 import org.wso2.carbon.identity.api.server.application.management.v1.RequestObjectEncryptionConfiguration;
 import org.wso2.carbon.identity.api.server.application.management.v1.SubjectConfiguration;
+import org.wso2.carbon.identity.api.server.application.management.v1.SubjectTokenConfiguration;
 import org.wso2.carbon.identity.oauth.dto.OAuthConsumerAppDTO;
 
 import java.util.ArrayList;
@@ -63,7 +64,8 @@ public class OAuthConsumerAppToApiModel implements Function<OAuthConsumerAppDTO,
                 .requestObject(buildRequestObjectConfiguration(oauthAppDTO))
                 .pushAuthorizationRequest(buildPARAuthenticationConfiguration(oauthAppDTO))
                 .subject(buildSubjectConfiguration(oauthAppDTO))
-                .isFAPIApplication(oauthAppDTO.isFapiConformanceEnabled());
+                .isFAPIApplication(oauthAppDTO.isFapiConformanceEnabled())
+                .subjectToken(buildSubjectTokenConfiguration(oauthAppDTO));
     }
 
     private List<String> getScopeValidators(OAuthConsumerAppDTO oauthAppDTO) {
@@ -200,5 +202,12 @@ public class OAuthConsumerAppToApiModel implements Function<OAuthConsumerAppDTO,
         return new SubjectConfiguration()
                 .subjectType(oAuthConsumerAppDTO.getSubjectType())
                 .sectorIdentifierUri(oAuthConsumerAppDTO.getSectorIdentifierURI());
+    }
+
+    private SubjectTokenConfiguration buildSubjectTokenConfiguration(OAuthConsumerAppDTO oAuthConsumerAppDTO) {
+
+        return new SubjectTokenConfiguration()
+                .enable(oAuthConsumerAppDTO.isSubjectTokenEnabled())
+                .applicationSubjectTokenExpiryInSeconds(oAuthConsumerAppDTO.getSubjectTokenExpiryTime());
     }
 }

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/resources/applications.yaml
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/resources/applications.yaml
@@ -3561,6 +3561,8 @@ components:
           $ref: '#/components/schemas/AccessTokenConfiguration'
         refreshToken:
           $ref: '#/components/schemas/RefreshTokenConfiguration'
+        subjectToken:
+          $ref: '#/components/schemas/SubjectTokenConfiguration'
         idToken:
           $ref: '#/components/schemas/IdTokenConfiguration'
         logout:
@@ -3637,6 +3639,15 @@ components:
           description: Decides whether the refresh token needs to be renewed during refresh grant flow.
           type: boolean
           example: true
+    SubjectTokenConfiguration:
+      type: object
+      properties:
+        enable:
+          type: boolean
+          description: "If enabled, subject token can be issued for token exchange grant type."
+        applicationSubjectTokenExpiryInSeconds:
+          type: integer
+          example: 3600
     IdTokenConfiguration:
       type: object
       properties:

--- a/pom.xml
+++ b/pom.xml
@@ -796,7 +796,7 @@
         <findsecbugs-plugin.version>1.12.0</findsecbugs-plugin.version>
         <maven.checkstyleplugin.excludes>**/gen/**/*</maven.checkstyleplugin.excludes>
         <identity.event.handler.version>1.8.7</identity.event.handler.version>
-        <identity.inbound.oauth2.version>7.0.65</identity.inbound.oauth2.version>
+        <identity.inbound.oauth2.version>7.0.75</identity.inbound.oauth2.version>
         <identity.inbound.saml2.version>5.11.41</identity.inbound.saml2.version>
         <commons.beanutils.version>1.9.4</commons.beanutils.version>
         <mavan.findbugsplugin.exclude.file>findbugs-exclude-filter.xml</mavan.findbugsplugin.exclude.file>


### PR DESCRIPTION
Public Issue: https://github.com/wso2/product-is/issues/20066

## Purpose
Each application should have 2 properties to store following configurations
- isSubjectTokenEnabled
- subjectTokenExpiryTime

## Approach
We decided to use inbound protocol properties to store it. in this way, these properties will be stored in IDN_OIDC_PROPERTY table. This PR will addressed the REST API improvement for this fix.

Need to merge [ this PR first.](https://github.com/wso2-extensions/identity-inbound-auth-oauth/pull/2447)