### PR TITLE
Improvement to authenticator type value returned in the authenticator APIs.

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.authenticators/org.wso2.carbon.identity.api.server.authenticators.v1/src/main/java/org/wso2/carbon/identity/api/server/authenticators/v1/core/ServerAuthenticatorManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.authenticators/org.wso2.carbon.identity.api.server.authenticators.v1/src/main/java/org/wso2/carbon/identity/api/server/authenticators/v1/core/ServerAuthenticatorManagementService.java
@@ -418,7 +418,7 @@ public class ServerAuthenticatorManagementService {
             authenticator.setDisplayName(identityProvider.getIdentityProviderName());
         }
         authenticator.setIsEnabled(identityProvider.isEnable());
-        authenticator.setType(Authenticator.TypeEnum.FEDERATED);
+        authenticator.setType(authenticator.getType());
         authenticator.setImage(identityProvider.getImageUrl());
         authenticator.setDescription(identityProvider.getIdentityProviderDescription());
         if (CollectionUtils.isNotEmpty(configTagsListDistinct)) {
@@ -511,7 +511,7 @@ public class ServerAuthenticatorManagementService {
         authenticator.setName(config.getName());
         authenticator.setDisplayName(config.getDisplayName());
         authenticator.setIsEnabled(config.isEnabled());
-        authenticator.setType(Authenticator.TypeEnum.LOCAL);
+        authenticator.setType(authenticator.getType());
         String[] tags = config.getTags();
         if (ArrayUtils.isNotEmpty(tags)) {
             authenticator.setTags(Arrays.asList(tags));

--- a/components/org.wso2.carbon.identity.api.server.authenticators/org.wso2.carbon.identity.api.server.authenticators.v1/src/main/resources/authenticators.yaml
+++ b/components/org.wso2.carbon.identity.api.server.authenticators/org.wso2.carbon.identity.api.server.authenticators.v1/src/main/resources/authenticators.yaml
@@ -207,6 +207,8 @@ components:
           enum:
             - LOCAL
             - FEDERATED
+            - CUSTOM
+            - REQUEST_PATH
         image:
           type: string
           example: basic-authenticator-logo-url

--- a/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/main/java/org/wso2/carbon/identity/api/server/configs/v1/core/ServerConfigManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/main/java/org/wso2/carbon/identity/api/server/configs/v1/core/ServerConfigManagementService.java
@@ -771,11 +771,7 @@ public class ServerConfigManagementService {
         authenticator.setName(config.getName());
         authenticator.setDisplayName(config.getDisplayName());
         authenticator.setIsEnabled(config.isEnabled());
-        if (config instanceof RequestPathAuthenticatorConfig) {
-            authenticator.setType(Authenticator.TypeEnum.REQUEST_PATH);
-        } else {
-            authenticator.setType(Authenticator.TypeEnum.LOCAL);
-        }
+        authenticator.setType(authenticator.getType());
         String[] tags = config.getTags();
         if (ArrayUtils.isNotEmpty(tags)) {
             authenticator.setTags(Arrays.asList(tags));


### PR DESCRIPTION
Task issue:
- https://github.com/wso2/product-is/issues/20887

Following changes will be added with the this PR:
- For the authenticator details coming in the /authenticators APIs, set type from the authenticatorConfig model.

Related PRs:
- https://github.com/wso2/carbon-identity-framework/pull/5854