### PR TITLE
API support for user defined authenticator creation.

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.authenticators/org.wso2.carbon.identity.api.server.authenticators.v1/src/main/resources/authenticators.yaml
+++ b/components/org.wso2.carbon.identity.api.server.authenticators/org.wso2.carbon.identity.api.server.authenticators.v1/src/main/resources/authenticators.yaml
@@ -118,18 +118,18 @@ paths:
           $ref: '#/components/responses/NotFound'
         '500':
           $ref: '#/components/responses/ServerError'
-  /authenticators/userDefined:
+  /authenticators/custom:
     post:
       tags:
-        - User Defined Authenticator
+        - User defined local authenticators
       summary: |
-        Create a new user defined authenticator.
+        Create a new user defined local authenticator.
       description: |
-        This API provides the capability to create a new user defined authenticators. <br>
+        This API provides the capability to create a new user defined local authenticator. <br>
         <b>Permission required:</b> <br>
-            * /permission/admin/manage/userDefinedAuthenticators/create <br>
+            * /permission/admin/manage/custom_authenticator/create <br>
         <b>Scope required:</b> <br>
-            * internal_authenticator_create <br>
+            * internal_custom_authenticator_create <br>
       operationId: createUserDefinedAuthenticator
       responses:
         '201':
@@ -138,6 +138,9 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Authenticator'
+              examples:
+                userDefinedAuthenticators:
+                  $ref: '#/components/examples/UserDefinedAuthenticatorExample'
         '400':
           description: Bad Request
           content:
@@ -164,69 +167,21 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/AuthenticatorCreation'
-        description: This represents the user defined authenticator to be created.
+              $ref: '#/components/schemas/UserDefinedLocalAuthenticatorCreation'
+        description: This represents the user defined local authenticator to be created.
         required: true
-  /authenticators/userDefined/{authenticator-id}:
-    get:
-      tags:
-        - User Defined Authenticator
-      summary: |
-        Create a new user defined authenticator.
-      description: |
-        This API provides the capability to create a new user defined authenticators. <br>
-        <b>Permission required:</b> <br>
-            * /permission/admin/manage/userDefinedAuthenticators/create <br>
-        <b>Scope required:</b> <br>
-            * internal_authenticator_create <br>
-      operationId: getUserDefinedAuthenticator
-      parameters:
-        - name: authenticator-id
-          in: path
-          description: ID of an authenticator
-          required: true
-          schema:
-            type: string
-      responses:
-        '200':
-          description: Successful response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Authenticator'
-        '400':
-          description: Bad Request
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-        '401':
-          description: Unauthorized
-        '403':
-          description: Forbidden
-        '409':
-          description: Conflict
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-        '500':
-          description: Server Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
+  /authenticators/custom/{authenticator-id}:
     patch:
       tags:
-        - User Defined Authenticator
+        - User defined local authenticators
       summary: |
-        Create a new user defined authenticator.
+        Update a user defined local authenticator.
       description: |
-        This API provides the capability to create a new user defined authenticators. <br>
+        This API provides the capability to update a user defined local authenticator configurations. <br>
         <b>Permission required:</b> <br>
-            * /permission/admin/manage/userDefinedAuthenticators/create <br>
+            * /permission/admin/manage/custom_authenticator/update <br>
         <b>Scope required:</b> <br>
-            * internal_authenticator_create <br>
+            * internal_custom_authenticator_update <br>
       operationId: updateUserDefinedAuthenticator
       parameters:
         - name: authenticator-id
@@ -242,6 +197,9 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Authenticator'
+              examples:
+                userDefinedAuthenticators:
+                  $ref: '#/components/examples/UserDefinedAuthenticatorExample'
         '400':
           description: Bad Request
           content:
@@ -268,20 +226,20 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/AuthenticatorCreation'
-        description: This represents the user defined authenticator to be created.
+              $ref: '#/components/schemas/UserDefinedLocalAuthenticatorUpdate'
+        description: This represents the user defined local authenticator to be created.
         required: true
     delete:
       tags:
-        - User Defined Authenticator
+        - User defined local authenticators
       summary: |
-        Create a new user defined authenticator.
+        Delete a user defined local authenticator.
       description: |
