### PR TITLE
Validate Password Recovery Connector Configuration Updates

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.common/src/main/java/org/wso2/carbon/identity/api/server/common/Util.java
+++ b/components/org.wso2.carbon.identity.api.server.common/src/main/java/org/wso2/carbon/identity/api/server/common/Util.java
@@ -18,8 +18,6 @@ package org.wso2.carbon.identity.api.server.common;
 
 import org.apache.commons.lang.StringUtils;
 import org.slf4j.MDC;
-import org.wso2.carbon.context.PrivilegedCarbonContext;
-import org.wso2.carbon.identity.recovery.ChallengeQuestionManager;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
@@ -36,17 +34,6 @@ public class Util {
     private static final String PAGE_LINK_REL_PREVIOUS = "previous";
     private static final String PAGINATION_LINK_FORMAT = Constants.V1_API_PATH_COMPONENT
             + "%s?offset=%d&limit=%d";
-
-    /**
-     * Get ChallengeQuestionManager osgi service
-     *
-     * @return ChallengeQuestionManager
-     */
-    @Deprecated
-    public static ChallengeQuestionManager getChallengeQuestionManager() {
-        return (ChallengeQuestionManager) PrivilegedCarbonContext.getThreadLocalCarbonContext()
-                .getOSGiService(ChallengeQuestionManager.class, null);
-    }
 
     /**
      * Get correlation id of current thread

--- a/components/org.wso2.carbon.identity.api.server.identity.governance/org.wso2.carbon.identity.api.server.identity.governance.common/src/main/java/org/wso2/carbon/identity/api/server/identity/governance/common/GovernanceConstants.java
+++ b/components/org.wso2.carbon.identity.api.server.identity.governance/org.wso2.carbon.identity.api.server.identity.governance.common/src/main/java/org/wso2/carbon/identity/api/server/identity/governance/common/GovernanceConstants.java
@@ -67,7 +67,9 @@ public class GovernanceConstants {
         ERROR_CODE_INCORRECT_CONNECTOR_NAME("50011", "Invalid connector name",
                 "Unable to find a connector with the name %s."),
         ERROR_CODE_UNSUPPORTED_PROPERTY_NAME("50012", "Unsupported property is requested.",
-                "The property %s is not supported by this API.");
+                "The property %s is not supported by this API."),
+        ERROR_CODE_INVALID_CONNECTOR_CONFIGURATION("50013", "Invalid connector configuration.",
+                "The connector configuration is invalid. %s");
 
         private final String code;
         private final String message;

--- a/components/org.wso2.carbon.identity.api.server.identity.governance/org.wso2.carbon.identity.api.server.identity.governance.common/src/main/java/org/wso2/carbon/identity/api/server/identity/governance/common/GovernanceConstants.java
+++ b/components/org.wso2.carbon.identity.api.server.identity.governance/org.wso2.carbon.identity.api.server.identity.governance.common/src/main/java/org/wso2/carbon/identity/api/server/identity/governance/common/GovernanceConstants.java
@@ -68,8 +68,8 @@ public class GovernanceConstants {
                 "Unable to find a connector with the name %s."),
         ERROR_CODE_UNSUPPORTED_PROPERTY_NAME("50012", "Unsupported property is requested.",
                 "The property %s is not supported by this API."),
-        ERROR_CODE_INVALID_CONNECTOR_CONFIGURATION("50013", "Invalid connector configuration.",
-                "The connector configuration is invalid. %s");
+        ERROR_CODE_INVALID_CONNECTOR_CONFIGURATION("50013", "Connector update failed.",
+                "Unable to update the identity governance connector. %s");
 
         private final String code;
         private final String message;

--- a/components/org.wso2.carbon.identity.api.server.identity.governance/org.wso2.carbon.identity.api.server.identity.governance.v1/src/main/java/org/wso2/carbon/identity/api/server/identity/governance/v1/core/ServerIdentityGovernanceService.java
+++ b/components/org.wso2.carbon.identity.api.server.identity.governance/org.wso2.carbon.identity.api.server.identity.governance.v1/src/main/java/org/wso2/carbon/identity/api/server/identity/governance/v1/core/ServerIdentityGovernanceService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2019-2024, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except

--- a/components/org.wso2.carbon.identity.api.server.identity.governance/org.wso2.carbon.identity.api.server.identity.governance.v1/src/main/resources/identity-governance.yaml
+++ b/components/org.wso2.carbon.identity.api.server.identity.governance/org.wso2.carbon.identity.api.server.identity.governance.v1/src/main/resources/identity-governance.yaml
@@ -407,7 +407,7 @@ paths:
               <td>Disable, if the client application handles notification sending</td>
             </tr>
             <tr>
-              <td rowspan="20">account-recovery</td>
+              <td rowspan="22">account-recovery</td>
               <td>Recovery.Notification.Password.Enable</td>
               <td>Notification based password recovery</td>
             </tr>
@@ -482,6 +482,14 @@ paths:
             </tr><tr>
               <td>Recovery.AutoLogin.Enable</td>
               <td>User will be logged in automatically after completing the Password Reset wizard</td>
+            </tr>
+            <tr>
+              <td>Recovery.Notification.Password.emailLink.Enable</td>
+              <td>Notification based password recovery via an email</td>
+            </tr>
+            <tr>
+              <td>Recovery.Notification.Password.smsOtp.Enable</td>
+              <td>Notification based password recovery using SMS OTP</td>
             </tr>
             <tr>
             <td rowspan="3">admin-forced-password-reset</td>

--- a/findbugs-exclude-filter.xml
+++ b/findbugs-exclude-filter.xml
@@ -133,4 +133,15 @@
             <Bug pattern="IMPROPER_UNICODE" />
         </Match>
     </FindBugsFilter>
+    <!--
+    The following exclusions added because the find bug issue is false positive.
+        The method is used to update the password recovery property values.
+    -->
+    <FindBugsFilter>
+        <Match>
+            <Class name="org.wso2.carbon.identity.api.server.identity.governance.v1.core.ServerIdentityGovernanceService" />
+            <Method name="updatePasswordRecoveryPropertyValues" />
+            <Bug pattern="HARD_CODE_PASSWORD" />
+        </Match>
+    </FindBugsFilter>
 </FindBugsFilter>

--- a/findbugs-exclude-filter.xml
+++ b/findbugs-exclude-filter.xml
@@ -133,15 +133,4 @@
             <Bug pattern="IMPROPER_UNICODE" />
         </Match>
     </FindBugsFilter>
-    <!--
-    The following exclusions added because the find bug issue is false positive.
-        The method is used to update the password recovery property values.
-    -->
-    <FindBugsFilter>
-        <Match>
-            <Class name="org.wso2.carbon.identity.api.server.identity.governance.v1.core.ServerIdentityGovernanceService" />
-            <Method name="updatePasswordRecoveryPropertyValues" />
-            <Bug pattern="HARD_CODE_PASSWORD" />
-        </Match>
-    </FindBugsFilter>
 </FindBugsFilter>

--- a/pom.xml
+++ b/pom.xml
@@ -790,7 +790,7 @@
         <version.org.wso2.orbit.javax.xml.bind>2.3.1.wso2v1</version.org.wso2.orbit.javax.xml.bind>
         <maven.buildnumber.plugin.version>1.4</maven.buildnumber.plugin.version>
         <org.apache.felix.annotations.version>1.2.4</org.apache.felix.annotations.version>
-        <identity.governance.version>1.8.62</identity.governance.version>
+        <identity.governance.version>1.9.17</identity.governance.version>
         <carbon.identity.framework.version>7.2.37</carbon.identity.framework.version>
         <maven.findbugsplugin.version>3.0.5</maven.findbugsplugin.version>
         <findsecbugs-plugin.version>1.12.0</findsecbugs-plugin.version>


### PR DESCRIPTION
## Purpose
> Under the feature "SMS OTP For Password Recovery" the recovery connector is introduced with two new configs. "Recovery.Notification.Password.emailLink.Enable" and "Recovery.Notification.Password.smsOtp.Enable". These new configs and the existing 'Recovery.Notification.Password.Enable" configuration are related hence configurations need to be in a valid state. This PR adds the validation to the connector configuration update requests. 
Invalid states being tested. 
- Connector is set to disable but one or more recovery options are set to be enabled. 
-   Connector is set to enable but no recovery options are set to be enabled. 

## Related PRs
- https://github.com/wso2/carbon-identity-framework/pull/5744 (DEPENDENT)
- https://github.com/wso2-extensions/identity-governance/pull/824
- https://github.com/wso2/product-is/pull/20557

### Related Issues
- https://github.com/wso2-enterprise/iam-product-management/issues/51
- https://github.com/wso2-enterprise/iam-engineering/issues/534
