### PR TITLE
Update scope metadata API implementation 

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.api.resource/org.wso2.carbon.identity.api.server.api.resource.v1/src/gen/java/org/wso2/carbon/identity/api/server/api/resource/v1/ApiResourcesApi.java
+++ b/components/org.wso2.carbon.identity.api.server.api.resource/org.wso2.carbon.identity.api.server.api.resource.v1/src/gen/java/org/wso2/carbon/identity/api/server/api/resource/v1/ApiResourcesApi.java
@@ -19,12 +19,27 @@
 package org.wso2.carbon.identity.api.server.api.resource.v1;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.apache.cxf.jaxrs.ext.multipart.Attachment;
+import org.apache.cxf.jaxrs.ext.multipart.Multipart;
+import java.io.InputStream;
 import java.util.List;
+
+import org.wso2.carbon.identity.api.server.api.resource.v1.APIResourceCreationModel;
+import org.wso2.carbon.identity.api.server.api.resource.v1.APIResourceListResponse;
+import org.wso2.carbon.identity.api.server.api.resource.v1.APIResourcePatchModel;
+import org.wso2.carbon.identity.api.server.api.resource.v1.APIResourceResponse;
+import org.wso2.carbon.identity.api.server.api.resource.v1.Error;
+import java.util.List;
+import org.wso2.carbon.identity.api.server.api.resource.v1.ScopeCreationModel;
+import org.wso2.carbon.identity.api.server.api.resource.v1.ScopeGetModel;
+import org.wso2.carbon.identity.api.server.api.resource.v1.ApiResourcesApiService;
 
 import javax.validation.Valid;
 import javax.ws.rs.*;
 import javax.ws.rs.core.Response;
 import io.swagger.annotations.*;
+
+import javax.validation.constraints.*;
 
 @Path("/api-resources")
 @Api(description = "The api-resources API")