-        This API provides the capability to create a new user defined authenticators. <br>
+        This API provides the capability to delete a user defined local authenticators. <br>
         <b>Permission required:</b> <br>
-            * /permission/admin/manage/userDefinedAuthenticators/create <br>
+            * /permission/admin/manage/custom_authenticator/delete <br>
         <b>Scope required:</b> <br>
-            * internal_authenticator_create <br>
+            * internal_custom_authenticator_delete <br>
       operationId: deleteUserDefinedAuthenticator
       parameters:
         - name: authenticator-id
@@ -408,11 +366,6 @@ components:
           enum:
             - LOCAL
             - FEDERATED
-        authenticationType:
-          type: string
-          enum:
-            - IDENTIFICATION
-            - VERIFICATION
         image:
           type: string
           example: basic-authenticator-logo-url
@@ -427,15 +380,16 @@ components:
         self:
           type: string
           example: /t/carbon.super/api/server/v1/configs/authenticators/eDUwOUNlcnRpZmljYXRlQXV0aGVudGljYXRvcg
-    AuthenticatorCreation:
+    UserDefinedLocalAuthenticatorCreation:
+      description: This represents the configuration for creating the user defined local authenticator.
       type: object
       properties:
         name:
           type: string
-          example: BasicAuthenticator
+          example: CustomAuthenticator
         displayName:
           type: string
-          example: basic
+          example: Custom auth
         isEnabled:
           type: boolean
           example: true
@@ -446,10 +400,69 @@ components:
             - VERIFICATION
         image:
           type: string
-          example: basic-authenticator-logo-url
+          example: https://custom-authenticator-logo-url
         description:
           type: string
-          example: The basic authenticator.
+          example: The user defined custom local authenticator.
+        endpoint:
+          $ref: '#/components/schemas/Endpoint'
+      required:
+        - name
+        - displayName
+        - isEnabled
+        - endpoint
+    UserDefinedLocalAuthenticatorUpdate:
+      description: TThis represents the configuration for updating user defined local authenticator.
+      type: object
+      properties:
+        displayName:
+          type: string
+          example: Custom auth
+        isEnabled:
+          type: boolean
+          example: true
+        image:
+          type: string
+          example: https://custom-authenticator-logo-url
+        description:
+          type: string
+          example: The user defined custom local authenticator.
+        endpoint:
+          $ref: '#/components/schemas/Endpoint'
+      required:
+        - name
+        - displayName
+        - isEnabled
+        - endpoint
+    Endpoint:
+      type: object
+      properties:
+        uri:
+          type: string
+          example: https://abc.com/token
+          pattern: '^https?://.+'
+        authentication:
+          $ref: '#/components/schemas/AuthenticationType'
+    AuthenticationType:
+      type: object
+      required:
+        - type
+        - properties
+      properties:
+        type:
+          type: string
+          enum:
+            - NONE
+            - BEARER
+            - API_KEY
+            - BASIC
+          example: BASIC
+        properties:
+          type: object
+          additionalProperties: true
+          example:
+            username: "auth_username"
+            password: "auth_password"
     ConnectedApps:
       type: object
       properties:
@@ -534,6 +547,25 @@ components:
         'application/json':
           schema:
             $ref: '#/components/schemas/Error'
+  #-----------------------------------------------------
+  # Example payload.
+  #-----------------------------------------------------
+  examples:
+    UserDefinedAuthenticatorExample:
+      summary: "Response for user defined local authenticator"
+      value:
+        id: "Q3VzdG9tQXV0aGVudGljYXRvcg"
+        name: "CustomAuthenticator"
+        displayName: "Custom auth"
+        isEnabled: true
+        definedBy: "USER"
+        type: "LOCAL"
+        authenticationType: "IDENTIFICATION"
+        image: "ttps://custom-authenticator-logo-url"
+        description: "he user defined custom local authenticator."
+        tags:
+          - "Custom"
+        self: "/t/carbon.super/api/server/v1/configs/authenticators/Q3VzdG9tQXV0aGVudGljYXRvcg"
   #-----------------------------------------------------
   # Applicable authentication mechanisms.
   #-----------------------------------------------------

