### PR TITLE
Update Application Branding Resolver Calling Method

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.branding.preference.management/org.wso2.carbon.identity.api.server.branding.preference.management.v1/src/main/java/org/wso2/carbon/identity/api/server/branding/preference/management/v1/core/BrandingPreferenceManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.branding.preference.management/org.wso2.carbon.identity.api.server.branding.preference.management.v1/src/main/java/org/wso2/carbon/identity/api/server/branding/preference/management/v1/core/BrandingPreferenceManagementService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2023, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2021-2024, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -202,7 +202,7 @@ public class BrandingPreferenceManagementService {
             if (APPLICATION_TYPE.equals(type)) {
                 // Get application specific branding preference.
                 responseDTO = BrandingPreferenceServiceHolder.getBrandingPreferenceManager().
-                        resolveApplicationBrandingPreference(name, DEFAULT_LOCALE);
+                        resolveBrandingPreference(APPLICATION_TYPE, name, DEFAULT_LOCALE);
             } else {
                 // Get default branding preference.
                 responseDTO = BrandingPreferenceServiceHolder.getBrandingPreferenceManager().


### PR DESCRIPTION
## Purpose
- The `resolveApplicationBrandingPreference` method is now deprecated and instead, `resolveBrandingPreference` method is used with the type as "APP".

## Related PRs
- https://github.com/wso2-extensions/identity-branding-preference-management/pull/40/
