### PR TITLE
Fixed invalid pagination cursor error from the GET organization API

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.v1/src/main/java/org/wso2/carbon/identity/api/server/organization/management/v1/service/OrganizationManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.v1/src/main/java/org/wso2/carbon/identity/api/server/organization/management/v1/service/OrganizationManagementService.java
@@ -74,6 +74,7 @@ import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
+import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.Base64;
 import java.util.Collections;
@@ -727,7 +728,8 @@ public class OrganizationManagementService {
                 Collections.reverse(organizations);
             }
             if (!isFirstPage) {
-                String encodedString = Base64.getEncoder().encodeToString(organizations.get(0).getCreated().toString()
+                Timestamp createdTimestamp = Timestamp.from(organizations.get(0).getCreated());
+                String encodedString = Base64.getEncoder().encodeToString(createdTimestamp.toString()
                         .getBytes(StandardCharsets.UTF_8));
                 Link link = new Link();
                 link.setHref(URI.create(
@@ -736,8 +738,9 @@ public class OrganizationManagementService {
                 organizationsResponse.addLinksItem(link);
             }
             if (!isLastPage) {
-                String encodedString = Base64.getEncoder().encodeToString(organizations.get(organizations.size() - 1)
-                        .getCreated().toString().getBytes(StandardCharsets.UTF_8));
+                Timestamp createdTimestamp = Timestamp.from(organizations.get(organizations.size() - 1).getCreated());
+                String encodedString = Base64.getEncoder().encodeToString(createdTimestamp.toString()
+                        .getBytes(StandardCharsets.UTF_8));
                 Link link = new Link();
                 link.setHref(URI.create(
                         OrganizationManagementEndpointUtil.buildURIForPagination(url) + "&after=" + encodedString));


### PR DESCRIPTION
## Purpose

Related to: https://github.com/wso2/product-is/issues/20689

> When getting organizations from the /organization GET API, the returned pagination cursor throws an invalid cursor error.

## Approach
- The issue arises because Instant and Timestamp have different string representations, and Timestamp.valueOf(String) expects a string in the format "yyyy-mm-dd hh:mm". However, Instant.toString() produces a string in ISO-8601 format, which includes a T and a Z.
- Create a Timestamp object from the Instant object and then encode it as the pagination cursor.

## Test environment
> JDK version: 11.0.23
> Product Version: IS 7.0.1