### PR TITLE
Add Trusted App Metadata to Application management APIs

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.common/src/main/java/org/wso2/carbon/identity/api/server/application/management/common/ApplicationManagementConstants.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.common/src/main/java/org/wso2/carbon/identity/api/server/application/management/common/ApplicationManagementConstants.java
@@ -160,7 +160,7 @@ public class ApplicationManagementConstants {
         BLOCK_RENAME_APP_NAME_TO_RESERVED_APP_NAME("60516",
                 "Renaming application name to a system reserved name is blocked",
                 "The application name %s is marked as systems reserved application name."),
-        ANDROID_THUMBPRINT_NOT_PROVIDED("60516",
+        INCORRECT_ANDROID_APP_DETAILS("60516",
                 "Invalid trusted app configuration.",
                 "Both package name and thumbprints are required when configuring an android application as a trusted " +
                         "mobile application."),

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.common/src/main/java/org/wso2/carbon/identity/api/server/application/management/common/ApplicationManagementConstants.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.common/src/main/java/org/wso2/carbon/identity/api/server/application/management/common/ApplicationManagementConstants.java
@@ -79,6 +79,7 @@ public class ApplicationManagementConstants {
     public static final String NON_EXISTING_USER_CODE = "30007 - ";
     public static final String APPLICATION_BASED_OUTBOUND_PROVISIONING_ENABLED =
             "OutboundProvisioning.enableApplicationBasedOutboundProvisioning";
+    public static final String ATTRIBUTE_SEPARATOR = ",";
 
 
     /**

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.common/src/main/java/org/wso2/carbon/identity/api/server/application/management/common/ApplicationManagementConstants.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.common/src/main/java/org/wso2/carbon/identity/api/server/application/management/common/ApplicationManagementConstants.java
@@ -160,6 +160,10 @@ public class ApplicationManagementConstants {
         BLOCK_RENAME_APP_NAME_TO_RESERVED_APP_NAME("60516",
                 "Renaming application name to a system reserved name is blocked",
                 "The application name %s is marked as systems reserved application name."),
+        ANDROID_THUMBPRINT_NOT_PROVIDED("60516",
+                "Invalid trusted app configuration.",
+                "Both package name and thumbprints are required when configuring an android application as a trusted " +
+                        "mobile application."),
 
         // Server Errors.
         ERROR_RETRIEVING_SAML_METADATA("65001",

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.common/src/main/java/org/wso2/carbon/identity/api/server/application/management/common/ApplicationManagementConstants.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.common/src/main/java/org/wso2/carbon/identity/api/server/application/management/common/ApplicationManagementConstants.java
@@ -160,10 +160,6 @@ public class ApplicationManagementConstants {
         BLOCK_RENAME_APP_NAME_TO_RESERVED_APP_NAME("60516",
                 "Renaming application name to a system reserved name is blocked",
                 "The application name %s is marked as systems reserved application name."),
-        INCORRECT_ANDROID_APP_DETAILS("60516",
-                "Invalid trusted app configuration.",
-                "Both package name and thumbprints are required when configuring an android application as a trusted " +
-                        "mobile application."),
 
         // Server Errors.
         ERROR_RETRIEVING_SAML_METADATA("65001",

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/application/management/v1/AdvancedApplicationConfiguration.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/application/management/v1/AdvancedApplicationConfiguration.java
@@ -27,6 +27,7 @@ import java.util.List;
 import org.wso2.carbon.identity.api.server.application.management.v1.AdditionalSpProperty;
 import org.wso2.carbon.identity.api.server.application.management.v1.AdvancedApplicationConfigurationAttestationMetaData;
 import org.wso2.carbon.identity.api.server.application.management.v1.Certificate;
+import org.wso2.carbon.identity.api.server.application.management.v1.TrustedAppConfiguration;
 import javax.validation.constraints.*;
 
 
@@ -47,6 +48,7 @@ public class AdvancedApplicationConfiguration  {
     private Boolean fragment;
     private Boolean enableAPIBasedAuthentication;
     private AdvancedApplicationConfigurationAttestationMetaData attestationMetaData;
+    private TrustedAppConfiguration trustedAppConfiguration;
     private List<AdditionalSpProperty> additionalSpProperties = null;
     private Boolean useExternalConsentPage;
 
@@ -259,6 +261,24 @@ public class AdvancedApplicationConfiguration  {
 
     /**
     **/
+    public AdvancedApplicationConfiguration trustedAppConfiguration(TrustedAppConfiguration trustedAppConfiguration) {
+
+        this.trustedAppConfiguration = trustedAppConfiguration;
+        return this;
+    }
+    
+    @ApiModelProperty(value = "")
+    @JsonProperty("trustedAppConfiguration")
+    @Valid
+    public TrustedAppConfiguration getTrustedAppConfiguration() {
+        return trustedAppConfiguration;
+    }
+    public void setTrustedAppConfiguration(TrustedAppConfiguration trustedAppConfiguration) {
+        this.trustedAppConfiguration = trustedAppConfiguration;
+    }
+
+    /**
+    **/
     public AdvancedApplicationConfiguration additionalSpProperties(List<AdditionalSpProperty> additionalSpProperties) {
 
         this.additionalSpProperties = additionalSpProperties;
@@ -306,12 +326,13 @@ public class AdvancedApplicationConfiguration  {
             Objects.equals(this.fragment, advancedApplicationConfiguration.fragment) &&
             Objects.equals(this.enableAPIBasedAuthentication, advancedApplicationConfiguration.enableAPIBasedAuthentication) &&
             Objects.equals(this.attestationMetaData, advancedApplicationConfiguration.attestationMetaData) &&
+            Objects.equals(this.trustedAppConfiguration, advancedApplicationConfiguration.trustedAppConfiguration) &&
             Objects.equals(this.additionalSpProperties, advancedApplicationConfiguration.additionalSpProperties);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(saas, discoverableByEndUsers, certificate, skipLoginConsent, skipLogoutConsent, useExternalConsentPage, returnAuthenticatedIdpList, enableAuthorization, fragment, enableAPIBasedAuthentication, attestationMetaData, additionalSpProperties);
+        return Objects.hash(saas, discoverableByEndUsers, certificate, skipLoginConsent, skipLogoutConsent, useExternalConsentPage, returnAuthenticatedIdpList, enableAuthorization, fragment, enableAPIBasedAuthentication, attestationMetaData, trustedAppConfiguration, additionalSpProperties);
     }
 
     @Override
@@ -331,6 +352,7 @@ public class AdvancedApplicationConfiguration  {
         sb.append("    fragment: ").append(toIndentedString(fragment)).append("\n");
         sb.append("    enableAPIBasedAuthentication: ").append(toIndentedString(enableAPIBasedAuthentication)).append("\n");
         sb.append("    attestationMetaData: ").append(toIndentedString(attestationMetaData)).append("\n");
+        sb.append("    trustedAppConfiguration: ").append(toIndentedString(trustedAppConfiguration)).append("\n");
         sb.append("    additionalSpProperties: ").append(toIndentedString(additionalSpProperties)).append("\n");
         sb.append("}");
         return sb.toString();

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/application/management/v1/TrustedAppConfiguration.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/application/management/v1/TrustedAppConfiguration.java
@@ -22,6 +22,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import java.util.ArrayList;
+import java.util.List;
 import javax.validation.constraints.*;
 
 /**
@@ -38,7 +40,8 @@ public class TrustedAppConfiguration  {
     private Boolean isFIDOTrustedApp;
     private Boolean isConsentGranted;
     private String androidPackageName;
-    private String androidThumbprints;
+    private List<String> androidThumbprints = null;
+
     private String appleAppId;
 
     /**
@@ -101,23 +104,31 @@ public class TrustedAppConfiguration  {
     /**
     * Decides the android thumbprints for the application.
     **/
-    public TrustedAppConfiguration androidThumbprints(String androidThumbprints) {
+    public TrustedAppConfiguration androidThumbprints(List<String> androidThumbprints) {
 
         this.androidThumbprints = androidThumbprints;
         return this;
     }
     
-    @ApiModelProperty(example = "18:94:0A:DE:63:77:B6:84:43:1E:85:8F:03:CF:8A:14:87:9C:DE:DF:EA:7A:25:53:CD:53:5A:AF:C3:54:A5:56", value = "Decides the android thumbprints for the application.")
+    @ApiModelProperty(value = "Decides the android thumbprints for the application.")
     @JsonProperty("androidThumbprints")
     @Valid
-    public String getAndroidThumbprints() {
+    public List<String> getAndroidThumbprints() {
         return androidThumbprints;
     }
-    public void setAndroidThumbprints(String androidThumbprints) {
+    public void setAndroidThumbprints(List<String> androidThumbprints) {
         this.androidThumbprints = androidThumbprints;
     }
 
-    /**
+    public TrustedAppConfiguration addAndroidThumbprintsItem(String androidThumbprintsItem) {
+        if (this.androidThumbprints == null) {
+            this.androidThumbprints = new ArrayList<>();
+        }
+        this.androidThumbprints.add(androidThumbprintsItem);
+        return this;
+    }
+
+        /**
     * Decides the apple app id for the application.
     **/
     public TrustedAppConfiguration appleAppId(String appleAppId) {
@@ -126,7 +137,7 @@ public class TrustedAppConfiguration  {
         return this;
     }
     
-    @ApiModelProperty(example = "APPLETEAMID.com.wso2.mobile.sample", value = "Decides the apple app id for the application.")
+    @ApiModelProperty(example = "APPLETEAMID.com.org.mobile.sample", value = "Decides the apple app id for the application.")
     @JsonProperty("appleAppId")
     @Valid
     public String getAppleAppId() {

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/application/management/v1/TrustedAppConfiguration.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/application/management/v1/TrustedAppConfiguration.java
@@ -36,6 +36,7 @@ import javax.xml.bind.annotation.*;
 public class TrustedAppConfiguration  {
   
     private Boolean isFIDOTrustedApp;
+    private Boolean isConsentGranted;
     private String androidPackageName;
     private String androidThumbprints;
     private String appleAppId;
@@ -57,6 +58,25 @@ public class TrustedAppConfiguration  {
     }
     public void setIsFIDOTrustedApp(Boolean isFIDOTrustedApp) {
         this.isFIDOTrustedApp = isFIDOTrustedApp;
+    }
+
+    /**
+    * Decides whether consent is granted for the trusted app.
+    **/
+    public TrustedAppConfiguration isConsentGranted(Boolean isConsentGranted) {
+
+        this.isConsentGranted = isConsentGranted;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "false", value = "Decides whether consent is granted for the trusted app.")
+    @JsonProperty("isConsentGranted")
+    @Valid
+    public Boolean getIsConsentGranted() {
+        return isConsentGranted;
+    }
+    public void setIsConsentGranted(Boolean isConsentGranted) {
+        this.isConsentGranted = isConsentGranted;
     }
 
     /**
@@ -129,6 +149,7 @@ public class TrustedAppConfiguration  {
         }
         TrustedAppConfiguration trustedAppConfiguration = (TrustedAppConfiguration) o;
         return Objects.equals(this.isFIDOTrustedApp, trustedAppConfiguration.isFIDOTrustedApp) &&
+            Objects.equals(this.isConsentGranted, trustedAppConfiguration.isConsentGranted) &&
             Objects.equals(this.androidPackageName, trustedAppConfiguration.androidPackageName) &&
             Objects.equals(this.androidThumbprints, trustedAppConfiguration.androidThumbprints) &&
             Objects.equals(this.appleAppId, trustedAppConfiguration.appleAppId);
@@ -136,7 +157,7 @@ public class TrustedAppConfiguration  {
 
     @Override
     public int hashCode() {
-        return Objects.hash(isFIDOTrustedApp, androidPackageName, androidThumbprints, appleAppId);
+        return Objects.hash(isFIDOTrustedApp, isConsentGranted, androidPackageName, androidThumbprints, appleAppId);
     }
 
     @Override
@@ -146,6 +167,7 @@ public class TrustedAppConfiguration  {
         sb.append("class TrustedAppConfiguration {\n");
         
         sb.append("    isFIDOTrustedApp: ").append(toIndentedString(isFIDOTrustedApp)).append("\n");
+        sb.append("    isConsentGranted: ").append(toIndentedString(isConsentGranted)).append("\n");
         sb.append("    androidPackageName: ").append(toIndentedString(androidPackageName)).append("\n");
         sb.append("    androidThumbprints: ").append(toIndentedString(androidThumbprints)).append("\n");
         sb.append("    appleAppId: ").append(toIndentedString(appleAppId)).append("\n");

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/application/management/v1/TrustedAppConfiguration.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/application/management/v1/TrustedAppConfiguration.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.application.management.v1;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import javax.validation.constraints.*;
+
+/**
+ * Decides the trusted app configurations for the application.
+ **/
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+import javax.validation.Valid;
+import javax.xml.bind.annotation.*;
+@ApiModel(description = "Decides the trusted app configurations for the application.")
+public class TrustedAppConfiguration  {
+  
+    private Boolean isFIDOTrustedApp;
+    private String androidPackageName;
+    private String androidThumbprints;
+    private String appleAppId;
+
+    /**
+    * Decides whether the application is a FIDO trusted app.
+    **/
+    public TrustedAppConfiguration isFIDOTrustedApp(Boolean isFIDOTrustedApp) {
+
+        this.isFIDOTrustedApp = isFIDOTrustedApp;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "false", value = "Decides whether the application is a FIDO trusted app.")
+    @JsonProperty("isFIDOTrustedApp")
+    @Valid
+    public Boolean getIsFIDOTrustedApp() {
+        return isFIDOTrustedApp;
+    }
+    public void setIsFIDOTrustedApp(Boolean isFIDOTrustedApp) {
+        this.isFIDOTrustedApp = isFIDOTrustedApp;
+    }
+
+    /**
+    * Decides the android package name for the application.
+    **/
+    public TrustedAppConfiguration androidPackageName(String androidPackageName) {
+
+        this.androidPackageName = androidPackageName;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "com.wso2.mobile.sample", value = "Decides the android package name for the application.")
+    @JsonProperty("androidPackageName")
+    @Valid
+    public String getAndroidPackageName() {
+        return androidPackageName;
+    }
+    public void setAndroidPackageName(String androidPackageName) {
+        this.androidPackageName = androidPackageName;
+    }
+
+    /**
+    * Decides the android thumbprints for the application.
+    **/
+    public TrustedAppConfiguration androidThumbprints(String androidThumbprints) {
+
+        this.androidThumbprints = androidThumbprints;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "18:94:0A:DE:63:77:B6:84:43:1E:85:8F:03:CF:8A:14:87:9C:DE:DF:EA:7A:25:53:CD:53:5A:AF:C3:54:A5:56", value = "Decides the android thumbprints for the application.")
+    @JsonProperty("androidThumbprints")
+    @Valid
+    public String getAndroidThumbprints() {
+        return androidThumbprints;
+    }
+    public void setAndroidThumbprints(String androidThumbprints) {
+        this.androidThumbprints = androidThumbprints;
+    }
+
+    /**
+    * Decides the apple app id for the application.
+    **/
+    public TrustedAppConfiguration appleAppId(String appleAppId) {
+
+        this.appleAppId = appleAppId;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "APPLETEAMID.com.wso2.mobile.sample", value = "Decides the apple app id for the application.")
+    @JsonProperty("appleAppId")
+    @Valid
+    public String getAppleAppId() {
+        return appleAppId;
+    }
+    public void setAppleAppId(String appleAppId) {
+        this.appleAppId = appleAppId;
+    }
+
+
+
+    @Override
+    public boolean equals(java.lang.Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        TrustedAppConfiguration trustedAppConfiguration = (TrustedAppConfiguration) o;
+        return Objects.equals(this.isFIDOTrustedApp, trustedAppConfiguration.isFIDOTrustedApp) &&
+            Objects.equals(this.androidPackageName, trustedAppConfiguration.androidPackageName) &&
+            Objects.equals(this.androidThumbprints, trustedAppConfiguration.androidThumbprints) &&
+            Objects.equals(this.appleAppId, trustedAppConfiguration.appleAppId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(isFIDOTrustedApp, androidPackageName, androidThumbprints, appleAppId);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class TrustedAppConfiguration {\n");
+        
+        sb.append("    isFIDOTrustedApp: ").append(toIndentedString(isFIDOTrustedApp)).append("\n");
+        sb.append("    androidPackageName: ").append(toIndentedString(androidPackageName)).append("\n");
+        sb.append("    androidThumbprints: ").append(toIndentedString(androidThumbprints)).append("\n");
+        sb.append("    appleAppId: ").append(toIndentedString(appleAppId)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+    * Convert the given object to string with each line indented by 4 spaces
+    * (except the first line).
+    */
+    private String toIndentedString(java.lang.Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}
+

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/functions/application/ServiceProviderToApiModel.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/functions/application/ServiceProviderToApiModel.java
@@ -75,6 +75,7 @@ import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import static org.wso2.carbon.identity.api.server.application.management.common.ApplicationManagementConstants.ATTRIBUTE_SEPARATOR;
 import static org.wso2.carbon.identity.api.server.application.management.v1.core.functions.Utils.arrayToStream;
 import static org.wso2.carbon.identity.api.server.application.management.v1.core.functions.application.UpdateAdvancedConfigurations.TYPE_JWKS;
 import static org.wso2.carbon.identity.api.server.application.management.v1.core.functions.application.UpdateAdvancedConfigurations.TYPE_PEM;
@@ -509,7 +510,8 @@ public class ServiceProviderToApiModel implements Function<ServiceProvider, Appl
         return new TrustedAppConfiguration()
                 .isFIDOTrustedApp(trustedAppMetadata.getIsFidoTrusted())
                 .androidPackageName(trustedAppMetadata.getAndroidPackageName())
-                .androidThumbprints(trustedAppMetadata.getAndroidThumbprints())
+                .androidThumbprints(Arrays.asList(trustedAppMetadata.getAndroidThumbprints()
+                        .split(ATTRIBUTE_SEPARATOR)))
                 .appleAppId(trustedAppMetadata.getAppleAppId())
                 .isConsentGranted(ApplicationMgtUtil.isTrustedAppConsentGranted(serviceProvider));
     }

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/functions/application/ServiceProviderToApiModel.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/functions/application/ServiceProviderToApiModel.java
@@ -55,11 +55,11 @@ import org.wso2.carbon.identity.application.common.model.ClientAttestationMetaDa
 import org.wso2.carbon.identity.application.common.model.InboundAuthenticationRequestConfig;
 import org.wso2.carbon.identity.application.common.model.LocalAndOutboundAuthenticationConfig;
 import org.wso2.carbon.identity.application.common.model.LocalAuthenticatorConfig;
-import org.wso2.carbon.identity.application.common.model.TrustedAppMetadata;
 import org.wso2.carbon.identity.application.common.model.RequestPathAuthenticatorConfig;
 import org.wso2.carbon.identity.application.common.model.RoleMapping;
 import org.wso2.carbon.identity.application.common.model.ServiceProvider;
 import org.wso2.carbon.identity.application.common.model.ServiceProviderProperty;
+import org.wso2.carbon.identity.application.common.model.SpTrustedAppMetadata;
 import org.wso2.carbon.identity.application.common.util.IdentityApplicationConstants;
 import org.wso2.carbon.identity.application.mgt.ApplicationConstants;
 import org.wso2.carbon.identity.application.mgt.ApplicationMgtUtil;
@@ -502,9 +502,9 @@ public class ServiceProviderToApiModel implements Function<ServiceProvider, Appl
     private TrustedAppConfiguration getTrustedAppConfiguration(ServiceProvider serviceProvider) {
 
         //TODO Need to add error handling
-        TrustedAppMetadata trustedAppMetadata = serviceProvider.getTrustedAppMetadata();
+        SpTrustedAppMetadata trustedAppMetadata = serviceProvider.getTrustedAppMetadata();
         if (trustedAppMetadata == null) {
-            trustedAppMetadata = new TrustedAppMetadata();
+            trustedAppMetadata = new SpTrustedAppMetadata();
         }
 
         return new TrustedAppConfiguration()
@@ -513,7 +513,6 @@ public class ServiceProviderToApiModel implements Function<ServiceProvider, Appl
                 .androidThumbprints(trustedAppMetadata.getAndroidThumbprints())
                 .appleAppId(trustedAppMetadata.getAppleAppId());
     }
-
 
     private List<AdditionalSpProperty> getSpProperties(ServiceProvider serviceProvider) {
 

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/functions/application/ServiceProviderToApiModel.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/functions/application/ServiceProviderToApiModel.java
@@ -42,6 +42,7 @@ import org.wso2.carbon.identity.api.server.application.management.v1.RequestedCl
 import org.wso2.carbon.identity.api.server.application.management.v1.Role;
 import org.wso2.carbon.identity.api.server.application.management.v1.RoleConfig;
 import org.wso2.carbon.identity.api.server.application.management.v1.SubjectConfig;
+import org.wso2.carbon.identity.api.server.application.management.v1.TrustedAppConfiguration;
 import org.wso2.carbon.identity.api.server.application.management.v1.core.functions.Utils;
 import org.wso2.carbon.identity.api.server.application.management.v1.core.functions.application.inbound.InboundAuthConfigToApiModel;
 import org.wso2.carbon.identity.api.server.application.management.v1.core.functions.application.provisioning.BuildProvisioningConfiguration;
@@ -54,6 +55,7 @@ import org.wso2.carbon.identity.application.common.model.ClientAttestationMetaDa
 import org.wso2.carbon.identity.application.common.model.InboundAuthenticationRequestConfig;
 import org.wso2.carbon.identity.application.common.model.LocalAndOutboundAuthenticationConfig;
 import org.wso2.carbon.identity.application.common.model.LocalAuthenticatorConfig;
+import org.wso2.carbon.identity.application.common.model.TrustedAppMetadata;
 import org.wso2.carbon.identity.application.common.model.RequestPathAuthenticatorConfig;
 import org.wso2.carbon.identity.application.common.model.RoleMapping;
 import org.wso2.carbon.identity.application.common.model.ServiceProvider;
@@ -458,6 +460,7 @@ public class ServiceProviderToApiModel implements Function<ServiceProvider, Appl
                 .fragment(isFragmentApp(serviceProvider))
                 .enableAPIBasedAuthentication(serviceProvider.isAPIBasedAuthenticationEnabled())
                 .attestationMetaData(getAttestationMetaData(serviceProvider))
+                .trustedAppConfiguration(getTrustedAppConfiguration(serviceProvider))
                 .additionalSpProperties(getSpProperties(serviceProvider));
     }
 
@@ -487,6 +490,28 @@ public class ServiceProviderToApiModel implements Function<ServiceProvider, Appl
                 .appleAppId(clientAttestationMetaData.getAppleAppId())
                 .androidAttestationServiceCredentials(parseAndroidServiceCredentials(clientAttestationMetaData
                         .getAndroidAttestationServiceCredentials()));
+    }
+
+    /**
+     * Retrieves the trusted app configuration for an application's advanced configuration based on the provided
+     * service provider.
+     *
+     * @param serviceProvider The service provider for which trusted app configuration is required.
+     * @return An instance of TrustedAppConfiguration containing trusted app configurations of the application.
+     */
+    private TrustedAppConfiguration getTrustedAppConfiguration(ServiceProvider serviceProvider) {
+
+        //TODO Need to add error handling
+        TrustedAppMetadata trustedAppMetadata = serviceProvider.getTrustedAppMetadata();
+        if (trustedAppMetadata == null) {
+            trustedAppMetadata = new TrustedAppMetadata();
+        }
+
+        return new TrustedAppConfiguration()
+                .isFIDOTrustedApp(trustedAppMetadata.getIsFidoTrusted())
+                .androidPackageName(trustedAppMetadata.getAndroidPackageName())
+                .androidThumbprints(trustedAppMetadata.getAndroidThumbprints())
+                .appleAppId(trustedAppMetadata.getAppleAppId());
     }
 
 

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/functions/application/ServiceProviderToApiModel.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/functions/application/ServiceProviderToApiModel.java
@@ -75,7 +75,6 @@ import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-import static org.wso2.carbon.identity.api.server.application.management.common.ApplicationManagementConstants.ATTRIBUTE_SEPARATOR;
 import static org.wso2.carbon.identity.api.server.application.management.v1.core.functions.Utils.arrayToStream;
 import static org.wso2.carbon.identity.api.server.application.management.v1.core.functions.application.UpdateAdvancedConfigurations.TYPE_JWKS;
 import static org.wso2.carbon.identity.api.server.application.management.v1.core.functions.application.UpdateAdvancedConfigurations.TYPE_PEM;
@@ -510,10 +509,9 @@ public class ServiceProviderToApiModel implements Function<ServiceProvider, Appl
         return new TrustedAppConfiguration()
                 .isFIDOTrustedApp(trustedAppMetadata.getIsFidoTrusted())
                 .androidPackageName(trustedAppMetadata.getAndroidPackageName())
-                .androidThumbprints(Arrays.asList(trustedAppMetadata.getAndroidThumbprints()
-                        .split(ATTRIBUTE_SEPARATOR)))
+                .androidThumbprints(Arrays.asList(trustedAppMetadata.getAndroidThumbprints()))
                 .appleAppId(trustedAppMetadata.getAppleAppId())
-                .isConsentGranted(ApplicationMgtUtil.isTrustedAppConsentGranted(serviceProvider));
+                .isConsentGranted(trustedAppMetadata.getIsConsentGranted());
     }
 
     private List<AdditionalSpProperty> getSpProperties(ServiceProvider serviceProvider) {

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/functions/application/ServiceProviderToApiModel.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/functions/application/ServiceProviderToApiModel.java
@@ -501,7 +501,6 @@ public class ServiceProviderToApiModel implements Function<ServiceProvider, Appl
      */
     private TrustedAppConfiguration getTrustedAppConfiguration(ServiceProvider serviceProvider) {
 
-        //TODO Need to add error handling
         SpTrustedAppMetadata trustedAppMetadata = serviceProvider.getTrustedAppMetadata();
         if (trustedAppMetadata == null) {
             trustedAppMetadata = new SpTrustedAppMetadata();

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/functions/application/ServiceProviderToApiModel.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/functions/application/ServiceProviderToApiModel.java
@@ -63,7 +63,6 @@ import org.wso2.carbon.identity.application.common.model.SpTrustedAppMetadata;
 import org.wso2.carbon.identity.application.common.util.IdentityApplicationConstants;
 import org.wso2.carbon.identity.application.mgt.ApplicationConstants;
 import org.wso2.carbon.identity.application.mgt.ApplicationMgtUtil;
-import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.role.v2.mgt.core.RoleConstants;
 import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
 
@@ -91,7 +90,6 @@ import static org.wso2.carbon.identity.application.common.util.IdentityApplicati
 import static org.wso2.carbon.identity.application.common.util.IdentityApplicationConstants.IS_MANAGEMENT_APP_SP_PROPERTY_NAME;
 import static org.wso2.carbon.identity.application.common.util.IdentityApplicationConstants.TEMPLATE_ID_SP_PROPERTY_NAME;
 import static org.wso2.carbon.identity.application.common.util.IdentityApplicationConstants.USE_USER_ID_FOR_DEFAULT_SUBJECT;
-import static org.wso2.carbon.identity.application.mgt.ApplicationConstants.TRUSTED_APP_CONSENT_REQUIRED_PROPERTY;
 import static org.wso2.carbon.identity.application.mgt.dao.impl.ApplicationDAOImpl.USE_DOMAIN_IN_ROLES;
 import static org.wso2.carbon.identity.base.IdentityConstants.SKIP_CONSENT;
 import static org.wso2.carbon.identity.base.IdentityConstants.SKIP_LOGOUT_CONSENT;
@@ -514,8 +512,7 @@ public class ServiceProviderToApiModel implements Function<ServiceProvider, Appl
                 .androidPackageName(trustedAppMetadata.getAndroidPackageName())
                 .androidThumbprints(thumbprints != null ? Arrays.asList(thumbprints) : null)
                 .appleAppId(trustedAppMetadata.getAppleAppId())
-                .isConsentGranted(Boolean.parseBoolean(IdentityUtil.getProperty(TRUSTED_APP_CONSENT_REQUIRED_PROPERTY))
-                        ? trustedAppMetadata.getIsConsentGranted() : null);
+                .isConsentGranted(trustedAppMetadata.getIsConsentGranted());
     }
 
     private List<AdditionalSpProperty> getSpProperties(ServiceProvider serviceProvider) {

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/functions/application/ServiceProviderToApiModel.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/functions/application/ServiceProviderToApiModel.java
@@ -503,7 +503,7 @@ public class ServiceProviderToApiModel implements Function<ServiceProvider, Appl
 
         SpTrustedAppMetadata trustedAppMetadata = serviceProvider.getTrustedAppMetadata();
         if (trustedAppMetadata == null) {
-            trustedAppMetadata = new SpTrustedAppMetadata();
+            return null;
         }
         String[] thumbprints = trustedAppMetadata.getAndroidThumbprints();
 

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/functions/application/ServiceProviderToApiModel.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/functions/application/ServiceProviderToApiModel.java
@@ -63,6 +63,7 @@ import org.wso2.carbon.identity.application.common.model.SpTrustedAppMetadata;
 import org.wso2.carbon.identity.application.common.util.IdentityApplicationConstants;
 import org.wso2.carbon.identity.application.mgt.ApplicationConstants;
 import org.wso2.carbon.identity.application.mgt.ApplicationMgtUtil;
+import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.role.v2.mgt.core.RoleConstants;
 import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
 
@@ -90,6 +91,7 @@ import static org.wso2.carbon.identity.application.common.util.IdentityApplicati
 import static org.wso2.carbon.identity.application.common.util.IdentityApplicationConstants.IS_MANAGEMENT_APP_SP_PROPERTY_NAME;
 import static org.wso2.carbon.identity.application.common.util.IdentityApplicationConstants.TEMPLATE_ID_SP_PROPERTY_NAME;
 import static org.wso2.carbon.identity.application.common.util.IdentityApplicationConstants.USE_USER_ID_FOR_DEFAULT_SUBJECT;
+import static org.wso2.carbon.identity.application.mgt.ApplicationConstants.TRUSTED_APP_CONSENT_REQUIRED_PROPERTY;
 import static org.wso2.carbon.identity.application.mgt.dao.impl.ApplicationDAOImpl.USE_DOMAIN_IN_ROLES;
 import static org.wso2.carbon.identity.base.IdentityConstants.SKIP_CONSENT;
 import static org.wso2.carbon.identity.base.IdentityConstants.SKIP_LOGOUT_CONSENT;
@@ -505,13 +507,15 @@ public class ServiceProviderToApiModel implements Function<ServiceProvider, Appl
         if (trustedAppMetadata == null) {
             trustedAppMetadata = new SpTrustedAppMetadata();
         }
+        String[] thumbprints = trustedAppMetadata.getAndroidThumbprints();
 
         return new TrustedAppConfiguration()
                 .isFIDOTrustedApp(trustedAppMetadata.getIsFidoTrusted())
                 .androidPackageName(trustedAppMetadata.getAndroidPackageName())
-                .androidThumbprints(Arrays.asList(trustedAppMetadata.getAndroidThumbprints()))
+                .androidThumbprints(thumbprints != null ? Arrays.asList(thumbprints) : null)
                 .appleAppId(trustedAppMetadata.getAppleAppId())
-                .isConsentGranted(trustedAppMetadata.getIsConsentGranted());
+                .isConsentGranted(Boolean.parseBoolean(IdentityUtil.getProperty(TRUSTED_APP_CONSENT_REQUIRED_PROPERTY))
+                        ? trustedAppMetadata.getIsConsentGranted() : null);
     }
 
     private List<AdditionalSpProperty> getSpProperties(ServiceProvider serviceProvider) {

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/functions/application/ServiceProviderToApiModel.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/functions/application/ServiceProviderToApiModel.java
@@ -510,7 +510,8 @@ public class ServiceProviderToApiModel implements Function<ServiceProvider, Appl
                 .isFIDOTrustedApp(trustedAppMetadata.getIsFidoTrusted())
                 .androidPackageName(trustedAppMetadata.getAndroidPackageName())
                 .androidThumbprints(trustedAppMetadata.getAndroidThumbprints())
-                .appleAppId(trustedAppMetadata.getAppleAppId());
+                .appleAppId(trustedAppMetadata.getAppleAppId())
+                .isConsentGranted(ApplicationMgtUtil.isTrustedAppConsentGranted(serviceProvider));
     }
 
     private List<AdditionalSpProperty> getSpProperties(ServiceProvider serviceProvider) {

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/functions/application/UpdateAdvancedConfigurations.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/functions/application/UpdateAdvancedConfigurations.java
@@ -131,6 +131,12 @@ public class UpdateAdvancedConfigurations implements UpdateFunction<ServiceProvi
         }
     }
 
+    /**
+     * Handles the trusted app configurations from the API model and sets them to the Service Provider object.
+     *
+     * @param trustedAppConfiguration The trusted app configuration of the API model.
+     * @param serviceProvider         The service provider to update.
+     */
     private void handleTrustedAppConfigurations(TrustedAppConfiguration trustedAppConfiguration,
                                                 ServiceProvider serviceProvider) {
 

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/functions/application/UpdateAdvancedConfigurations.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/functions/application/UpdateAdvancedConfigurations.java
@@ -135,8 +135,8 @@ public class UpdateAdvancedConfigurations implements UpdateFunction<ServiceProvi
     private void handleTrustedAppConfigurations(TrustedAppConfiguration trustedAppConfiguration,
                                                 ServiceProvider serviceProvider) {
 
-        SpTrustedAppMetadata trustedAppMetadata = new SpTrustedAppMetadata();
         if (trustedAppConfiguration != null) {
+            SpTrustedAppMetadata trustedAppMetadata = new SpTrustedAppMetadata();
             List<String> thumbprints = trustedAppConfiguration.getAndroidThumbprints();
 
             setIfNotNull(trustedAppConfiguration.getAndroidPackageName(), trustedAppMetadata::setAndroidPackageName);
@@ -145,7 +145,9 @@ public class UpdateAdvancedConfigurations implements UpdateFunction<ServiceProvi
             setIfNotNull(trustedAppConfiguration.getAppleAppId(), trustedAppMetadata::setAppleAppId);
             setIfNotNull(trustedAppConfiguration.getIsFIDOTrustedApp(), trustedAppMetadata::setIsFidoTrusted);
             setIfNotNull(trustedAppConfiguration.getIsConsentGranted(), trustedAppMetadata::setIsConsentGranted);
+            serviceProvider.setTrustedAppMetadata(trustedAppMetadata);
+        } else {
+            serviceProvider.setTrustedAppMetadata(null);
         }
-        serviceProvider.setTrustedAppMetadata(trustedAppMetadata);
     }
 }

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/functions/application/UpdateAdvancedConfigurations.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/functions/application/UpdateAdvancedConfigurations.java
@@ -24,6 +24,7 @@ import org.wso2.carbon.identity.api.server.application.management.v1.core.functi
 import org.wso2.carbon.identity.application.common.model.ClientAttestationMetaData;
 import org.wso2.carbon.identity.application.common.model.LocalAndOutboundAuthenticationConfig;
 import org.wso2.carbon.identity.application.common.model.ServiceProvider;
+import org.wso2.carbon.identity.application.common.model.TrustedAppMetadata;
 
 import java.util.List;
 
@@ -75,6 +76,18 @@ public class UpdateAdvancedConfigurations implements UpdateFunction<ServiceProvi
                             clientAttestationMetaData::setAndroidAttestationServiceCredentials);
                 }
                 serviceProvider.setClientAttestationMetaData(clientAttestationMetaData);
+            }
+            if (advancedConfigurations.getTrustedAppConfiguration() != null) {
+                TrustedAppMetadata trustedAppMetadata = new TrustedAppMetadata();
+                setIfNotNull(advancedConfigurations.getTrustedAppConfiguration().getIsFIDOTrustedApp(),
+                        trustedAppMetadata::setIsFidoTrusted);
+                setIfNotNull(advancedConfigurations.getTrustedAppConfiguration().getAndroidPackageName(),
+                        trustedAppMetadata::setAndroidPackageName);
+                setIfNotNull(advancedConfigurations.getTrustedAppConfiguration().getAndroidThumbprints(),
+                        trustedAppMetadata::setAndroidThumbprints);
+                setIfNotNull(advancedConfigurations.getTrustedAppConfiguration().getAppleAppId(),
+                        trustedAppMetadata::setAppleAppId);
+                serviceProvider.setTrustedAppMetadata(trustedAppMetadata);
             }
             updateCertificate(advancedConfigurations.getCertificate(), serviceProvider);
         }

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/functions/application/UpdateAdvancedConfigurations.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/functions/application/UpdateAdvancedConfigurations.java
@@ -17,6 +17,7 @@ package org.wso2.carbon.identity.api.server.application.management.v1.core.funct
 
 import com.google.gson.Gson;
 import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.lang.StringUtils;
 import org.wso2.carbon.identity.api.server.application.management.v1.AdditionalSpProperty;
 import org.wso2.carbon.identity.api.server.application.management.v1.AdvancedApplicationConfiguration;
 import org.wso2.carbon.identity.api.server.application.management.v1.Certificate;
@@ -24,11 +25,12 @@ import org.wso2.carbon.identity.api.server.application.management.v1.core.functi
 import org.wso2.carbon.identity.application.common.model.ClientAttestationMetaData;
 import org.wso2.carbon.identity.application.common.model.LocalAndOutboundAuthenticationConfig;
 import org.wso2.carbon.identity.application.common.model.ServiceProvider;
-import org.wso2.carbon.identity.application.common.model.TrustedAppMetadata;
+import org.wso2.carbon.identity.application.common.model.SpTrustedAppMetadata;
 
 import java.util.List;
 
 import static org.wso2.carbon.identity.api.server.application.management.common.ApplicationManagementConstants.ErrorMessage.ADDITIONAL_SP_PROP_NOT_SUPPORTED;
+import static org.wso2.carbon.identity.api.server.application.management.common.ApplicationManagementConstants.ErrorMessage.ANDROID_THUMBPRINT_NOT_PROVIDED;
 import static org.wso2.carbon.identity.api.server.application.management.v1.core.functions.Utils.buildBadRequestError;
 import static org.wso2.carbon.identity.api.server.application.management.v1.core.functions.Utils.setIfNotNull;
 
@@ -78,7 +80,13 @@ public class UpdateAdvancedConfigurations implements UpdateFunction<ServiceProvi
                 serviceProvider.setClientAttestationMetaData(clientAttestationMetaData);
             }
             if (advancedConfigurations.getTrustedAppConfiguration() != null) {
-                TrustedAppMetadata trustedAppMetadata = new TrustedAppMetadata();
+                if (StringUtils.isNotBlank(advancedConfigurations.getTrustedAppConfiguration().getAndroidPackageName())
+                        && StringUtils.isBlank(advancedConfigurations.getTrustedAppConfiguration()
+                        .getAndroidThumbprints())) {
+                    throw buildBadRequestError(ANDROID_THUMBPRINT_NOT_PROVIDED.getCode(),
+                            ANDROID_THUMBPRINT_NOT_PROVIDED.getDescription());
+                }
+                SpTrustedAppMetadata trustedAppMetadata = new SpTrustedAppMetadata();
                 setIfNotNull(advancedConfigurations.getTrustedAppConfiguration().getIsFIDOTrustedApp(),
                         trustedAppMetadata::setIsFidoTrusted);
                 setIfNotNull(advancedConfigurations.getTrustedAppConfiguration().getAndroidPackageName(),

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/functions/application/UpdateAdvancedConfigurations.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/functions/application/UpdateAdvancedConfigurations.java
@@ -30,7 +30,7 @@ import org.wso2.carbon.identity.application.common.model.SpTrustedAppMetadata;
 import java.util.List;
 
 import static org.wso2.carbon.identity.api.server.application.management.common.ApplicationManagementConstants.ErrorMessage.ADDITIONAL_SP_PROP_NOT_SUPPORTED;
-import static org.wso2.carbon.identity.api.server.application.management.common.ApplicationManagementConstants.ErrorMessage.ANDROID_THUMBPRINT_NOT_PROVIDED;
+import static org.wso2.carbon.identity.api.server.application.management.common.ApplicationManagementConstants.ErrorMessage.INCORRECT_ANDROID_APP_DETAILS;
 import static org.wso2.carbon.identity.api.server.application.management.v1.core.functions.Utils.buildBadRequestError;
 import static org.wso2.carbon.identity.api.server.application.management.v1.core.functions.Utils.setIfNotNull;
 
@@ -80,19 +80,19 @@ public class UpdateAdvancedConfigurations implements UpdateFunction<ServiceProvi
                 serviceProvider.setClientAttestationMetaData(clientAttestationMetaData);
             }
             if (advancedConfigurations.getTrustedAppConfiguration() != null) {
-                if (StringUtils.isNotBlank(advancedConfigurations.getTrustedAppConfiguration().getAndroidPackageName())
-                        && StringUtils.isBlank(advancedConfigurations.getTrustedAppConfiguration()
-                        .getAndroidThumbprints())) {
-                    throw buildBadRequestError(ANDROID_THUMBPRINT_NOT_PROVIDED.getCode(),
-                            ANDROID_THUMBPRINT_NOT_PROVIDED.getDescription());
+                String androidPackageName = advancedConfigurations.getTrustedAppConfiguration().getAndroidPackageName();
+                String androidThumbprints = advancedConfigurations.getTrustedAppConfiguration().getAndroidThumbprints();
+
+                if ((StringUtils.isNotBlank(androidPackageName) && StringUtils.isBlank(androidThumbprints)) ||
+                        (StringUtils.isBlank(androidPackageName) && StringUtils.isNotBlank(androidThumbprints))) {
+                    throw buildBadRequestError(INCORRECT_ANDROID_APP_DETAILS.getCode(),
+                            INCORRECT_ANDROID_APP_DETAILS.getDescription());
                 }
                 SpTrustedAppMetadata trustedAppMetadata = new SpTrustedAppMetadata();
+                setIfNotNull(androidPackageName, trustedAppMetadata::setAndroidPackageName);
+                setIfNotNull(androidThumbprints, trustedAppMetadata::setAndroidThumbprints);
                 setIfNotNull(advancedConfigurations.getTrustedAppConfiguration().getIsFIDOTrustedApp(),
                         trustedAppMetadata::setIsFidoTrusted);
-                setIfNotNull(advancedConfigurations.getTrustedAppConfiguration().getAndroidPackageName(),
-                        trustedAppMetadata::setAndroidPackageName);
-                setIfNotNull(advancedConfigurations.getTrustedAppConfiguration().getAndroidThumbprints(),
-                        trustedAppMetadata::setAndroidThumbprints);
                 setIfNotNull(advancedConfigurations.getTrustedAppConfiguration().getAppleAppId(),
                         trustedAppMetadata::setAppleAppId);
                 serviceProvider.setTrustedAppMetadata(trustedAppMetadata);

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/functions/application/UpdateAdvancedConfigurations.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/functions/application/UpdateAdvancedConfigurations.java
@@ -32,6 +32,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import static org.wso2.carbon.identity.api.server.application.management.common.ApplicationManagementConstants.ATTRIBUTE_SEPARATOR;
 import static org.wso2.carbon.identity.api.server.application.management.common.ApplicationManagementConstants.ErrorMessage.ADDITIONAL_SP_PROP_NOT_SUPPORTED;
 import static org.wso2.carbon.identity.api.server.application.management.v1.core.functions.Utils.buildBadRequestError;
 import static org.wso2.carbon.identity.api.server.application.management.v1.core.functions.Utils.setIfNotNull;
@@ -143,7 +144,8 @@ public class UpdateAdvancedConfigurations implements UpdateFunction<ServiceProvi
         if (trustedAppConfiguration != null) {
             SpTrustedAppMetadata trustedAppMetadata = new SpTrustedAppMetadata();
             setIfNotNull(trustedAppConfiguration.getAndroidPackageName(), trustedAppMetadata::setAndroidPackageName);
-            setIfNotNull(trustedAppConfiguration.getAndroidThumbprints(), trustedAppMetadata::setAndroidThumbprints);
+            setIfNotNull(String.join(ATTRIBUTE_SEPARATOR, trustedAppConfiguration.getAndroidThumbprints()),
+                    trustedAppMetadata::setAndroidThumbprints);
             setIfNotNull(trustedAppConfiguration.getIsFIDOTrustedApp(), trustedAppMetadata::setIsFidoTrusted);
             setIfNotNull(trustedAppConfiguration.getAppleAppId(), trustedAppMetadata::setAppleAppId);
             serviceProvider.setTrustedAppMetadata(trustedAppMetadata);

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/functions/application/UpdateAdvancedConfigurations.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/functions/application/UpdateAdvancedConfigurations.java
@@ -135,15 +135,17 @@ public class UpdateAdvancedConfigurations implements UpdateFunction<ServiceProvi
     private void handleTrustedAppConfigurations(TrustedAppConfiguration trustedAppConfiguration,
                                                 ServiceProvider serviceProvider) {
 
+        SpTrustedAppMetadata trustedAppMetadata = new SpTrustedAppMetadata();
         if (trustedAppConfiguration != null) {
-            SpTrustedAppMetadata trustedAppMetadata = new SpTrustedAppMetadata();
+            List<String> thumbprints = trustedAppConfiguration.getAndroidThumbprints();
+
             setIfNotNull(trustedAppConfiguration.getAndroidPackageName(), trustedAppMetadata::setAndroidPackageName);
-            setIfNotNull(trustedAppConfiguration.getAndroidThumbprints().toArray(new String[0]),
+            setIfNotNull(thumbprints != null ? thumbprints.toArray(new String[0]) : null,
                     trustedAppMetadata::setAndroidThumbprints);
             setIfNotNull(trustedAppConfiguration.getAppleAppId(), trustedAppMetadata::setAppleAppId);
             setIfNotNull(trustedAppConfiguration.getIsFIDOTrustedApp(), trustedAppMetadata::setIsFidoTrusted);
             setIfNotNull(trustedAppConfiguration.getIsConsentGranted(), trustedAppMetadata::setIsConsentGranted);
-            serviceProvider.setTrustedAppMetadata(trustedAppMetadata);
         }
+        serviceProvider.setTrustedAppMetadata(trustedAppMetadata);
     }
 }

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/functions/application/UpdateAdvancedConfigurations.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/functions/application/UpdateAdvancedConfigurations.java
@@ -25,19 +25,13 @@ import org.wso2.carbon.identity.api.server.application.management.v1.core.functi
 import org.wso2.carbon.identity.application.common.model.ClientAttestationMetaData;
 import org.wso2.carbon.identity.application.common.model.LocalAndOutboundAuthenticationConfig;
 import org.wso2.carbon.identity.application.common.model.ServiceProvider;
-import org.wso2.carbon.identity.application.common.model.ServiceProviderProperty;
 import org.wso2.carbon.identity.application.common.model.SpTrustedAppMetadata;
 
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
-import static org.wso2.carbon.identity.api.server.application.management.common.ApplicationManagementConstants.ATTRIBUTE_SEPARATOR;
 import static org.wso2.carbon.identity.api.server.application.management.common.ApplicationManagementConstants.ErrorMessage.ADDITIONAL_SP_PROP_NOT_SUPPORTED;
 import static org.wso2.carbon.identity.api.server.application.management.v1.core.functions.Utils.buildBadRequestError;
 import static org.wso2.carbon.identity.api.server.application.management.v1.core.functions.Utils.setIfNotNull;
-import static org.wso2.carbon.identity.application.common.util.IdentityApplicationConstants.TRUSTED_APP_CONSENT_GRANTED_SP_PROPERTY_DISPLAY_NAME;
-import static org.wso2.carbon.identity.application.common.util.IdentityApplicationConstants.TRUSTED_APP_CONSENT_GRANTED_SP_PROPERTY_NAME;
 
 /**
  * Updates the advanced application configurations defined by the API model in the Service Provider model.
@@ -144,30 +138,12 @@ public class UpdateAdvancedConfigurations implements UpdateFunction<ServiceProvi
         if (trustedAppConfiguration != null) {
             SpTrustedAppMetadata trustedAppMetadata = new SpTrustedAppMetadata();
             setIfNotNull(trustedAppConfiguration.getAndroidPackageName(), trustedAppMetadata::setAndroidPackageName);
-            setIfNotNull(String.join(ATTRIBUTE_SEPARATOR, trustedAppConfiguration.getAndroidThumbprints()),
+            setIfNotNull(trustedAppConfiguration.getAndroidThumbprints().toArray(new String[0]),
                     trustedAppMetadata::setAndroidThumbprints);
-            setIfNotNull(trustedAppConfiguration.getIsFIDOTrustedApp(), trustedAppMetadata::setIsFidoTrusted);
             setIfNotNull(trustedAppConfiguration.getAppleAppId(), trustedAppMetadata::setAppleAppId);
+            setIfNotNull(trustedAppConfiguration.getIsFIDOTrustedApp(), trustedAppMetadata::setIsFidoTrusted);
+            setIfNotNull(trustedAppConfiguration.getIsConsentGranted(), trustedAppMetadata::setIsConsentGranted);
             serviceProvider.setTrustedAppMetadata(trustedAppMetadata);
-
-            if (trustedAppConfiguration.getIsConsentGranted() != null) {
-                // Update the SP properties with the consent granted status of the trusted app.
-                ArrayList<ServiceProviderProperty> serviceProviderProperties =
-                        new ArrayList<>(Arrays.asList(serviceProvider.getSpProperties()));
-
-                for (ServiceProviderProperty spProperty : serviceProviderProperties) {
-                    if (TRUSTED_APP_CONSENT_GRANTED_SP_PROPERTY_NAME.equals(spProperty.getName())) {
-                        serviceProviderProperties.remove(spProperty);
-                        break;
-                    }
-                }
-                ServiceProviderProperty serviceProviderProperty = new ServiceProviderProperty();
-                serviceProviderProperty.setName(TRUSTED_APP_CONSENT_GRANTED_SP_PROPERTY_NAME);
-                serviceProviderProperty.setValue(trustedAppConfiguration.getIsConsentGranted().toString());
-                serviceProviderProperty.setDisplayName(TRUSTED_APP_CONSENT_GRANTED_SP_PROPERTY_DISPLAY_NAME);
-                serviceProviderProperties.add(serviceProviderProperty);
-                serviceProvider.setSpProperties(serviceProviderProperties.toArray(new ServiceProviderProperty[0]));
-            }
         }
     }
 }

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/resources/applications.yaml
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/resources/applications.yaml
@@ -3121,6 +3121,8 @@ components:
               type: string
               description: Decides the apple app id which denotes {apple-teamId}.{bundleId}.
               example: "APPLETEAMID.com.wso2.mobile.sample"
+        trustedAppConfiguration:
+          $ref: '#/components/schemas/TrustedAppConfiguration'
         additionalSpProperties:
           $ref: '#/components/schemas/AdditionalProperties'
     AdditionalProperties:
@@ -3142,6 +3144,26 @@ components:
         displayName:
           type: string
           example: "Internal Application"
+    TrustedAppConfiguration:
+      type: object
+      description: Decides the trusted app configurations for the application.
+      properties:
+        isFIDOTrustedApp:
+          type: boolean
+          description: Decides whether the application is a FIDO trusted app.
+          example: false
+        androidPackageName:
+          type: string
+          description: Decides the android package name for the application.
+          example: "com.wso2.mobile.sample"
+        androidThumbprints:
+          type: string
+          description: Decides the android thumbprints for the application.
+          example: "18:94:0A:DE:63:77:B6:84:43:1E:85:8F:03:CF:8A:14:87:9C:DE:DF:EA:7A:25:53:CD:53:5A:AF:C3:54:A5:56"
+        appleAppId:
+          type: string
+          description: Decides the apple app id for the application.
+          example: "APPLETEAMID.com.wso2.mobile.sample"
     Certificate:
       type: object
       properties:

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/resources/applications.yaml
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/resources/applications.yaml
@@ -3152,6 +3152,10 @@ components:
           type: boolean
           description: Decides whether the application is a FIDO trusted app.
           example: false
+        isConsentGranted:
+          type: boolean
+          description: Decides whether consent is granted for the trusted app.
+          example: false
         androidPackageName:
           type: string
           description: Decides the android package name for the application.

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/resources/applications.yaml
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/resources/applications.yaml
@@ -3161,13 +3161,16 @@ components:
           description: Decides the android package name for the application.
           example: "com.wso2.mobile.sample"
         androidThumbprints:
-          type: string
+          type: array
+          items:
+            type: string
+            example:
+              - "18:94:0A:DE:63:77:B6:84:43:1E:85:8F:03:CF:8A:14:87:9C:DE:DF:EA:7A:25:53:CD:53:5A:AF:C3:54:A5:56"
           description: Decides the android thumbprints for the application.
-          example: "18:94:0A:DE:63:77:B6:84:43:1E:85:8F:03:CF:8A:14:87:9C:DE:DF:EA:7A:25:53:CD:53:5A:AF:C3:54:A5:56"
         appleAppId:
           type: string
           description: Decides the apple app id for the application.
-          example: "APPLETEAMID.com.wso2.mobile.sample"
+          example: "APPLETEAMID.com.org.mobile.sample"
     Certificate:
       type: object
       properties:

--- a/pom.xml
+++ b/pom.xml
@@ -791,7 +791,7 @@
         <maven.buildnumber.plugin.version>1.4</maven.buildnumber.plugin.version>
         <org.apache.felix.annotations.version>1.2.4</org.apache.felix.annotations.version>
         <identity.governance.version>1.9.17</identity.governance.version>
-        <carbon.identity.framework.version>7.3.22-SNAPSHOT</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.3.26</carbon.identity.framework.version>
         <maven.findbugsplugin.version>3.0.5</maven.findbugsplugin.version>
         <findsecbugs-plugin.version>1.12.0</findsecbugs-plugin.version>
         <maven.checkstyleplugin.excludes>**/gen/**/*</maven.checkstyleplugin.excludes>

--- a/pom.xml
+++ b/pom.xml
@@ -791,7 +791,7 @@
         <maven.buildnumber.plugin.version>1.4</maven.buildnumber.plugin.version>
         <org.apache.felix.annotations.version>1.2.4</org.apache.felix.annotations.version>
         <identity.governance.version>1.9.17</identity.governance.version>
-        <carbon.identity.framework.version>7.2.37</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.3.22-SNAPSHOT</carbon.identity.framework.version>
         <maven.findbugsplugin.version>3.0.5</maven.findbugsplugin.version>
         <findsecbugs-plugin.version>1.12.0</findsecbugs-plugin.version>
         <maven.checkstyleplugin.excludes>**/gen/**/*</maven.checkstyleplugin.excludes>

--- a/pom.xml
+++ b/pom.xml
@@ -791,7 +791,7 @@
         <maven.buildnumber.plugin.version>1.4</maven.buildnumber.plugin.version>
         <org.apache.felix.annotations.version>1.2.4</org.apache.felix.annotations.version>
         <identity.governance.version>1.8.62</identity.governance.version>
-        <carbon.identity.framework.version>7.2.37</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.2.42-SNAPSHOT</carbon.identity.framework.version>
         <maven.findbugsplugin.version>3.0.5</maven.findbugsplugin.version>
         <findsecbugs-plugin.version>1.12.0</findsecbugs-plugin.version>
         <maven.checkstyleplugin.excludes>**/gen/**/*</maven.checkstyleplugin.excludes>


### PR DESCRIPTION
Related issue: https://github.com/wso2/product-is/issues/20487

This PR adds Trusted App Metadata to Application object under advanced configurations section as follows:

```
{
    "advancedConfigurations": {
        "trustedAppConfiguration": {
            "isFIDOTrustedApp": true,
            "isConsentGranted": true,
            "androidPackageName": "com.wso2.mobile.sample1",
            "androidThumbprints": "18:94:0A:DE:63:77:B6:84:43:1E:85:8F:03:CF:8A:14:87:9C:DE:DF:EA:7A:25:53:CD:53:5A:AF:C3:54:A5:56",
            "appleAppId": "APPLETEAMID.com.org.mobile.sample"
        }
    }
}
``` 

Merge after https://github.com/wso2/carbon-identity-framework/pull/5753