### PR TITLE
Extending Organization Filtering to Metadata Attributes

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/management/v1/OrganizationsApi.java
+++ b/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/management/v1/OrganizationsApi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -230,7 +230,7 @@ public class OrganizationsApi  {
     
     
     @Produces({ "application/json" })
-    @ApiOperation(value = "Retrieve organizations created for this tenant which matches the defined search criteria, if any.", notes = "This API is used to search and retrieve organizations created for this tenant.", response = OrganizationsResponse.class, authorizations = {
+    @ApiOperation(value = "Retrieve organizations created for this tenant which matches the defined search criteria, if any.", notes = "This API is used to search and retrieve organizations created for this tenant.  Organizations can be filtered by id, name, description, created, lastModified, status, parentId, and meta attributes.         Supported operators: \"eq\" (equals), \"co\" (contains), \"sw\" (starts with), \"ew\" (ends with), \"ge\" (greater than or equals), \"le\" (less than or equals), \"gt\" (greater than), \"lt\" (less than)  Multiple attributes can be combined using the \"and\" operator.  Examples:   - filter=name+eq+ABC Builders   - filter=attributes.Country+eq+Sri Lanka  <b>Scope(Permission) required:</b> `internal_organization_view` ", response = OrganizationsResponse.class, authorizations = {
         @Authorization(value = "BasicAuth"),
         @Authorization(value = "OAuth2", scopes = {
             

--- a/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/management/v1/model/BasicOrganizationResponse.java
+++ b/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/management/v1/model/BasicOrganizationResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -22,13 +22,13 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import java.util.ArrayList;
+import java.util.List;
+import org.wso2.carbon.identity.api.server.organization.management.v1.model.Attribute;
 import javax.validation.constraints.*;
 
 
 import io.swagger.annotations.*;
-
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Objects;
 import javax.validation.Valid;
 import javax.xml.bind.annotation.*;
@@ -74,36 +74,12 @@ public enum StatusEnum {
     private String ref;
     private List<Attribute> attributes = null;
 
+
     /**
     **/
     public BasicOrganizationResponse id(String id) {
 
         this.id = id;
-        return this;
-    }
-
-    public BasicOrganizationResponse attributes(List<Attribute> attributes) {
-
-        this.attributes = attributes;
-        return this;
-    }
-
-    @ApiModelProperty(value = "")
-    @JsonProperty("attributes")
-    @Valid
-    public List<Attribute> getAttributes() {
-        return attributes;
-    }
-    public void setAttributes(List<Attribute> attributes) {
-        this.attributes = attributes;
-    }
-
-    public BasicOrganizationResponse addAttributesItem(Attribute attributesItem) {
-
-        if (this.attributes == null) {
-            this.attributes = new ArrayList<>();
-        }
-        this.attributes.add(attributesItem);
         return this;
     }
     
@@ -179,7 +155,33 @@ public enum StatusEnum {
         this.ref = ref;
     }
 
+    /**
+    **/
+    public BasicOrganizationResponse attributes(List<Attribute> attributes) {
 
+        this.attributes = attributes;
+        return this;
+    }
+    
+    @ApiModelProperty(value = "")
+    @JsonProperty("attributes")
+    @Valid
+    public List<Attribute> getAttributes() {
+        return attributes;
+    }
+    public void setAttributes(List<Attribute> attributes) {
+        this.attributes = attributes;
+    }
+
+    public BasicOrganizationResponse addAttributesItem(Attribute attributesItem) {
+        if (this.attributes == null) {
+            this.attributes = new ArrayList<>();
+        }
+        this.attributes.add(attributesItem);
+        return this;
+    }
+
+    
 
     @Override
     public boolean equals(java.lang.Object o) {
@@ -194,13 +196,13 @@ public enum StatusEnum {
         return Objects.equals(this.id, basicOrganizationResponse.id) &&
             Objects.equals(this.name, basicOrganizationResponse.name) &&
             Objects.equals(this.status, basicOrganizationResponse.status) &&
-            Objects.equals(this.attributes, basicOrganizationResponse.attributes) &&
-            Objects.equals(this.ref, basicOrganizationResponse.ref);
+            Objects.equals(this.ref, basicOrganizationResponse.ref) &&
+            Objects.equals(this.attributes, basicOrganizationResponse.attributes);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, name, status, attributes, ref);
+        return Objects.hash(id, name, status, ref, attributes);
     }
 
     @Override
@@ -212,8 +214,8 @@ public enum StatusEnum {
         sb.append("    id: ").append(toIndentedString(id)).append("\n");
         sb.append("    name: ").append(toIndentedString(name)).append("\n");
         sb.append("    status: ").append(toIndentedString(status)).append("\n");
-        sb.append("    attributes: ").append(toIndentedString(attributes)).append("\n");
         sb.append("    ref: ").append(toIndentedString(ref)).append("\n");
+        sb.append("    attributes: ").append(toIndentedString(attributes)).append("\n");
         sb.append("}");
         return sb.toString();
     }

--- a/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/management/v1/model/BasicOrganizationResponse.java
+++ b/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/management/v1/model/BasicOrganizationResponse.java
@@ -26,6 +26,9 @@ import javax.validation.constraints.*;
 
 
 import io.swagger.annotations.*;
+
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
 import javax.validation.Valid;
 import javax.xml.bind.annotation.*;
@@ -69,12 +72,38 @@ public enum StatusEnum {
 
     private StatusEnum status;
     private String ref;
+    private List<Attribute> attributes = null;
 
     /**
     **/
     public BasicOrganizationResponse id(String id) {
 
         this.id = id;
+        return this;
+    }
+
+    public BasicOrganizationResponse attributes(List<Attribute> attributes) {
+
+        this.attributes = attributes;
+        return this;
+    }
+
+    @ApiModelProperty(value = "")
+    @JsonProperty("attributes")
+    @Valid
+    public List<Attribute> getAttributes() {
+        return attributes;
+    }
+    public void setAttributes(List<Attribute> attributes) {
+        this.attributes = attributes;
+    }
+
+    public BasicOrganizationResponse addAttributesItem(Attribute attributesItem) {
+
+        if (this.attributes == null) {
+            this.attributes = new ArrayList<>();
+        }
+        this.attributes.add(attributesItem);
         return this;
     }
     
@@ -165,12 +194,13 @@ public enum StatusEnum {
         return Objects.equals(this.id, basicOrganizationResponse.id) &&
             Objects.equals(this.name, basicOrganizationResponse.name) &&
             Objects.equals(this.status, basicOrganizationResponse.status) &&
+            Objects.equals(this.attributes, basicOrganizationResponse.attributes) &&
             Objects.equals(this.ref, basicOrganizationResponse.ref);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, name, status, ref);
+        return Objects.hash(id, name, status, attributes, ref);
     }
 
     @Override
@@ -182,6 +212,7 @@ public enum StatusEnum {
         sb.append("    id: ").append(toIndentedString(id)).append("\n");
         sb.append("    name: ").append(toIndentedString(name)).append("\n");
         sb.append("    status: ").append(toIndentedString(status)).append("\n");
+        sb.append("    attributes: ").append(toIndentedString(attributes)).append("\n");
         sb.append("    ref: ").append(toIndentedString(ref)).append("\n");
         sb.append("}");
         return sb.toString();

--- a/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.v1/src/main/java/org/wso2/carbon/identity/api/server/organization/management/v1/service/OrganizationManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.v1/src/main/java/org/wso2/carbon/identity/api/server/organization/management/v1/service/OrganizationManagementService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2023-2024, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except

--- a/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.v1/src/main/java/org/wso2/carbon/identity/api/server/organization/management/v1/service/OrganizationManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.v1/src/main/java/org/wso2/carbon/identity/api/server/organization/management/v1/service/OrganizationManagementService.java
@@ -119,7 +119,7 @@ public class OrganizationManagementService {
         try {
             limit = validateLimit(limit);
             String sortOrder = StringUtils.isNotBlank(before) ? ASC_SORT_ORDER : DESC_SORT_ORDER;
-            List<BasicOrganization> organizations = getOrganizationManager().getOrganizations(limit + 1, after,
+            List<Organization> organizations = getOrganizationManager().getOrganizationsList(limit + 1, after,
                     before, sortOrder, filter, Boolean.TRUE.equals(recursive));
             return Response.ok().entity(getOrganizationsResponse(limit, after, before, filter, organizations,
                     Boolean.TRUE.equals(recursive))).build();
@@ -694,7 +694,7 @@ public class OrganizationManagementService {
     }
 
     private OrganizationsResponse getOrganizationsResponse(Integer limit, String after, String before, String filter,
-                                                           List<BasicOrganization> organizations, boolean recursive)
+                                                           List<Organization> organizations, boolean recursive)
             throws OrganizationManagementServerException {
 
         OrganizationsResponse organizationsResponse = new OrganizationsResponse();
@@ -727,7 +727,7 @@ public class OrganizationManagementService {
                 Collections.reverse(organizations);
             }
             if (!isFirstPage) {
-                String encodedString = Base64.getEncoder().encodeToString(organizations.get(0).getCreated()
+                String encodedString = Base64.getEncoder().encodeToString(organizations.get(0).getCreated().toString()
                         .getBytes(StandardCharsets.UTF_8));
                 Link link = new Link();
                 link.setHref(URI.create(
@@ -737,7 +737,7 @@ public class OrganizationManagementService {
             }
             if (!isLastPage) {
                 String encodedString = Base64.getEncoder().encodeToString(organizations.get(organizations.size() - 1)
-                        .getCreated().getBytes(StandardCharsets.UTF_8));
+                        .getCreated().toString().getBytes(StandardCharsets.UTF_8));
                 Link link = new Link();
                 link.setHref(URI.create(
                         OrganizationManagementEndpointUtil.buildURIForPagination(url) + "&after=" + encodedString));
@@ -746,12 +746,16 @@ public class OrganizationManagementService {
             }
 
             List<BasicOrganizationResponse> organizationDTOs = new ArrayList<>();
-            for (BasicOrganization organization : organizations) {
+            for (Organization organization : organizations) {
                 BasicOrganizationResponse organizationDTO = new BasicOrganizationResponse();
                 organizationDTO.setId(organization.getId());
                 organizationDTO.setName(organization.getName());
                 organizationDTO.setStatus(BasicOrganizationResponse.StatusEnum.valueOf(organization.getStatus()));
                 organizationDTO.setRef(buildOrganizationURL(organization.getId()).toString());
+                List<Attribute> attributeList = getOrganizationAttributes(organization);
+                if (!attributeList.isEmpty()) {
+                    organizationDTO.setAttributes(attributeList);
+                }
                 organizationDTOs.add(organizationDTO);
             }
             organizationsResponse.setOrganizations(organizationDTOs);

--- a/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.v1/src/main/resources/org.wso2.carbon.identity.organization.management.yaml
+++ b/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.v1/src/main/resources/org.wso2.carbon.identity.organization.management.yaml
@@ -971,6 +971,10 @@ components:
         ref:
           type: string
           example: 'o/10084a8d-113f-4211-a0d5-efe36b082211/api/server/v1/organizations/b4526d91-a8bf-43d2-8b14-c548cf73065b'
+        attributes:
+          type: array
+          items:
+            $ref: '#/components/schemas/Attribute'
     OrganizationResponse:
       type: object
       required:

--- a/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.v1/src/main/resources/org.wso2.carbon.identity.organization.management.yaml
+++ b/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.v1/src/main/resources/org.wso2.carbon.identity.organization.management.yaml
@@ -60,8 +60,20 @@ paths:
         '500':
           $ref: '#/components/responses/ServerError'
     get:
-      description:
+      description: |
         This API is used to search and retrieve organizations created for this tenant.
+        
+        Organizations can be filtered by id, name, description, created, lastModified, status, parentId, and meta attributes. 
+              
+        Supported operators: "eq" (equals), "co" (contains), "sw" (starts with), "ew" (ends with), "ge" (greater than or equals), "le" (less than or equals), "gt" (greater than), "lt" (less than)
+        
+        Multiple attributes can be combined using the "and" operator.
+        
+        Examples:
+          - filter=name+eq+ABC Builders
+          - filter=attributes.Country+eq+Sri Lanka
+        
+        <b>Scope(Permission) required:</b> `internal_organization_view`
       summary:
         Retrieve organizations created for this tenant which matches the defined search criteria, if any.
       operationId: organizationsGet

--- a/pom.xml
+++ b/pom.xml
@@ -815,7 +815,7 @@
         <identity.verification.version>1.0.3</identity.verification.version>
 
         <!-- Organization management core Version -->
-        <org.wso2.carbon.identity.organization.management.core.version>1.0.89
+        <org.wso2.carbon.identity.organization.management.core.version>1.1.10
         </org.wso2.carbon.identity.organization.management.core.version>
         <org.wso2.carbon.identity.organization.management.core.version.range>[1.0.0, 2.0.0)
         </org.wso2.carbon.identity.organization.management.core.version.range>


### PR DESCRIPTION
## Purpose

Related to: https://github.com/wso2/product-is/issues/20611

> The current organization filtering functionality is limited to primary attributes (ID, name, description, created date, last modified date, status, and parentID). This feature aims to extend the filtering capability to include metadata attributes of organizations.

## Approach
> Updated the BasicOrgnizationResponse to return Attributes.

## Related PRs
**Need to bump version after merging the following PR:**
> https://github.com/wso2/identity-organization-management-core/pull/139

## Test environment
> JDK version: 11.0.23
> Product Version: IS 7.0.1