### PR TITLE
AssociatedRolesConfig null check is only required when getting list of roles

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/functions/application/UpdateAssociatedRoles.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/functions/application/UpdateAssociatedRoles.java
@@ -36,13 +36,15 @@ public class UpdateAssociatedRoles implements UpdateFunction<ServiceProvider, As
 
         org.wso2.carbon.identity.application.common.model.AssociatedRolesConfig rolesConfig =
                 new org.wso2.carbon.identity.application.common.model.AssociatedRolesConfig();
-        if (associatedRolesConfig != null && associatedRolesConfig.getRoles() != null) {
+        if (associatedRolesConfig != null) {
             rolesConfig.setAllowedAudience(associatedRolesConfig.getAllowedAudience().toString());
-            List<org.wso2.carbon.identity.application.common.model.RoleV2> listOfRoles =
-                    associatedRolesConfig.getRoles().stream()
-                            .map(role -> new org.wso2.carbon.identity.application.common.model.RoleV2(role.getId()))
-                            .collect(Collectors.toList());
-            rolesConfig.setRoles(listOfRoles.toArray(new RoleV2[0]));
+            if (associatedRolesConfig.getRoles() != null) {
+                List<org.wso2.carbon.identity.application.common.model.RoleV2> listOfRoles =
+                        associatedRolesConfig.getRoles().stream()
+                                .map(role -> new org.wso2.carbon.identity.application.common.model.RoleV2(role.getId()))
+                                .collect(Collectors.toList());
+                rolesConfig.setRoles(listOfRoles.toArray(new RoleV2[0]));
+            }
         }
         serviceProvider.setAssociatedRolesConfig(rolesConfig);
     }


### PR DESCRIPTION
The null check for associatedRolesConfig was restricting the rolesConfig from being updated. Hence the null check is moved to only when trying to get the list of roles