### PR TITLE
Add PUT endpoint for organization configuration management API

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.organization.configs/org.wso2.carbon.identity.api.server.organization.configs.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/configs/v1/OrganizationConfigsApi.java
+++ b/components/org.wso2.carbon.identity.api.server.organization.configs/org.wso2.carbon.identity.api.server.organization.configs.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/configs/v1/OrganizationConfigsApi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2023-2024, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -99,7 +99,7 @@ public class OrganizationConfigsApi  {
         @Authorization(value = "OAuth2", scopes = {
             
         })
-    }, tags={ "Discovery" })
+    }, tags={ "Discovery", })
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "Successful response.", response = Config.class),
         @ApiResponse(code = 401, message = "Authentication information is missing or invalid.", response = Void.class),
@@ -110,6 +110,29 @@ public class OrganizationConfigsApi  {
     public Response getDiscoveryConfig() {
 
         return delegate.getDiscoveryConfig();
+    }
+
+    @Valid
+    @PUT
+    @Path("/discovery")
+    @Consumes({ "application/json" })
+    @Produces({ "application/json" })
+    @ApiOperation(value = "Update organization discovery configuration.", notes = "This API provides the capability to update discovery configuration of the primary organization. <br>   <b>Permission required:</b> <br>     * /permission/admin/manage/identity/configmgt/update <br>   <b>Scope required:</b> <br>     * internal_config_mgt_update ", response = Config.class, authorizations = {
+        @Authorization(value = "BasicAuth"),
+        @Authorization(value = "OAuth2", scopes = {
+            
+        })
+    }, tags={ "Discovery" })
+    @ApiResponses(value = { 
+        @ApiResponse(code = 200, message = "Successful Response", response = Config.class),
+        @ApiResponse(code = 400, message = "Invalid input in the request.", response = Error.class),
+        @ApiResponse(code = 401, message = "Authentication information is missing or invalid.", response = Void.class),
+        @ApiResponse(code = 403, message = "Access forbidden.", response = Void.class),
+        @ApiResponse(code = 500, message = "Internal server error.", response = Error.class)
+    })
+    public Response updateDiscoveryConfig(@ApiParam(value = "" ) @Valid Config config) {
+
+        return delegate.updateDiscoveryConfig(config );
     }
 
 }