--- a/components/org.wso2.carbon.identity.api.server.authenticators/org.wso2.carbon.identity.api.server.authenticators.v1/src/main/resources/authenticators.yaml
+++ b/components/org.wso2.carbon.identity.api.server.authenticators/org.wso2.carbon.identity.api.server.authenticators.v1/src/main/resources/authenticators.yaml
@@ -118,7 +118,203 @@ paths:
           $ref: '#/components/responses/NotFound'
         '500':
           $ref: '#/components/responses/ServerError'
-
+  /authenticators/userDefined:
+    post:
+      tags:
+        - User Defined Authenticator
+      summary: |
+        Create a new user defined authenticator.
+      description: |
+        This API provides the capability to create a new user defined authenticators. <br>
+        <b>Permission required:</b> <br>
+            * /permission/admin/manage/userDefinedAuthenticators/create <br>
+        <b>Scope required:</b> <br>
+            * internal_authenticator_create <br>
+      operationId: createUserDefinedAuthenticator
+      responses:
+        '201':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Authenticator'
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '409':
+          description: Conflict
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '500':
+          description: Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AuthenticatorCreation'
+        description: This represents the user defined authenticator to be created.
+        required: true
+  /authenticators/userDefined/{authenticator-id}:
+    get:
+      tags:
+        - User Defined Authenticator
+      summary: |
+        Create a new user defined authenticator.
+      description: |
+        This API provides the capability to create a new user defined authenticators. <br>
+        <b>Permission required:</b> <br>
+            * /permission/admin/manage/userDefinedAuthenticators/create <br>
+        <b>Scope required:</b> <br>
+            * internal_authenticator_create <br>
+      operationId: getUserDefinedAuthenticator
+      parameters:
+        - name: authenticator-id
+          in: path
+          description: ID of an authenticator
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Authenticator'
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '409':
+          description: Conflict
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '500':
+          description: Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+    patch:
+      tags:
+        - User Defined Authenticator
+      summary: |
+        Create a new user defined authenticator.
+      description: |
+        This API provides the capability to create a new user defined authenticators. <br>
+        <b>Permission required:</b> <br>
+            * /permission/admin/manage/userDefinedAuthenticators/create <br>
+        <b>Scope required:</b> <br>
+            * internal_authenticator_create <br>
+      operationId: updateUserDefinedAuthenticator
+      parameters:
+        - name: authenticator-id
+          in: path
+          description: ID of an authenticator
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Authenticator'
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '409':
+          description: Conflict
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '500':
+          description: Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AuthenticatorCreation'
+        description: This represents the user defined authenticator to be created.
+        required: true
+    delete:
+      tags:
+        - User Defined Authenticator
+      summary: |
+        Create a new user defined authenticator.
+      description: |
+        This API provides the capability to create a new user defined authenticators. <br>
+        <b>Permission required:</b> <br>
+            * /permission/admin/manage/userDefinedAuthenticators/create <br>
+        <b>Scope required:</b> <br>
+            * internal_authenticator_create <br>
+      operationId: deleteUserDefinedAuthenticator
+      parameters:
+        - name: authenticator-id
+          in: path
+          description: ID of an authenticator
+          required: true
+          schema:
+            type: string
+      responses:
+        '204':
+          description: Successful response
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '409':
+          description: Conflict
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '500':
+          description: Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
 components:
   parameters:
     filterQueryParam:
@@ -212,6 +408,11 @@ components:
           enum:
             - LOCAL
             - FEDERATED
+        authenticationType:
+          type: string
+          enum:
+            - IDENTIFICATION
+            - VERIFICATION
         image:
           type: string
           example: basic-authenticator-logo-url
@@ -226,6 +427,29 @@ components:
         self:
           type: string
           example: /t/carbon.super/api/server/v1/configs/authenticators/eDUwOUNlcnRpZmljYXRlQXV0aGVudGljYXRvcg
+    AuthenticatorCreation:
+      type: object
+      properties:
+        name:
+          type: string
+          example: BasicAuthenticator
+        displayName:
+          type: string
+          example: basic
+        isEnabled:
+          type: boolean
+          example: true
+        authenticationType:
+          type: string
+          enum:
+            - IDENTIFICATION
+            - VERIFICATION
+        image:
+          type: string
+          example: basic-authenticator-logo-url
+        description:
+          type: string
+          example: The basic authenticator.
     ConnectedApps:
       type: object
       properties:

