### PR TITLE
Onboard app level pvtkeyjwt reuse config

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.common/src/main/java/org/wso2/carbon/identity/api/server/application/management/common/ApplicationManagementConstants.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.common/src/main/java/org/wso2/carbon/identity/api/server/application/management/common/ApplicationManagementConstants.java
@@ -57,6 +57,8 @@ public class ApplicationManagementConstants {
     public static final String RBAC = "RBAC";
     public static final String NO_POLICY = "NO POLICY";
     public static final String SELECT_OPTION = "Select Option";
+    public static final String TOKEN_EP_ALLOW_REUSE_PVT_KEY_JWT_DEFAULT_VALUE = "OAuth.OpenIDConnect." +
+            "TokenEndpointAllowReusePrivateKeyJWT";
     public static final String TOKEN_EP_SIGNATURE_ALGORITHMS_SUPPORTED = "OAuth.OpenIDConnect." +
             "SupportedTokenEndpointSigningAlgorithms.SupportedTokenEndpointSigningAlgorithm";
     public static final String ID_TOKEN_SIGNATURE_ALGORITHMS_SUPPORTED = "OAuth.OpenIDConnect." +

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/application/management/v1/ClientAuthenticationConfiguration.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/application/management/v1/ClientAuthenticationConfiguration.java
@@ -68,9 +68,9 @@ public class ClientAuthenticationConfiguration {
     }
 
     /**
-     * Allow reuse of the private key for JWT generation at the token endpoint.
+     * Allow reuse of the private key JWT at the token endpoint.
      *
-     * @param tokenEndpointAllowReusePvtKeyJwt Allow reuse of the private key for JWT generation at the token endpoint.
+     * @param tokenEndpointAllowReusePvtKeyJwt Allow reuse of the private key JWT at the token endpoint.
      * @return ClientAuthenticationConfiguration object.
      **/
     public ClientAuthenticationConfiguration tokenEndpointAllowReusePvtKeyJwt(

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/application/management/v1/ClientAuthenticationConfiguration.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/application/management/v1/ClientAuthenticationConfiguration.java
@@ -28,6 +28,7 @@ public class ClientAuthenticationConfiguration {
 
     private String tokenEndpointAuthMethod;
     private String tokenEndpointAuthSigningAlg;
+    private Boolean tokenEndpointAllowReusePvtKeyJwt;
     private String tlsClientAuthSubjectDn;
 
     /**
@@ -67,6 +68,30 @@ public class ClientAuthenticationConfiguration {
     }
 
     /**
+     * Allow reuse of the private key for JWT generation at the token endpoint.
+     *
+     * @param tokenEndpointAllowReusePvtKeyJwt Allow reuse of the private key for JWT generation at the token endpoint.
+     * @return ClientAuthenticationConfiguration object.
+     **/
+    public ClientAuthenticationConfiguration tokenEndpointAllowReusePvtKeyJwt(
+            Boolean tokenEndpointAllowReusePvtKeyJwt) {
+
+        this.tokenEndpointAllowReusePvtKeyJwt = tokenEndpointAllowReusePvtKeyJwt;
+        return this;
+    }
+
+    @ApiModelProperty(example = "false", value = "")
+    @JsonProperty("tokenEndpointAllowReusePvtKeyJwt")
+    @Valid
+    public Boolean isTokenEndpointAllowReusePvtKeyJwt() {
+        return tokenEndpointAllowReusePvtKeyJwt;
+    }
+
+    public void setTokenEndpointAllowReusePvtKeyJwt(Boolean tokenEndpointAllowReusePvtKeyJwt) {
+        this.tokenEndpointAllowReusePvtKeyJwt = tokenEndpointAllowReusePvtKeyJwt;
+    }
+
+    /**
      **/
     public ClientAuthenticationConfiguration tlsClientAuthSubjectDn(String tlsClientAuthSubjectDn) {
 
@@ -94,14 +119,20 @@ public class ClientAuthenticationConfiguration {
             return false;
         }
         ClientAuthenticationConfiguration clientAuthenticationConfiguration = (ClientAuthenticationConfiguration) o;
-        return Objects.equals(this.tokenEndpointAuthMethod, clientAuthenticationConfiguration.tokenEndpointAuthMethod) &&
-            Objects.equals(this.tokenEndpointAuthSigningAlg, clientAuthenticationConfiguration.tokenEndpointAuthSigningAlg) &&
-            Objects.equals(this.tlsClientAuthSubjectDn, clientAuthenticationConfiguration.tlsClientAuthSubjectDn);
+        return Objects.equals(this.tokenEndpointAuthMethod,
+                clientAuthenticationConfiguration.tokenEndpointAuthMethod) &&
+                Objects.equals(this.tokenEndpointAuthSigningAlg,
+                        clientAuthenticationConfiguration.tokenEndpointAuthSigningAlg) &&
+                Objects.equals(this.tlsClientAuthSubjectDn, clientAuthenticationConfiguration.tlsClientAuthSubjectDn) &&
+                Objects.equals(this.tokenEndpointAllowReusePvtKeyJwt,
+                        clientAuthenticationConfiguration.tokenEndpointAllowReusePvtKeyJwt);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(tokenEndpointAuthMethod, tokenEndpointAuthSigningAlg, tlsClientAuthSubjectDn);
+
+        return Objects.hash(tokenEndpointAuthMethod, tokenEndpointAuthSigningAlg, tokenEndpointAllowReusePvtKeyJwt,
+                tlsClientAuthSubjectDn);
     }
 
     @Override
@@ -112,6 +143,8 @@ public class ClientAuthenticationConfiguration {
 
         sb.append("    tokenEndpointAuthMethod: ").append(toIndentedString(tokenEndpointAuthMethod)).append("\n");
         sb.append("    tokenEndpointAuthSigningAlg: ").append(toIndentedString(tokenEndpointAuthSigningAlg)).append("\n");
+        sb.append("    tokenEndpointAllowReusePvtKeyJwt: ").append(toIndentedString(tokenEndpointAllowReusePvtKeyJwt))
+                .append("\n");
         sb.append("    tlsClientAuthSubjectDn: ").append(toIndentedString(tlsClientAuthSubjectDn)).append("\n");
         sb.append("}");
         return sb.toString();

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/application/management/v1/OIDCMetaData.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/application/management/v1/OIDCMetaData.java
@@ -272,9 +272,9 @@ public class OIDCMetaData  {
     }
 
     /**
-     * Allow reuse of the private key for JWT generation at the token endpoint.
+     * Allow reuse of the private key JWT at the token endpoint.
      *
-     * @param tokenEndpointAllowReusePvtKeyJwt Allow reuse of the private key for JWT generation at the token endpoint.
+     * @param tokenEndpointAllowReusePvtKeyJwt Allow reuse of the private key JWT at the token endpoint.
      * @return OIDCMetaData object.
      **/
     public OIDCMetaData tokenEndpointAllowReusePvtKeyJwt(Boolean tokenEndpointAllowReusePvtKeyJwt) {

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/application/management/v1/OIDCMetaData.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/application/management/v1/OIDCMetaData.java
@@ -48,6 +48,7 @@ public class OIDCMetaData  {
     private ClientAuthenticationMethodMetadata tokenEndpointAuthMethod;
     private MetadataProperty tokenEndpointSignatureAlgorithm;
     private MetadataProperty idTokenSignatureAlgorithm;
+    private Boolean tokenEndpointAllowReusePvtKeyJwt;
     private MetadataProperty requestObjectSignatureAlgorithm;
     private MetadataProperty requestObjectEncryptionAlgorithm;
     private MetadataProperty requestObjectEncryptionMethod;
@@ -271,6 +272,31 @@ public class OIDCMetaData  {
     }
 
     /**
+     * Allow reuse of the private key for JWT generation at the token endpoint.
+     *
+     * @param tokenEndpointAllowReusePvtKeyJwt Allow reuse of the private key for JWT generation at the token endpoint.
+     * @return OIDCMetaData object.
+     **/
+    public OIDCMetaData tokenEndpointAllowReusePvtKeyJwt(Boolean tokenEndpointAllowReusePvtKeyJwt) {
+
+        this.tokenEndpointAllowReusePvtKeyJwt = tokenEndpointAllowReusePvtKeyJwt;
+        return this;
+    }
+
+    @ApiModelProperty(example = "false", value = "")
+    @JsonProperty("tokenEndpointAllowReusePvtKeyJwt")
+    @Valid
+    public Boolean getTokenEndpointAllowReusePvtKeyJwt() {
+
+        return tokenEndpointAllowReusePvtKeyJwt;
+    }
+
+    public void setTokenEndpointAllowReusePvtKeyJwt(Boolean tokenEndpointAllowReusePvtKeyJwt) {
+
+        this.tokenEndpointAllowReusePvtKeyJwt = tokenEndpointAllowReusePvtKeyJwt;
+    }
+
+    /**
      **/
     public OIDCMetaData idTokenSignatureAlgorithm(MetadataProperty idTokenSignatureAlgorithm) {
 
@@ -402,6 +428,7 @@ public class OIDCMetaData  {
             Objects.equals(this.accessTokenBindingType, oiDCMetaData.accessTokenBindingType) &&
             Objects.equals(this.tokenEndpointAuthMethod, oiDCMetaData.tokenEndpointAuthMethod) &&
             Objects.equals(this.tokenEndpointSignatureAlgorithm, oiDCMetaData.tokenEndpointSignatureAlgorithm) &&
+            Objects.equals(this.tokenEndpointAllowReusePvtKeyJwt, oiDCMetaData.tokenEndpointAllowReusePvtKeyJwt) &&
             Objects.equals(this.tokenEndpointSignatureAlgorithm, oiDCMetaData.idTokenSignatureAlgorithm) &&
             Objects.equals(this.tokenEndpointSignatureAlgorithm, oiDCMetaData.requestObjectSignatureAlgorithm) &&
             Objects.equals(this.tokenEndpointSignatureAlgorithm, oiDCMetaData.requestObjectEncryptionAlgorithm) &&
@@ -433,6 +460,8 @@ public class OIDCMetaData  {
         sb.append("    accessTokenBindingType: ").append(toIndentedString(accessTokenBindingType)).append("\n");
         sb.append("    tokenEndpointAuthMethod: ").append(toIndentedString(tokenEndpointAuthMethod)).append("\n");
         sb.append("    tokenEndpointSignatureAlgorithm: ").append(toIndentedString(tokenEndpointSignatureAlgorithm)).append("\n");
+        sb.append("    tokenEndpointAllowReusePvtKeyJwt: ").append(toIndentedString(tokenEndpointAllowReusePvtKeyJwt))
+                .append("\n");
         sb.append("    idTokenSignatureAlgorithm: ").append(toIndentedString(idTokenSignatureAlgorithm)).append("\n");
         sb.append("    requestObjectSignatureAlgorithm: ").append(toIndentedString(requestObjectSignatureAlgorithm)).append("\n");
         sb.append("    requestObjectEncryptionAlgorithm: ").append(toIndentedString(requestObjectEncryptionAlgorithm)).append("\n");

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/ServerApplicationMetadataService.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/ServerApplicationMetadataService.java
@@ -169,6 +169,9 @@ public class ServerApplicationMetadataService {
         supportedClientAuthMethods.addAll(getClientAuthenticationMethods());
         oidcMetaData.setTokenEndpointAuthMethod(
                 new ClientAuthenticationMethodMetadata().options(supportedClientAuthMethods));
+        boolean tokenEpAllowReusePvtKeyJwtDefaultValue = Boolean.parseBoolean(IdentityUtil
+                .getProperty(ApplicationManagementConstants.TOKEN_EP_ALLOW_REUSE_PVT_KEY_JWT_DEFAULT_VALUE));
+        oidcMetaData.setTokenEndpointAllowReusePvtKeyJwt(tokenEpAllowReusePvtKeyJwtDefaultValue);
         List<String> tokenEpSigningAlgorithms = IdentityUtil
                 .getPropertyAsList(ApplicationManagementConstants.TOKEN_EP_SIGNATURE_ALGORITHMS_SUPPORTED);
         oidcMetaData.setTokenEndpointSignatureAlgorithm(new MetadataProperty()

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/functions/application/inbound/oauth2/ApiModelToOAuthConsumerApp.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/functions/application/inbound/oauth2/ApiModelToOAuthConsumerApp.java
@@ -249,6 +249,7 @@ public class ApiModelToOAuthConsumerApp implements ApiModelToOAuthConsumerAppFun
         if (clientAuthentication != null) {
             appDTO.setTokenEndpointAuthMethod(clientAuthentication.getTokenEndpointAuthMethod());
             appDTO.setTokenEndpointAuthSignatureAlgorithm(clientAuthentication.getTokenEndpointAuthSigningAlg());
+            appDTO.setTokenEndpointAllowReusePvtKeyJwt(clientAuthentication.isTokenEndpointAllowReusePvtKeyJwt());
             appDTO.setTlsClientAuthSubjectDN(clientAuthentication.getTlsClientAuthSubjectDn());
         }
     }

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/functions/application/inbound/oauth2/OAuthConsumerAppToApiModel.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/functions/application/inbound/oauth2/OAuthConsumerAppToApiModel.java
@@ -174,6 +174,7 @@ public class OAuthConsumerAppToApiModel implements Function<OAuthConsumerAppDTO,
         return new ClientAuthenticationConfiguration()
                 .tokenEndpointAuthMethod(appDTO.getTokenEndpointAuthMethod())
                 .tokenEndpointAuthSigningAlg(appDTO.getTokenEndpointAuthSignatureAlgorithm())
+                .tokenEndpointAllowReusePvtKeyJwt(appDTO.isTokenEndpointAllowReusePvtKeyJwt())
                 .tlsClientAuthSubjectDn(appDTO.getTlsClientAuthSubjectDN());
     }
 

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/resources/applications.yaml
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/resources/applications.yaml
@@ -3729,6 +3729,9 @@ components:
         tokenEndpointAuthMethod:
           type: string
           example: 'client_secret_basic'
+        tokenEndpointAllowReusePvtKeyJwt:
+          type: boolean
+          example: false
         tokenEndpointAuthSigningAlg:
           type: string
           example: 'PS256'
@@ -3995,6 +3998,9 @@ components:
           $ref: '#/components/schemas/MetadataProperty'
         tokenEndpointAuthMethod:
           $ref: '#/components/schemas/ClientAuthenticationMethodMetadata'
+        tokenEndpointAllowReusePvtKeyJwt:
+          type: boolean
+          default: false
         tokenEndpointSignatureAlgorithm:
           $ref: '#/components/schemas/MetadataProperty'
         idTokenSignatureAlgorithm:

--- a/pom.xml
+++ b/pom.xml
@@ -796,14 +796,14 @@
         <findsecbugs-plugin.version>1.12.0</findsecbugs-plugin.version>
         <maven.checkstyleplugin.excludes>**/gen/**/*</maven.checkstyleplugin.excludes>
         <identity.event.handler.version>1.8.19</identity.event.handler.version>
-        <identity.inbound.oauth2.version>7.0.103</identity.inbound.oauth2.version>
+        <identity.inbound.oauth2.version>7.0.114</identity.inbound.oauth2.version>
         <identity.inbound.saml2.version>5.11.41</identity.inbound.saml2.version>
         <commons.beanutils.version>1.9.4</commons.beanutils.version>
         <mavan.findbugsplugin.exclude.file>findbugs-exclude-filter.xml</mavan.findbugsplugin.exclude.file>
         <carbon.kernel.version>4.9.17</carbon.kernel.version>
         <carbon.multitenancy.version>4.9.10</carbon.multitenancy.version>
         <org.wso2.carbon.identity.remotefetch.version>0.7.12</org.wso2.carbon.identity.remotefetch.version>
-        <org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.version>2.4.21</org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.version>
+        <org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.version>2.5.13</org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.version>
         <org.wso2.carbon.logging.service.version>4.10.7</org.wso2.carbon.logging.service.version>
         <org.wso2.carbon.event.publisher.version>5.2.15</org.wso2.carbon.event.publisher.version>
         <identity.branding.preference.management.version>1.1.1</identity.branding.preference.management.version>


### PR DESCRIPTION
## Purpose
> This PR contains changes relevant to onboarding of App level config to `Allow Reuse of Private Key JWT`. The changes will be reflected at the below endpoints:

1. `/{applicationId}/inbound-protocols/oidc` - GET, PUT, DELETE
2. `/meta/inbound-protocols/oidc`

- The config will be saved as a SP OIDC property. 
- For the already created applications, as the config is not added, the old org level config will be taken.
    - When retrieving the application via a GET request, if the config is unavailable, org level config will be set.
- For the newly created applications, the user configured value will be saved.
    - The org level config will be totally irrelevant for the new application.

Related PRs:
> https://github.com/wso2/product-is/issues/20546