### PR TITLE
Restrict not implemented action types from Action Mangement APIs

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.action.management/org.wso2.carbon.identity.api.server.action.management.v1/src/main/java/org/wso2/carbon/identity/api/server/action/management/v1/constants/ActionMgtEndpointConstants.java
+++ b/components/org.wso2.carbon.identity.api.server.action.management/org.wso2.carbon.identity.api.server.action.management.v1/src/main/java/org/wso2/carbon/identity/api/server/action/management/v1/constants/ActionMgtEndpointConstants.java
@@ -47,7 +47,12 @@ public class ActionMgtEndpointConstants {
                 "Authentication property values cannot be empty."),
         ERROR_NO_ACTION_FOUND_ON_GIVEN_ACTION_TYPE_AND_ID("60004",
                 "Action is not found.",
-                "No action is found for given action id and action type");
+                "No action is found for given action id and action type"),
+
+        // Server errors.
+        ERROR_NOT_IMPLEMENTED_ACTION_TYPE("65001",
+                "Unable to perform the operation.",
+                "The requested action type is not currently supported by the server.");
 
         private final String code;
         private final String message;


### PR DESCRIPTION
## Purpose
> Since the following action types executions are not implemented in the system, this PR will block the action management APIs related to those action types.

<img width="1071" alt="image" src="https://github.com/user-attachments/assets/54b67729-c9b8-4eaf-ba24-b2d8e9618583">


### Related Issue
- https://github.com/wso2/product-is/issues/20748