### PR TITLE
[Impersonation] Tenant wise config for impersonation

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.common/pom.xml
+++ b/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.common/pom.xml
@@ -68,6 +68,11 @@
             <scope>compile</scope>
         </dependency>
         <dependency>
+            <groupId>org.wso2.carbon.identity.inbound.auth.oauth2</groupId>
+            <artifactId>org.wso2.carbon.identity.oauth</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>org.wso2.carbon.commons</groupId>
             <artifactId>org.wso2.carbon.logging.service</artifactId>
             <scope>provided</scope>

--- a/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.common/src/main/java/org/wso2/carbon/identity/api/server/configs/common/ConfigsServiceHolder.java
+++ b/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.common/src/main/java/org/wso2/carbon/identity/api/server/configs/common/ConfigsServiceHolder.java
@@ -19,6 +19,7 @@ package org.wso2.carbon.identity.api.server.configs.common;
 import org.wso2.carbon.identity.application.mgt.ApplicationManagementService;
 import org.wso2.carbon.identity.cors.mgt.core.CORSManagementService;
 import org.wso2.carbon.identity.oauth.dcr.DCRConfigurationMgtService;
+import org.wso2.carbon.identity.oauth2.impersonation.services.ImpersonationConfigMgtService;
 import org.wso2.carbon.idp.mgt.IdentityProviderManager;
 import org.wso2.carbon.logging.service.RemoteLoggingConfigService;
 
