### PR TITLE
Add trace ID to error response for existing discovery attributes

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.v1/src/main/java/org/wso2/carbon/identity/api/server/organization/management/v1/util/OrganizationManagementEndpointUtil.java
+++ b/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.v1/src/main/java/org/wso2/carbon/identity/api/server/organization/management/v1/util/OrganizationManagementEndpointUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2023-2024, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -31,6 +31,7 @@ import javax.ws.rs.core.Response;
 
 import static org.wso2.carbon.identity.api.server.common.ContextLoader.buildURIForBody;
 import static org.wso2.carbon.identity.api.server.common.ContextLoader.buildURIForHeader;
+import static org.wso2.carbon.identity.api.server.common.Util.getCorrelation;
 import static org.wso2.carbon.identity.api.server.organization.management.v1.constants.OrganizationManagementEndpointConstants.DISCOVERY_PATH;
 import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.ErrorMessages.ERROR_CODE_INVALID_APPLICATION;
 import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.ErrorMessages.ERROR_CODE_INVALID_ORGANIZATION;
@@ -116,6 +117,7 @@ public class OrganizationManagementEndpointUtil {
         error.setCode(errorCode);
         error.setMessage(errorMessage);
         error.setDescription(errorDescription);
+        error.setTraceId(getCorrelation());
         return error;
     }
 


### PR DESCRIPTION
## Purpose
> This pull request enhances the error messages returned by the API when a POST request attempts to add discovery attributes to an organization that already has them. Specifically, the error message now includes a Trace ID for easier debugging and error tracing.


## Goals

- Improve the clarity and usefulness of the error message by including a `Trace ID`.

- Assist developers in debugging and tracing issues related to discovery attributes that have already been added to an organization.

## Approach

- Modified the error handling in the `addOrganizationDiscoveryAttributes` method to include a generated Trace ID in the response body whenever an error is thrown due to existing discovery attributes.

- Ensured that the Trace ID is unique for each error instance to aid in tracking and debugging.

## Testing
> Verified that the changes are functioning correctly for all cases where the `buildException(Status, Log, OrganizationManagementException)` method is used. Specifically, tested scenarios for `NOT_FOUND`, `FORBIDDEN`, `BAD_REQUEST`, and `INTERNAL_SERVER_ERROR` statuses to ensure the Trace ID is correctly included in the error response.