### PR TITLE
Add new authenticator property.

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/functions/application/UpdateAuthenticationSequence.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/functions/application/UpdateAuthenticationSequence.java
@@ -31,6 +31,7 @@ import org.wso2.carbon.identity.application.common.model.RequestPathAuthenticato
 import org.wso2.carbon.identity.application.common.model.ServiceProvider;
 import org.wso2.carbon.identity.application.common.model.script.AuthenticationScriptConfig;
 import org.wso2.carbon.identity.application.mgt.ApplicationConstants;
+import org.wso2.carbon.identity.base.IdentityConstants;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -160,11 +161,13 @@ public class UpdateAuthenticationSequence implements UpdateFunction<ServiceProvi
                 LocalAuthenticatorConfig localAuthOption = new LocalAuthenticatorConfig();
                 localAuthOption.setEnabled(true);
                 localAuthOption.setName(option.getAuthenticator());
+                localAuthOption.setDefinedByType(IdentityConstants.DefinedByType.SYSTEM);
                 localAuthOptions.add(localAuthOption);
             } else {
                 FederatedAuthenticatorConfig federatedAuthConfig = new FederatedAuthenticatorConfig();
                 federatedAuthConfig.setEnabled(true);
                 federatedAuthConfig.setName(option.getAuthenticator());
+                federatedAuthConfig.setDefinedByType(IdentityConstants.DefinedByType.SYSTEM);
 
                 IdentityProvider federatedIdp = new IdentityProvider();
                 federatedIdp.setIdentityProviderName(option.getIdp());

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/functions/application/UpdateAuthenticationSequence.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/functions/application/UpdateAuthenticationSequence.java
@@ -31,7 +31,8 @@ import org.wso2.carbon.identity.application.common.model.RequestPathAuthenticato
 import org.wso2.carbon.identity.application.common.model.ServiceProvider;
 import org.wso2.carbon.identity.application.common.model.script.AuthenticationScriptConfig;
 import org.wso2.carbon.identity.application.mgt.ApplicationConstants;
-import org.wso2.carbon.identity.base.IdentityConstants;
+import org.wso2.carbon.identity.base.AuthenticatorPropertiesConstant.AuthenticationType;
+import org.wso2.carbon.identity.base.AuthenticatorPropertiesConstant.DefinedByType;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -161,13 +162,15 @@ public class UpdateAuthenticationSequence implements UpdateFunction<ServiceProvi
                 LocalAuthenticatorConfig localAuthOption = new LocalAuthenticatorConfig();
                 localAuthOption.setEnabled(true);
                 localAuthOption.setName(option.getAuthenticator());
-                localAuthOption.setDefinedByType(IdentityConstants.DefinedByType.SYSTEM);
+                localAuthOption.setDefinedByType(DefinedByType.SYSTEM);
+                localAuthOption.setAuthenticationType(AuthenticationType.IDENTIFICATION);
                 localAuthOptions.add(localAuthOption);
             } else {
                 FederatedAuthenticatorConfig federatedAuthConfig = new FederatedAuthenticatorConfig();
                 federatedAuthConfig.setEnabled(true);
                 federatedAuthConfig.setName(option.getAuthenticator());
-                federatedAuthConfig.setDefinedByType(IdentityConstants.DefinedByType.SYSTEM);
+                federatedAuthConfig.setDefinedByType(DefinedByType.SYSTEM);
+                federatedAuthConfig.setAuthenticationType(AuthenticationType.IDENTIFICATION);
 
                 IdentityProvider federatedIdp = new IdentityProvider();
                 federatedIdp.setIdentityProviderName(option.getIdp());

--- a/components/org.wso2.carbon.identity.api.server.authenticators/org.wso2.carbon.identity.api.server.authenticators.v1/src/gen/java/org/wso2/carbon/identity/api/server/authenticators/v1/model/Authenticator.java
+++ b/components/org.wso2.carbon.identity.api.server.authenticators/org.wso2.carbon.identity.api.server.authenticators.v1/src/gen/java/org/wso2/carbon/identity/api/server/authenticators/v1/model/Authenticator.java
@@ -37,6 +37,40 @@ public class Authenticator  {
     private String displayName;
     private Boolean isEnabled;
 
+@XmlType(name="DefinedByEnum")
+@XmlEnum(String.class)
+public enum DefinedByEnum {
+
+    @XmlEnumValue("SYSTEM") SYSTEM(String.valueOf("SYSTEM")), @XmlEnumValue("USER") USER(String.valueOf("USER"));
+
+
+    private String value;
+
+    DefinedByEnum(String v) {
+        value = v;
+    }
+
+    public String value() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    public static DefinedByEnum fromValue(String value) {
+        for (DefinedByEnum b : DefinedByEnum.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
+}
+
+    private DefinedByEnum definedBy;
+
 @XmlType(name="TypeEnum")
 @XmlEnum(String.class)
 public enum TypeEnum {
@@ -146,6 +180,24 @@ public enum TypeEnum {
     }
     public void setIsEnabled(Boolean isEnabled) {
         this.isEnabled = isEnabled;
+    }
+
+    /**
+    **/
+    public Authenticator definedBy(DefinedByEnum definedBy) {
+
+        this.definedBy = definedBy;
+        return this;
+    }
+    
+    @ApiModelProperty(value = "")
+    @JsonProperty("definedBy")
+    @Valid
+    public DefinedByEnum getDefinedBy() {
+        return definedBy;
+    }
+    public void setDefinedBy(DefinedByEnum definedBy) {
+        this.definedBy = definedBy;
     }
 
     /**
@@ -262,6 +314,7 @@ public enum TypeEnum {
             Objects.equals(this.name, authenticator.name) &&
             Objects.equals(this.displayName, authenticator.displayName) &&
             Objects.equals(this.isEnabled, authenticator.isEnabled) &&
+            Objects.equals(this.definedBy, authenticator.definedBy) &&
             Objects.equals(this.type, authenticator.type) &&
             Objects.equals(this.image, authenticator.image) &&
             Objects.equals(this.description, authenticator.description) &&
@@ -271,7 +324,7 @@ public enum TypeEnum {
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, name, displayName, isEnabled, type, image, description, tags, self);
+        return Objects.hash(id, name, displayName, isEnabled, definedBy, type, image, description, tags, self);
     }
 
     @Override
@@ -284,6 +337,7 @@ public enum TypeEnum {
         sb.append("    name: ").append(toIndentedString(name)).append("\n");
         sb.append("    displayName: ").append(toIndentedString(displayName)).append("\n");
         sb.append("    isEnabled: ").append(toIndentedString(isEnabled)).append("\n");
+        sb.append("    definedBy: ").append(toIndentedString(definedBy)).append("\n");
         sb.append("    type: ").append(toIndentedString(type)).append("\n");
         sb.append("    image: ").append(toIndentedString(image)).append("\n");
         sb.append("    description: ").append(toIndentedString(description)).append("\n");

--- a/components/org.wso2.carbon.identity.api.server.authenticators/org.wso2.carbon.identity.api.server.authenticators.v1/src/gen/java/org/wso2/carbon/identity/api/server/authenticators/v1/model/Authenticator.java
+++ b/components/org.wso2.carbon.identity.api.server.authenticators/org.wso2.carbon.identity.api.server.authenticators.v1/src/gen/java/org/wso2/carbon/identity/api/server/authenticators/v1/model/Authenticator.java
@@ -71,6 +71,40 @@ public enum DefinedByEnum {
 
     private DefinedByEnum definedBy;
 
+@XmlType(name="AuthenticationTypeEnum")
+@XmlEnum(String.class)
+public enum AuthenticationTypeEnum {
+
+    @XmlEnumValue("IDENTIFICATION") IDENTIFICATION(String.valueOf("IDENTIFICATION")), @XmlEnumValue("VERIFICATION_ONLY") VERIFICATION_ONLY(String.valueOf("VERIFICATION_ONLY")), @XmlEnumValue("REQUEST_PATH") REQUEST_PATH(String.valueOf("REQUEST_PATH"));
+
+
+    private String value;
+
+    AuthenticationTypeEnum(String v) {
+        value = v;
+    }
+
+    public String value() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    public static AuthenticationTypeEnum fromValue(String value) {
+        for (AuthenticationTypeEnum b : AuthenticationTypeEnum.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
+}
+
+    private AuthenticationTypeEnum authenticationType;
+
 @XmlType(name="TypeEnum")
 @XmlEnum(String.class)
 public enum TypeEnum {
@@ -202,6 +236,24 @@ public enum TypeEnum {
 
     /**
     **/
+    public Authenticator authenticationType(AuthenticationTypeEnum authenticationType) {
+
+        this.authenticationType = authenticationType;
+        return this;
+    }
+    
+    @ApiModelProperty(value = "")
+    @JsonProperty("authenticationType")
+    @Valid
+    public AuthenticationTypeEnum getAuthenticationType() {
+        return authenticationType;
+    }
+    public void setAuthenticationType(AuthenticationTypeEnum authenticationType) {
+        this.authenticationType = authenticationType;
+    }
+
+    /**
+    **/
     public Authenticator type(TypeEnum type) {
 
         this.type = type;
@@ -315,6 +367,7 @@ public enum TypeEnum {
             Objects.equals(this.displayName, authenticator.displayName) &&
             Objects.equals(this.isEnabled, authenticator.isEnabled) &&
             Objects.equals(this.definedBy, authenticator.definedBy) &&
+            Objects.equals(this.authenticationType, authenticator.authenticationType) &&
             Objects.equals(this.type, authenticator.type) &&
             Objects.equals(this.image, authenticator.image) &&
             Objects.equals(this.description, authenticator.description) &&
@@ -324,7 +377,7 @@ public enum TypeEnum {
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, name, displayName, isEnabled, definedBy, type, image, description, tags, self);
+        return Objects.hash(id, name, displayName, isEnabled, definedBy, authenticationType, type, image, description, tags, self);
     }
 
     @Override
@@ -338,6 +391,7 @@ public enum TypeEnum {
         sb.append("    displayName: ").append(toIndentedString(displayName)).append("\n");
         sb.append("    isEnabled: ").append(toIndentedString(isEnabled)).append("\n");
         sb.append("    definedBy: ").append(toIndentedString(definedBy)).append("\n");
+        sb.append("    authenticationType: ").append(toIndentedString(authenticationType)).append("\n");
         sb.append("    type: ").append(toIndentedString(type)).append("\n");
         sb.append("    image: ").append(toIndentedString(image)).append("\n");
         sb.append("    description: ").append(toIndentedString(description)).append("\n");

--- a/components/org.wso2.carbon.identity.api.server.authenticators/org.wso2.carbon.identity.api.server.authenticators.v1/src/main/java/org/wso2/carbon/identity/api/server/authenticators/v1/core/ServerAuthenticatorManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.authenticators/org.wso2.carbon.identity.api.server.authenticators.v1/src/main/java/org/wso2/carbon/identity/api/server/authenticators/v1/core/ServerAuthenticatorManagementService.java
@@ -41,6 +41,7 @@ import org.wso2.carbon.identity.application.common.model.FederatedAuthenticatorC
 import org.wso2.carbon.identity.application.common.model.IdentityProvider;
 import org.wso2.carbon.identity.application.common.model.LocalAuthenticatorConfig;
 import org.wso2.carbon.identity.application.common.model.RequestPathAuthenticatorConfig;
+import org.wso2.carbon.identity.base.IdentityConstants;
 import org.wso2.carbon.identity.base.IdentityException;
 import org.wso2.carbon.identity.core.model.ExpressionNode;
 import org.wso2.carbon.identity.core.model.FilterTreeBuilder;
@@ -421,6 +422,13 @@ public class ServerAuthenticatorManagementService {
         authenticator.setType(Authenticator.TypeEnum.FEDERATED);
         authenticator.setImage(identityProvider.getImageUrl());
         authenticator.setDescription(identityProvider.getIdentityProviderDescription());
+        if (identityProvider.getFederatedAuthenticatorConfigs().length == 1) {
+            IdentityConstants.DefinedByType definedByType =
+                    identityProvider.getFederatedAuthenticatorConfigs()[0].getDefinedByType();
+            authenticator.definedBy(Authenticator.DefinedByEnum.valueOf(definedByType.toString()));
+        } else {
+            authenticator.definedBy(Authenticator.DefinedByEnum.SYSTEM);
+        }
         if (CollectionUtils.isNotEmpty(configTagsListDistinct)) {
             authenticator.setTags(configTagsListDistinct);
         }
@@ -512,6 +520,7 @@ public class ServerAuthenticatorManagementService {
         authenticator.setDisplayName(config.getDisplayName());
         authenticator.setIsEnabled(config.isEnabled());
         authenticator.setType(Authenticator.TypeEnum.LOCAL);
+        authenticator.definedBy(Authenticator.DefinedByEnum.valueOf(config.getDefinedByType().toString()));
         String[] tags = config.getTags();
         if (ArrayUtils.isNotEmpty(tags)) {
             authenticator.setTags(Arrays.asList(tags));

--- a/components/org.wso2.carbon.identity.api.server.authenticators/org.wso2.carbon.identity.api.server.authenticators.v1/src/main/java/org/wso2/carbon/identity/api/server/authenticators/v1/core/ServerAuthenticatorManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.authenticators/org.wso2.carbon.identity.api.server.authenticators.v1/src/main/java/org/wso2/carbon/identity/api/server/authenticators/v1/core/ServerAuthenticatorManagementService.java
@@ -41,7 +41,7 @@ import org.wso2.carbon.identity.application.common.model.FederatedAuthenticatorC
 import org.wso2.carbon.identity.application.common.model.IdentityProvider;
 import org.wso2.carbon.identity.application.common.model.LocalAuthenticatorConfig;
 import org.wso2.carbon.identity.application.common.model.RequestPathAuthenticatorConfig;
-import org.wso2.carbon.identity.base.IdentityConstants;
+import org.wso2.carbon.identity.base.AuthenticatorPropertiesConstant.DefinedByType;
 import org.wso2.carbon.identity.base.IdentityException;
 import org.wso2.carbon.identity.core.model.ExpressionNode;
 import org.wso2.carbon.identity.core.model.FilterTreeBuilder;
@@ -418,12 +418,13 @@ public class ServerAuthenticatorManagementService {
         } else {
             authenticator.setDisplayName(identityProvider.getIdentityProviderName());
         }
+        authenticator.setAuthenticationType(Authenticator.AuthenticationTypeEnum.IDENTIFICATION);
         authenticator.setIsEnabled(identityProvider.isEnable());
         authenticator.setType(Authenticator.TypeEnum.FEDERATED);
         authenticator.setImage(identityProvider.getImageUrl());
         authenticator.setDescription(identityProvider.getIdentityProviderDescription());
         if (identityProvider.getFederatedAuthenticatorConfigs().length == 1) {
-            IdentityConstants.DefinedByType definedByType =
+            DefinedByType definedByType =
                     identityProvider.getFederatedAuthenticatorConfigs()[0].getDefinedByType();
             authenticator.definedBy(Authenticator.DefinedByEnum.valueOf(definedByType.toString()));
         } else {
@@ -521,6 +522,8 @@ public class ServerAuthenticatorManagementService {
         authenticator.setIsEnabled(config.isEnabled());
         authenticator.setType(Authenticator.TypeEnum.LOCAL);
         authenticator.definedBy(Authenticator.DefinedByEnum.valueOf(config.getDefinedByType().toString()));
+        authenticator.setAuthenticationType(
+                Authenticator.AuthenticationTypeEnum.valueOf(config.getAuthenticationType().toString()));
         String[] tags = config.getTags();
         if (ArrayUtils.isNotEmpty(tags)) {
             authenticator.setTags(Arrays.asList(tags));

--- a/components/org.wso2.carbon.identity.api.server.authenticators/org.wso2.carbon.identity.api.server.authenticators.v1/src/main/resources/authenticators.yaml
+++ b/components/org.wso2.carbon.identity.api.server.authenticators/org.wso2.carbon.identity.api.server.authenticators.v1/src/main/resources/authenticators.yaml
@@ -207,6 +207,12 @@ components:
           enum:
             - SYSTEM
             - USER
+        authenticationType:
+          type: string
+          enum:
+            - IDENTIFICATION
+            - VERIFICATION_ONLY
+            - REQUEST_PATH
         type:
           type: string
           enum:

--- a/components/org.wso2.carbon.identity.api.server.authenticators/org.wso2.carbon.identity.api.server.authenticators.v1/src/main/resources/authenticators.yaml
+++ b/components/org.wso2.carbon.identity.api.server.authenticators/org.wso2.carbon.identity.api.server.authenticators.v1/src/main/resources/authenticators.yaml
@@ -202,6 +202,11 @@ components:
         isEnabled:
           type: boolean
           example: true
+        definedBy:
+          type: string
+          enum:
+            - SYSTEM
+            - USER
         type:
           type: string
           enum:

--- a/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/gen/java/org/wso2/carbon/identity/api/server/configs/v1/model/Authenticator.java
+++ b/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/gen/java/org/wso2/carbon/identity/api/server/configs/v1/model/Authenticator.java
@@ -38,6 +38,40 @@ public class Authenticator  {
     private String displayName;
     private Boolean isEnabled = true;
 
+@XmlType(name="DefinedByEnum")
+@XmlEnum(String.class)
+public enum DefinedByEnum {
+
+    @XmlEnumValue("SYSTEM") SYSTEM(String.valueOf("SYSTEM")), @XmlEnumValue("USER") USER(String.valueOf("USER"));
+
+
+    private String value;
+
+    DefinedByEnum(String v) {
+        value = v;
+    }
+
+    public String value() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    public static DefinedByEnum fromValue(String value) {
+        for (DefinedByEnum b : DefinedByEnum.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
+}
+
+    private DefinedByEnum definedBy;
+
 @XmlType(name="TypeEnum")
 @XmlEnum(String.class)
 public enum TypeEnum {
@@ -154,6 +188,24 @@ public enum TypeEnum {
 
     /**
     **/
+    public Authenticator definedBy(DefinedByEnum definedBy) {
+
+        this.definedBy = definedBy;
+        return this;
+    }
+    
+    @ApiModelProperty(value = "")
+    @JsonProperty("definedBy")
+    @Valid
+    public DefinedByEnum getDefinedBy() {
+        return definedBy;
+    }
+    public void setDefinedBy(DefinedByEnum definedBy) {
+        this.definedBy = definedBy;
+    }
+
+    /**
+    **/
     public Authenticator type(TypeEnum type) {
 
         this.type = type;
@@ -238,6 +290,7 @@ public enum TypeEnum {
             Objects.equals(this.name, authenticator.name) &&
             Objects.equals(this.displayName, authenticator.displayName) &&
             Objects.equals(this.isEnabled, authenticator.isEnabled) &&
+            Objects.equals(this.definedBy, authenticator.definedBy) &&
             Objects.equals(this.type, authenticator.type) &&
             Objects.equals(this.tags, authenticator.tags) &&
             Objects.equals(this.properties, authenticator.properties);
@@ -245,7 +298,7 @@ public enum TypeEnum {
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, name, displayName, isEnabled, type, tags, properties);
+        return Objects.hash(id, name, displayName, isEnabled, definedBy, type, tags, properties);
     }
 
     @Override
@@ -258,6 +311,7 @@ public enum TypeEnum {
         sb.append("    name: ").append(toIndentedString(name)).append("\n");
         sb.append("    displayName: ").append(toIndentedString(displayName)).append("\n");
         sb.append("    isEnabled: ").append(toIndentedString(isEnabled)).append("\n");
+        sb.append("    definedBy: ").append(toIndentedString(definedBy)).append("\n");
         sb.append("    type: ").append(toIndentedString(type)).append("\n");
         sb.append("    tags: ").append(toIndentedString(tags)).append("\n");
         sb.append("    properties: ").append(toIndentedString(properties)).append("\n");

--- a/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/gen/java/org/wso2/carbon/identity/api/server/configs/v1/model/Authenticator.java
+++ b/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/gen/java/org/wso2/carbon/identity/api/server/configs/v1/model/Authenticator.java
@@ -72,6 +72,40 @@ public enum DefinedByEnum {
 
     private DefinedByEnum definedBy;
 
+@XmlType(name="AuthenticationTypeEnum")
+@XmlEnum(String.class)
+public enum AuthenticationTypeEnum {
+
+    @XmlEnumValue("IDENTIFICATION") IDENTIFICATION(String.valueOf("IDENTIFICATION")), @XmlEnumValue("VERIFICATION_ONLY") VERIFICATION_ONLY(String.valueOf("VERIFICATION_ONLY")), @XmlEnumValue("REQUEST_PATH") REQUEST_PATH(String.valueOf("REQUEST_PATH"));
+
+
+    private String value;
+
+    AuthenticationTypeEnum(String v) {
+        value = v;
+    }
+
+    public String value() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    public static AuthenticationTypeEnum fromValue(String value) {
+        for (AuthenticationTypeEnum b : AuthenticationTypeEnum.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
+}
+
+    private AuthenticationTypeEnum authenticationType;
+
 @XmlType(name="TypeEnum")
 @XmlEnum(String.class)
 public enum TypeEnum {
@@ -206,6 +240,24 @@ public enum TypeEnum {
 
     /**
     **/
+    public Authenticator authenticationType(AuthenticationTypeEnum authenticationType) {
+
+        this.authenticationType = authenticationType;
+        return this;
+    }
+    
+    @ApiModelProperty(value = "")
+    @JsonProperty("authenticationType")
+    @Valid
+    public AuthenticationTypeEnum getAuthenticationType() {
+        return authenticationType;
+    }
+    public void setAuthenticationType(AuthenticationTypeEnum authenticationType) {
+        this.authenticationType = authenticationType;
+    }
+
+    /**
+    **/
     public Authenticator type(TypeEnum type) {
 
         this.type = type;
@@ -291,6 +343,7 @@ public enum TypeEnum {
             Objects.equals(this.displayName, authenticator.displayName) &&
             Objects.equals(this.isEnabled, authenticator.isEnabled) &&
             Objects.equals(this.definedBy, authenticator.definedBy) &&
+            Objects.equals(this.authenticationType, authenticator.authenticationType) &&
             Objects.equals(this.type, authenticator.type) &&
             Objects.equals(this.tags, authenticator.tags) &&
             Objects.equals(this.properties, authenticator.properties);
@@ -298,7 +351,7 @@ public enum TypeEnum {
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, name, displayName, isEnabled, definedBy, type, tags, properties);
+        return Objects.hash(id, name, displayName, isEnabled, definedBy, authenticationType, type, tags, properties);
     }
 
     @Override
@@ -312,6 +365,7 @@ public enum TypeEnum {
         sb.append("    displayName: ").append(toIndentedString(displayName)).append("\n");
         sb.append("    isEnabled: ").append(toIndentedString(isEnabled)).append("\n");
         sb.append("    definedBy: ").append(toIndentedString(definedBy)).append("\n");
+        sb.append("    authenticationType: ").append(toIndentedString(authenticationType)).append("\n");
         sb.append("    type: ").append(toIndentedString(type)).append("\n");
         sb.append("    tags: ").append(toIndentedString(tags)).append("\n");
         sb.append("    properties: ").append(toIndentedString(properties)).append("\n");

--- a/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/gen/java/org/wso2/carbon/identity/api/server/configs/v1/model/AuthenticatorListItem.java
+++ b/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/gen/java/org/wso2/carbon/identity/api/server/configs/v1/model/AuthenticatorListItem.java
@@ -37,6 +37,74 @@ public class AuthenticatorListItem  {
     private String displayName;
     private Boolean isEnabled = true;
 
+@XmlType(name="DefinedByEnum")
+@XmlEnum(String.class)
+public enum DefinedByEnum {
+
+    @XmlEnumValue("SYSTEM") SYSTEM(String.valueOf("SYSTEM")), @XmlEnumValue("USER") USER(String.valueOf("USER"));
+
+
+    private String value;
+
+    DefinedByEnum(String v) {
+        value = v;
+    }
+
+    public String value() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    public static DefinedByEnum fromValue(String value) {
+        for (DefinedByEnum b : DefinedByEnum.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
+}
+
+    private DefinedByEnum definedBy;
+
+@XmlType(name="AuthenticationTypeEnum")
+@XmlEnum(String.class)
+public enum AuthenticationTypeEnum {
+
+    @XmlEnumValue("IDENTIFICATION") IDENTIFICATION(String.valueOf("IDENTIFICATION")), @XmlEnumValue("VERIFICATION_ONLY") VERIFICATION_ONLY(String.valueOf("VERIFICATION_ONLY")), @XmlEnumValue("REQUEST_PATH") REQUEST_PATH(String.valueOf("REQUEST_PATH"));
+
+
+    private String value;
+
+    AuthenticationTypeEnum(String v) {
+        value = v;
+    }
+
+    public String value() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    public static AuthenticationTypeEnum fromValue(String value) {
+        for (AuthenticationTypeEnum b : AuthenticationTypeEnum.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
+}
+
+    private AuthenticationTypeEnum authenticationType;
+
 @XmlType(name="TypeEnum")
 @XmlEnum(String.class)
 public enum TypeEnum {
@@ -148,6 +216,42 @@ public enum TypeEnum {
 
     /**
     **/
+    public AuthenticatorListItem definedBy(DefinedByEnum definedBy) {
+
+        this.definedBy = definedBy;
+        return this;
+    }
+    
+    @ApiModelProperty(value = "")
+    @JsonProperty("definedBy")
+    @Valid
+    public DefinedByEnum getDefinedBy() {
+        return definedBy;
+    }
+    public void setDefinedBy(DefinedByEnum definedBy) {
+        this.definedBy = definedBy;
+    }
+
+    /**
+    **/
+    public AuthenticatorListItem authenticationType(AuthenticationTypeEnum authenticationType) {
+
+        this.authenticationType = authenticationType;
+        return this;
+    }
+    
+    @ApiModelProperty(value = "")
+    @JsonProperty("authenticationType")
+    @Valid
+    public AuthenticationTypeEnum getAuthenticationType() {
+        return authenticationType;
+    }
+    public void setAuthenticationType(AuthenticationTypeEnum authenticationType) {
+        this.authenticationType = authenticationType;
+    }
+
+    /**
+    **/
     public AuthenticatorListItem type(TypeEnum type) {
 
         this.type = type;
@@ -224,6 +328,8 @@ public enum TypeEnum {
             Objects.equals(this.name, authenticatorListItem.name) &&
             Objects.equals(this.displayName, authenticatorListItem.displayName) &&
             Objects.equals(this.isEnabled, authenticatorListItem.isEnabled) &&
+            Objects.equals(this.definedBy, authenticatorListItem.definedBy) &&
+            Objects.equals(this.authenticationType, authenticatorListItem.authenticationType) &&
             Objects.equals(this.type, authenticatorListItem.type) &&
             Objects.equals(this.tags, authenticatorListItem.tags) &&
             Objects.equals(this.self, authenticatorListItem.self);
@@ -231,7 +337,7 @@ public enum TypeEnum {
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, name, displayName, isEnabled, type, tags, self);
+        return Objects.hash(id, name, displayName, isEnabled, definedBy, authenticationType, type, tags, self);
     }
 
     @Override
@@ -244,6 +350,8 @@ public enum TypeEnum {
         sb.append("    name: ").append(toIndentedString(name)).append("\n");
         sb.append("    displayName: ").append(toIndentedString(displayName)).append("\n");
         sb.append("    isEnabled: ").append(toIndentedString(isEnabled)).append("\n");
+        sb.append("    definedBy: ").append(toIndentedString(definedBy)).append("\n");
+        sb.append("    authenticationType: ").append(toIndentedString(authenticationType)).append("\n");
         sb.append("    type: ").append(toIndentedString(type)).append("\n");
         sb.append("    tags: ").append(toIndentedString(tags)).append("\n");
         sb.append("    self: ").append(toIndentedString(self)).append("\n");

--- a/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/main/java/org/wso2/carbon/identity/api/server/configs/v1/core/ServerConfigManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/main/java/org/wso2/carbon/identity/api/server/configs/v1/core/ServerConfigManagementService.java
@@ -703,6 +703,9 @@ public class ServerConfigManagementService {
                 authenticatorListItem.setName(config.getName());
                 authenticatorListItem.setDisplayName(config.getDisplayName());
                 authenticatorListItem.setIsEnabled(config.isEnabled());
+                authenticatorListItem.setDefinedBy(AuthenticatorListItem.DefinedByEnum.SYSTEM);
+                authenticatorListItem.setAuthenticationType(AuthenticatorListItem.AuthenticationTypeEnum.valueOf(
+                        config.getAuthenticationType().toString()));
                 authenticatorListItem.setType(AuthenticatorListItem.TypeEnum.LOCAL);
                 String[] tags = config.getTags();
                 if (ArrayUtils.isNotEmpty(tags)) {
@@ -721,6 +724,7 @@ public class ServerConfigManagementService {
                 authenticatorListItem.setName(config.getName());
                 authenticatorListItem.setDisplayName(config.getDisplayName());
                 authenticatorListItem.setIsEnabled(config.isEnabled());
+                authenticatorListItem.setDefinedBy(AuthenticatorListItem.DefinedByEnum.SYSTEM);
                 authenticatorListItem.setType(AuthenticatorListItem.TypeEnum.REQUEST_PATH);
                 String[] tags = config.getTags();
                 if (ArrayUtils.isNotEmpty(tags)) {
@@ -771,6 +775,8 @@ public class ServerConfigManagementService {
         authenticator.setName(config.getName());
         authenticator.setDisplayName(config.getDisplayName());
         authenticator.setDefinedBy(Authenticator.DefinedByEnum.valueOf(config.getDefinedByType().toString()));
+        authenticator.setAuthenticationType(
+                Authenticator.AuthenticationTypeEnum.valueOf(config.getAuthenticationType().toString()));
         authenticator.setIsEnabled(config.isEnabled());
         if (config instanceof RequestPathAuthenticatorConfig) {
             authenticator.setType(Authenticator.TypeEnum.REQUEST_PATH);

--- a/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/main/java/org/wso2/carbon/identity/api/server/configs/v1/core/ServerConfigManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/main/java/org/wso2/carbon/identity/api/server/configs/v1/core/ServerConfigManagementService.java
@@ -770,6 +770,7 @@ public class ServerConfigManagementService {
         authenticator.setId(base64URLEncode(config.getName()));
         authenticator.setName(config.getName());
         authenticator.setDisplayName(config.getDisplayName());
+        authenticator.setDefinedBy(Authenticator.DefinedByEnum.valueOf(config.getDefinedByType().toString()));
         authenticator.setIsEnabled(config.isEnabled());
         if (config instanceof RequestPathAuthenticatorConfig) {
             authenticator.setType(Authenticator.TypeEnum.REQUEST_PATH);

--- a/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/main/resources/configs.yaml
+++ b/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/main/resources/configs.yaml
@@ -1187,6 +1187,17 @@ components:
           type: boolean
           default: true
           example: true
+        definedBy:
+          type: string
+          enum:
+            - SYSTEM
+            - USER
+        authenticationType:
+          type: string
+          enum:
+            - IDENTIFICATION
+            - VERIFICATION_ONLY
+            - REQUEST_PATH
         type:
           type: string
           enum:
@@ -1222,6 +1233,12 @@ components:
           enum:
             - SYSTEM
             - USER
+        authenticationType:
+          type: string
+          enum:
+            - IDENTIFICATION
+            - VERIFICATION_ONLY
+            - REQUEST_PATH
         type:
           type: string
           enum:

--- a/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/main/resources/configs.yaml
+++ b/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/main/resources/configs.yaml
@@ -1217,6 +1217,11 @@ components:
         isEnabled:
           type: boolean
           default: true
+        definedBy:
+          type: string
+          enum:
+            - SYSTEM
+            - USER
         type:
           type: string
           enum:

--- a/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/gen/java/org/wso2/carbon/identity/api/server/idp/v1/model/FederatedAuthenticator.java
+++ b/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/gen/java/org/wso2/carbon/identity/api/server/idp/v1/model/FederatedAuthenticator.java
@@ -70,6 +70,40 @@ public enum DefinedByEnum {
 }
 
     private DefinedByEnum definedBy;
+
+@XmlType(name="AuthenticationTypeEnum")
+@XmlEnum(String.class)
+public enum AuthenticationTypeEnum {
+
+    @XmlEnumValue("IDENTIFICATION") IDENTIFICATION(String.valueOf("IDENTIFICATION")), @XmlEnumValue("VERIFICATION_ONLY") VERIFICATION_ONLY(String.valueOf("VERIFICATION_ONLY")), @XmlEnumValue("REQUEST_PATH") REQUEST_PATH(String.valueOf("REQUEST_PATH"));
+
+
+    private String value;
+
+    AuthenticationTypeEnum(String v) {
+        value = v;
+    }
+
+    public String value() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    public static AuthenticationTypeEnum fromValue(String value) {
+        for (AuthenticationTypeEnum b : AuthenticationTypeEnum.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
+}
+
+    private AuthenticationTypeEnum authenticationType;
     private Boolean isDefault = false;
     private List<String> tags = null;
 
@@ -148,6 +182,24 @@ public enum DefinedByEnum {
     }
     public void setDefinedBy(DefinedByEnum definedBy) {
         this.definedBy = definedBy;
+    }
+
+    /**
+    **/
+    public FederatedAuthenticator authenticationType(AuthenticationTypeEnum authenticationType) {
+
+        this.authenticationType = authenticationType;
+        return this;
+    }
+    
+    @ApiModelProperty(value = "")
+    @JsonProperty("authenticationType")
+    @Valid
+    public AuthenticationTypeEnum getAuthenticationType() {
+        return authenticationType;
+    }
+    public void setAuthenticationType(AuthenticationTypeEnum authenticationType) {
+        this.authenticationType = authenticationType;
     }
 
     /**
@@ -236,6 +288,7 @@ public enum DefinedByEnum {
             Objects.equals(this.name, federatedAuthenticator.name) &&
             Objects.equals(this.isEnabled, federatedAuthenticator.isEnabled) &&
             Objects.equals(this.definedBy, federatedAuthenticator.definedBy) &&
+            Objects.equals(this.authenticationType, federatedAuthenticator.authenticationType) &&
             Objects.equals(this.isDefault, federatedAuthenticator.isDefault) &&
             Objects.equals(this.tags, federatedAuthenticator.tags) &&
             Objects.equals(this.properties, federatedAuthenticator.properties);
@@ -243,7 +296,7 @@ public enum DefinedByEnum {
 
     @Override
     public int hashCode() {
-        return Objects.hash(authenticatorId, name, isEnabled, definedBy, isDefault, tags, properties);
+        return Objects.hash(authenticatorId, name, isEnabled, definedBy, authenticationType, isDefault, tags, properties);
     }
 
     @Override
@@ -256,6 +309,7 @@ public enum DefinedByEnum {
         sb.append("    name: ").append(toIndentedString(name)).append("\n");
         sb.append("    isEnabled: ").append(toIndentedString(isEnabled)).append("\n");
         sb.append("    definedBy: ").append(toIndentedString(definedBy)).append("\n");
+        sb.append("    authenticationType: ").append(toIndentedString(authenticationType)).append("\n");
         sb.append("    isDefault: ").append(toIndentedString(isDefault)).append("\n");
         sb.append("    tags: ").append(toIndentedString(tags)).append("\n");
         sb.append("    properties: ").append(toIndentedString(properties)).append("\n");

--- a/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/gen/java/org/wso2/carbon/identity/api/server/idp/v1/model/FederatedAuthenticator.java
+++ b/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/gen/java/org/wso2/carbon/identity/api/server/idp/v1/model/FederatedAuthenticator.java
@@ -36,6 +36,40 @@ public class FederatedAuthenticator  {
     private String authenticatorId;
     private String name;
     private Boolean isEnabled = false;
+
+@XmlType(name="DefinedByEnum")
+@XmlEnum(String.class)
+public enum DefinedByEnum {
+
+    @XmlEnumValue("SYSTEM") SYSTEM(String.valueOf("SYSTEM")), @XmlEnumValue("USER") USER(String.valueOf("USER"));
+
+
+    private String value;
+
+    DefinedByEnum(String v) {
+        value = v;
+    }
+
+    public String value() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    public static DefinedByEnum fromValue(String value) {
+        for (DefinedByEnum b : DefinedByEnum.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
+}
+
+    private DefinedByEnum definedBy;
     private Boolean isDefault = false;
     private List<String> tags = null;
 
@@ -96,6 +130,24 @@ public class FederatedAuthenticator  {
     }
     public void setIsEnabled(Boolean isEnabled) {
         this.isEnabled = isEnabled;
+    }
+
+    /**
+    **/
+    public FederatedAuthenticator definedBy(DefinedByEnum definedBy) {
+
+        this.definedBy = definedBy;
+        return this;
+    }
+    
+    @ApiModelProperty(value = "")
+    @JsonProperty("definedBy")
+    @Valid
+    public DefinedByEnum getDefinedBy() {
+        return definedBy;
+    }
+    public void setDefinedBy(DefinedByEnum definedBy) {
+        this.definedBy = definedBy;
     }
 
     /**
@@ -183,6 +235,7 @@ public class FederatedAuthenticator  {
         return Objects.equals(this.authenticatorId, federatedAuthenticator.authenticatorId) &&
             Objects.equals(this.name, federatedAuthenticator.name) &&
             Objects.equals(this.isEnabled, federatedAuthenticator.isEnabled) &&
+            Objects.equals(this.definedBy, federatedAuthenticator.definedBy) &&
             Objects.equals(this.isDefault, federatedAuthenticator.isDefault) &&
             Objects.equals(this.tags, federatedAuthenticator.tags) &&
             Objects.equals(this.properties, federatedAuthenticator.properties);
@@ -190,7 +243,7 @@ public class FederatedAuthenticator  {
 
     @Override
     public int hashCode() {
-        return Objects.hash(authenticatorId, name, isEnabled, isDefault, tags, properties);
+        return Objects.hash(authenticatorId, name, isEnabled, definedBy, isDefault, tags, properties);
     }
 
     @Override
@@ -202,6 +255,7 @@ public class FederatedAuthenticator  {
         sb.append("    authenticatorId: ").append(toIndentedString(authenticatorId)).append("\n");
         sb.append("    name: ").append(toIndentedString(name)).append("\n");
         sb.append("    isEnabled: ").append(toIndentedString(isEnabled)).append("\n");
+        sb.append("    definedBy: ").append(toIndentedString(definedBy)).append("\n");
         sb.append("    isDefault: ").append(toIndentedString(isDefault)).append("\n");
         sb.append("    tags: ").append(toIndentedString(tags)).append("\n");
         sb.append("    properties: ").append(toIndentedString(properties)).append("\n");

--- a/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/gen/java/org/wso2/carbon/identity/api/server/idp/v1/model/FederatedAuthenticatorListItem.java
+++ b/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/gen/java/org/wso2/carbon/identity/api/server/idp/v1/model/FederatedAuthenticatorListItem.java
@@ -69,6 +69,40 @@ public enum DefinedByEnum {
 }
 
     private DefinedByEnum definedBy;
+
+@XmlType(name="AuthenticationTypeEnum")
+@XmlEnum(String.class)
+public enum AuthenticationTypeEnum {
+
+    @XmlEnumValue("IDENTIFICATION") IDENTIFICATION(String.valueOf("IDENTIFICATION")), @XmlEnumValue("VERIFICATION_ONLY") VERIFICATION_ONLY(String.valueOf("VERIFICATION_ONLY")), @XmlEnumValue("REQUEST_PATH") REQUEST_PATH(String.valueOf("REQUEST_PATH"));
+
+
+    private String value;
+
+    AuthenticationTypeEnum(String v) {
+        value = v;
+    }
+
+    public String value() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    public static AuthenticationTypeEnum fromValue(String value) {
+        for (AuthenticationTypeEnum b : AuthenticationTypeEnum.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
+}
+
+    private AuthenticationTypeEnum authenticationType;
     private List<String> tags = null;
 
     private String self;
@@ -147,6 +181,24 @@ public enum DefinedByEnum {
 
     /**
     **/
+    public FederatedAuthenticatorListItem authenticationType(AuthenticationTypeEnum authenticationType) {
+
+        this.authenticationType = authenticationType;
+        return this;
+    }
+    
+    @ApiModelProperty(value = "")
+    @JsonProperty("authenticationType")
+    @Valid
+    public AuthenticationTypeEnum getAuthenticationType() {
+        return authenticationType;
+    }
+    public void setAuthenticationType(AuthenticationTypeEnum authenticationType) {
+        this.authenticationType = authenticationType;
+    }
+
+    /**
+    **/
     public FederatedAuthenticatorListItem tags(List<String> tags) {
 
         this.tags = tags;
@@ -205,13 +257,14 @@ public enum DefinedByEnum {
             Objects.equals(this.name, federatedAuthenticatorListItem.name) &&
             Objects.equals(this.isEnabled, federatedAuthenticatorListItem.isEnabled) &&
             Objects.equals(this.definedBy, federatedAuthenticatorListItem.definedBy) &&
+            Objects.equals(this.authenticationType, federatedAuthenticatorListItem.authenticationType) &&
             Objects.equals(this.tags, federatedAuthenticatorListItem.tags) &&
             Objects.equals(this.self, federatedAuthenticatorListItem.self);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(authenticatorId, name, isEnabled, definedBy, tags, self);
+        return Objects.hash(authenticatorId, name, isEnabled, definedBy, authenticationType, tags, self);
     }
 
     @Override
@@ -224,6 +277,7 @@ public enum DefinedByEnum {
         sb.append("    name: ").append(toIndentedString(name)).append("\n");
         sb.append("    isEnabled: ").append(toIndentedString(isEnabled)).append("\n");
         sb.append("    definedBy: ").append(toIndentedString(definedBy)).append("\n");
+        sb.append("    authenticationType: ").append(toIndentedString(authenticationType)).append("\n");
         sb.append("    tags: ").append(toIndentedString(tags)).append("\n");
         sb.append("    self: ").append(toIndentedString(self)).append("\n");
         sb.append("}");

--- a/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/gen/java/org/wso2/carbon/identity/api/server/idp/v1/model/FederatedAuthenticatorListItem.java
+++ b/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/gen/java/org/wso2/carbon/identity/api/server/idp/v1/model/FederatedAuthenticatorListItem.java
@@ -35,6 +35,40 @@ public class FederatedAuthenticatorListItem  {
     private String authenticatorId;
     private String name;
     private Boolean isEnabled = false;
+
+@XmlType(name="DefinedByEnum")
+@XmlEnum(String.class)
+public enum DefinedByEnum {
+
+    @XmlEnumValue("SYSTEM") SYSTEM(String.valueOf("SYSTEM")), @XmlEnumValue("USER") USER(String.valueOf("USER"));
+
+
+    private String value;
+
+    DefinedByEnum(String v) {
+        value = v;
+    }
+
+    public String value() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    public static DefinedByEnum fromValue(String value) {
+        for (DefinedByEnum b : DefinedByEnum.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
+}
+
+    private DefinedByEnum definedBy;
     private List<String> tags = null;
 
     private String self;
@@ -91,6 +125,24 @@ public class FederatedAuthenticatorListItem  {
     }
     public void setIsEnabled(Boolean isEnabled) {
         this.isEnabled = isEnabled;
+    }
+
+    /**
+    **/
+    public FederatedAuthenticatorListItem definedBy(DefinedByEnum definedBy) {
+
+        this.definedBy = definedBy;
+        return this;
+    }
+    
+    @ApiModelProperty(value = "")
+    @JsonProperty("definedBy")
+    @Valid
+    public DefinedByEnum getDefinedBy() {
+        return definedBy;
+    }
+    public void setDefinedBy(DefinedByEnum definedBy) {
+        this.definedBy = definedBy;
     }
 
     /**
@@ -152,13 +204,14 @@ public class FederatedAuthenticatorListItem  {
         return Objects.equals(this.authenticatorId, federatedAuthenticatorListItem.authenticatorId) &&
             Objects.equals(this.name, federatedAuthenticatorListItem.name) &&
             Objects.equals(this.isEnabled, federatedAuthenticatorListItem.isEnabled) &&
+            Objects.equals(this.definedBy, federatedAuthenticatorListItem.definedBy) &&
             Objects.equals(this.tags, federatedAuthenticatorListItem.tags) &&
             Objects.equals(this.self, federatedAuthenticatorListItem.self);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(authenticatorId, name, isEnabled, tags, self);
+        return Objects.hash(authenticatorId, name, isEnabled, definedBy, tags, self);
     }
 
     @Override
@@ -170,6 +223,7 @@ public class FederatedAuthenticatorListItem  {
         sb.append("    authenticatorId: ").append(toIndentedString(authenticatorId)).append("\n");
         sb.append("    name: ").append(toIndentedString(name)).append("\n");
         sb.append("    isEnabled: ").append(toIndentedString(isEnabled)).append("\n");
+        sb.append("    definedBy: ").append(toIndentedString(definedBy)).append("\n");
         sb.append("    tags: ").append(toIndentedString(tags)).append("\n");
         sb.append("    self: ").append(toIndentedString(self)).append("\n");
         sb.append("}");

--- a/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/gen/java/org/wso2/carbon/identity/api/server/idp/v1/model/FederatedAuthenticatorPUTRequest.java
+++ b/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/gen/java/org/wso2/carbon/identity/api/server/idp/v1/model/FederatedAuthenticatorPUTRequest.java
@@ -37,6 +37,74 @@ public class FederatedAuthenticatorPUTRequest  {
     private String name;
     private Boolean isEnabled = false;
     private Boolean isDefault = false;
+
+@XmlType(name="DefinedByEnum")
+@XmlEnum(String.class)
+public enum DefinedByEnum {
+
+    @XmlEnumValue("SYSTEM") SYSTEM(String.valueOf("SYSTEM")), @XmlEnumValue("USER") USER(String.valueOf("USER"));
+
+
+    private String value;
+
+    DefinedByEnum(String v) {
+        value = v;
+    }
+
+    public String value() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    public static DefinedByEnum fromValue(String value) {
+        for (DefinedByEnum b : DefinedByEnum.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
+}
+
+    private DefinedByEnum definedBy;
+
+@XmlType(name="AuthenticationTypeEnum")
+@XmlEnum(String.class)
+public enum AuthenticationTypeEnum {
+
+    @XmlEnumValue("IDENTIFICATION") IDENTIFICATION(String.valueOf("IDENTIFICATION")), @XmlEnumValue("VERIFICATION_ONLY") VERIFICATION_ONLY(String.valueOf("VERIFICATION_ONLY")), @XmlEnumValue("REQUEST_PATH") REQUEST_PATH(String.valueOf("REQUEST_PATH"));
+
+
+    private String value;
+
+    AuthenticationTypeEnum(String v) {
+        value = v;
+    }
+
+    public String value() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    public static AuthenticationTypeEnum fromValue(String value) {
+        for (AuthenticationTypeEnum b : AuthenticationTypeEnum.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
+}
+
+    private AuthenticationTypeEnum authenticationType;
     private List<Property> properties = null;
 
 
@@ -114,6 +182,42 @@ public class FederatedAuthenticatorPUTRequest  {
 
     /**
     **/
+    public FederatedAuthenticatorPUTRequest definedBy(DefinedByEnum definedBy) {
+
+        this.definedBy = definedBy;
+        return this;
+    }
+    
+    @ApiModelProperty(value = "")
+    @JsonProperty("definedBy")
+    @Valid
+    public DefinedByEnum getDefinedBy() {
+        return definedBy;
+    }
+    public void setDefinedBy(DefinedByEnum definedBy) {
+        this.definedBy = definedBy;
+    }
+
+    /**
+    **/
+    public FederatedAuthenticatorPUTRequest authenticationType(AuthenticationTypeEnum authenticationType) {
+
+        this.authenticationType = authenticationType;
+        return this;
+    }
+    
+    @ApiModelProperty(value = "")
+    @JsonProperty("authenticationType")
+    @Valid
+    public AuthenticationTypeEnum getAuthenticationType() {
+        return authenticationType;
+    }
+    public void setAuthenticationType(AuthenticationTypeEnum authenticationType) {
+        this.authenticationType = authenticationType;
+    }
+
+    /**
+    **/
     public FederatedAuthenticatorPUTRequest properties(List<Property> properties) {
 
         this.properties = properties;
@@ -154,12 +258,14 @@ public class FederatedAuthenticatorPUTRequest  {
             Objects.equals(this.name, federatedAuthenticatorPUTRequest.name) &&
             Objects.equals(this.isEnabled, federatedAuthenticatorPUTRequest.isEnabled) &&
             Objects.equals(this.isDefault, federatedAuthenticatorPUTRequest.isDefault) &&
+            Objects.equals(this.definedBy, federatedAuthenticatorPUTRequest.definedBy) &&
+            Objects.equals(this.authenticationType, federatedAuthenticatorPUTRequest.authenticationType) &&
             Objects.equals(this.properties, federatedAuthenticatorPUTRequest.properties);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(authenticatorId, name, isEnabled, isDefault, properties);
+        return Objects.hash(authenticatorId, name, isEnabled, isDefault, definedBy, authenticationType, properties);
     }
 
     @Override
@@ -172,6 +278,8 @@ public class FederatedAuthenticatorPUTRequest  {
         sb.append("    name: ").append(toIndentedString(name)).append("\n");
         sb.append("    isEnabled: ").append(toIndentedString(isEnabled)).append("\n");
         sb.append("    isDefault: ").append(toIndentedString(isDefault)).append("\n");
+        sb.append("    definedBy: ").append(toIndentedString(definedBy)).append("\n");
+        sb.append("    authenticationType: ").append(toIndentedString(authenticationType)).append("\n");
         sb.append("    properties: ").append(toIndentedString(properties)).append("\n");
         sb.append("}");
         return sb.toString();

--- a/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/gen/java/org/wso2/carbon/identity/api/server/idp/v1/model/MetaFederatedAuthenticator.java
+++ b/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/gen/java/org/wso2/carbon/identity/api/server/idp/v1/model/MetaFederatedAuthenticator.java
@@ -36,6 +36,40 @@ public class MetaFederatedAuthenticator  {
     private String authenticatorId;
     private String name;
     private String displayName;
+
+@XmlType(name="DefinedByEnum")
+@XmlEnum(String.class)
+public enum DefinedByEnum {
+
+    @XmlEnumValue("SYSTEM") SYSTEM(String.valueOf("SYSTEM")), @XmlEnumValue("USER") USER(String.valueOf("USER"));
+
+
+    private String value;
+
+    DefinedByEnum(String v) {
+        value = v;
+    }
+
+    public String value() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    public static DefinedByEnum fromValue(String value) {
+        for (DefinedByEnum b : DefinedByEnum.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
+}
+
+    private DefinedByEnum definedBy;
     private List<String> tags = null;
 
     private List<MetaProperty> properties = null;
@@ -93,6 +127,24 @@ public class MetaFederatedAuthenticator  {
     }
     public void setDisplayName(String displayName) {
         this.displayName = displayName;
+    }
+
+    /**
+    **/
+    public MetaFederatedAuthenticator definedBy(DefinedByEnum definedBy) {
+
+        this.definedBy = definedBy;
+        return this;
+    }
+    
+    @ApiModelProperty(value = "")
+    @JsonProperty("definedBy")
+    @Valid
+    public DefinedByEnum getDefinedBy() {
+        return definedBy;
+    }
+    public void setDefinedBy(DefinedByEnum definedBy) {
+        this.definedBy = definedBy;
     }
 
     /**
@@ -162,13 +214,14 @@ public class MetaFederatedAuthenticator  {
         return Objects.equals(this.authenticatorId, metaFederatedAuthenticator.authenticatorId) &&
             Objects.equals(this.name, metaFederatedAuthenticator.name) &&
             Objects.equals(this.displayName, metaFederatedAuthenticator.displayName) &&
+            Objects.equals(this.definedBy, metaFederatedAuthenticator.definedBy) &&
             Objects.equals(this.tags, metaFederatedAuthenticator.tags) &&
             Objects.equals(this.properties, metaFederatedAuthenticator.properties);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(authenticatorId, name, displayName, tags, properties);
+        return Objects.hash(authenticatorId, name, displayName, definedBy, tags, properties);
     }
 
     @Override
@@ -180,6 +233,7 @@ public class MetaFederatedAuthenticator  {
         sb.append("    authenticatorId: ").append(toIndentedString(authenticatorId)).append("\n");
         sb.append("    name: ").append(toIndentedString(name)).append("\n");
         sb.append("    displayName: ").append(toIndentedString(displayName)).append("\n");
+        sb.append("    definedBy: ").append(toIndentedString(definedBy)).append("\n");
         sb.append("    tags: ").append(toIndentedString(tags)).append("\n");
         sb.append("    properties: ").append(toIndentedString(properties)).append("\n");
         sb.append("}");

--- a/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/gen/java/org/wso2/carbon/identity/api/server/idp/v1/model/MetaFederatedAuthenticator.java
+++ b/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/gen/java/org/wso2/carbon/identity/api/server/idp/v1/model/MetaFederatedAuthenticator.java
@@ -70,6 +70,40 @@ public enum DefinedByEnum {
 }
 
     private DefinedByEnum definedBy;
+
+@XmlType(name="AuthenticationTypeEnum")
+@XmlEnum(String.class)
+public enum AuthenticationTypeEnum {
+
+    @XmlEnumValue("IDENTIFICATION") IDENTIFICATION(String.valueOf("IDENTIFICATION")), @XmlEnumValue("VERIFICATION_ONLY") VERIFICATION_ONLY(String.valueOf("VERIFICATION_ONLY")), @XmlEnumValue("REQUEST_PATH") REQUEST_PATH(String.valueOf("REQUEST_PATH"));
+
+
+    private String value;
+
+    AuthenticationTypeEnum(String v) {
+        value = v;
+    }
+
+    public String value() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    public static AuthenticationTypeEnum fromValue(String value) {
+        for (AuthenticationTypeEnum b : AuthenticationTypeEnum.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
+}
+
+    private AuthenticationTypeEnum authenticationType;
     private List<String> tags = null;
 
     private List<MetaProperty> properties = null;
@@ -149,6 +183,24 @@ public enum DefinedByEnum {
 
     /**
     **/
+    public MetaFederatedAuthenticator authenticationType(AuthenticationTypeEnum authenticationType) {
+
+        this.authenticationType = authenticationType;
+        return this;
+    }
+    
+    @ApiModelProperty(value = "")
+    @JsonProperty("authenticationType")
+    @Valid
+    public AuthenticationTypeEnum getAuthenticationType() {
+        return authenticationType;
+    }
+    public void setAuthenticationType(AuthenticationTypeEnum authenticationType) {
+        this.authenticationType = authenticationType;
+    }
+
+    /**
+    **/
     public MetaFederatedAuthenticator tags(List<String> tags) {
 
         this.tags = tags;
@@ -215,13 +267,14 @@ public enum DefinedByEnum {
             Objects.equals(this.name, metaFederatedAuthenticator.name) &&
             Objects.equals(this.displayName, metaFederatedAuthenticator.displayName) &&
             Objects.equals(this.definedBy, metaFederatedAuthenticator.definedBy) &&
+            Objects.equals(this.authenticationType, metaFederatedAuthenticator.authenticationType) &&
             Objects.equals(this.tags, metaFederatedAuthenticator.tags) &&
             Objects.equals(this.properties, metaFederatedAuthenticator.properties);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(authenticatorId, name, displayName, definedBy, tags, properties);
+        return Objects.hash(authenticatorId, name, displayName, definedBy, authenticationType, tags, properties);
     }
 
     @Override
@@ -234,6 +287,7 @@ public enum DefinedByEnum {
         sb.append("    name: ").append(toIndentedString(name)).append("\n");
         sb.append("    displayName: ").append(toIndentedString(displayName)).append("\n");
         sb.append("    definedBy: ").append(toIndentedString(definedBy)).append("\n");
+        sb.append("    authenticationType: ").append(toIndentedString(authenticationType)).append("\n");
         sb.append("    tags: ").append(toIndentedString(tags)).append("\n");
         sb.append("    properties: ").append(toIndentedString(properties)).append("\n");
         sb.append("}");

--- a/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/gen/java/org/wso2/carbon/identity/api/server/idp/v1/model/MetaFederatedAuthenticatorListItem.java
+++ b/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/gen/java/org/wso2/carbon/identity/api/server/idp/v1/model/MetaFederatedAuthenticatorListItem.java
@@ -34,6 +34,40 @@ public class MetaFederatedAuthenticatorListItem  {
   
     private String authenticatorId;
     private String name;
+
+@XmlType(name="DefinedByEnum")
+@XmlEnum(String.class)
+public enum DefinedByEnum {
+
+    @XmlEnumValue("SYSTEM") SYSTEM(String.valueOf("SYSTEM")), @XmlEnumValue("USER") USER(String.valueOf("USER"));
+
+
+    private String value;
+
+    DefinedByEnum(String v) {
+        value = v;
+    }
+
+    public String value() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    public static DefinedByEnum fromValue(String value) {
+        for (DefinedByEnum b : DefinedByEnum.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
+}
+
+    private DefinedByEnum definedBy;
     private List<String> tags = null;
 
     private String self;
@@ -72,6 +106,24 @@ public class MetaFederatedAuthenticatorListItem  {
     }
     public void setName(String name) {
         this.name = name;
+    }
+
+    /**
+    **/
+    public MetaFederatedAuthenticatorListItem definedBy(DefinedByEnum definedBy) {
+
+        this.definedBy = definedBy;
+        return this;
+    }
+    
+    @ApiModelProperty(value = "")
+    @JsonProperty("definedBy")
+    @Valid
+    public DefinedByEnum getDefinedBy() {
+        return definedBy;
+    }
+    public void setDefinedBy(DefinedByEnum definedBy) {
+        this.definedBy = definedBy;
     }
 
     /**
@@ -132,13 +184,14 @@ public class MetaFederatedAuthenticatorListItem  {
         MetaFederatedAuthenticatorListItem metaFederatedAuthenticatorListItem = (MetaFederatedAuthenticatorListItem) o;
         return Objects.equals(this.authenticatorId, metaFederatedAuthenticatorListItem.authenticatorId) &&
             Objects.equals(this.name, metaFederatedAuthenticatorListItem.name) &&
+            Objects.equals(this.definedBy, metaFederatedAuthenticatorListItem.definedBy) &&
             Objects.equals(this.tags, metaFederatedAuthenticatorListItem.tags) &&
             Objects.equals(this.self, metaFederatedAuthenticatorListItem.self);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(authenticatorId, name, tags, self);
+        return Objects.hash(authenticatorId, name, definedBy, tags, self);
     }
 
     @Override
@@ -149,6 +202,7 @@ public class MetaFederatedAuthenticatorListItem  {
         
         sb.append("    authenticatorId: ").append(toIndentedString(authenticatorId)).append("\n");
         sb.append("    name: ").append(toIndentedString(name)).append("\n");
+        sb.append("    definedBy: ").append(toIndentedString(definedBy)).append("\n");
         sb.append("    tags: ").append(toIndentedString(tags)).append("\n");
         sb.append("    self: ").append(toIndentedString(self)).append("\n");
         sb.append("}");

--- a/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/gen/java/org/wso2/carbon/identity/api/server/idp/v1/model/MetaFederatedAuthenticatorListItem.java
+++ b/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/gen/java/org/wso2/carbon/identity/api/server/idp/v1/model/MetaFederatedAuthenticatorListItem.java
@@ -68,6 +68,40 @@ public enum DefinedByEnum {
 }
 
     private DefinedByEnum definedBy;
+
+@XmlType(name="AuthenticationTypeEnum")
+@XmlEnum(String.class)
+public enum AuthenticationTypeEnum {
+
+    @XmlEnumValue("IDENTIFICATION") IDENTIFICATION(String.valueOf("IDENTIFICATION")), @XmlEnumValue("VERIFICATION_ONLY") VERIFICATION_ONLY(String.valueOf("VERIFICATION_ONLY")), @XmlEnumValue("REQUEST_PATH") REQUEST_PATH(String.valueOf("REQUEST_PATH"));
+
+
+    private String value;
+
+    AuthenticationTypeEnum(String v) {
+        value = v;
+    }
+
+    public String value() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    public static AuthenticationTypeEnum fromValue(String value) {
+        for (AuthenticationTypeEnum b : AuthenticationTypeEnum.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
+}
+
+    private AuthenticationTypeEnum authenticationType;
     private List<String> tags = null;
 
     private String self;
@@ -124,6 +158,24 @@ public enum DefinedByEnum {
     }
     public void setDefinedBy(DefinedByEnum definedBy) {
         this.definedBy = definedBy;
+    }
+
+    /**
+    **/
+    public MetaFederatedAuthenticatorListItem authenticationType(AuthenticationTypeEnum authenticationType) {
+
+        this.authenticationType = authenticationType;
+        return this;
+    }
+    
+    @ApiModelProperty(value = "")
+    @JsonProperty("authenticationType")
+    @Valid
+    public AuthenticationTypeEnum getAuthenticationType() {
+        return authenticationType;
+    }
+    public void setAuthenticationType(AuthenticationTypeEnum authenticationType) {
+        this.authenticationType = authenticationType;
     }
 
     /**
@@ -185,13 +237,14 @@ public enum DefinedByEnum {
         return Objects.equals(this.authenticatorId, metaFederatedAuthenticatorListItem.authenticatorId) &&
             Objects.equals(this.name, metaFederatedAuthenticatorListItem.name) &&
             Objects.equals(this.definedBy, metaFederatedAuthenticatorListItem.definedBy) &&
+            Objects.equals(this.authenticationType, metaFederatedAuthenticatorListItem.authenticationType) &&
             Objects.equals(this.tags, metaFederatedAuthenticatorListItem.tags) &&
             Objects.equals(this.self, metaFederatedAuthenticatorListItem.self);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(authenticatorId, name, definedBy, tags, self);
+        return Objects.hash(authenticatorId, name, definedBy, authenticationType, tags, self);
     }
 
     @Override
@@ -203,6 +256,7 @@ public enum DefinedByEnum {
         sb.append("    authenticatorId: ").append(toIndentedString(authenticatorId)).append("\n");
         sb.append("    name: ").append(toIndentedString(name)).append("\n");
         sb.append("    definedBy: ").append(toIndentedString(definedBy)).append("\n");
+        sb.append("    authenticationType: ").append(toIndentedString(authenticationType)).append("\n");
         sb.append("    tags: ").append(toIndentedString(tags)).append("\n");
         sb.append("    self: ").append(toIndentedString(self)).append("\n");
         sb.append("}");

--- a/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/main/java/org/wso2/carbon/identity/api/server/idp/v1/core/ServerIdpManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/main/java/org/wso2/carbon/identity/api/server/idp/v1/core/ServerIdpManagementService.java
@@ -94,7 +94,8 @@ import org.wso2.carbon.identity.application.common.model.ProvisioningConnectorCo
 import org.wso2.carbon.identity.application.common.model.RoleMapping;
 import org.wso2.carbon.identity.application.common.model.SubProperty;
 import org.wso2.carbon.identity.application.common.util.IdentityApplicationConstants;
-import org.wso2.carbon.identity.base.IdentityConstants;
+import org.wso2.carbon.identity.base.AuthenticatorPropertiesConstant.AuthenticationType;
+import org.wso2.carbon.identity.base.AuthenticatorPropertiesConstant.DefinedByType;
 import org.wso2.carbon.identity.claim.metadata.mgt.exception.ClaimMetadataException;
 import org.wso2.carbon.identity.claim.metadata.mgt.model.LocalClaim;
 import org.wso2.carbon.identity.configuration.mgt.core.model.ResourceSearchBean;
@@ -1772,14 +1773,17 @@ public class ServerIdpManagementService {
                 authConfig.setName(base64URLDecode(authenticator.getAuthenticatorId()));
                 authConfig.setDisplayName(getDisplayNameOfAuthenticator(authConfig.getName()));
                 authConfig.setEnabled(authenticator.getIsEnabled());
+                /* Resolve definedBy type: If there is authenticator by same name and its type is system: SYSTEM.
+                 If not: USER. */
                 FederatedAuthenticatorConfig authenticatorConfig = ApplicationAuthenticatorService.getInstance()
                         .getFederatedAuthenticatorByName(authenticator.getAuthenticatorId());
                 if (authenticatorConfig != null &&
-                        IdentityConstants.DefinedByType.SYSTEM.equals(authenticatorConfig.getDefinedByType())) {
-                    authConfig.setDefinedByType(IdentityConstants.DefinedByType.SYSTEM);
+                        DefinedByType.SYSTEM.equals(authenticatorConfig.getDefinedByType())) {
+                    authConfig.setDefinedByType(DefinedByType.SYSTEM);
                 } else {
-                    authConfig.setDefinedByType(IdentityConstants.DefinedByType.USER);
+                    authConfig.setDefinedByType(DefinedByType.USER);
                 }
+                authConfig.setAuthenticationType(AuthenticationType.IDENTIFICATION);
                 List<org.wso2.carbon.identity.api.server.idp.v1.model.Property> authProperties =
                         authenticator.getProperties();
                 if (IdentityApplicationConstants.Authenticator.SAML2SSO.FED_AUTH_NAME.equals(authConfig.getName())) {
@@ -2467,6 +2471,7 @@ public class ServerIdpManagementService {
             fedAuthListItem.setIsEnabled(fedAuthConfig.isEnabled());
             fedAuthListItem.setDefinedBy(FederatedAuthenticatorListItem.DefinedByEnum.valueOf(
                     fedAuthConfig.getDefinedByType().toString()));
+            fedAuthListItem.setAuthenticationType(FederatedAuthenticatorListItem.AuthenticationTypeEnum.IDENTIFICATION);
             FederatedAuthenticatorConfig federatedAuthenticatorConfig =
                     ApplicationAuthenticatorService.getInstance().getFederatedAuthenticatorByName(
                             fedAuthConfig.getName());
@@ -2849,14 +2854,16 @@ public class ServerIdpManagementService {
         authConfig.setName(authenticatorName);
         authConfig.setDisplayName(getDisplayNameOfAuthenticator(authenticatorName));
         authConfig.setEnabled(authenticator.getIsEnabled());
+        // Resolve definedBy type: If there is authenticator by same name and its type is system: SYSTEM. If not: USER.
         FederatedAuthenticatorConfig authenticatorConfig = ApplicationAuthenticatorService.getInstance()
                    .getFederatedAuthenticatorByName(authenticatorName);
         if (authenticatorConfig != null &&
-                IdentityConstants.DefinedByType.SYSTEM.equals(authenticatorConfig.getDefinedByType())) {
-            authConfig.setDefinedByType(IdentityConstants.DefinedByType.SYSTEM);
+                DefinedByType.SYSTEM.equals(authenticatorConfig.getDefinedByType())) {
+            authConfig.setDefinedByType(DefinedByType.SYSTEM);
         } else {
-            authConfig.setDefinedByType(IdentityConstants.DefinedByType.USER);
+            authConfig.setDefinedByType(DefinedByType.USER);
         }
+        authConfig.setAuthenticationType(AuthenticationType.IDENTIFICATION);
         List<org.wso2.carbon.identity.api.server.idp.v1.model.Property> authProperties = authenticator.getProperties();
         if (IdentityApplicationConstants.Authenticator.SAML2SSO.FED_AUTH_NAME.equals(authenticatorName)) {
             validateSamlMetadata(authProperties);
@@ -3051,6 +3058,7 @@ public class ServerIdpManagementService {
             federatedAuthenticator.setIsDefault(isDefaultAuthenticator);
             federatedAuthenticator.setDefinedBy(FederatedAuthenticator.DefinedByEnum.valueOf(
                     config.getDefinedByType().toString()));
+            federatedAuthenticator.setAuthenticationType(FederatedAuthenticator.AuthenticationTypeEnum.IDENTIFICATION);
             FederatedAuthenticatorConfig federatedAuthenticatorConfig =
                     ApplicationAuthenticatorService.getInstance().getFederatedAuthenticatorByName(
                             config.getName());

--- a/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/main/java/org/wso2/carbon/identity/api/server/idp/v1/core/ServerIdpManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/main/java/org/wso2/carbon/identity/api/server/idp/v1/core/ServerIdpManagementService.java
@@ -94,6 +94,7 @@ import org.wso2.carbon.identity.application.common.model.ProvisioningConnectorCo
 import org.wso2.carbon.identity.application.common.model.RoleMapping;
 import org.wso2.carbon.identity.application.common.model.SubProperty;
 import org.wso2.carbon.identity.application.common.util.IdentityApplicationConstants;
+import org.wso2.carbon.identity.base.IdentityConstants;
 import org.wso2.carbon.identity.claim.metadata.mgt.exception.ClaimMetadataException;
 import org.wso2.carbon.identity.claim.metadata.mgt.model.LocalClaim;
 import org.wso2.carbon.identity.configuration.mgt.core.model.ResourceSearchBean;
@@ -1771,6 +1772,14 @@ public class ServerIdpManagementService {
                 authConfig.setName(base64URLDecode(authenticator.getAuthenticatorId()));
                 authConfig.setDisplayName(getDisplayNameOfAuthenticator(authConfig.getName()));
                 authConfig.setEnabled(authenticator.getIsEnabled());
+                FederatedAuthenticatorConfig authenticatorConfig = ApplicationAuthenticatorService.getInstance()
+                        .getFederatedAuthenticatorByName(authenticator.getAuthenticatorId());
+                if (authenticatorConfig != null &&
+                        IdentityConstants.DefinedByType.SYSTEM.equals(authenticatorConfig.getDefinedByType())) {
+                    authConfig.setDefinedByType(IdentityConstants.DefinedByType.SYSTEM);
+                } else {
+                    authConfig.setDefinedByType(IdentityConstants.DefinedByType.USER);
+                }
                 List<org.wso2.carbon.identity.api.server.idp.v1.model.Property> authProperties =
                         authenticator.getProperties();
                 if (IdentityApplicationConstants.Authenticator.SAML2SSO.FED_AUTH_NAME.equals(authConfig.getName())) {
@@ -2456,6 +2465,8 @@ public class ServerIdpManagementService {
             fedAuthListItem.setAuthenticatorId(base64URLEncode(fedAuthConfig.getName()));
             fedAuthListItem.setName(fedAuthConfig.getName());
             fedAuthListItem.setIsEnabled(fedAuthConfig.isEnabled());
+            fedAuthListItem.setDefinedBy(FederatedAuthenticatorListItem.DefinedByEnum.valueOf(
+                    fedAuthConfig.getDefinedByType().toString()));
             FederatedAuthenticatorConfig federatedAuthenticatorConfig =
                     ApplicationAuthenticatorService.getInstance().getFederatedAuthenticatorByName(
                             fedAuthConfig.getName());
@@ -2838,6 +2849,14 @@ public class ServerIdpManagementService {
         authConfig.setName(authenticatorName);
         authConfig.setDisplayName(getDisplayNameOfAuthenticator(authenticatorName));
         authConfig.setEnabled(authenticator.getIsEnabled());
+        FederatedAuthenticatorConfig authenticatorConfig = ApplicationAuthenticatorService.getInstance()
+                   .getFederatedAuthenticatorByName(authenticatorName);
+        if (authenticatorConfig != null &&
+                IdentityConstants.DefinedByType.SYSTEM.equals(authenticatorConfig.getDefinedByType())) {
+            authConfig.setDefinedByType(IdentityConstants.DefinedByType.SYSTEM);
+        } else {
+            authConfig.setDefinedByType(IdentityConstants.DefinedByType.USER);
+        }
         List<org.wso2.carbon.identity.api.server.idp.v1.model.Property> authProperties = authenticator.getProperties();
         if (IdentityApplicationConstants.Authenticator.SAML2SSO.FED_AUTH_NAME.equals(authenticatorName)) {
             validateSamlMetadata(authProperties);
@@ -3030,6 +3049,8 @@ public class ServerIdpManagementService {
             federatedAuthenticator.setName(config.getName());
             federatedAuthenticator.setIsEnabled(config.isEnabled());
             federatedAuthenticator.setIsDefault(isDefaultAuthenticator);
+            federatedAuthenticator.setDefinedBy(FederatedAuthenticator.DefinedByEnum.valueOf(
+                    config.getDefinedByType().toString()));
             FederatedAuthenticatorConfig federatedAuthenticatorConfig =
                     ApplicationAuthenticatorService.getInstance().getFederatedAuthenticatorByName(
                             config.getName());

--- a/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/main/resources/idp.yaml
+++ b/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/main/resources/idp.yaml
@@ -2783,6 +2783,11 @@ components:
         name:
           type: string
           example: SAML2Authenticator
+        definedBy:
+          type: string
+          enum:
+            - SYSTEM
+            - USER
         tags:
           type: array
           items:
@@ -2804,6 +2809,11 @@ components:
         displayName:
           type: string
           example: 'SAML2 Web SSO Configuration'
+        definedBy:
+          type: string
+          enum:
+            - SYSTEM
+            - USER
         tags:
           type: array
           items:
@@ -2849,6 +2859,11 @@ components:
           type: boolean
           default: false
           example: true
+        definedBy:
+          type: string
+          enum:
+            - SYSTEM
+            - USER
         isDefault:
           type: boolean
           default: false
@@ -2908,6 +2923,11 @@ components:
           type: boolean
           default: false
           example: true
+        definedBy:
+          type: string
+          enum:
+            - SYSTEM
+            - USER
         tags:
           type: array
           items:

--- a/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/main/resources/idp.yaml
+++ b/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/main/resources/idp.yaml
@@ -2788,6 +2788,12 @@ components:
           enum:
             - SYSTEM
             - USER
+        authenticationType:
+          type: string
+          enum:
+            - IDENTIFICATION
+            - VERIFICATION_ONLY
+            - REQUEST_PATH
         tags:
           type: array
           items:
@@ -2814,6 +2820,12 @@ components:
           enum:
             - SYSTEM
             - USER
+        authenticationType:
+          type: string
+          enum:
+            - IDENTIFICATION
+            - VERIFICATION_ONLY
+            - REQUEST_PATH
         tags:
           type: array
           items:
@@ -2864,6 +2876,12 @@ components:
           enum:
             - SYSTEM
             - USER
+        authenticationType:
+          type: string
+          enum:
+            - IDENTIFICATION
+            - VERIFICATION_ONLY
+            - REQUEST_PATH
         isDefault:
           type: boolean
           default: false
@@ -2896,6 +2914,17 @@ components:
           type: boolean
           default: false
           example: false
+        definedBy:
+          type: string
+          enum:
+            - SYSTEM
+            - USER
+        authenticationType:
+          type: string
+          enum:
+            - IDENTIFICATION
+            - VERIFICATION_ONLY
+            - REQUEST_PATH
         properties:
           type: array
           items:
@@ -2928,6 +2957,12 @@ components:
           enum:
             - SYSTEM
             - USER
+        authenticationType:
+          type: string
+          enum:
+            - IDENTIFICATION
+            - VERIFICATION_ONLY
+            - REQUEST_PATH
         tags:
           type: array
           items:


### PR DESCRIPTION
Issue:
- https://github.com/wso2/product-is/issues/21111

With https://github.com/wso2/carbon-identity-framework/pull/5938 PR, we have introduced  following new properties for authentication configs and authenticator instances. 
- `DefinedBy` - to indicate whether the authenticator is system-defined or user-defined. 
1. SYSTEM: Sytem defined authenticators, all the existing authenticators  are this type.
2. USER: User defined authenticators, all the custom authenticators of authentication extension come under this type.
- `AuthenticationType` - To indicate whether authenticator is one of following
 1. IDENTIFICATION: This authenticator collects the identifier and authenticates user accounts.
 3. VERIFICATION_ONLY: This authenticator can only verify users in the second or subsequent steps of the login 
process.


With this PR following changes are added.
1. Set new authenticator property DefinedBy for the FederatedAuthenticatedConfig and LocalAuthenticatorConfig objects that pass to the framework.
2. Retrieve the DefinedBy property from the config and display them in the APIs.
3. Update yaml files to accommodate above point.