### PR TITLE
Add GET API Endpoint for Organization Meta Attributes

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/management/v1/OrganizationsApi.java
+++ b/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/management/v1/OrganizationsApi.java
@@ -28,6 +28,7 @@ import org.wso2.carbon.identity.api.server.organization.management.v1.model.Appl
 import org.wso2.carbon.identity.api.server.organization.management.v1.model.Error;
 import org.wso2.carbon.identity.api.server.organization.management.v1.model.GetOrganizationResponse;
 import java.util.List;
+import org.wso2.carbon.identity.api.server.organization.management.v1.model.MetaAttributesResponse;
 import org.wso2.carbon.identity.api.server.organization.management.v1.model.OrganizationDiscoveryAttributes;
 import org.wso2.carbon.identity.api.server.organization.management.v1.model.OrganizationDiscoveryCheckPOSTRequest;
 import org.wso2.carbon.identity.api.server.organization.management.v1.model.OrganizationDiscoveryCheckPOSTResponse;
@@ -244,9 +245,33 @@ public class OrganizationsApi  {
         @ApiResponse(code = 500, message = "Internal server error.", response = Error.class),
         @ApiResponse(code = 501, message = "Not Implemented.", response = Error.class)
     })
-    public Response organizationsGet(    @Valid@ApiParam(value = "Condition to filter the retrieval of records.")  @QueryParam("filter") String filter,     @Valid @Min(0)@ApiParam(value = "Maximum number of records to be returned. (Should be greater than 0)")  @QueryParam("limit") Integer limit,     @Valid@ApiParam(value = "Points to the next range of data to be returned.")  @QueryParam("after") String after,     @Valid@ApiParam(value = "Points to the previous range of data that can be retrieved.")  @QueryParam("before") String before,     @Valid@ApiParam(value = "Determines whether a recursive search should happen.", defaultValue="false") @DefaultValue("false")  @QueryParam("recursive") Boolean recursive) {
+    public Response organizationsGet(    @Valid@ApiParam(value = "Condition to filter the retrieval of records.")  @QueryParam("filter") String filter,     @Valid @Min(0)@ApiParam(value = "Maximum number of records to be returned. (Should be greater than 0)")  @QueryParam("limit") Integer limit,     @Valid@ApiParam(value = "Points to the next range of data to be returned.")  @QueryParam("after") String after,     @Valid@ApiParam(value = "Points to the previous range of data that can be retrieved.")  @QueryParam("before") String before,     @Valid@ApiParam(value = "Determines whether a recursive search should happen. If set to true, will include organizations in all levels of the hierarchy; If set to false, includes only organizations in the next level of the hierarchy. ", defaultValue="false") @DefaultValue("false")  @QueryParam("recursive") Boolean recursive) {
 
         return delegate.organizationsGet(filter,  limit,  after,  before,  recursive );
+    }
+
+    @Valid
+    @GET
+    @Path("/meta-attributes")
+    
+    @Produces({ "application/json" })
+    @ApiOperation(value = "Get meta attributes of organizations with filter capabilities.", notes = "This API facilitates the retrieval of organization meta attributes which matches the defined search criteria, if any.  Supported operators: \"eq\"(equals), \"co\"(contains), \"sw\"(starts with), \"ew\"(ends with), \"ge\"(greater than or equals), \"le\"(less than or equals), \"gt\"(greater than), \"lt\"(less than)  Multiple filters can be combined using the \"and\" operator.  Example: filter=attributes+eq+Country  <b>Scope(Permission) required:</b> `internal_organization_view` ", response = MetaAttributesResponse.class, authorizations = {
+        @Authorization(value = "BasicAuth"),
+        @Authorization(value = "OAuth2", scopes = {
+            
+        })
+    }, tags={ "Organization Meta Attributes", })
+    @ApiResponses(value = { 
+        @ApiResponse(code = 200, message = "Successful response", response = MetaAttributesResponse.class),
+        @ApiResponse(code = 400, message = "Invalid input in the request.", response = Error.class),
+        @ApiResponse(code = 401, message = "Authentication information is missing or invalid.", response = Void.class),
+        @ApiResponse(code = 403, message = "Access forbidden.", response = Void.class),
+        @ApiResponse(code = 500, message = "Internal server error.", response = Error.class),
+        @ApiResponse(code = 501, message = "Not Implemented.", response = Error.class)
+    })
+    public Response organizationsMetaAttributesGet(    @Valid@ApiParam(value = "Condition to filter the retrieval of records.")  @QueryParam("filter") String filter,     @Valid @Min(0)@ApiParam(value = "Maximum number of records to be returned. (Should be greater than 0)")  @QueryParam("limit") Integer limit,     @Valid@ApiParam(value = "Points to the next range of data to be returned.")  @QueryParam("after") String after,     @Valid@ApiParam(value = "Points to the previous range of data that can be retrieved.")  @QueryParam("before") String before,     @Valid@ApiParam(value = "Determines whether a recursive search should happen. If set to true, will include organizations in all levels of the hierarchy; If set to false, includes only organizations in the next level of the hierarchy. ", defaultValue="false") @DefaultValue("false")  @QueryParam("recursive") Boolean recursive) {
+
+        return delegate.organizationsMetaAttributesGet(filter,  limit,  after,  before,  recursive );
     }
 
     @Valid

--- a/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/management/v1/OrganizationsApi.java
+++ b/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/management/v1/OrganizationsApi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -230,7 +230,7 @@ public class OrganizationsApi  {
     
     
     @Produces({ "application/json" })
-    @ApiOperation(value = "Retrieve organizations created for this tenant which matches the defined search criteria, if any.", notes = "This API is used to search and retrieve organizations created for this tenant.", response = OrganizationsResponse.class, authorizations = {
+    @ApiOperation(value = "Retrieve organizations created for this tenant which matches the defined search criteria, if any.", notes = "This API is used to search and retrieve organizations created for this tenant.  Organizations can be filtered by id, name, description, created, lastModified, status, parentId, and meta attributes.         Supported operators: \"eq\" (equals), \"co\" (contains), \"sw\" (starts with), \"ew\" (ends with), \"ge\" (greater than or equals), \"le\" (less than or equals), \"gt\" (greater than), \"lt\" (less than)  Multiple attributes can be combined using the \"and\" operator.  Examples:   - filter=name+eq+ABC Builders   - filter=attributes.Country+eq+Sri Lanka  <b>Scope(Permission) required:</b> `internal_organization_view` ", response = OrganizationsResponse.class, authorizations = {
         @Authorization(value = "BasicAuth"),
         @Authorization(value = "OAuth2", scopes = {
             

--- a/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/management/v1/OrganizationsApiService.java
+++ b/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/management/v1/OrganizationsApiService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -28,6 +28,7 @@ import org.wso2.carbon.identity.api.server.organization.management.v1.model.Appl
 import org.wso2.carbon.identity.api.server.organization.management.v1.model.Error;
 import org.wso2.carbon.identity.api.server.organization.management.v1.model.GetOrganizationResponse;
 import java.util.List;
+import org.wso2.carbon.identity.api.server.organization.management.v1.model.MetaAttributesResponse;
 import org.wso2.carbon.identity.api.server.organization.management.v1.model.OrganizationDiscoveryAttributes;
 import org.wso2.carbon.identity.api.server.organization.management.v1.model.OrganizationDiscoveryCheckPOSTRequest;
 import org.wso2.carbon.identity.api.server.organization.management.v1.model.OrganizationDiscoveryCheckPOSTResponse;
@@ -63,6 +64,8 @@ public interface OrganizationsApiService {
       public Response organizationsDiscoveryGet(String filter, Integer offset, Integer limit);
 
       public Response organizationsGet(String filter, Integer limit, String after, String before, Boolean recursive);
+
+      public Response organizationsMetaAttributesGet(String filter, Integer limit, String after, String before, Boolean recursive);
 
       public Response organizationsOrganizationIdDelete(String organizationId);
 

--- a/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/management/v1/model/MetaAttributesResponse.java
+++ b/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/management/v1/model/MetaAttributesResponse.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.organization.management.v1.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import java.util.ArrayList;
+import java.util.List;
+import org.wso2.carbon.identity.api.server.organization.management.v1.model.Link;
+import javax.validation.constraints.*;
+
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+import javax.validation.Valid;
+import javax.xml.bind.annotation.*;
+
+public class MetaAttributesResponse  {
+  
+    private List<Link> links = null;
+
+    private List<String> attributes = null;
+
+
+    /**
+    **/
+    public MetaAttributesResponse links(List<Link> links) {
+
+        this.links = links;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "[{\"href\":\"/o/10084a8d-113f-4211-a0d5-efe36b082211/api/server/v1/organizations/meta-attributes?limit=10&filter=key+co+country&next=MjAyMS0xMi0yMSAwNToxODozMS4wMDQzNDg=\",\"rel\":\"next\"},{\"href\":\"/o/10084a8d-113f-4211-a0d5-efe36b082211/api/server/v1/organizations/meta-attributes?limit=10&filter=key+co+country&before=MjAyMS0xMi0yMSAwNToxODozMS4wMDQzNDg=\",\"rel\":\"previous\"}]", value = "")
+    @JsonProperty("links")
+    @Valid
+    public List<Link> getLinks() {
+        return links;
+    }
+    public void setLinks(List<Link> links) {
+        this.links = links;
+    }
+
+    public MetaAttributesResponse addLinksItem(Link linksItem) {
+        if (this.links == null) {
+            this.links = new ArrayList<>();
+        }
+        this.links.add(linksItem);
+        return this;
+    }
+
+        /**
+    **/
+    public MetaAttributesResponse attributes(List<String> attributes) {
+
+        this.attributes = attributes;
+        return this;
+    }
+    
+    @ApiModelProperty(value = "")
+    @JsonProperty("attributes")
+    @Valid
+    public List<String> getAttributes() {
+        return attributes;
+    }
+    public void setAttributes(List<String> attributes) {
+        this.attributes = attributes;
+    }
+
+    public MetaAttributesResponse addAttributesItem(String attributesItem) {
+        if (this.attributes == null) {
+            this.attributes = new ArrayList<>();
+        }
+        this.attributes.add(attributesItem);
+        return this;
+    }
+
+    
+
+    @Override
+    public boolean equals(java.lang.Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        MetaAttributesResponse metaAttributesResponse = (MetaAttributesResponse) o;
+        return Objects.equals(this.links, metaAttributesResponse.links) &&
+            Objects.equals(this.attributes, metaAttributesResponse.attributes);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(links, attributes);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class MetaAttributesResponse {\n");
+        
+        sb.append("    links: ").append(toIndentedString(links)).append("\n");
+        sb.append("    attributes: ").append(toIndentedString(attributes)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+    * Convert the given object to string with each line indented by 4 spaces
+    * (except the first line).
+    */
+    private String toIndentedString(java.lang.Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}
+

--- a/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.v1/src/main/java/org/wso2/carbon/identity/api/server/organization/management/v1/impl/OrganizationsApiServiceImpl.java
+++ b/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.v1/src/main/java/org/wso2/carbon/identity/api/server/organization/management/v1/impl/OrganizationsApiServiceImpl.java
@@ -89,6 +89,13 @@ public class OrganizationsApiServiceImpl implements OrganizationsApiService {
     }
 
     @Override
+    public Response organizationsMetaAttributesGet(String filter, Integer limit, String after, String before,
+                                                  Boolean recursive) {
+
+        return organizationManagementService.getOrganizationsMetaAttributes(filter, limit, after, before, recursive);
+    }
+
+    @Override
     public Response organizationCheckDiscovery(
             OrganizationDiscoveryCheckPOSTRequest organizationDiscoveryCheckPOSTRequest) {
 

--- a/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.v1/src/main/java/org/wso2/carbon/identity/api/server/organization/management/v1/service/OrganizationManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.v1/src/main/java/org/wso2/carbon/identity/api/server/organization/management/v1/service/OrganizationManagementService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2023-2024, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except

--- a/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.v1/src/main/java/org/wso2/carbon/identity/api/server/organization/management/v1/service/OrganizationManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.v1/src/main/java/org/wso2/carbon/identity/api/server/organization/management/v1/service/OrganizationManagementService.java
@@ -33,6 +33,7 @@ import org.wso2.carbon.identity.api.server.organization.management.v1.model.Disc
 import org.wso2.carbon.identity.api.server.organization.management.v1.model.Error;
 import org.wso2.carbon.identity.api.server.organization.management.v1.model.GetOrganizationResponse;
 import org.wso2.carbon.identity.api.server.organization.management.v1.model.Link;
+import org.wso2.carbon.identity.api.server.organization.management.v1.model.MetaAttributesResponse;
 import org.wso2.carbon.identity.api.server.organization.management.v1.model.OrganizationDiscoveryAttributes;
 import org.wso2.carbon.identity.api.server.organization.management.v1.model.OrganizationDiscoveryCheckPOSTRequest;
 import org.wso2.carbon.identity.api.server.organization.management.v1.model.OrganizationDiscoveryCheckPOSTResponse;
@@ -542,6 +543,33 @@ public class OrganizationManagementService {
         }
     }
 
+    /**
+     * Retrieve organizations' meta attributes.
+     *
+     * @param filter    The filter string.
+     * @param limit     The maximum number of records to be returned.
+     * @param after     The pointer to next page.
+     * @param before    The pointer to previous page.
+     * @param recursive Determines whether recursive search is required.
+     * @return The list of organizations' meta attributes.
+     */
+    public Response getOrganizationsMetaAttributes(String filter, Integer limit, String after, String before,
+                                      Boolean recursive) {
+
+        try {
+            limit = validateLimit(limit);
+            String sortOrder = StringUtils.isNotBlank(before) ? ASC_SORT_ORDER : DESC_SORT_ORDER;
+            List<String> metaAttributes = getOrganizationManager().getOrganizationsMetaAttributes(limit + 1, after,
+                                                            before, sortOrder, filter, Boolean.TRUE.equals(recursive));
+            return Response.ok().entity(getMetaAttributesResponse(limit, after, before, filter, metaAttributes,
+                                                            Boolean.TRUE.equals(recursive))).build();
+        } catch (OrganizationManagementClientException e) {
+            return OrganizationManagementEndpointUtil.handleClientErrorResponse(e, LOG);
+        } catch (OrganizationManagementException e) {
+            return OrganizationManagementEndpointUtil.handleServerErrorResponse(e, LOG);
+        }
+    }
+
     private Organization getOrganizationFromPostRequest(OrganizationPOSTRequest organizationPOSTRequest) {
 
         String organizationId = generateUniqueID();
@@ -913,6 +941,61 @@ public class OrganizationManagementService {
         organizationMetadata.setDiscoveryAttributes(attributes);
 
         return organizationMetadata;
+    }
+
+    private MetaAttributesResponse getMetaAttributesResponse(Integer limit, String after, String before, String filter,
+                                                             List<String> metaAttributes, boolean recursive)
+            throws OrganizationManagementServerException {
+
+        MetaAttributesResponse metaAttributesResponse = new MetaAttributesResponse();
+
+        if (limit != 0 && CollectionUtils.isNotEmpty(metaAttributes)) {
+            boolean hasMoreItems = metaAttributes.size() > limit;
+            boolean needsReverse = StringUtils.isNotBlank(before);
+            boolean isFirstPage = (StringUtils.isBlank(before) && StringUtils.isBlank(after)) ||
+                    (StringUtils.isNotBlank(before) && !hasMoreItems);
+            boolean isLastPage = !hasMoreItems && (StringUtils.isNotBlank(after) || StringUtils.isBlank(before));
+
+            String url = "?limit=" + limit + "&recursive=" + recursive;
+            if (StringUtils.isNotBlank(filter)) {
+                try {
+                    url += "&filter=" + URLEncoder.encode(filter, StandardCharsets.UTF_8.name());
+                } catch (UnsupportedEncodingException e) {
+                    LOG.error("Server encountered an error while building pagination URL for the response.", e);
+                    Error error = OrganizationManagementEndpointUtil.getError(
+                            ERROR_CODE_ERROR_BUILDING_PAGINATED_RESPONSE_URL.getCode(),
+                            ERROR_CODE_ERROR_BUILDING_PAGINATED_RESPONSE_URL.getMessage(),
+                            ERROR_CODE_ERROR_BUILDING_PAGINATED_RESPONSE_URL.getDescription());
+                    throw new OrganizationManagementEndpointException(Response.Status.INTERNAL_SERVER_ERROR, error);
+                }
+            }
+            if (hasMoreItems) {
+                metaAttributes.remove(metaAttributes.size() - 1);
+            }
+            if (needsReverse) {
+                Collections.reverse(metaAttributes);
+            }
+            if (!isFirstPage) {
+                String encodedString = Base64.getEncoder().encodeToString(metaAttributes.get(0)
+                                                                    .getBytes(StandardCharsets.UTF_8));
+                Link link = new Link();
+                link.setHref(URI.create(OrganizationManagementEndpointUtil.buildURIForPagination(url) + "&before="
+                                    + encodedString));
+                link.setRel("previous");
+                metaAttributesResponse.addLinksItem(link);
+            }
+            if (!isLastPage) {
+                String encodedString = Base64.getEncoder().encodeToString(metaAttributes.get(metaAttributes.size() - 1)
+                                                                    .getBytes(StandardCharsets.UTF_8));
+                Link link = new Link();
+                link.setHref(URI.create(OrganizationManagementEndpointUtil.buildURIForPagination(url) + "&after="
+                                    + encodedString));
+                link.setRel("next");
+                metaAttributesResponse.addLinksItem(link);
+            }
+            metaAttributesResponse.attributes(metaAttributes);
+        }
+        return metaAttributesResponse;
     }
 
     private OrganizationManager getOrganizationManager() {

--- a/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.v1/src/main/resources/org.wso2.carbon.identity.organization.management.yaml
+++ b/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.v1/src/main/resources/org.wso2.carbon.identity.organization.management.yaml
@@ -60,8 +60,20 @@ paths:
         '500':
           $ref: '#/components/responses/ServerError'
     get:
-      description:
+      description: |
         This API is used to search and retrieve organizations created for this tenant.
+        
+        Organizations can be filtered by id, name, description, created, lastModified, status, parentId, and meta attributes. 
+              
+        Supported operators: "eq" (equals), "co" (contains), "sw" (starts with), "ew" (ends with), "ge" (greater than or equals), "le" (less than or equals), "gt" (greater than), "lt" (less than)
+        
+        Multiple attributes can be combined using the "and" operator.
+        
+        Examples:
+          - filter=name+eq+ABC Builders
+          - filter=attributes.Country+eq+Sri Lanka
+        
+        <b>Scope(Permission) required:</b> `internal_organization_view`
       summary:
         Retrieve organizations created for this tenant which matches the defined search criteria, if any.
       operationId: organizationsGet

--- a/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.v1/src/main/resources/org.wso2.carbon.identity.organization.management.yaml
+++ b/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.v1/src/main/resources/org.wso2.carbon.identity.organization.management.yaml
@@ -752,6 +752,45 @@ paths:
           $ref: '#/components/responses/Forbidden'
         '500':
           $ref: '#/components/responses/ServerError'
+  /organizations/meta-attributes:
+    get:
+      tags:
+        - Organization Meta Attributes
+      description: |
+        This API facilitates the retrieval of organization meta attributes which matches the defined search criteria, if any.
+        
+        Supported operators: "eq"(equals), "co"(contains), "sw"(starts with), "ew"(ends with), "ge"(greater than or equals), "le"(less than or equals), "gt"(greater than), "lt"(less than)
+        
+        Multiple filters can be combined using the "and" operator.
+        
+        Example: filter=attributes+eq+Country
+        
+        <b>Scope(Permission) required:</b> `internal_organization_view`
+      summary: Get meta attributes of organizations with filter capabilities.
+      operationId: organizationsMetaAttributesGet
+      parameters:
+        - $ref: '#/components/parameters/filterQueryParam'
+        - $ref: '#/components/parameters/limitQueryParam'
+        - $ref: '#/components/parameters/afterQueryParam'
+        - $ref: '#/components/parameters/beforeQueryParam'
+        - $ref: '#/components/parameters/recursiveQueryParam'
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MetaAttributesResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '500':
+          $ref: '#/components/responses/ServerError'
+        '501':
+          $ref: '#/components/responses/NotImplemented'
 
 components:
   parameters:
@@ -802,8 +841,9 @@ components:
       in: query
       name: recursive
       required: false
-      description:
+      description: |
         Determines whether a recursive search should happen.
+        If set to true, will include organizations in all levels of the hierarchy; If set to false, includes only organizations in the next level of the hierarchy.
       schema:
         type: boolean
         default: false
@@ -1073,6 +1113,30 @@ components:
           type: array
           items:
             type: string
+    MetaAttributesResponse:
+      type: object
+      properties:
+        links:
+          type: array
+          items:
+            $ref: '#/components/schemas/Link'
+          example:
+            [
+              {
+                "href": "/o/10084a8d-113f-4211-a0d5-efe36b082211/api/server/v1/organizations/meta-attributes?limit=10&filter=key+co+country&next=MjAyMS0xMi0yMSAwNToxODozMS4wMDQzNDg=",
+                "rel": "next",
+              },  {
+              "href": "/o/10084a8d-113f-4211-a0d5-efe36b082211/api/server/v1/organizations/meta-attributes?limit=10&filter=key+co+country&before=MjAyMS0xMi0yMSAwNToxODozMS4wMDQzNDg=",
+              "rel": "previous",
+            }
+            ]
+        attributes:
+          type: array
+          items:
+            type: string
+            example:
+              - "Country"
+              - "Region"
     #-----------------------------------------------------
     # Organization Parent Object
     #-----------------------------------------------------


### PR DESCRIPTION
## Purpose

Related to: https://github.com/wso2/product-is/issues/20611

> To support the frontend implementation requiring backend API support to filter and return meta attributes belonging to a specific organizational hierarchy level.

## Approach
> Implemented a new GET endpoint **/meta-attributes** to support filtering and returning meta attributes for specific organizational hierarchy levels. 

## Related PRs
**Need to bump version after merging the following PR:**
> https://github.com/wso2/identity-organization-management-core/pull/143

## Test environment
> JDK version: 11.0.23
> Product Version: IS 7.0.1