### PR TITLE
Block IDP creation with the name SSO

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/main/java/org/wso2/carbon/identity/api/server/idp/v1/core/ServerIdpManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/main/java/org/wso2/carbon/identity/api/server/idp/v1/core/ServerIdpManagementService.java
@@ -246,6 +246,7 @@ public class ServerIdpManagementService {
 
         IdentityProvider identityProvider;
         try {
+            validateSystemReservedIDP(identityProviderPOSTRequest.getName());
             identityProvider = IdentityProviderServiceHolder.getIdentityProviderManager().addIdPWithResourceId(
                     createIDP(identityProviderPOSTRequest), ContextLoader.getTenantDomainFromContext());
         } catch (IdentityProviderManagementException e) {
@@ -3801,6 +3802,14 @@ public class ServerIdpManagementService {
         } catch (JsonProcessingException e) {
             throw new IdentityProviderManagementClientException(String.format("Error in reading JSON " +
                     "file configuration for Identity Provider: %s.", fileContent.getFileName()), e);
+        }
+    }
+
+    private void validateSystemReservedIDP(String idpName) throws IdentityProviderManagementClientException {
+
+        if (FrameworkConstants.ORGANIZATION_LOGIN_IDP_NAME.equals(idpName)) {
+            throw new IdentityProviderManagementClientException(String.format("The Connection with name %s is " +
+                    "a system reserved name.", idpName));
         }
     }
 }

--- a/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/main/java/org/wso2/carbon/identity/api/server/idp/v1/core/ServerIdpManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/main/java/org/wso2/carbon/identity/api/server/idp/v1/core/ServerIdpManagementService.java
@@ -299,6 +299,7 @@ public class ServerIdpManagementService {
             }
             IdentityProvider idpToUpdate = createIdPClone(identityProvider);
             processPatchRequest(patchRequest, idpToUpdate);
+            validateSystemReservedIDP(idpToUpdate.getIdentityProviderName());
             IdentityProvider updatedIdP = IdentityProviderServiceHolder.getIdentityProviderManager()
                     .updateIdPByResourceId(identityProviderId, idpToUpdate,
                             ContextLoader.getTenantDomainFromContext());

--- a/pom.xml
+++ b/pom.xml
@@ -791,7 +791,7 @@
         <maven.buildnumber.plugin.version>1.4</maven.buildnumber.plugin.version>
         <org.apache.felix.annotations.version>1.2.4</org.apache.felix.annotations.version>
         <identity.governance.version>1.8.62</identity.governance.version>
-        <carbon.identity.framework.version>7.2.23</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.2.35</carbon.identity.framework.version>
         <maven.findbugsplugin.version>3.0.5</maven.findbugsplugin.version>
         <findsecbugs-plugin.version>1.12.0</findsecbugs-plugin.version>
         <maven.checkstyleplugin.excludes>**/gen/**/*</maven.checkstyleplugin.excludes>


### PR DESCRIPTION
## Purpose
> The SSO IDP name is used for the organization sso authenticator which is used for the B2B login flows.

### Related Issues
- https://github.com/wso2/product-is/issues/20445