--- a/components/org.wso2.carbon.identity.api.server.organization.configs/org.wso2.carbon.identity.api.server.organization.configs.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/configs/v1/OrganizationConfigsApi.java
+++ b/components/org.wso2.carbon.identity.api.server.organization.configs/org.wso2.carbon.identity.api.server.organization.configs.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/configs/v1/OrganizationConfigsApi.java
@@ -117,7 +117,7 @@ public class OrganizationConfigsApi  {
     @Path("/discovery")
     @Consumes({ "application/json" })
     @Produces({ "application/json" })
-    @ApiOperation(value = "Update organization discovery configuration.", notes = "This API provides the capability to update discovery configuration of the primary organization. <br>   <b>Permission required:</b> <br>     * /permission/admin/manage/identity/configmgt/update <br>   <b>Scope required:</b> <br>     * internal_config_mgt_update ", response = Config.class, authorizations = {
+    @ApiOperation(value = "Update organization discovery configuration.", notes = "This API provides the capability to update discovery configuration of the primary organization. <br>     <b>Scope(Permission) required:</b> <br>     * internal_config_mgt_update ", response = Config.class, authorizations = {
         @Authorization(value = "BasicAuth"),
         @Authorization(value = "OAuth2", scopes = {
             

--- a/components/org.wso2.carbon.identity.api.server.organization.configs/org.wso2.carbon.identity.api.server.organization.configs.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/configs/v1/OrganizationConfigsApiService.java
+++ b/components/org.wso2.carbon.identity.api.server.organization.configs/org.wso2.carbon.identity.api.server.organization.configs.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/configs/v1/OrganizationConfigsApiService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2023-2024, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -36,4 +36,6 @@ public interface OrganizationConfigsApiService {
       public Response deleteDiscoveryConfig();
 
       public Response getDiscoveryConfig();
+
+      public Response updateDiscoveryConfig(Config config);
 }

--- a/components/org.wso2.carbon.identity.api.server.organization.configs/org.wso2.carbon.identity.api.server.organization.configs.v1/src/main/java/org/wso2/carbon/identity/api/server/organization/configs/v1/core/OrganizationConfigsService.java
+++ b/components/org.wso2.carbon.identity.api.server.organization.configs/org.wso2.carbon.identity.api.server.organization.configs.v1/src/main/java/org/wso2/carbon/identity/api/server/organization/configs/v1/core/OrganizationConfigsService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2023-2024, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -57,6 +57,24 @@ public class OrganizationConfigsService {
                 .collect(Collectors.toList());
         try {
             OrganizationConfigsServiceHolder.getOrganizationConfigManager().addDiscoveryConfiguration
+                    (new DiscoveryConfig(configProperties));
+        } catch (OrganizationConfigException e) {
+            throw handleException(e);
+        }
+    }
+
+    /**
+     * Update the organization discovery configuration in the primary organization.
+     *
+     * @param config The organization discovery configuration.
+     */
+    public void updateDiscoveryConfiguration(Config config) {
+
+        List<ConfigProperty> configProperties = config.getProperties().stream()
+                .map(property -> new ConfigProperty(property.getKey(), property.getValue()))
+                .collect(Collectors.toList());
+        try {
+            OrganizationConfigsServiceHolder.getOrganizationConfigManager().updateDiscoveryConfiguration
                     (new DiscoveryConfig(configProperties));
         } catch (OrganizationConfigException e) {
             throw handleException(e);

--- a/components/org.wso2.carbon.identity.api.server.organization.configs/org.wso2.carbon.identity.api.server.organization.configs.v1/src/main/java/org/wso2/carbon/identity/api/server/organization/configs/v1/impl/OrganizationConfigsApiServiceImpl.java
+++ b/components/org.wso2.carbon.identity.api.server.organization.configs/org.wso2.carbon.identity.api.server.organization.configs.v1/src/main/java/org/wso2/carbon/identity/api/server/organization/configs/v1/impl/OrganizationConfigsApiServiceImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2023-2024, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -51,5 +51,12 @@ public class OrganizationConfigsApiServiceImpl implements OrganizationConfigsApi
     public Response getDiscoveryConfig() {
 
         return Response.ok().entity(organizationConfigsService.getDiscoveryConfiguration()).build();
+    }
+
+    @Override
+    public Response updateDiscoveryConfig(Config config) {
+
+        organizationConfigsService.updateDiscoveryConfiguration(config);
+        return Response.ok().entity(config).build();
     }
 }

--- a/components/org.wso2.carbon.identity.api.server.organization.configs/org.wso2.carbon.identity.api.server.organization.configs.v1/src/main/resources/organization-configs.yaml
+++ b/components/org.wso2.carbon.identity.api.server.organization.configs/org.wso2.carbon.identity.api.server.organization.configs.v1/src/main/resources/organization-configs.yaml
@@ -86,9 +86,7 @@ paths:
       summary: Update organization discovery configuration.
       description: |
         This API provides the capability to update discovery configuration of the primary organization. <br>
-          <b>Permission required:</b> <br>
-            * /permission/admin/manage/identity/configmgt/update <br>
-          <b>Scope required:</b> <br>
+          <b>Scope(Permission) required:</b> <br>
             * internal_config_mgt_update
       operationId: updateDiscoveryConfig
       requestBody:

--- a/components/org.wso2.carbon.identity.api.server.organization.configs/org.wso2.carbon.identity.api.server.organization.configs.v1/src/main/resources/organization-configs.yaml
+++ b/components/org.wso2.carbon.identity.api.server.organization.configs/org.wso2.carbon.identity.api.server.organization.configs.v1/src/main/resources/organization-configs.yaml
@@ -80,6 +80,37 @@ paths:
           $ref: '#/components/responses/Conflict'
         '500':
           $ref: '#/components/responses/ServerError'
+    put:
+      tags:
+        - Discovery
+      summary: Update organization discovery configuration.
+      description: |
+        This API provides the capability to update discovery configuration of the primary organization. <br>
+          <b>Permission required:</b> <br>
+            * /permission/admin/manage/identity/configmgt/update <br>
+          <b>Scope required:</b> <br>
+            * internal_config_mgt_update
+      operationId: updateDiscoveryConfig
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Config'
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Config'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '500':
+          $ref: '#/components/responses/ServerError'
     delete:
       tags:
         - Discovery

--- a/pom.xml
+++ b/pom.xml
@@ -839,7 +839,7 @@
         </org.wso2.carbon.identity.organization.management.core.version.range>
 
         <!-- Organization management service Version -->
-        <org.wso2.carbon.identity.organization.management.version>1.4.52
+        <org.wso2.carbon.identity.organization.management.version>1.4.56
         </org.wso2.carbon.identity.organization.management.version>
 
         <!-- Unit test versions -->


### PR DESCRIPTION
## Purpose
This PR adds a new PUT endpoint to the organization configuration management API.

### Depends on
- https://github.com/wso2-extensions/identity-organization-management/pull/410

### Related issues
- https://github.com/wso2/product-is/issues/21572