--- a/components/org.wso2.carbon.identity.api.server.api.resource/org.wso2.carbon.identity.api.server.api.resource.v1/src/gen/java/org/wso2/carbon/identity/api/server/api/resource/v1/ApiResourcesApi.java
+++ b/components/org.wso2.carbon.identity.api.server.api.resource/org.wso2.carbon.identity.api.server.api.resource.v1/src/gen/java/org/wso2/carbon/identity/api/server/api/resource/v1/ApiResourcesApi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -218,7 +218,7 @@ public class ApiResourcesApi  {
     @Path("/{apiResourceId}/scopes/{scopeName}")
     @Consumes({ "application/json" })
     @Produces({ "application/json" })
-    @ApiOperation(value = "Patch scope specified by the name", notes = "Patch scope specified by the name. Patch operation only supports \"name\", \"displayName\" and \"description\" fields at the moment. <b>Permission required:</b> <br>   * /permission/admin/manage/identity/apiresourcemgt/update <br> <b>Scope required:</b> <br>   * internal_api_resource_update ", response = Void.class, authorizations = {
+    @ApiOperation(value = "Patch scope specified by the name", notes = "Patch scope specified by the name. Patch operation only supports \"displayName\" and \"description\" fields at the moment. <b>Permission required:</b> <br>   * /permission/admin/manage/identity/apiresourcemgt/update <br> <b>Scope required:</b> <br>   * internal_api_resource_update ", response = Void.class, authorizations = {
         @Authorization(value = "BasicAuth"),
         @Authorization(value = "OAuth2", scopes = {
             

--- a/components/org.wso2.carbon.identity.api.server.api.resource/org.wso2.carbon.identity.api.server.api.resource.v1/src/gen/java/org/wso2/carbon/identity/api/server/api/resource/v1/ApiResourcesApi.java
+++ b/components/org.wso2.carbon.identity.api.server.api.resource/org.wso2.carbon.identity.api.server.api.resource.v1/src/gen/java/org/wso2/carbon/identity/api/server/api/resource/v1/ApiResourcesApi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -19,27 +19,12 @@
 package org.wso2.carbon.identity.api.server.api.resource.v1;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.apache.cxf.jaxrs.ext.multipart.Attachment;
-import org.apache.cxf.jaxrs.ext.multipart.Multipart;
-import java.io.InputStream;
 import java.util.List;
-
-import org.wso2.carbon.identity.api.server.api.resource.v1.APIResourceCreationModel;
-import org.wso2.carbon.identity.api.server.api.resource.v1.APIResourceListResponse;
-import org.wso2.carbon.identity.api.server.api.resource.v1.APIResourcePatchModel;
-import org.wso2.carbon.identity.api.server.api.resource.v1.APIResourceResponse;
-import org.wso2.carbon.identity.api.server.api.resource.v1.Error;
-import java.util.List;
-import org.wso2.carbon.identity.api.server.api.resource.v1.ScopeCreationModel;
-import org.wso2.carbon.identity.api.server.api.resource.v1.ScopeGetModel;
-import org.wso2.carbon.identity.api.server.api.resource.v1.ApiResourcesApiService;
 
 import javax.validation.Valid;
 import javax.ws.rs.*;
 import javax.ws.rs.core.Response;
 import io.swagger.annotations.*;
-
-import javax.validation.constraints.*;
 
 @Path("/api-resources")
 @Api(description = "The api-resources API")
@@ -211,6 +196,31 @@ public class ApiResourcesApi  {
     public Response apiResourcesApiResourceIdScopesScopeNameDelete(@ApiParam(value = "ID of the API Resource.",required=true) @PathParam("apiResourceId") String apiResourceId, @ApiParam(value = "Name of the Scope.",required=true) @PathParam("scopeName") String scopeName) {
 
         return delegate.apiResourcesApiResourceIdScopesScopeNameDelete(apiResourceId,  scopeName );
+    }
+
+    @Valid
+    @PATCH
+    @Path("/{apiResourceId}/scopes/{scopeName}")
+    @Consumes({ "application/json" })
+    @Produces({ "application/json" })
+    @ApiOperation(value = "Patch scope specified by the name", notes = "Patch scope specified by the name. Patch operation only supports \"name\", \"displayName\" and \"description\" fields at the moment. <b>Permission required:</b> <br>   * /permission/admin/manage/identity/apiresourcemgt/update <br> <b>Scope required:</b> <br>   * internal_api_resource_update ", response = Void.class, authorizations = {
+        @Authorization(value = "BasicAuth"),
+        @Authorization(value = "OAuth2", scopes = {
+            
+        })
+    }, tags = { "API Resource Scopes", })
+    @ApiResponses(value = { 
+        @ApiResponse(code = 204, message = "Not Content", response = Void.class),
+        @ApiResponse(code = 400, message = "Bad Request", response = Error.class),
+        @ApiResponse(code = 401, message = "Unauthorized", response = Void.class),
+        @ApiResponse(code = 403, message = "Forbidden", response = Void.class),
+        @ApiResponse(code = 404, message = "Not Found", response = Error.class),
+        @ApiResponse(code = 500, message = "Server Error", response = Error.class)
+    })
+    public Response apiResourcesApiResourceIdScopesScopeNamePatch(@ApiParam(value = "ID of the API Resource.", required = true) @PathParam("apiResourceId") String apiResourceId, @ApiParam(value = "Name of the Scope.", required = true) @PathParam("scopeName") String scopeName, @ApiParam(value = "This represents the scopes to be patched." , required = true) @Valid
+    ScopePatchModel scopePatchModel) {
+
+        return delegate.apiResourcesApiResourceIdScopesScopeNamePatch(apiResourceId,  scopeName, scopePatchModel);
     }
 
     @Valid

--- a/components/org.wso2.carbon.identity.api.server.api.resource/org.wso2.carbon.identity.api.server.api.resource.v1/src/gen/java/org/wso2/carbon/identity/api/server/api/resource/v1/ApiResourcesApiService.java
+++ b/components/org.wso2.carbon.identity.api.server.api.resource/org.wso2.carbon.identity.api.server.api.resource.v1/src/gen/java/org/wso2/carbon/identity/api/server/api/resource/v1/ApiResourcesApiService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except

--- a/components/org.wso2.carbon.identity.api.server.api.resource/org.wso2.carbon.identity.api.server.api.resource.v1/src/gen/java/org/wso2/carbon/identity/api/server/api/resource/v1/ApiResourcesApiService.java
+++ b/components/org.wso2.carbon.identity.api.server.api.resource/org.wso2.carbon.identity.api.server.api.resource.v1/src/gen/java/org/wso2/carbon/identity/api/server/api/resource/v1/ApiResourcesApiService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -18,20 +18,7 @@
 
 package org.wso2.carbon.identity.api.server.api.resource.v1;
 
-import org.wso2.carbon.identity.api.server.api.resource.v1.*;
-import org.wso2.carbon.identity.api.server.api.resource.v1.*;
-import org.apache.cxf.jaxrs.ext.multipart.Attachment;
-import org.apache.cxf.jaxrs.ext.multipart.Multipart;
-import java.io.InputStream;
 import java.util.List;
-import org.wso2.carbon.identity.api.server.api.resource.v1.APIResourceCreationModel;
-import org.wso2.carbon.identity.api.server.api.resource.v1.APIResourceListResponse;
-import org.wso2.carbon.identity.api.server.api.resource.v1.APIResourcePatchModel;
-import org.wso2.carbon.identity.api.server.api.resource.v1.APIResourceResponse;
-import org.wso2.carbon.identity.api.server.api.resource.v1.Error;
-import java.util.List;
-import org.wso2.carbon.identity.api.server.api.resource.v1.ScopeCreationModel;
-import org.wso2.carbon.identity.api.server.api.resource.v1.ScopeGetModel;
 import javax.ws.rs.core.Response;
 
 
@@ -50,6 +37,8 @@ public interface ApiResourcesApiService {
       public Response apiResourcesApiResourceIdScopesPut(String apiResourceId, List<ScopeCreationModel> scopeCreationModel);
 
       public Response apiResourcesApiResourceIdScopesScopeNameDelete(String apiResourceId, String scopeName);
+
+      public Response apiResourcesApiResourceIdScopesScopeNamePatch(String apiResourceId, String scopeName, ScopePatchModel scopePatchModel);
 
       public Response getAPIResources(String before, String after, String filter, Integer limit, String attributes);
 }

--- a/components/org.wso2.carbon.identity.api.server.api.resource/org.wso2.carbon.identity.api.server.api.resource.v1/src/gen/java/org/wso2/carbon/identity/api/server/api/resource/v1/ApiResourcesApiService.java
+++ b/components/org.wso2.carbon.identity.api.server.api.resource/org.wso2.carbon.identity.api.server.api.resource.v1/src/gen/java/org/wso2/carbon/identity/api/server/api/resource/v1/ApiResourcesApiService.java
@@ -18,7 +18,20 @@
 
 package org.wso2.carbon.identity.api.server.api.resource.v1;
 
+import org.wso2.carbon.identity.api.server.api.resource.v1.*;
+import org.wso2.carbon.identity.api.server.api.resource.v1.*;
+import org.apache.cxf.jaxrs.ext.multipart.Attachment;
+import org.apache.cxf.jaxrs.ext.multipart.Multipart;
+import java.io.InputStream;
 import java.util.List;
+import org.wso2.carbon.identity.api.server.api.resource.v1.APIResourceCreationModel;
+import org.wso2.carbon.identity.api.server.api.resource.v1.APIResourceListResponse;
+import org.wso2.carbon.identity.api.server.api.resource.v1.APIResourcePatchModel;
+import org.wso2.carbon.identity.api.server.api.resource.v1.APIResourceResponse;
+import org.wso2.carbon.identity.api.server.api.resource.v1.Error;
+import java.util.List;
+import org.wso2.carbon.identity.api.server.api.resource.v1.ScopeCreationModel;
+import org.wso2.carbon.identity.api.server.api.resource.v1.ScopeGetModel;
 import javax.ws.rs.core.Response;
 
 

--- a/components/org.wso2.carbon.identity.api.server.api.resource/org.wso2.carbon.identity.api.server.api.resource.v1/src/gen/java/org/wso2/carbon/identity/api/server/api/resource/v1/ScopePatchModel.java
+++ b/components/org.wso2.carbon.identity.api.server.api.resource/org.wso2.carbon.identity.api.server.api.resource.v1/src/gen/java/org/wso2/carbon/identity/api/server/api/resource/v1/ScopePatchModel.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.api.resource.v1;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.annotations.ApiModelProperty;
+
+import java.util.Objects;
+import javax.validation.Valid;
+
+/**
+ *
+ **/
+public class ScopePatchModel {
+  
+    private String displayName;
+    private String description;
+
+    /**
+    **/
+    public ScopePatchModel displayName(String displayName) {
+
+        this.displayName = displayName;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "Write Greetings", value = "")
+    @JsonProperty("displayName")
+    @Valid
+    public String getDisplayName() {
+        return displayName;
+    }
+    public void setDisplayName(String displayName) {
+        this.displayName = displayName;
+    }
+
+    /**
+    **/
+    public ScopePatchModel description(String description) {
+
+        this.description = description;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "Allows writing greetings", value = "")
+    @JsonProperty("description")
+    @Valid
+    public String getDescription() {
+        return description;
+    }
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    @Override
+    public boolean equals(java.lang.Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ScopePatchModel scopePatchModel = (ScopePatchModel) o;
+        return Objects.equals(this.displayName, scopePatchModel.displayName) &&
+            Objects.equals(this.description, scopePatchModel.description);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(displayName, description);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class ScopePatchModel {\n");
+        
+        sb.append("    displayName: ").append(toIndentedString(displayName)).append("\n");
+        sb.append("    description: ").append(toIndentedString(description)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+    * Convert the given object to string with each line indented by 4 spaces
+    * (except the first line).
+    */
+    private String toIndentedString(java.lang.Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}
+

--- a/components/org.wso2.carbon.identity.api.server.api.resource/org.wso2.carbon.identity.api.server.api.resource.v1/src/main/java/org/wso2/carbon/identity/api/server/api/resource/v1/core/ServerAPIResourceManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.api.resource/org.wso2.carbon.identity.api.server.api.resource.v1/src/main/java/org/wso2/carbon/identity/api/server/api/resource/v1/core/ServerAPIResourceManagementService.java
@@ -377,8 +377,8 @@ public class ServerAPIResourceManagementService {
                 throw APIResourceMgtEndpointUtil.handleException(Response.Status.NOT_FOUND,
                         APIResourceMgtEndpointConstants.ErrorMessage.ERROR_CODE_INVALID_SCOPE_NAME);
             }
-            String displayName = scopePatchModel.getDisplayName() == null ? scopeWithMetadata.getDisplayName() :
-                    scopePatchModel.getDisplayName();
+            String displayName = StringUtils.isBlank(scopePatchModel.getDisplayName()) ?
+                    scopeWithMetadata.getDisplayName() : scopePatchModel.getDisplayName();
             String description = scopePatchModel.getDescription() == null ? scopeWithMetadata.getDescription() :
                     scopePatchModel.getDescription();
 

--- a/components/org.wso2.carbon.identity.api.server.api.resource/org.wso2.carbon.identity.api.server.api.resource.v1/src/main/java/org/wso2/carbon/identity/api/server/api/resource/v1/core/ServerAPIResourceManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.api.resource/org.wso2.carbon.identity.api.server.api.resource.v1/src/main/java/org/wso2/carbon/identity/api/server/api/resource/v1/core/ServerAPIResourceManagementService.java
@@ -350,17 +350,17 @@ public class ServerAPIResourceManagementService {
     }
 
     /**
-     * Patch scopes by the scope name.
+     * Patch scope metadata by the scope name.
      *
      * @param apiResourceId     API Resource ID.
      * @param scopeName         Scope Name.
      * @param scopePatchModel   Parameters to be updated.
      */
-    public void patchScopeByScopeName(String apiResourceId, String scopeName, ScopePatchModel scopePatchModel) {
+    public void patchScopeMetadataByScopeName(String apiResourceId, String scopeName, ScopePatchModel scopePatchModel) {
 
         try {
             if (LOG.isDebugEnabled()) {
-                LOG.debug("Updating scope with ID: " + scopeName + " of API Resource ID: " + apiResourceId);
+                LOG.debug("Updating scope with name: " + scopeName + " of API Resource ID: " + apiResourceId);
             }
             String tenantDomain = CarbonContext.getThreadLocalCarbonContext().getTenantDomain();
 

--- a/components/org.wso2.carbon.identity.api.server.api.resource/org.wso2.carbon.identity.api.server.api.resource.v1/src/main/java/org/wso2/carbon/identity/api/server/api/resource/v1/impl/ApiResourcesApiServiceImpl.java
+++ b/components/org.wso2.carbon.identity.api.server.api.resource/org.wso2.carbon.identity.api.server.api.resource.v1/src/main/java/org/wso2/carbon/identity/api/server/api/resource/v1/impl/ApiResourcesApiServiceImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except

--- a/components/org.wso2.carbon.identity.api.server.api.resource/org.wso2.carbon.identity.api.server.api.resource.v1/src/main/java/org/wso2/carbon/identity/api/server/api/resource/v1/impl/ApiResourcesApiServiceImpl.java
+++ b/components/org.wso2.carbon.identity.api.server.api.resource/org.wso2.carbon.identity.api.server.api.resource.v1/src/main/java/org/wso2/carbon/identity/api/server/api/resource/v1/impl/ApiResourcesApiServiceImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -24,6 +24,7 @@ import org.wso2.carbon.identity.api.server.api.resource.v1.APIResourcePatchModel
 import org.wso2.carbon.identity.api.server.api.resource.v1.APIResourceResponse;
 import org.wso2.carbon.identity.api.server.api.resource.v1.ApiResourcesApiService;
 import org.wso2.carbon.identity.api.server.api.resource.v1.ScopeCreationModel;
+import org.wso2.carbon.identity.api.server.api.resource.v1.ScopePatchModel;
 import org.wso2.carbon.identity.api.server.api.resource.v1.constants.APIResourceMgtEndpointConstants;
 import org.wso2.carbon.identity.api.server.api.resource.v1.core.ServerAPIResourceManagementService;
 import org.wso2.carbon.identity.api.server.common.ContextLoader;
@@ -92,6 +93,14 @@ public class ApiResourcesApiServiceImpl implements ApiResourcesApiService {
     public Response apiResourcesApiResourceIdScopesScopeNameDelete(String apiResourceId, String scopeName) {
 
         serverAPIResourceManagementService.deleteScopeByScopeName(apiResourceId, scopeName);
+        return Response.noContent().build();
+    }
+
+    @Override
+    public Response apiResourcesApiResourceIdScopesScopeNamePatch(String apiResourceId, String scopeName,
+                                                                  ScopePatchModel scopePatchModel) {
+
+        serverAPIResourceManagementService.patchScopeByScopeName(apiResourceId, scopeName, scopePatchModel);
         return Response.noContent().build();
     }
 

--- a/components/org.wso2.carbon.identity.api.server.api.resource/org.wso2.carbon.identity.api.server.api.resource.v1/src/main/java/org/wso2/carbon/identity/api/server/api/resource/v1/impl/ApiResourcesApiServiceImpl.java
+++ b/components/org.wso2.carbon.identity.api.server.api.resource/org.wso2.carbon.identity.api.server.api.resource.v1/src/main/java/org/wso2/carbon/identity/api/server/api/resource/v1/impl/ApiResourcesApiServiceImpl.java
@@ -100,7 +100,7 @@ public class ApiResourcesApiServiceImpl implements ApiResourcesApiService {
     public Response apiResourcesApiResourceIdScopesScopeNamePatch(String apiResourceId, String scopeName,
                                                                   ScopePatchModel scopePatchModel) {
 
-        serverAPIResourceManagementService.patchScopeByScopeName(apiResourceId, scopeName, scopePatchModel);
+        serverAPIResourceManagementService.patchScopeMetadataByScopeName(apiResourceId, scopeName, scopePatchModel);
         return Response.noContent().build();
     }
 

--- a/components/org.wso2.carbon.identity.api.server.api.resource/org.wso2.carbon.identity.api.server.api.resource.v1/src/main/resources/APIResources.yaml
+++ b/components/org.wso2.carbon.identity.api.server.api.resource/org.wso2.carbon.identity.api.server.api.resource.v1/src/main/resources/APIResources.yaml
@@ -338,7 +338,7 @@ paths:
         - API Resource Scopes
       summary: Patch scope specified by the name
       description: >
-        Patch scope specified by the name. Patch operation only supports "name", "displayName" and "description" fields at the moment.
+        Patch scope specified by the name. Patch operation only supports "displayName" and "description" fields at the moment.
         <b>Permission required:</b> <br>
           * /permission/admin/manage/identity/apiresourcemgt/update <br>
         <b>Scope required:</b> <br>

--- a/components/org.wso2.carbon.identity.api.server.api.resource/org.wso2.carbon.identity.api.server.api.resource.v1/src/main/resources/APIResources.yaml
+++ b/components/org.wso2.carbon.identity.api.server.api.resource/org.wso2.carbon.identity.api.server.api.resource.v1/src/main/resources/APIResources.yaml
@@ -333,6 +333,53 @@ paths:
         required: true
 
   /api-resources/{apiResourceId}/scopes/{scopeName}:
+    patch:
+      tags:
+        - API Resource Scopes
+      summary: Patch scope specified by the name
+      description: >
+        Patch scope specified by the name. Patch operation only supports "name", "displayName" and "description" fields at the moment.
+        <b>Permission required:</b> <br>
+          * /permission/admin/manage/identity/apiresourcemgt/update <br>
+        <b>Scope required:</b> <br>
+          * internal_api_resource_update
+      parameters:
+        - $ref: '#/components/parameters/apiResourceId'
+        - $ref: '#/components/parameters/scopeName'
+      responses:
+        204:
+          description: Not Content
+        400:
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        401:
+          description: Unauthorized
+        403:
+          description: Forbidden
+        404:
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        500:
+          description: Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ScopePatchModel'
+        description: This represents the scopes to be patched.
+        required: true
+
     delete:
       tags:
         - API Resource Scopes
@@ -873,6 +920,16 @@ components:
         name:
           type: string
           example: 'greetings:write'
+        displayName:
+          type: string
+          example: "Write Greetings"
+        description:
+          type: string
+          example: "Allows writing greetings"
+
+    ScopePatchModel:
+      type: object
+      properties:
         displayName:
           type: string
           example: "Write Greetings"

--- a/pom.xml
+++ b/pom.xml
@@ -803,7 +803,7 @@
         <maven.buildnumber.plugin.version>1.4</maven.buildnumber.plugin.version>
         <org.apache.felix.annotations.version>1.2.4</org.apache.felix.annotations.version>
         <identity.governance.version>1.9.17</identity.governance.version>
-        <carbon.identity.framework.version>7.3.59</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.3.72</carbon.identity.framework.version>
         <maven.findbugsplugin.version>3.0.5</maven.findbugsplugin.version>
         <findsecbugs-plugin.version>1.12.0</findsecbugs-plugin.version>
         <maven.checkstyleplugin.excludes>**/gen/**/*</maven.checkstyleplugin.excludes>


### PR DESCRIPTION
Currently we do not have the capabilities to update a scope after creation. Here we are introducing the APIs to support updating scope's display name and description.