### PR TITLE
Add useClientIdAsSubClaimForAppTokens and omitUsernameInIntrospectionRespForAppTokens configs to app

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/application/management/v1/OpenIDConnectConfiguration.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/application/management/v1/OpenIDConnectConfiguration.java
@@ -88,6 +88,8 @@ public enum StateEnum {
     private RefreshTokenConfiguration refreshToken;
     private SubjectTokenConfiguration subjectToken;
     private IdTokenConfiguration idToken;
+    private Boolean useClientIdAsSubClaimForAppTokens;
+    private Boolean omitUsernameInIntrospectionRespForAppTokens;
     private OIDCLogoutConfiguration logout;
     private Boolean validateRequestObjectSignature = false;
     private List<String> scopeValidators = null;
@@ -359,6 +361,45 @@ public enum StateEnum {
     }
 
     /**
+     * If enabled, client_id will be sent as the subject claim value for app tokens.
+     */
+    public OpenIDConnectConfiguration useClientIdAsSubClaimForAppTokens(Boolean useClientIdAsSubClaimForAppTokens) {
+
+        this.useClientIdAsSubClaimForAppTokens = useClientIdAsSubClaimForAppTokens;
+        return this;
+    }
+
+    @ApiModelProperty("If enable, client_id will be sent as the sub claim value for app tokens.")
+    @JsonProperty("useClientIdAsSubClaimForAppTokens")
+    @Valid
+    public Boolean getUseClientIdAsSubClaimForAppTokens() {
+        return useClientIdAsSubClaimForAppTokens;
+    }
+    public void setUseClientIdAsSubClaimForAppTokens(Boolean useClientIdAsSubClaimForAppTokens) {
+        this.useClientIdAsSubClaimForAppTokens = useClientIdAsSubClaimForAppTokens;
+    }
+
+    /**
+     * If enabled, username will not be sent in the introspection response for app tokens.
+     */
+    public OpenIDConnectConfiguration omitUsernameInIntrospectionRespForAppTokens(
+            Boolean omitUsernameInIntrospectionRespForAppTokens) {
+
+        this.omitUsernameInIntrospectionRespForAppTokens = omitUsernameInIntrospectionRespForAppTokens;
+        return this;
+    }
+
+    @ApiModelProperty("If enabled, username will not be sent in the introspection response for app tokens.")
+    @JsonProperty("omitUsernameInIntrospectionRespForAppTokens")
+    @Valid
+    public Boolean getOmitUsernameInIntrospectionRespForAppTokens() {
+        return omitUsernameInIntrospectionRespForAppTokens;
+    }
+    public void setOmitUsernameInIntrospectionRespForAppTokens(Boolean omitUsernameInIntrospectionRespForAppTokens) {
+        this.omitUsernameInIntrospectionRespForAppTokens = omitUsernameInIntrospectionRespForAppTokens;
+    }
+
+    /**
     **/
     public OpenIDConnectConfiguration logout(OIDCLogoutConfiguration logout) {
 
@@ -552,6 +593,10 @@ public enum StateEnum {
             Objects.equals(this.refreshToken, openIDConnectConfiguration.refreshToken) &&
             Objects.equals(this.subjectToken, openIDConnectConfiguration.subjectToken) &&
             Objects.equals(this.idToken, openIDConnectConfiguration.idToken) &&
+            Objects.equals(this.useClientIdAsSubClaimForAppTokens,
+                    openIDConnectConfiguration.useClientIdAsSubClaimForAppTokens) &&
+            Objects.equals(this.omitUsernameInIntrospectionRespForAppTokens,
+                    openIDConnectConfiguration.omitUsernameInIntrospectionRespForAppTokens) &&
             Objects.equals(this.logout, openIDConnectConfiguration.logout) &&
             Objects.equals(this.validateRequestObjectSignature, openIDConnectConfiguration.validateRequestObjectSignature) &&
             Objects.equals(this.scopeValidators, openIDConnectConfiguration.scopeValidators) &&
@@ -566,7 +611,7 @@ public enum StateEnum {
     @Override
     public int hashCode() {
 
-        return Objects.hash(clientId, clientSecret, state, grantTypes, callbackURLs, allowedOrigins, publicClient, pkce, hybridFlow, accessToken, refreshToken, subjectToken, idToken, logout, validateRequestObjectSignature, scopeValidators, clientAuthentication, requestObject, pushAuthorizationRequest, subject, isFAPIApplication, fapiMetadata);
+        return Objects.hash(clientId, clientSecret, state, grantTypes, callbackURLs, allowedOrigins, publicClient, pkce, hybridFlow, accessToken, refreshToken, subjectToken, idToken, useClientIdAsSubClaimForAppTokens, omitUsernameInIntrospectionRespForAppTokens, logout, validateRequestObjectSignature, scopeValidators, clientAuthentication, requestObject, pushAuthorizationRequest, subject, isFAPIApplication, fapiMetadata);
     }
 
     @Override
@@ -588,6 +633,8 @@ public enum StateEnum {
         sb.append("    refreshToken: ").append(toIndentedString(refreshToken)).append("\n");
         sb.append("    subjectToken: ").append(toIndentedString(subjectToken)).append("\n");
         sb.append("    idToken: ").append(toIndentedString(idToken)).append("\n");
+        sb.append("    useClientIdAsSubClaimForAppTokens: ").append(toIndentedString(useClientIdAsSubClaimForAppTokens)).append("\n");
+        sb.append("    omitUsernameInIntrospectionRespForAppTokens: ").append(toIndentedString(omitUsernameInIntrospectionRespForAppTokens)).append("\n");
         sb.append("    logout: ").append(toIndentedString(logout)).append("\n");
         sb.append("    validateRequestObjectSignature: ").append(toIndentedString(validateRequestObjectSignature)).append("\n");
         sb.append("    scopeValidators: ").append(toIndentedString(scopeValidators)).append("\n");

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/functions/application/inbound/oauth2/ApiModelToOAuthConsumerApp.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/functions/application/inbound/oauth2/ApiModelToOAuthConsumerApp.java
@@ -69,6 +69,10 @@ public class ApiModelToOAuthConsumerApp implements ApiModelToOAuthConsumerAppFun
         consumerAppDTO.setBypassClientCredentials(oidcModel.getPublicClient());
         consumerAppDTO.setRequestObjectSignatureValidationEnabled(oidcModel.getValidateRequestObjectSignature());
 
+        consumerAppDTO.setUseClientIdAsSubClaimForAppTokens(oidcModel.getUseClientIdAsSubClaimForAppTokens());
+        consumerAppDTO.setOmitUsernameInIntrospectionRespForAppTokens(
+                oidcModel.getOmitUsernameInIntrospectionRespForAppTokens());
+
         updateAllowedOrigins(consumerAppDTO, oidcModel.getAllowedOrigins());
         updatePkceConfigurations(consumerAppDTO, oidcModel.getPkce());
         updateHybridFlowConfigurations(consumerAppDTO, oidcModel.getHybridFlow());

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/functions/application/inbound/oauth2/OAuthConsumerAppToApiModel.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/functions/application/inbound/oauth2/OAuthConsumerAppToApiModel.java
@@ -59,6 +59,9 @@ public class OAuthConsumerAppToApiModel implements Function<OAuthConsumerAppDTO,
                 .accessToken(buildTokenConfiguration(oauthAppDTO))
                 .refreshToken(buildRefreshTokenConfiguration(oauthAppDTO))
                 .idToken(buildIdTokenConfiguration(oauthAppDTO))
+                .useClientIdAsSubClaimForAppTokens(oauthAppDTO.isUseClientIdAsSubClaimForAppTokens())
+                .omitUsernameInIntrospectionRespForAppTokens(
+                        oauthAppDTO.isOmitUsernameInIntrospectionRespForAppTokens())
                 .logout(buildLogoutConfiguration(oauthAppDTO))
                 .scopeValidators(getScopeValidators(oauthAppDTO))
                 .validateRequestObjectSignature(oauthAppDTO.isRequestObjectSignatureValidationEnabled())

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/resources/applications.yaml
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/resources/applications.yaml
@@ -3603,6 +3603,12 @@ components:
             Enabling this option will allow the client to authenticate without a
             client secret.
           example: false
+        useClientIdAsSubClaimForAppTokens:
+          type: boolean
+          description: If enabled, client_id will be sent as the sub claim value for app tokens.
+        omitUsernameInIntrospectionRespForAppTokens:
+          type: boolean
+          description: If enabled, username will not be sent in the introspection response for app tokens.
         pkce:
           $ref: '#/components/schemas/OAuth2PKCEConfiguration'
         accessToken:

--- a/pom.xml
+++ b/pom.xml
@@ -808,7 +808,7 @@
         <findsecbugs-plugin.version>1.12.0</findsecbugs-plugin.version>
         <maven.checkstyleplugin.excludes>**/gen/**/*</maven.checkstyleplugin.excludes>
         <identity.event.handler.version>1.8.19</identity.event.handler.version>
-        <identity.inbound.oauth2.version>7.0.137</identity.inbound.oauth2.version>
+        <identity.inbound.oauth2.version>7.0.140</identity.inbound.oauth2.version>
         <identity.inbound.saml2.version>5.11.41</identity.inbound.saml2.version>
         <commons.beanutils.version>1.9.4</commons.beanutils.version>
         <mavan.findbugsplugin.exclude.file>findbugs-exclude-filter.xml</mavan.findbugsplugin.exclude.file>


### PR DESCRIPTION
### Proposed changes in this pull request
> useClientIdAsSubClaimForAppTokens and omitUsernameInIntrospectionRespForAppTokens configs are being introduce to support the on the fly migration for client apps for the issue mentioned in [1]. 

The configs values will be default false for old apps, default true for new apps. Old app owners can do necessary changes and change the config value to true marking a successful migration.

[1] https://github.com/wso2/product-is/issues/16060
[2] 

Related Issues:
- https://github.com/wso2/product-is/issues/20917