### PR TITLE
Add filtering support for identity verification providers list retrieving api.

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.idv.provider/org.wso2.carbon.identity.api.server.idv.provider.v1/src/gen/java/org/wso2/carbon/identity/api/server/idv/provider/v1/IdvProvidersApi.java
+++ b/components/org.wso2.carbon.identity.api.server.idv.provider/org.wso2.carbon.identity.api.server.idv.provider.v1/src/gen/java/org/wso2/carbon/identity/api/server/idv/provider/v1/IdvProvidersApi.java
@@ -50,7 +50,7 @@ public class IdvProvidersApi  {
     
     @Consumes({ "application/json" })
     @Produces({ "application/json", "application/xml",  })
-    @ApiOperation(value = "Add a new identity verification provider. ", notes = "This API provides the capability to add an identity verification provider. <b>Permission required:</b> <br>     * /permission/admin/manage/identity/idvpmgt/create <br> <b>Scope required:</b> <br>     * internal_idvp_add ", response = IdVProviderResponse.class, authorizations = {
+    @ApiOperation(value = "Add a new identity verification provider. ", notes = "This API provides the capability to add an identity verification provider. <b>Permission required:</b> <br>     * /permission/admin/manage/identity/idvp/add <br> <b>Scope required:</b> <br>     * internal_idvp_add ", response = IdVProviderResponse.class, authorizations = {
         @Authorization(value = "BasicAuth"),
         @Authorization(value = "OAuth2", scopes = {
             
@@ -74,7 +74,7 @@ public class IdvProvidersApi  {
     @Path("/{idv-provider-id}")
     
     @Produces({ "application/json" })
-    @ApiOperation(value = "Delete an identity verification provider by using the identity provider's ID. ", notes = "This API provides the capability to delete an identity verification provider by giving its ID. <br> <b>Permission required:</b> <br>     * /permission/admin/manage/identity/idvpmgt/delete <br> <b>Scope required:</b> <br>     * internal_idvp_delete ", response = Void.class, authorizations = {
+    @ApiOperation(value = "Delete an identity verification provider by using the identity provider's ID. ", notes = "This API provides the capability to delete an identity verification provider by giving its ID. <br> <b>Permission required:</b> <br>     * /permission/admin/manage/identity/idvp/delete <br> <b>Scope required:</b> <br>     * internal_idvp_delete ", response = Void.class, authorizations = {
         @Authorization(value = "BasicAuth"),
         @Authorization(value = "OAuth2", scopes = {
             
@@ -98,7 +98,7 @@ public class IdvProvidersApi  {
     @Path("/{idv-provider-id}")
     
     @Produces({ "application/json", "application/xml",  })
-    @ApiOperation(value = "Retrieve identity verification provider by identity verification provider's ID ", notes = "This API provides the capability to retrieve the identity verification provider details by using its ID.  <b>Permission required:</b> <br>     * /permission/admin/manage/identity/idvpmgt/view <br> <b>Scope required:</b> <br>     * internal_idvp_view ", response = IdVProviderResponse.class, authorizations = {
+    @ApiOperation(value = "Retrieve identity verification provider by identity verification provider's ID ", notes = "This API provides the capability to retrieve the identity verification provider details by using its ID.  <b>Permission required:</b> <br>     * /permission/admin/manage/identity/idvp/view <br> <b>Scope required:</b> <br>     * internal_idvp_view ", response = IdVProviderResponse.class, authorizations = {
         @Authorization(value = "BasicAuth"),
         @Authorization(value = "OAuth2", scopes = {
             
@@ -122,7 +122,7 @@ public class IdvProvidersApi  {
     
     
     @Produces({ "application/json" })
-    @ApiOperation(value = "List identity verification providers. ", notes = "This API provides the capability to retrieve the list of identity verification providers.<br> <b>Permission required:</b> <br>     * /permission/admin/manage/identity/idvpmgt/view <br> <b>Scope required:</b> <br>     * internal_idvp_view ", response = IdVProviderListResponse.class, authorizations = {
+    @ApiOperation(value = "List identity verification providers. ", notes = "This API provides the capability to retrieve the list of identity verification providers.<br> <b>Permission required:</b> <br>     * /permission/admin/manage/identity/idvp/view <br> <b>Scope required:</b> <br>     * internal_idvp_view ", response = IdVProviderListResponse.class, authorizations = {
         @Authorization(value = "BasicAuth"),
         @Authorization(value = "OAuth2", scopes = {
             
@@ -137,9 +137,9 @@ public class IdvProvidersApi  {
         @ApiResponse(code = 500, message = "Server Error", response = Error.class),
         @ApiResponse(code = 501, message = "Not Implemented", response = Error.class)
     })
-    public Response getIdVProviders(    @Valid@ApiParam(value = "Maximum number of records to return. ")  @QueryParam("limit") Integer limit,     @Valid@ApiParam(value = "Number of records to skip for pagination. ")  @QueryParam("offset") Integer offset) {
+    public Response getIdVProviders(    @Valid@ApiParam(value = "Maximum number of records to return. ")  @QueryParam("limit") Integer limit,     @Valid@ApiParam(value = "Number of records to skip for pagination. ")  @QueryParam("offset") Integer offset,     @Valid@ApiParam(value = "Condition to filter the retrieval of records. Supports 'sw', 'co', 'ew' and 'eq' operations and also complex queries with 'and' operations. E.g. /idv-providers?filter=name+sw+onfido+and+isEnabled+eq+true ")  @QueryParam("filter") String filter) {
 
-        return delegate.getIdVProviders(limit,  offset );
+        return delegate.getIdVProviders(limit,  offset,  filter );
     }
 
     @Valid
@@ -147,7 +147,7 @@ public class IdvProvidersApi  {
     @Path("/{idv-provider-id}")
     @Consumes({ "application/json" })
     @Produces({ "application/json" })
-    @ApiOperation(value = "Update an identity verification provider. ", notes = "This API provides the capability to update an identity verification provider <br> <b>Permission required:</b> <br>     * /permission/admin/manage/identity/idvpmgt/update <br> <b>Scope required:</b> <br>     * internal_idvp_update ", response = IdVProviderResponse.class, authorizations = {
+    @ApiOperation(value = "Update an identity verification provider. ", notes = "This API provides the capability to update an identity verification provider <br> <b>Permission required:</b> <br>     * /permission/admin/manage/identity/idvp/update <br> <b>Scope required:</b> <br>     * internal_idvp_update ", response = IdVProviderResponse.class, authorizations = {
         @Authorization(value = "BasicAuth"),
         @Authorization(value = "OAuth2", scopes = {
             

--- a/components/org.wso2.carbon.identity.api.server.idv.provider/org.wso2.carbon.identity.api.server.idv.provider.v1/src/gen/java/org/wso2/carbon/identity/api/server/idv/provider/v1/IdvProvidersApiService.java
+++ b/components/org.wso2.carbon.identity.api.server.idv.provider/org.wso2.carbon.identity.api.server.idv.provider.v1/src/gen/java/org/wso2/carbon/identity/api/server/idv/provider/v1/IdvProvidersApiService.java
@@ -39,7 +39,7 @@ public interface IdvProvidersApiService {
 
       public Response getIdVProvider(String idvProviderId);
 
-      public Response getIdVProviders(Integer limit, Integer offset);
+      public Response getIdVProviders(Integer limit, Integer offset, String filter);
 
       public Response updateIdVProviders(String idvProviderId, IdVProviderRequest idVProviderRequest);
 }

--- a/components/org.wso2.carbon.identity.api.server.idv.provider/org.wso2.carbon.identity.api.server.idv.provider.v1/src/main/java/org/wso2/carbon/identity/api/server/idv/provider/v1/core/IdVProviderService.java
+++ b/components/org.wso2.carbon.identity.api.server.idv.provider/org.wso2.carbon.identity.api.server.idv.provider.v1/src/main/java/org/wso2/carbon/identity/api/server/idv/provider/v1/core/IdVProviderService.java
@@ -154,15 +154,27 @@ public class IdVProviderService {
      */
     public IdVProviderListResponse getIdVProviders(Integer limit, Integer offset) {
 
+        return getIdVProviders(limit, offset, null);
+    }
+
+    /**
+     * Get all identity verification providers with filtering.
+     *
+     * @param limit  Limit per page.
+     * @param offset Offset value.
+     * @return Identity verification providers.
+     */
+    public IdVProviderListResponse getIdVProviders(Integer limit, Integer offset, String filter) {
+
         int tenantId = getTenantId();
         try {
             IdVProviderManager idVProviderManager = IdentityVerificationServiceHolder.getIdVProviderManager();
-            int totalResults = idVProviderManager.getCountOfIdVProviders(tenantId);
+            int totalResults = idVProviderManager.getCountOfIdVProviders(tenantId, filter);
 
             IdVProviderListResponse idVProviderListResponse = new IdVProviderListResponse();
 
             if (totalResults > 0) {
-                List<IdVProvider> idVProviders = idVProviderManager.getIdVProviders(limit, offset, tenantId);
+                List<IdVProvider> idVProviders = idVProviderManager.getIdVProviders(limit, offset, filter, tenantId);
 
                 if (CollectionUtils.isNotEmpty(idVProviders)) {
                     List<IdVProviderResponse> idVProvidersList = new ArrayList<>();

--- a/components/org.wso2.carbon.identity.api.server.idv.provider/org.wso2.carbon.identity.api.server.idv.provider.v1/src/main/java/org/wso2/carbon/identity/api/server/idv/provider/v1/impl/IdvProvidersApiServiceImpl.java
+++ b/components/org.wso2.carbon.identity.api.server.idv.provider/org.wso2.carbon.identity.api.server.idv.provider.v1/src/main/java/org/wso2/carbon/identity/api/server/idv/provider/v1/impl/IdvProvidersApiServiceImpl.java
@@ -64,9 +64,9 @@ public class IdvProvidersApiServiceImpl implements IdvProvidersApiService {
     }
 
     @Override
-    public Response getIdVProviders(Integer limit, Integer offset) {
+    public Response getIdVProviders(Integer limit, Integer offset, String filter) {
 
-        IdVProviderListResponse idVProviderListResponse = idVProviderService.getIdVProviders(limit, offset);
+        IdVProviderListResponse idVProviderListResponse = idVProviderService.getIdVProviders(limit, offset, filter);
         return Response.ok().entity(idVProviderListResponse).build();
     }
 

--- a/components/org.wso2.carbon.identity.api.server.idv.provider/org.wso2.carbon.identity.api.server.idv.provider.v1/src/main/resources/idv-provider.yaml
+++ b/components/org.wso2.carbon.identity.api.server.idv.provider/org.wso2.carbon.identity.api.server.idv.provider.v1/src/main/resources/idv-provider.yaml
@@ -43,6 +43,7 @@ paths:
       parameters:
         - $ref: '#/components/parameters/limitQueryParam'
         - $ref: '#/components/parameters/offsetQueryParam'
+        - $ref: '#/components/parameters/filterQueryParam'
       responses:
         '200':
           description: Successful Response
@@ -317,6 +318,16 @@ components:
       schema:
         type: integer
         format: int32
+    filterQueryParam:
+      in: query
+      name: filter
+      required: false
+      description: >
+        Condition to filter the retrieval of records. Supports 'sw', 'co', 'ew'
+        and 'eq' operations and also complex queries with 'and' operations. E.g.
+        /idv-providers?filter=name+sw+onfido+and+isEnabled+eq+true
+      schema:
+        type: string
     idVPQueryParam:
       in: query
       name: idvProviderid


### PR DESCRIPTION
## Purpose
- The current implementation of the API for retrieving the list of Identity Verification Providers [1] does not support filtering. This lack of filtering support limits the ability to narrow down the list of providers based on specific criteria, such as `name`, `type`, `description`, `id` or `isEnabled`. With this PR this limitation is addressed.

## To be merged after
- https://github.com/wso2-extensions/identity-verification/pull/19

## References : 

[1] https://github.com/wso2/identity-api-server/blob/9df161ac012f91dd7e36d8e568d2587183b1b6d4/components/org.wso2.carbon.identity.api.server.idv.provider/org.wso2.carbon.identity.api.server.idv.provider.v1/src/main/resources/idv-provider.yaml