--- a/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/main/resources/configs.yaml
+++ b/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/main/resources/configs.yaml
@@ -230,7 +230,40 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Authenticator'
+                oneOf:
+                  - $ref: '#/components/schemas/Authenticator'
+                  - $ref: '#/components/schemas/UserDefinedAuthenticator'
+              examples:
+                UserDefinedAuthenticatorExample:
+                  summary: "Response for user defined authenticator"
+                  value:
+                    id: "Y3VzdG9tQXV0aGVudGljYXRvcg"
+                    name: "customAuthenticator"
+                    displayName: "Custom auth"
+                    definedBy: "SYSTEM"
+                    type: "LOCAL"
+                    isEnabled: true
+                    tags: [MFA]
+                    endpoint:
+                      uri: "https://abc.com/token"
+                      authentication:
+                        type: "BASIC"
+                        properties:
+                          username: "auth_username"
+                          password: "auth_password"
+                SystemDefinedAuthenticatorExample:
+                  summary: "Response for system defined authenticators"
+                  value:
+                    id: "QmFzaWNBdXRoZW50aWNhdG9y"
+                    name: "BasicAuthenticator"
+                    displayName: "basic"
+                    definedBy: "USER"
+                    type: "LOCAL"
+                    isEnabled: true
+                    tags: [Custom, 2FA]
+                    properties:
+                      - key: "somePropertyKey"
+                        value: "somePropertyValue"
         '400':
           description: Bad Request
           content:
@@ -1245,6 +1278,75 @@ components:
       required:
         - name
         - displayName
+    UserDefinedAuthenticator:
+      type: object
+      properties:
+        id:
+          type: string
+          example: Q3VzdG9tQXV0aGVudGljYXRvcg
+          readOnly: true
+        name:
+          type: string
+          example: customAuthenticator
+        displayName:
+          type: string
+          example: Custom auth
+        isEnabled:
+          type: boolean
+          default: true
+        definedBy:
+          type: string
+          enum:
+            - SYSTEM
+            - USER
+          readOnly: true
+        type:
+          type: string
+          enum:
+            - LOCAL
+            - REQUEST_PATH
+        tags:
+          type: array
+          items:
+            type: string
+          example: [2FA,MFA]
+          readOnly: true
+        endpoint:
+          type: array
+          items:
+            $ref: '#/components/schemas/Endpoint'
+      required:
+        - name
+        - displayName
+    Endpoint:
+      type: object
+      properties:
+        uri:
+          type: string
+          example: https://abc.com/token
+          pattern: '^https?://.+'
+        authentication:
+          $ref: '#/components/schemas/AuthenticationType'
+    AuthenticationType:
+      type: object
+      required:
+        - type
+        - properties
+      properties:
+        type:
+          type: string
+          enum:
+            - NONE
+            - BEARER
+            - API_KEY
+            - BASIC
+          example: BASIC
+        properties:
+          type: object
+          additionalProperties: true
+          example:
+            username: "auth_username"
+            password: "auth_password"
     AuthenticatorProperty:
       required:
         - key

--- a/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/main/resources/idp.yaml
+++ b/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/main/resources/idp.yaml
@@ -137,6 +137,11 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/IdentityProviderPOSTRequest'
+            examples:
+              identityProviderWithSystemDefinedAuthenticator:
+                $ref: '#/components/examples/IdentityProviderWithSystemDefinedAuthenticator'
+              identityProviderWithUserDefineAuthenticator:
+                $ref: '#/components/examples/IdentityProviderWithUserDefinedAuthenticator'
           application/xml:
             schema:
               $ref: '#/components/schemas/IdentityProviderPOSTRequest'
@@ -786,6 +791,11 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/FederatedAuthenticatorRequest'
+            examples:
+              systemDefinedAuthenticatorsExample:
+                $ref: '#/components/examples/SystemDefinedAuthenticatorsListPUTExample'
+              userDefinedAuthenticators:
+                $ref: '#/components/examples/UserDefinedAuthenticatorsListPUTExample'
         description: This represents the federated authenticators to be updated
         required: true
   '/identity-providers/{identity-provider-id}/federated-authenticators/{federated-authenticator-id}':