@@ -33,6 +34,7 @@ public class ConfigsServiceHolder {
     private IdentityProviderManager identityProviderManager;
     private CORSManagementService corsManagementService;
     private RemoteLoggingConfigService remoteLoggingConfigService;
+    private ImpersonationConfigMgtService impersonationConfigMgtService;
     private DCRConfigurationMgtService dcrConfigurationMgtService;
 
     private ConfigsServiceHolder() {}
@@ -138,5 +140,25 @@ public class ConfigsServiceHolder {
     public void setDcrConfigurationMgtService(DCRConfigurationMgtService dcrConfigurationMgtService) {
 
         ConfigsServiceHolder.getInstance().dcrConfigurationMgtService = dcrConfigurationMgtService;
+    }
+
+    /**
+     * Get Impersonation Config Mgt osgi service.
+     *
+     * @return RemoteLoggingConfigService
+     */
+    public ImpersonationConfigMgtService getImpersonationConfigMgtService() {
+
+        return ConfigsServiceHolder.getInstance().impersonationConfigMgtService;
+    }
+
+    /**
+     * Set  Impersonation Config Mgt osgi service.
+     *
+     * @param impersonationConfigMgtService ImpersonationConfigMgtService.
+     */
+    public void setImpersonationConfigMgtService(ImpersonationConfigMgtService impersonationConfigMgtService) {
+
+        ConfigsServiceHolder.getInstance().impersonationConfigMgtService = impersonationConfigMgtService;
     }
 }

--- a/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.common/src/main/java/org/wso2/carbon/identity/api/server/configs/common/Constants.java
+++ b/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.common/src/main/java/org/wso2/carbon/identity/api/server/configs/common/Constants.java
@@ -57,6 +57,11 @@ public class Constants {
     public static final String PRIVATE_KEY_JWT_VALIDATION_CONFIG_TOKEN_REUSE = "/enableTokenReuse";
 
     /**
+     * PATCH operation path for Impersonation configuration.
+     */
+    public static final String IMPERSONATION_CONFIG_ENABLE_EMAIL_NOTIFICATION = "/enableEmailNotification";
+
+    /**
      * PATCH operation paths for DCR configuration.
      */
     public static final String DCR_CONFIG_ENABLE_FAPI_ENFORCEMENT = "/enableFapiEnforcement";
@@ -185,7 +190,14 @@ public class Constants {
                 "Server encountered an error while retrieving the Passive STS inbound auth configs."),
         ERROR_CODE_ERROR_PASSIVE_STS_INBOUND_AUTH_CONFIG_UPDATE("65016",
                 "Unable to update Passive STS inbound auth configs.",
-                "Server encountered an error while updating the Passive STS inbound auth configs.");
+                "Server encountered an error while updating the Passive STS inbound auth configs."),
+        ERROR_CODE_IMP_CONFIG_RETRIEVE("65018",
+                "Unable to retrieve Impersonation configuration.",
+                "Server encountered an error while retrieving the Impersonation configuration of %s."),
+
+        ERROR_CODE_IMP_CONFIG_UPDATE("65019",
+                "Unable to update Impersonation configuration.",
+                "Server encountered an error while updating the Impersonation configuration of %s.");
 
         private final String code;
         private final String message;

--- a/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.common/src/main/java/org/wso2/carbon/identity/api/server/configs/common/Constants.java
+++ b/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.common/src/main/java/org/wso2/carbon/identity/api/server/configs/common/Constants.java
@@ -194,7 +194,6 @@ public class Constants {
         ERROR_CODE_IMP_CONFIG_RETRIEVE("65018",
                 "Unable to retrieve Impersonation configuration.",
                 "Server encountered an error while retrieving the Impersonation configuration of %s."),
-
         ERROR_CODE_IMP_CONFIG_UPDATE("65019",
                 "Unable to update Impersonation configuration.",
                 "Server encountered an error while updating the Impersonation configuration of %s.");

--- a/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.common/src/main/java/org/wso2/carbon/identity/api/server/configs/common/factory/ImpersonationMgtOGSiServiceFactory.java
+++ b/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.common/src/main/java/org/wso2/carbon/identity/api/server/configs/common/factory/ImpersonationMgtOGSiServiceFactory.java
@@ -1,17 +1,19 @@
 /*
- * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
- *                                                                         
- * Licensed under the Apache License, Version 2.0 (the "License");         
- * you may not use this file except in compliance with the License.        
- * You may obtain a copy of the License at                                 
- *                                                                         
- * http://www.apache.org/licenses/LICENSE-2.0                              
- *                                                                         
- * Unless required by applicable law or agreed to in writing, software     
- * distributed under the License is distributed on an "AS IS" BASIS,       
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and     
- * limitations under the License.
+ * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 
 package org.wso2.carbon.identity.api.server.configs.common.factory;

--- a/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.common/src/main/java/org/wso2/carbon/identity/api/server/configs/common/factory/ImpersonationMgtOGSiServiceFactory.java
+++ b/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.common/src/main/java/org/wso2/carbon/identity/api/server/configs/common/factory/ImpersonationMgtOGSiServiceFactory.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *                                                                         
+ * Licensed under the Apache License, Version 2.0 (the "License");         
+ * you may not use this file except in compliance with the License.        
+ * You may obtain a copy of the License at                                 
+ *                                                                         
+ * http://www.apache.org/licenses/LICENSE-2.0                              
+ *                                                                         
+ * Unless required by applicable law or agreed to in writing, software     
+ * distributed under the License is distributed on an "AS IS" BASIS,       
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and     
+ * limitations under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.configs.common.factory;
+
+import org.springframework.beans.factory.config.AbstractFactoryBean;
+import org.wso2.carbon.context.PrivilegedCarbonContext;
+import org.wso2.carbon.identity.oauth2.impersonation.services.ImpersonationConfigMgtService;
+
+/**
+ * Factory bean for creating instances of ImpersonationConfigMgtService.
+ */
+public class ImpersonationMgtOGSiServiceFactory extends AbstractFactoryBean<ImpersonationConfigMgtService> {
+
+    private ImpersonationConfigMgtService impersonationConfigMgtService;
+
+    /**
+     * Specifies the type of object that this FactoryBean creates.
+     *
+     * @return The type of object created by this FactoryBean.
+     */
+    @Override
+    public Class<?> getObjectType() {
+
+        return Object.class;
+    }
+
+    /**
+     * Creates an instance of ImpersonationConfigMgtService.
+     *
+     * @return The created ImpersonationConfigMgtService instance.
+     * @throws Exception If there is an error while creating the instance.
+     */
+    @Override
+    protected ImpersonationConfigMgtService createInstance() throws Exception {
+        // Check if the service instance has already been created.
+        if (this.impersonationConfigMgtService == null) {
+            // Attempt to retrieve the ImpersonationConfigMgtService instance from OSGi services.
+            ImpersonationConfigMgtService taskOperationService =
+                    (ImpersonationConfigMgtService) PrivilegedCarbonContext.getThreadLocalCarbonContext()
+                            .getOSGiService(ImpersonationConfigMgtService.class, null);
+            // If the service instance is retrieved successfully, store it in the instance variable.
+            if (taskOperationService != null) {
+                this.impersonationConfigMgtService = taskOperationService;
+            } else {
+                // If the service instance cannot be retrieved, throw an exception.
+                throw new Exception("Unable to retrieve ImpersonationConfigMgtService service.");
+            }
+        }
+        // Return the stored ImpersonationConfigMgtService instance.
+        return this.impersonationConfigMgtService;
+    }
+}

--- a/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/gen/java/org/wso2/carbon/identity/api/server/configs/v1/ConfigsApi.java
+++ b/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/gen/java/org/wso2/carbon/identity/api/server/configs/v1/ConfigsApi.java
@@ -31,6 +31,8 @@ import org.wso2.carbon.identity.api.server.configs.v1.model.CORSPatch;
 import org.wso2.carbon.identity.api.server.configs.v1.model.DCRConfig;
 import org.wso2.carbon.identity.api.server.configs.v1.model.DCRPatch;
 import org.wso2.carbon.identity.api.server.configs.v1.model.Error;
+import org.wso2.carbon.identity.api.server.configs.v1.model.ImpersonationConfiguration;
+import org.wso2.carbon.identity.api.server.configs.v1.model.ImpersonationPatch;
 import org.wso2.carbon.identity.api.server.configs.v1.model.InboundAuthPassiveSTSConfig;
 import org.wso2.carbon.identity.api.server.configs.v1.model.InboundAuthSAML2Config;
 import org.wso2.carbon.identity.api.server.configs.v1.model.JWTKeyValidatorPatch;
@@ -154,6 +156,30 @@ public class ConfigsApi  {
     public Response getHomeRealmIdentifiers() {
 
         return delegate.getHomeRealmIdentifiers();
+    }
+
+    @Valid
+    @GET
+    @Path("/impersonation")
+    
+    @Produces({ "application/json" })
+    @ApiOperation(value = "Retrieve the tenant impersonation configuration.", notes = "Retrieve the tenant impersonation configuration.", response = ImpersonationConfiguration.class, authorizations = {
+        @Authorization(value = "BasicAuth"),
+        @Authorization(value = "OAuth2", scopes = {
+            
+        })
+    }, tags={ "Impersonation Configurations", })
+    @ApiResponses(value = { 
+        @ApiResponse(code = 200, message = "Successful Response", response = ImpersonationConfiguration.class),
+        @ApiResponse(code = 400, message = "Bad Request", response = Error.class),
+        @ApiResponse(code = 401, message = "Unauthorized", response = Void.class),
+        @ApiResponse(code = 403, message = "Forbidden", response = Void.class),
+        @ApiResponse(code = 404, message = "Not Found", response = Error.class),
+        @ApiResponse(code = 500, message = "Server Error", response = Error.class)
+    })
+    public Response getImpersonationConfiguration() {
+
+        return delegate.getImpersonationConfiguration();
     }
 
     @Valid
@@ -443,6 +469,30 @@ public class ConfigsApi  {
     public Response patchConfigs(@ApiParam(value = "" ,required=true) @Valid List<Patch> patch) {
 
         return delegate.patchConfigs(patch );
+    }
+
+    @Valid
+    @PATCH
+    @Path("/impersonation")
+    @Consumes({ "application/json" })
+    @Produces({ "application/json" })
+    @ApiOperation(value = "Patch the tenant impersonation configuration.", notes = "Patch the tenant impersonation configuration.  A JSONPatch as defined by RFC 6902.", response = Void.class, authorizations = {
+        @Authorization(value = "BasicAuth"),
+        @Authorization(value = "OAuth2", scopes = {
+
+        })
+    }, tags={ "Impersonation Configurations", })
+    @ApiResponses(value = {
+        @ApiResponse(code = 200, message = "Successful Response", response = Void.class),
+        @ApiResponse(code = 400, message = "Bad Request", response = Error.class),
+        @ApiResponse(code = 401, message = "Unauthorized", response = Void.class),
+        @ApiResponse(code = 403, message = "Forbidden", response = Void.class),
+        @ApiResponse(code = 404, message = "Not Found", response = Error.class),
+        @ApiResponse(code = 500, message = "Server Error", response = Error.class)
+    })
+    public Response patchImpersonationConfiguration(@ApiParam(value = "" ,required=true) @Valid List<ImpersonationPatch> impersonationPatch) {
+
+        return delegate.patchImpersonationConfiguration(impersonationPatch );
     }
 
     @Valid

--- a/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/gen/java/org/wso2/carbon/identity/api/server/configs/v1/ConfigsApiService.java
+++ b/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/gen/java/org/wso2/carbon/identity/api/server/configs/v1/ConfigsApiService.java
@@ -29,6 +29,7 @@ import org.wso2.carbon.identity.api.server.configs.v1.model.AuthenticatorListIte
 import org.wso2.carbon.identity.api.server.configs.v1.model.CORSConfig;
 import org.wso2.carbon.identity.api.server.configs.v1.model.CORSPatch;
 import org.wso2.carbon.identity.api.server.configs.v1.model.Error;
+import org.wso2.carbon.identity.api.server.configs.v1.model.ImpersonationPatch;
 import org.wso2.carbon.identity.api.server.configs.v1.model.InboundAuthPassiveSTSConfig;
 import org.wso2.carbon.identity.api.server.configs.v1.model.InboundAuthSAML2Config;
 import org.wso2.carbon.identity.api.server.configs.v1.model.JWTKeyValidatorPatch;
@@ -54,6 +55,8 @@ public interface ConfigsApiService {
 
       public Response getHomeRealmIdentifiers();
 
+      public Response getImpersonationConfiguration();
+
       public Response getInboundScimConfigs();
 
       public Response getPassiveSTSInboundAuthConfig();
@@ -76,6 +79,8 @@ public interface ConfigsApiService {
       public Response patchCORSConfiguration(List<CORSPatch> coRSPatch);
 
       public Response patchConfigs(List<Patch> patch);
+
+      public Response patchImpersonationConfiguration(List<ImpersonationPatch> impersonationPatch);
 
       public Response patchPrivatKeyJWTValidationConfiguration(List<JWTKeyValidatorPatch> jwTKeyValidatorPatch);
 

--- a/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/gen/java/org/wso2/carbon/identity/api/server/configs/v1/model/ImpersonationConfiguration.java
+++ b/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/gen/java/org/wso2/carbon/identity/api/server/configs/v1/model/ImpersonationConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except

--- a/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/gen/java/org/wso2/carbon/identity/api/server/configs/v1/model/ImpersonationConfiguration.java
+++ b/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/gen/java/org/wso2/carbon/identity/api/server/configs/v1/model/ImpersonationConfiguration.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.configs.v1.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import javax.validation.constraints.*;
+
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+import javax.validation.Valid;
+import javax.xml.bind.annotation.*;
+
+public class ImpersonationConfiguration  {
+  
+    private Boolean enableEmailNotification;
+
+    /**
+    * If true, then email notification will sent to user when impersonation starts.
+    **/
+    public ImpersonationConfiguration enableEmailNotification(Boolean enableEmailNotification) {
+
+        this.enableEmailNotification = enableEmailNotification;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "true", value = "If true, then email notification will sent to user when impersonation starts.")
+    @JsonProperty("enableEmailNotification")
+    @Valid
+    public Boolean getEnableEmailNotification() {
+        return enableEmailNotification;
+    }
+    public void setEnableEmailNotification(Boolean enableEmailNotification) {
+        this.enableEmailNotification = enableEmailNotification;
+    }
+
+
+
+    @Override
+    public boolean equals(java.lang.Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ImpersonationConfiguration impersonationConfiguration = (ImpersonationConfiguration) o;
+        return Objects.equals(this.enableEmailNotification, impersonationConfiguration.enableEmailNotification);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(enableEmailNotification);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class ImpersonationConfiguration {\n");
+        
+        sb.append("    enableEmailNotification: ").append(toIndentedString(enableEmailNotification)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+    * Convert the given object to string with each line indented by 4 spaces
+    * (except the first line).
+    */
+    private String toIndentedString(java.lang.Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}
+

--- a/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/gen/java/org/wso2/carbon/identity/api/server/configs/v1/model/ImpersonationPatch.java
+++ b/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/gen/java/org/wso2/carbon/identity/api/server/configs/v1/model/ImpersonationPatch.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except

--- a/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/gen/java/org/wso2/carbon/identity/api/server/configs/v1/model/ImpersonationPatch.java
+++ b/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/gen/java/org/wso2/carbon/identity/api/server/configs/v1/model/ImpersonationPatch.java
@@ -1,0 +1,182 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.configs.v1.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import javax.validation.constraints.*;
+
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+import javax.validation.Valid;
+import javax.xml.bind.annotation.*;
+
+public class ImpersonationPatch  {
+  
+
+@XmlType(name="OperationEnum")
+@XmlEnum(String.class)
+public enum OperationEnum {
+
+    @XmlEnumValue("ADD") ADD(String.valueOf("ADD")), @XmlEnumValue("REMOVE") REMOVE(String.valueOf("REMOVE")), @XmlEnumValue("REPLACE") REPLACE(String.valueOf("REPLACE"));
+
+
+    private String value;
+
+    OperationEnum(String v) {
+        value = v;
+    }
+
+    public String value() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    public static OperationEnum fromValue(String value) {
+        for (OperationEnum b : OperationEnum.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
+}
+
+    private OperationEnum operation;
+    private String path;
+    private Boolean value;
+
+    /**
+    * The operation to be performed.
+    **/
+    public ImpersonationPatch operation(OperationEnum operation) {
+
+        this.operation = operation;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "ADD", required = true, value = "The operation to be performed.")
+    @JsonProperty("operation")
+    @Valid
+    @NotNull(message = "Property operation cannot be null.")
+
+    public OperationEnum getOperation() {
+        return operation;
+    }
+    public void setOperation(OperationEnum operation) {
+        this.operation = operation;
+    }
+
+    /**
+    * A JSON-Pointer
+    **/
+    public ImpersonationPatch path(String path) {
+
+        this.path = path;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "/enableEmailNotification", required = true, value = "A JSON-Pointer")
+    @JsonProperty("path")
+    @Valid
+    @NotNull(message = "Property path cannot be null.")
+
+    public String getPath() {
+        return path;
+    }
+    public void setPath(String path) {
+        this.path = path;
+    }
+
+    /**
+    * The value to be used within the operations.
+    **/
+    public ImpersonationPatch value(Boolean value) {
+
+        this.value = value;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "false", required = true, value = "The value to be used within the operations.")
+    @JsonProperty("value")
+    @Valid
+    @NotNull(message = "Property value cannot be null.")
+
+    public Boolean getValue() {
+        return value;
+    }
+    public void setValue(Boolean value) {
+        this.value = value;
+    }
+
+
+
+    @Override
+    public boolean equals(java.lang.Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ImpersonationPatch impersonationPatch = (ImpersonationPatch) o;
+        return Objects.equals(this.operation, impersonationPatch.operation) &&
+            Objects.equals(this.path, impersonationPatch.path) &&
+            Objects.equals(this.value, impersonationPatch.value);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(operation, path, value);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class ImpersonationPatch {\n");
+        
+        sb.append("    operation: ").append(toIndentedString(operation)).append("\n");
+        sb.append("    path: ").append(toIndentedString(path)).append("\n");
+        sb.append("    value: ").append(toIndentedString(value)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+    * Convert the given object to string with each line indented by 4 spaces
+    * (except the first line).
+    */
+    private String toIndentedString(java.lang.Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}
+

--- a/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/main/java/org/wso2/carbon/identity/api/server/configs/v1/impl/ConfigsApiServiceImpl.java
+++ b/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/main/java/org/wso2/carbon/identity/api/server/configs/v1/impl/ConfigsApiServiceImpl.java
@@ -23,6 +23,7 @@ import org.wso2.carbon.identity.api.server.configs.v1.ConfigsApiService;
 import org.wso2.carbon.identity.api.server.configs.v1.core.ServerConfigManagementService;
 import org.wso2.carbon.identity.api.server.configs.v1.model.CORSPatch;
 import org.wso2.carbon.identity.api.server.configs.v1.model.DCRPatch;
+import org.wso2.carbon.identity.api.server.configs.v1.model.ImpersonationPatch;
 import org.wso2.carbon.identity.api.server.configs.v1.model.InboundAuthPassiveSTSConfig;
 import org.wso2.carbon.identity.api.server.configs.v1.model.InboundAuthSAML2Config;
 import org.wso2.carbon.identity.api.server.configs.v1.model.JWTKeyValidatorPatch;
@@ -67,6 +68,11 @@ public class ConfigsApiServiceImpl implements ConfigsApiService {
     @Override
     public Response getHomeRealmIdentifiers() {
         return Response.ok().entity(configManagementService.getHomeRealmIdentifiers()).build();
+    }
+
+    @Override
+    public Response getImpersonationConfiguration() {
+        return Response.ok().entity(configManagementService.getImpersonationConfiguration()).build();
     }
 
     @Override
@@ -170,6 +176,12 @@ public class ConfigsApiServiceImpl implements ConfigsApiService {
         configManagementService.patchConfigs(patch);
         return Response.ok().build();
     }
+
+    @Override
+    public Response patchImpersonationConfiguration(List<ImpersonationPatch> impersonationPatch) {
+
+        configManagementService.patchImpersonationConfiguration(impersonationPatch);
+        return Response.ok().build();    }
 
     @Override
     public Response updateInboundScimConfigs(ScimConfig scimConfig) {

--- a/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/main/java/org/wso2/carbon/identity/api/server/configs/v1/impl/ConfigsApiServiceImpl.java
+++ b/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/main/java/org/wso2/carbon/identity/api/server/configs/v1/impl/ConfigsApiServiceImpl.java
@@ -72,6 +72,7 @@ public class ConfigsApiServiceImpl implements ConfigsApiService {
 
     @Override
     public Response getImpersonationConfiguration() {
+
         return Response.ok().entity(configManagementService.getImpersonationConfiguration()).build();
     }
 
@@ -181,7 +182,8 @@ public class ConfigsApiServiceImpl implements ConfigsApiService {
     public Response patchImpersonationConfiguration(List<ImpersonationPatch> impersonationPatch) {
 
         configManagementService.patchImpersonationConfiguration(impersonationPatch);
-        return Response.ok().build();    }
+        return Response.ok().build();
+    }
 
     @Override
     public Response updateInboundScimConfigs(ScimConfig scimConfig) {

--- a/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/main/resources/META-INF/cxf/configs-server-v1-cxf.xml
+++ b/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/main/resources/META-INF/cxf/configs-server-v1-cxf.xml
@@ -22,6 +22,8 @@
           class="org.wso2.carbon.identity.api.server.configs.common.factory.ApplicationMgtOSGIServiceFactory"/>
     <bean id="IdPMgtServiceFactoryBean"
           class="org.wso2.carbon.identity.api.server.configs.common.factory.IdPMgtOSGIServiceFactory"/>
+    <bean id="ImpersonationConfigMgtServiceFactoryBean"
+          class="org.wso2.carbon.identity.api.server.configs.common.factory.ImpersonationMgtOGSiServiceFactory"/>
     <bean id="CORSMgtServiceFactoryBean"
           class="org.wso2.carbon.identity.api.server.configs.common.factory.CORSMgtOGSiServiceFactory"/>
     <bean id="RemoteLoggingOGSiServiceFactoryBean"
@@ -35,6 +37,7 @@
         <property name="corsManagementService" ref="CORSMgtServiceFactoryBean"/>
         <property name="remoteLoggingConfigService" ref="RemoteLoggingOGSiServiceFactoryBean"/>
         <property name="dcrConfigurationMgtService" ref="DCRMgtOGSiServiceFactoryBean"/>
+        <property name="impersonationConfigMgtService" ref="ImpersonationConfigMgtServiceFactoryBean"/>
     </bean>
 </beans>
 

--- a/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/main/resources/configs.yaml
+++ b/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/main/resources/configs.yaml
@@ -473,6 +473,79 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
 
+  /configs/impersonation:
+    get:
+      tags:
+        - Impersonation Configurations
+      summary: Retrieve the tenant impersonation configuration.
+      operationId: getImpersonationConfiguration
+      description: Retrieve the tenant impersonation configuration.
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ImpersonationConfiguration'
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '500':
+          description: Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+    patch:
+      tags:
+        - Impersonation Configurations
+      summary: Patch the tenant impersonation configuration.
+      operationId: patchImpersonationConfiguration
+      description: Patch the tenant impersonation configuration.  A JSONPatch as defined by RFC 6902.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ImpersonationPatchRequest'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '500':
+          description: Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
   /configs/home-realm-identifiers:
     get:
       tags:
@@ -1295,6 +1368,13 @@ components:
           type: string
           description: The value to be used within the operations.
           example: false
+    ImpersonationConfiguration:
+      type: object
+      properties:
+        enableEmailNotification:
+          type: boolean
+          description: If true, then email notification will sent to user when impersonation starts.
+          example: true
     CORSPatchRequest:
       type: array
       items:
@@ -1345,6 +1425,33 @@ components:
           type: string
           description: A JSON-Pointer
           example: '/enableTokenReuse'
+        value:
+          type: boolean
+          description: The value to be used within the operations.
+          example: false
+    ImpersonationPatchRequest:
+      type: array
+      items:
+        $ref: '#/components/schemas/ImpersonationPatch'
+    ImpersonationPatch:
+      type: object
+      required:
+        - operation
+        - path
+        - value
+      properties:
+        operation:
+          type: string
+          description: The operation to be performed.
+          enum:
+            - ADD
+            - REMOVE
+            - REPLACE
+          example: ADD
+        path:
+          type: string
+          description: A JSON-Pointer
+          example: '/enableEmailNotification'
         value:
           type: boolean
           description: The value to be used within the operations.

--- a/pom.xml
+++ b/pom.xml
@@ -796,7 +796,7 @@
         <findsecbugs-plugin.version>1.12.0</findsecbugs-plugin.version>
         <maven.checkstyleplugin.excludes>**/gen/**/*</maven.checkstyleplugin.excludes>
         <identity.event.handler.version>1.8.7</identity.event.handler.version>
-        <identity.inbound.oauth2.version>7.0.75</identity.inbound.oauth2.version>
+        <identity.inbound.oauth2.version>7.0.97</identity.inbound.oauth2.version>
         <identity.inbound.saml2.version>5.11.41</identity.inbound.saml2.version>
         <commons.beanutils.version>1.9.4</commons.beanutils.version>
         <mavan.findbugsplugin.exclude.file>findbugs-exclude-filter.xml</mavan.findbugsplugin.exclude.file>


### PR DESCRIPTION
Public Issue: https://github.com/wso2/product-is/issues/20066

## Purpose
With this PR we are adding BE support for impersonation tenant wise configuration. Currently it used to configure enableEmail notification.

## Approach
We decided to use tenant resource table to store this configuration.

Need to merge [ this PR first.](https://github.com/wso2-extensions/identity-inbound-auth-oauth/pull/2482)