### PR TITLE
Add API Support to Resolve Branding Preferences only using Published Preferences

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.branding.preference.management/org.wso2.carbon.identity.api.server.branding.preference.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/branding/preference/management/v1/BrandingPreferenceApi.java
+++ b/components/org.wso2.carbon.identity.api.server.branding.preference.management/org.wso2.carbon.identity.api.server.branding.preference.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/branding/preference/management/v1/BrandingPreferenceApi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2023, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2021-2024, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -206,9 +206,9 @@ public class BrandingPreferenceApi  {
         @ApiResponse(code = 404, message = "Requested resource is not found.", response = Error.class),
         @ApiResponse(code = 500, message = "Internal server error.", response = Error.class)
     })
-    public Response resolveBrandingPreference(    @Valid@ApiParam(value = "Type to filter the retrieval of customizations.", allowableValues="ORG, APP, CUSTOM")  @QueryParam("type") String type,     @Valid@ApiParam(value = "Tenant/Application name to filter the retrieval of customizations.")  @QueryParam("name") String name,     @Valid@ApiParam(value = "Locale to filter the retrieval of customizations.")  @QueryParam("locale") String locale) {
+    public Response resolveBrandingPreference(    @Valid@ApiParam(value = "Type to filter the retrieval of customizations.", allowableValues="ORG, APP, CUSTOM")  @QueryParam("type") String type,     @Valid@ApiParam(value = "Tenant/Application name to filter the retrieval of customizations.")  @QueryParam("name") String name,     @Valid@ApiParam(value = "Locale to filter the retrieval of customizations.")  @QueryParam("locale") String locale,     @Valid@ApiParam(value = "Specifies whether to use only published branding preferences for resolving. If set to true, branding preference will be resolved only using published branding preferences. If set to false, branding preference will be resolved using both published and unpublished branding preferences. ", defaultValue="false") @DefaultValue("false")  @QueryParam("restrictToPublished") Boolean restrictToPublished) {
 
-        return delegate.resolveBrandingPreference(type,  name,  locale );
+        return delegate.resolveBrandingPreference(type,  name,  locale,  restrictToPublished );
     }
 
     @Valid

--- a/components/org.wso2.carbon.identity.api.server.branding.preference.management/org.wso2.carbon.identity.api.server.branding.preference.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/branding/preference/management/v1/BrandingPreferenceApiService.java
+++ b/components/org.wso2.carbon.identity.api.server.branding.preference.management/org.wso2.carbon.identity.api.server.branding.preference.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/branding/preference/management/v1/BrandingPreferenceApiService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2023, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2021-2024, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -44,7 +44,7 @@ public interface BrandingPreferenceApiService {
 
       public Response getCustomText(String type, String name, String locale, String screen);
 
-      public Response resolveBrandingPreference(String type, String name, String locale);
+      public Response resolveBrandingPreference(String type, String name, String locale, Boolean restrictToPublished);
 
       public Response resolveCustomText(String type, String name, String locale, String screen);
 

--- a/components/org.wso2.carbon.identity.api.server.branding.preference.management/org.wso2.carbon.identity.api.server.branding.preference.management.v1/src/main/java/org/wso2/carbon/identity/api/server/branding/preference/management/v1/core/BrandingPreferenceManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.branding.preference.management/org.wso2.carbon.identity.api.server.branding.preference.management.v1/src/main/java/org/wso2/carbon/identity/api/server/branding/preference/management/v1/core/BrandingPreferenceManagementService.java
@@ -191,6 +191,21 @@ public class BrandingPreferenceManagementService {
      */
     public BrandingPreferenceModel resolveBrandingPreference(String type, String name, String locale) {
 
+        return resolveBrandingPreference(type, name, locale, false);
+    }
+
+    /**
+     * Retrieve the resolved branding preferences.
+     *
+     * @param type                Resource Type.
+     * @param name                Name.
+     * @param locale              Language preference.
+     * @param restrictToPublished Whether to resolve using only published branding preferences.
+     * @return The resolved branding preference resource. If not exists return the default preferences.
+     */
+    public BrandingPreferenceModel resolveBrandingPreference(String type, String name, String locale,
+                                                             boolean restrictToPublished) {
+
         /*
          Currently this API provides the support to only configure organization wise & application wise
          branding preference for 'en-US' locale.
@@ -202,11 +217,11 @@ public class BrandingPreferenceManagementService {
             if (APPLICATION_TYPE.equals(type)) {
                 // Get application specific branding preference.
                 responseDTO = BrandingPreferenceServiceHolder.getBrandingPreferenceManager().
-                        resolveBrandingPreference(APPLICATION_TYPE, name, DEFAULT_LOCALE);
+                        resolveBrandingPreference(APPLICATION_TYPE, name, DEFAULT_LOCALE, restrictToPublished);
             } else {
                 // Get default branding preference.
                 responseDTO = BrandingPreferenceServiceHolder.getBrandingPreferenceManager().
-                        resolveBrandingPreference(ORGANIZATION_TYPE, tenantDomain, DEFAULT_LOCALE);
+                        resolveBrandingPreference(ORGANIZATION_TYPE, tenantDomain, DEFAULT_LOCALE, restrictToPublished);
             }
 
             return buildBrandingResponseFromResponseDTO(responseDTO);

--- a/components/org.wso2.carbon.identity.api.server.branding.preference.management/org.wso2.carbon.identity.api.server.branding.preference.management.v1/src/main/java/org/wso2/carbon/identity/api/server/branding/preference/management/v1/impl/BrandingPreferenceApiServiceImpl.java
+++ b/components/org.wso2.carbon.identity.api.server.branding.preference.management/org.wso2.carbon.identity.api.server.branding.preference.management.v1/src/main/java/org/wso2/carbon/identity/api/server/branding/preference/management/v1/impl/BrandingPreferenceApiServiceImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2023, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2021-2024, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -203,15 +203,15 @@ public class BrandingPreferenceApiServiceImpl implements BrandingPreferenceApiSe
     }
 
     @Override
-    public Response resolveBrandingPreference(String type, String name, String locale) {
+    public Response resolveBrandingPreference(String type, String name, String locale, Boolean restrictToPublished) {
 
         if (type != null) {
             if (!(ORGANIZATION_TYPE.equals(type) || APPLICATION_TYPE.equals(type) || CUSTOM_TYPE.equals(type))) {
                 return Response.status(Response.Status.BAD_REQUEST).build();
             }
         }
-        return Response.ok()
-                .entity(brandingPreferenceManagementService.resolveBrandingPreference(type, name, locale)).build();
+        return Response.ok().entity(brandingPreferenceManagementService
+                .resolveBrandingPreference(type, name, locale, restrictToPublished)).build();
     }
 
     @Override

--- a/components/org.wso2.carbon.identity.api.server.branding.preference.management/org.wso2.carbon.identity.api.server.branding.preference.management.v1/src/main/resources/branding-preference.yaml
+++ b/components/org.wso2.carbon.identity.api.server.branding.preference.management/org.wso2.carbon.identity.api.server.branding.preference.management.v1/src/main/resources/branding-preference.yaml
@@ -181,6 +181,7 @@ paths:
         - $ref: '#/components/parameters/typeQueryParam'
         - $ref: '#/components/parameters/nameQueryParam'
         - $ref: '#/components/parameters/localeQueryParam'
+        - $ref: '#/components/parameters/restrictToPublishedQueryParam'
       responses:
         '200':
           description: OK
@@ -404,6 +405,18 @@ components:
       schema:
         type: string
       example: "login"
+    restrictToPublishedQueryParam:
+      in: query
+      name: restrictToPublished
+      required: false
+      description: |
+        Specifies whether to use only published branding preferences for resolving.
+        If set to true, branding preference will be resolved only using published branding preferences.
+        If set to false, branding preference will be resolved using both published and unpublished branding preferences.
+      schema:
+        type: boolean
+        default: false
+      example: true
 
   schemas:
     BrandingPreferenceModel:

--- a/pom.xml
+++ b/pom.xml
@@ -818,7 +818,7 @@
         <org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.version>2.5.15</org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.version>
         <org.wso2.carbon.logging.service.version>4.10.7</org.wso2.carbon.logging.service.version>
         <org.wso2.carbon.event.publisher.version>5.2.15</org.wso2.carbon.event.publisher.version>
-        <identity.branding.preference.management.version>1.1.13</identity.branding.preference.management.version>
+        <identity.branding.preference.management.version>1.1.16</identity.branding.preference.management.version>
         <apache.felix.scr.ds.annotations.version>1.2.4</apache.felix.scr.ds.annotations.version>
 
         <!--<maven.checkstyleplugin.excludes>**/gen/**/*</maven.checkstyleplugin.excludes>-->


### PR DESCRIPTION
## Purpose

- This PR introduces a new query parameter to the branding preference resolve GET endpoint, enabling the resolution of branding preferences using only published preferences.

- By adding the restrictToPublished query parameter, users can specify whether to retrieve branding preferences only from published sources or from both published and unpublished preferences.

### Example Usage:
```
curl --location '{base-url}/api/server/v1/branding-preference/resolve?locale={locale}&name={name}&type={branding-type}&restrictToPublished={true/false}' 
```
#### EX:
```
curl --location 'https://localhost:9443/t/carbon.super/api/server/v1/branding-preference/resolve?locale=en-US&name=e3548660-6ff9-4a39-acd6-d4071d6a6e69&type=APP&restrictToPublished=true' 
```

### Parameter Behavior of restrictToPublished
- `true`: Returns resolved branding preferences considering only published preferences.
- `false`: Returns resolved branding preferences considering both published and unpublished preferences.
- `Not set`: Defaults to false, considering both published and unpublished preferences.

## When should this PR be merged
- This should be merged after merging the following PR.
    - https://github.com/wso2-extensions/identity-branding-preference-management/pull/43

## Related Issues
- https://github.com/wso2/product-is/issues/20769