@@ -823,6 +833,11 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/FederatedAuthenticator'
+              examples:
+                systemDefinedAuthenticatorsExample:
+                  $ref: '#/components/examples/SystemDefinedAuthenticatorExample'
+                userDefinedAuthenticators:
+                  $ref: '#/components/examples/UserDefinedAuthenticatorExample'
         '400':
           description: Bad Request
           content:
@@ -883,7 +898,14 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/FederatedAuthenticator'
+                oneOf:
+                  - $ref: '#/components/schemas/FederatedAuthenticator'
+                  - $ref: '#/components/schemas/FederatedUserDefinedAuthenticator'
+              examples:
+                systemDefinedAuthenticatorsExample:
+                  $ref: '#/components/examples/SystemDefinedAuthenticatorExample'
+                userDefinedAuthenticators:
+                  $ref: '#/components/examples/UserDefinedAuthenticatorExample'
         '400':
           description: Bad Request
           content:
@@ -910,7 +932,14 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/FederatedAuthenticatorPUTRequest'
+              oneOf:
+                - $ref: '#/components/schemas/FederatedAuthenticatorPUTRequest'
+                - $ref: '#/components/schemas/FederatedUserDefinedAuthenticatorPUTRequest'
+            examples:
+              systemDefinedAuthenticatorsExample:
+                $ref: '#/components/examples/SystemDefinedAuthenticatorPUTExample'
+              userDefinedAuthenticators:
+                $ref: '#/components/examples/UserDefinedAuthenticatorPUTExample'
         description: This represents the federated authenticator to be updated
         required: true
   '/identity-providers/{identity-provider-id}/provisioning':
@@ -2838,7 +2867,9 @@ components:
         authenticators:
           type: array
           items:
-            $ref: '#/components/schemas/FederatedAuthenticator'
+            oneOf:
+              - $ref: '#/components/schemas/FederatedAuthenticator'
+              - $ref: '#/components/schemas/FederatedUserDefinedAuthenticator'
           description: >-
             Includes the list of federated authenticators supported by the
             respective identity provider. This should include the authenticator
@@ -2863,7 +2894,7 @@ components:
           type: string
           enum:
             - SYSTEM
-            - USER
+          readOnly: true
         isDefault:
           type: boolean
           default: false
@@ -2877,6 +2908,67 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/Property'
+    FederatedUserDefinedAuthenticator:
+      type: object
+      required:
+        - authenticatorId
+      properties:
+        authenticatorId:
+          type: string
+          example: Y3VzdG9tQXV0aGVudGljYXRvcg
+        name:
+          type: string
+          example: "customAuthenticator"
+          readOnly: true
+        isEnabled:
+          type: boolean
+          default: false
+          example: true
+        definedBy:
+          type: string
+          enum:
+            - USER
+          readOnly: true
+        isDefault:
+          type: boolean
+          default: false
+        tags:
+          type: array
+          items:
+            type: string
+          example: [Custom]
+          readOnly: true
+        endpoint:
+          $ref: '#/components/schemas/Endpoint'
+    Endpoint:
+      type: object
+      properties:
+        uri:
+          type: string
+          example: https://abc.com/token
+          pattern: '^https?://.+'
+        authentication:
+          $ref: '#/components/schemas/AuthenticationType'
+    AuthenticationType:
+      type: object
+      required:
+        - type
+        - properties
+      properties:
+        type:
+          type: string
+          enum:
+            - NONE
+            - BEARER
+            - API_KEY
+            - BASIC
+          example: BASIC
+        properties:
+          type: object
+          additionalProperties: true
+          example:
+            username: "auth_username"
+            password: "auth_password"
     FederatedAuthenticatorPUTRequest:
       type: object
       properties:
@@ -2905,6 +2997,23 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/Property'
+    FederatedUserDefinedAuthenticatorPUTRequest:
+      type: object
+      properties:
+        authenticatorId:
+          type: string
+          example:
+          readOnly: true
+        isEnabled:
+          type: boolean
+          default: false
+          example: true
+        isDefault:
+          type: boolean
+          default: false
+          example: false
+        endpoint:
+          $ref: '#/components/schemas/Endpoint'
     FederatedAuthenticatorListResponse:
       type: object
       properties:
@@ -3445,3 +3554,219 @@ components:
           type: string
           format: binary
           description: file to upload
+
+  examples:
+    UserDefinedAuthenticatorPUTExample:
+      summary: "Put request for user defined authenticators"
+      value:
+        authenticatorId: "Y3VzdG9tQXV0aGVudGljYXRvcg"
+        name: "customAuthenticator"
+        default: true
+        endpoint:
+          uri: "https://abc.com/token"
+          authentication:
+            type: "BASIC"
+            properties:
+              username: "auth_username"
+              password: "auth_password"
+    SystemDefinedAuthenticatorPUTExample:
+      summary: "Put request for system defined authenticators"
+      value:
+        authenticatorId: "U0FNTDJBdXRoZW50aWNhdG9y"
+        isEnabled:  "true"
+        isDefault:  true
+        properties:
+          - key: "somePropertyKey"
+            value: "somePropertyValue"
+    UserDefinedAuthenticatorsListPUTExample:
+      summary: "Put request for user defined authenticators list"
+      value:
+        defaultAuthenticatorId: "Y3VzdG9tQXV0aGVudGljYXRvcg"
+        authenticators:
+          - authenticatorId: "Y3VzdG9tQXV0aGVudGljYXRvcg"
+            name: "customAuthenticator"
+            default: true
+            endpoint:
+              uri: "https://abc.com/token"
+              authentication:
+                type: "BASIC"
+                properties:
+                  username: "auth_username"
+                  password: "auth_password"
+    SystemDefinedAuthenticatorsListPUTExample:
+      summary: "Put request for system defined authenticators list"
+      value:
+        defaultAuthenticatorId: "U0FNTDJBdXRoZW50aWNhdG9y"
+        authenticators:
+          - authenticatorId: "U0FNTDJBdXRoZW50aWNhdG9y"
+            isEnabled:  "true"
+            isDefault:  true
+            properties:
+              - key: "somePropertyKey"
+                value: "somePropertyValue"
+    UserDefinedAuthenticatorExample:
+      summary: "Response for user defined authenticator"
+      value:
+        authenticatorId: "Y3VzdG9tQXV0aGVudGljYXRvcg"
+        name: "customAuthenticator"
+        definedBy: "SYSTEM"
+        default: true
+        endpoint:
+          uri: "https://abc.com/token"
+          authentication:
+            type: "BASIC"
+            properties:
+              username: "auth_username"
+              password: "auth_password"
+    SystemDefinedAuthenticatorExample:
+      summary: "Response for system defined authenticators"
+      value:
+        authenticatorId: "U0FNTDJBdXRoZW50aWNhdG9y"
+        definedBy: "USER"
+        isEnabled: "true"
+        isDefault: true
+        properties:
+          - key: "somePropertyKey"
+            value: "somePropertyValue"
+    UserDefinedAuthenticatorsListExample:
+      summary: "Response for user defined authenticators list"
+      value:
+        defaultAuthenticatorId: "Y3VzdG9tQXV0aGVudGljYXRvcg"
+        authenticators:
+          - authenticatorId: "Y3VzdG9tQXV0aGVudGljYXRvcg"
+            name: "customAuthenticator"
+            definedBy: "SYSTEM"
+            default: true
+            endpoint:
+              uri: "https://abc.com/token"
+              authentication:
+                type: "BASIC"
+                properties:
+                  username: "auth_username"
+                  password: "auth_password"
+    SystemDefinedAuthenticatorsListExample:
+      summary: "Response for system defined authenticators list"
+      value:
+        defaultAuthenticatorId: "U0FNTDJBdXRoZW50aWNhdG9y"
+        authenticators:
+          - authenticatorId: "U0FNTDJBdXRoZW50aWNhdG9y"
+            definedBy: "USER"
+            isEnabled: "true"
+            isDefault: true
+            properties:
+              - key: "somePropertyKey"
+                value: "somePropertyValue"
+    IdentityProviderWithUserDefinedAuthenticator:
+      summary: "Request for identity provider with user defined authenticator"
+      value:
+        name: "google"
+        description: "IdP for Google Federation"
+        image: "google-logo-url"
+        templateId: "8ea23303-49c0-4253-b81f-82c0fe6fb4a0"
+        isPrimary: false
+        isFederationHub: false
+        homeRealmIdentifier: "localhost"
+        certificate:
+          certificates:
+            - "string"
+          jwksUri: "https://localhost:9444/oauth2/jwks"
+        alias: "https://localhost:9444/oauth2/token"
+        idpIssuerName: "https://www.idp.com"
+        claims:
+          userIdClaim:
+            uri: "http://wso2.org/claims/username"
+          roleClaim:
+            uri: "http://wso2.org/claims/username"
+          mappings:
+            - idpClaim: "country"
+              localClaim:
+                uri: "http://wso2.org/claims/username"
+          provisioningClaims:
+            - claim:
+                uri: "http://wso2.org/claims/username"
+              defaultValue: "sathya"
+        roles:
+          mappings:
+            - idpRole: "google-manager"
+              localRole: "manager"
+          outboundProvisioningRoles:
+            - "manager"
+            - "hr-admin"
+        groups:
+          - name: "google-admin"
+            id: "6b1f8513-3de0-4f28-9cad-b7400dbc94ae"
+        federatedAuthenticators:
+          defaultAuthenticatorId: "U0FNTDJBdXRoZW50aWNhdG9y"
+          authenticators:
+            - authenticatorId: "Y3VzdG9tQXV0aGVudGljYXRvcg"
+              isEnabled: true
+              isDefault: false
+              endpoint:
+                uri: "https://abc.com/token"
+                authentication:
+                  type: "BASIC"
+                  properties:
+                    username: "auth_username"
+                    password: "auth_password"
+        provisioning:
+          jit:
+            isEnabled: true
+            scheme: "PROVISION_SILENTLY"
+            userstore: "PRIMARY"
+            associateLocalUser: true
+            attributeSyncMethod: "OVERRIDE_ALL"
+          outboundConnectors:
+            defaultConnectorId: "U0NJTQ"
+            connectors:
+              - connectorId: "U0NJTQ"
+                isEnabled: true
+                isDefault: false
+                blockingEnabled: false
+                rulesEnabled: false
+                properties:
+                  - key: "somePropertyKey"
+                    value: "somePropertyValue"
+        implicitAssociation:
+          isEnabled: false
+          lookupAttribute:
+            - "email"
+    IdentityProviderWithSystemDefinedAuthenticator:
+      summary: "Request for identity provider with system defined authenticator"
+      value:
+        name: "Custom IDP"
+        description: "IDP with custom federated authenticator"
+        image: "https://custom-authenticator-logo-url"
+        templateId: "8ea23303-49c0-4253-b81f-82c0fe6fb4a0"
+        isPrimary: false
+        isFederationHub: false
+        homeRealmIdentifier: ""
+        certificate:
+          certificates:
+            - ""
+          jwksUri: ""
+        claims:
+          userIdClaim:
+            uri: ""
+          roleClaim:
+            uri: ""
+          mappings: []
+          provisioningClaims: []
+        roles:
+          mappings: [ ]
+          outboundProvisioningRoles: [ ]
+        federatedAuthenticators:
+          defaultAuthenticatorId: "U0FNTDJBdXRoZW50aWNhdG9y"
+          authenticators:
+            - authenticatorId: "U0FNTDJBdXRoZW50aWNhdG9y"
+              isEnabled: true
+              isDefault: false
+              properties:
+                - key: "somePropertyKey"
+                  value: "somePropertyValue"
+        provisioning:
+          jit:
+            isEnabled: true
+            scheme: "PROVISION_SILENTLY"
+            userstore: "PRIMARY"
+            associateLocalUser: true
+            attributeSyncMethod: "OVERRIDE_ALL"


### PR DESCRIPTION
We’re introducing the following API changes to enhance the management of custom authentication extensions, supporting both local and federated types. Based on previous discussions, we decided to treat external authentication service endpoint configurations as primary properties for payloads related to the custom authentication. This results in two distinct models:
- System-defined authenticators: The properties field is a primary property.
- User-defined (custom) authenticators: The endpoint field is a primary property, with no general properties field.

The upcoming API changes include:

- /authenticators/custom/ : New API to create user-defined local authenticators 
- /configs/authenticators/{authenticator-id} : response body for the GET request.
- /identity-providers : request body for the PUT request.
- /identity-providers/{identity-provider-id}/federated-authenticators : request body for the PUT request.
- /identity-providers/{identity-provider-id}/federated-authenticators/{federated-authenticator-id} : response and request body for both GET and PUT requests.