### PR TITLE
Update the /identity-providers/ API to manage user-defined federated authenticators.

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.common/src/main/java/org/wso2/carbon/identity/api/server/idp/common/Constants.java
+++ b/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.common/src/main/java/org/wso2/carbon/identity/api/server/idp/common/Constants.java
@@ -146,18 +146,18 @@ public class Constants {
         ERROR_CODE_ERROR_LISTING_TRUSTED_TOKEN_ISSUERS("60021",
                 "Unable to list existing trusted token issuers.",
                 "Server encountered an error while listing the trusted token issuers."),
-        ERROR_CODE_ENDPOINT_PROVIDED_FOR_SYSTEM_AUTH("60039", "Endpoint provided for the system " +
-                "defined federated authenticator", "No endpoint configuration must be provided for " +
-                "the system defined federated authenticators %s."),
-        ERROR_CODE_PROPERTIES_PROVIDED_FOR_USER_AUTH("60040", "Properties provided for the user " +
-                "defined federated authenticator", "No properties must be provided for the user defined " +
+        ERROR_CODE_ENDPOINT_PROVIDED_FOR_SYSTEM_AUTH("60039", "No endpoint configuration is allowed " +
+                "for system defined authenticators.", "No endpoint configuration must be " +
+                "provided for the system defined federated authenticators %s."),
+        ERROR_CODE_PROPERTIES_PROVIDED_FOR_USER_AUTH("60040", "No properties are allowed for " +
+                "user defined authenticators.", "No properties must be provided for the user defined " +
                 "federated authenticators %s."),
         ERROR_CODE_NO_ENDPOINT_PROVIDED("60041", "No endpoint provided.", "Endpoint " +
                 "configuration must be provided for the user defined federated authenticators %s."),
         ERROR_CODE_NON_DECODABLE_AUTH_ID("60042", "Non-decodable authenticator ID.",
                 "Unable to decode the provided authenticator ID %s."),
         ERROR_CODE_NO_SYSTEM_AUTHENTICATOR_FOUND("60043", "No system authenticator found.",
-                "No system authenticator found for the provided authenticator Id."),
+                "No system authenticator found for the provided authenticator Id %s."),
 
         // Server Error starting from 650xx.
         ERROR_CODE_ERROR_ADDING_IDP("65002",

--- a/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.common/src/main/java/org/wso2/carbon/identity/api/server/idp/common/Constants.java
+++ b/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.common/src/main/java/org/wso2/carbon/identity/api/server/idp/common/Constants.java
@@ -146,6 +146,18 @@ public class Constants {
         ERROR_CODE_ERROR_LISTING_TRUSTED_TOKEN_ISSUERS("60021",
                 "Unable to list existing trusted token issuers.",
                 "Server encountered an error while listing the trusted token issuers."),
+        ERROR_CODE_ENDPOINT_PROVIDED_FOR_SYSTEM_AUTH("60039", "Endpoint provided for the system " +
+                "defined federated authenticator", "No endpoint configuration must be provided for " +
+                "the system defined federated authenticators %s."),
+        ERROR_CODE_PROPERTIES_PROVIDED_FOR_USER_AUTH("60040", "Properties provided for the user " +
+                "defined federated authenticator", "No properties must be provided for the user defined " +
+                "federated authenticators %s."),
+        ERROR_CODE_NO_ENDPOINT_PROVIDED("60041", "No endpoint provided.", "Endpoint " +
+                "configuration must be provided for the user defined federated authenticators %s."),
+        ERROR_CODE_NON_DECODABLE_AUTH_ID("60042", "Non-decodable authenticator ID.",
+                "Unable to decode the provided authenticator ID %s."),
+        ERROR_CODE_NO_SYSTEM_AUTHENTICATOR_FOUND("60043", "No system authenticator found.",
+                "No system authenticator found for the provided authenticator Id."),
 
         // Server Error starting from 650xx.
         ERROR_CODE_ERROR_ADDING_IDP("65002",

--- a/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.common/src/main/java/org/wso2/carbon/identity/api/server/idp/common/Constants.java
+++ b/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.common/src/main/java/org/wso2/carbon/identity/api/server/idp/common/Constants.java
@@ -146,13 +146,13 @@ public class Constants {
         ERROR_CODE_ERROR_LISTING_TRUSTED_TOKEN_ISSUERS("60021",
                 "Unable to list existing trusted token issuers.",
                 "Server encountered an error while listing the trusted token issuers."),
-        ERROR_CODE_ENDPOINT_PROVIDED_FOR_SYSTEM_AUTH("60039", "Invalid Request.",
+        ERROR_CODE_ENDPOINT_PROVIDED_FOR_SYSTEM_AUTH("60039", "No endpoint configuration is allowed.",
                 "No endpoint configuration must be " +
                 "provided for the system defined federated authenticators %s."),
-        ERROR_CODE_PROPERTIES_PROVIDED_FOR_USER_AUTH("60040", "Invalid Request.",
+        ERROR_CODE_PROPERTIES_PROVIDED_FOR_USER_AUTH("60040", "No properties are allowed.",
                 "No properties must be provided for the user defined " +
                 "federated authenticators %s."),
-        ERROR_CODE_NO_ENDPOINT_PROVIDED("60041", "Invalid Request.", "Endpoint " +
+        ERROR_CODE_NO_ENDPOINT_PROVIDED("60041", "No endpoint provided.", "Endpoint " +
                 "configuration must be provided for the user defined federated authenticators %s."),
         ERROR_CODE_NON_DECODABLE_AUTH_ID("60042", "Non-decodable authenticator ID.",
                 "Unable to decode the provided authenticator ID %s."),

--- a/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.common/src/main/java/org/wso2/carbon/identity/api/server/idp/common/Constants.java
+++ b/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.common/src/main/java/org/wso2/carbon/identity/api/server/idp/common/Constants.java
@@ -146,13 +146,13 @@ public class Constants {
         ERROR_CODE_ERROR_LISTING_TRUSTED_TOKEN_ISSUERS("60021",
                 "Unable to list existing trusted token issuers.",
                 "Server encountered an error while listing the trusted token issuers."),
-        ERROR_CODE_ENDPOINT_PROVIDED_FOR_SYSTEM_AUTH("60039", "No endpoint configuration is allowed " +
-                "for system defined authenticators.", "No endpoint configuration must be " +
+        ERROR_CODE_ENDPOINT_PROVIDED_FOR_SYSTEM_AUTH("60039", "Invalid Request.",
+                "No endpoint configuration must be " +
                 "provided for the system defined federated authenticators %s."),
-        ERROR_CODE_PROPERTIES_PROVIDED_FOR_USER_AUTH("60040", "No properties are allowed for " +
-                "user defined authenticators.", "No properties must be provided for the user defined " +
+        ERROR_CODE_PROPERTIES_PROVIDED_FOR_USER_AUTH("60040", "Invalid Request.",
+                "No properties must be provided for the user defined " +
                 "federated authenticators %s."),
-        ERROR_CODE_NO_ENDPOINT_PROVIDED("60041", "No endpoint provided.", "Endpoint " +
+        ERROR_CODE_NO_ENDPOINT_PROVIDED("60041", "Invalid Request.", "Endpoint " +
                 "configuration must be provided for the user defined federated authenticators %s."),
         ERROR_CODE_NON_DECODABLE_AUTH_ID("60042", "Non-decodable authenticator ID.",
                 "Unable to decode the provided authenticator ID %s."),

--- a/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.common/src/main/java/org/wso2/carbon/identity/api/server/idp/common/Constants.java
+++ b/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.common/src/main/java/org/wso2/carbon/identity/api/server/idp/common/Constants.java
@@ -158,6 +158,8 @@ public class Constants {
                 "Unable to decode the provided authenticator ID %s."),
         ERROR_CODE_NO_SYSTEM_AUTHENTICATOR_FOUND("60043", "No system authenticator found.",
                 "No system authenticator found for the provided authenticator Id %s."),
+        ERROR_COED_MULTIPLE_USER_DEFINED_AUTHENTICATORS_FOUND("60044", "Multiple authenticators found.",
+                "Multiple user defined authenticators are not allowed."),
 
         // Server Error starting from 650xx.
         ERROR_CODE_ERROR_ADDING_IDP("65002",

--- a/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/gen/java/org/wso2/carbon/identity/api/server/idp/v1/model/AuthenticationType.java
+++ b/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/gen/java/org/wso2/carbon/identity/api/server/idp/v1/model/AuthenticationType.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.idp.v1.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import javax.validation.constraints.*;
+
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+import javax.validation.Valid;
+import javax.xml.bind.annotation.*;
+
+public class AuthenticationType  {
+  
+
+@XmlType(name="TypeEnum")
+@XmlEnum(String.class)
+public enum TypeEnum {
+
+    @XmlEnumValue("NONE") NONE(String.valueOf("NONE")), @XmlEnumValue("BEARER") BEARER(String.valueOf("BEARER")), @XmlEnumValue("API_KEY") API_KEY(String.valueOf("API_KEY")), @XmlEnumValue("BASIC") BASIC(String.valueOf("BASIC"));
+
+
+    private String value;
+
+    TypeEnum(String v) {
+        value = v;
+    }
+
+    public String value() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    public static TypeEnum fromValue(String value) {
+        for (TypeEnum b : TypeEnum.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
+}
+
+    private TypeEnum type;
+    private Map<String, Object> properties = new HashMap<>();
+
+
+    /**
+    **/
+    public AuthenticationType type(TypeEnum type) {
+
+        this.type = type;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "BASIC", required = true, value = "")
+    @JsonProperty("type")
+    @Valid
+    @NotNull(message = "Property type cannot be null.")
+
+    public TypeEnum getType() {
+        return type;
+    }
+    public void setType(TypeEnum type) {
+        this.type = type;
+    }
+
+    /**
+    **/
+    public AuthenticationType properties(Map<String, Object> properties) {
+
+        this.properties = properties;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "{\"username\":\"auth_username\",\"password\":\"auth_password\"}", required = true, value = "")
+    @JsonProperty("properties")
+    @Valid
+    @NotNull(message = "Property properties cannot be null.")
+
+    public Map<String, Object> getProperties() {
+        return properties;
+    }
+    public void setProperties(Map<String, Object> properties) {
+        this.properties = properties;
+    }
+
+
+    public AuthenticationType putPropertiesItem(String key, Object propertiesItem) {
+        this.properties.put(key, propertiesItem);
+        return this;
+    }
+
+    
+
+    @Override
+    public boolean equals(java.lang.Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        AuthenticationType authenticationType = (AuthenticationType) o;
+        return Objects.equals(this.type, authenticationType.type) &&
+            Objects.equals(this.properties, authenticationType.properties);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(type, properties);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class AuthenticationType {\n");
+        
+        sb.append("    type: ").append(toIndentedString(type)).append("\n");
+        sb.append("    properties: ").append(toIndentedString(properties)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+    * Convert the given object to string with each line indented by 4 spaces
+    * (except the first line).
+    */
+    private String toIndentedString(java.lang.Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}
+

--- a/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/gen/java/org/wso2/carbon/identity/api/server/idp/v1/model/AuthenticationType.java
+++ b/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/gen/java/org/wso2/carbon/identity/api/server/idp/v1/model/AuthenticationType.java
@@ -69,7 +69,7 @@ public enum TypeEnum {
 }
 
     private TypeEnum type;
-    private Map<String, Object> properties = new HashMap<>();
+    private Map<String, Object> properties = null;
 
 
     /**
@@ -100,11 +100,9 @@ public enum TypeEnum {
         return this;
     }
     
-    @ApiModelProperty(example = "{\"username\":\"auth_username\",\"password\":\"auth_password\"}", required = true, value = "")
+    @ApiModelProperty(example = "{\"username\":\"auth_username\",\"password\":\"auth_password\"}", value = "")
     @JsonProperty("properties")
     @Valid
-    @NotNull(message = "Property properties cannot be null.")
-
     public Map<String, Object> getProperties() {
         return properties;
     }
@@ -114,6 +112,9 @@ public enum TypeEnum {
 
 
     public AuthenticationType putPropertiesItem(String key, Object propertiesItem) {
+        if (this.properties == null) {
+            this.properties = new HashMap<>();
+        }
         this.properties.put(key, propertiesItem);
         return this;
     }

--- a/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/gen/java/org/wso2/carbon/identity/api/server/idp/v1/model/Endpoint.java
+++ b/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/gen/java/org/wso2/carbon/identity/api/server/idp/v1/model/Endpoint.java
@@ -44,9 +44,11 @@ public class Endpoint  {
         return this;
     }
     
-    @ApiModelProperty(example = "https://abc.com/token", value = "")
+    @ApiModelProperty(example = "https://abc.com/token", required = true, value = "")
     @JsonProperty("uri")
-    @Valid @Pattern(regexp="^https?://.+")
+    @Valid
+    @NotNull(message = "Property uri cannot be null.")
+ @Pattern(regexp="^https?://.+")
     public String getUri() {
         return uri;
     }
@@ -62,9 +64,11 @@ public class Endpoint  {
         return this;
     }
     
-    @ApiModelProperty(value = "")
+    @ApiModelProperty(required = true, value = "")
     @JsonProperty("authentication")
     @Valid
+    @NotNull(message = "Property authentication cannot be null.")
+
     public AuthenticationType getAuthentication() {
         return authentication;
     }

--- a/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/gen/java/org/wso2/carbon/identity/api/server/idp/v1/model/Endpoint.java
+++ b/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/gen/java/org/wso2/carbon/identity/api/server/idp/v1/model/Endpoint.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.idp.v1.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import org.wso2.carbon.identity.api.server.idp.v1.model.AuthenticationType;
+import javax.validation.constraints.*;
+
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+import javax.validation.Valid;
+import javax.xml.bind.annotation.*;
+
+public class Endpoint  {
+  
+    private String uri;
+    private AuthenticationType authentication;
+
+    /**
+    **/
+    public Endpoint uri(String uri) {
+
+        this.uri = uri;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "https://abc.com/token", value = "")
+    @JsonProperty("uri")
+    @Valid @Pattern(regexp="^https?://.+")
+    public String getUri() {
+        return uri;
+    }
+    public void setUri(String uri) {
+        this.uri = uri;
+    }
+
+    /**
+    **/
+    public Endpoint authentication(AuthenticationType authentication) {
+
+        this.authentication = authentication;
+        return this;
+    }
+    
+    @ApiModelProperty(value = "")
+    @JsonProperty("authentication")
+    @Valid
+    public AuthenticationType getAuthentication() {
+        return authentication;
+    }
+    public void setAuthentication(AuthenticationType authentication) {
+        this.authentication = authentication;
+    }
+
+
+
+    @Override
+    public boolean equals(java.lang.Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Endpoint endpoint = (Endpoint) o;
+        return Objects.equals(this.uri, endpoint.uri) &&
+            Objects.equals(this.authentication, endpoint.authentication);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(uri, authentication);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class Endpoint {\n");
+        
+        sb.append("    uri: ").append(toIndentedString(uri)).append("\n");
+        sb.append("    authentication: ").append(toIndentedString(authentication)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+    * Convert the given object to string with each line indented by 4 spaces
+    * (except the first line).
+    */
+    private String toIndentedString(java.lang.Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}
+

--- a/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/gen/java/org/wso2/carbon/identity/api/server/idp/v1/model/FederatedAuthenticatorPUTRequest.java
+++ b/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/gen/java/org/wso2/carbon/identity/api/server/idp/v1/model/FederatedAuthenticatorPUTRequest.java
@@ -22,6 +22,7 @@ import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import java.util.ArrayList;
 import java.util.List;
+import org.wso2.carbon.identity.api.server.idp.v1.model.Endpoint;
 import org.wso2.carbon.identity.api.server.idp.v1.model.Property;
 import javax.validation.constraints.*;
 
@@ -73,6 +74,7 @@ public enum DefinedByEnum {
     private DefinedByEnum definedBy;
     private List<Property> properties = null;
 
+    private Endpoint endpoint;
 
     /**
     **/
@@ -190,7 +192,25 @@ public enum DefinedByEnum {
         return this;
     }
 
+        /**
+    **/
+    public FederatedAuthenticatorPUTRequest endpoint(Endpoint endpoint) {
+
+        this.endpoint = endpoint;
+        return this;
+    }
     
+    @ApiModelProperty(value = "")
+    @JsonProperty("endpoint")
+    @Valid
+    public Endpoint getEndpoint() {
+        return endpoint;
+    }
+    public void setEndpoint(Endpoint endpoint) {
+        this.endpoint = endpoint;
+    }
+
+
 
     @Override
     public boolean equals(java.lang.Object o) {
@@ -207,12 +227,13 @@ public enum DefinedByEnum {
             Objects.equals(this.isEnabled, federatedAuthenticatorPUTRequest.isEnabled) &&
             Objects.equals(this.isDefault, federatedAuthenticatorPUTRequest.isDefault) &&
             Objects.equals(this.definedBy, federatedAuthenticatorPUTRequest.definedBy) &&
-            Objects.equals(this.properties, federatedAuthenticatorPUTRequest.properties);
+            Objects.equals(this.properties, federatedAuthenticatorPUTRequest.properties) &&
+            Objects.equals(this.endpoint, federatedAuthenticatorPUTRequest.endpoint);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(authenticatorId, name, isEnabled, isDefault, definedBy, properties);
+        return Objects.hash(authenticatorId, name, isEnabled, isDefault, definedBy, properties, endpoint);
     }
 
     @Override
@@ -227,6 +248,7 @@ public enum DefinedByEnum {
         sb.append("    isDefault: ").append(toIndentedString(isDefault)).append("\n");
         sb.append("    definedBy: ").append(toIndentedString(definedBy)).append("\n");
         sb.append("    properties: ").append(toIndentedString(properties)).append("\n");
+        sb.append("    endpoint: ").append(toIndentedString(endpoint)).append("\n");
         sb.append("}");
         return sb.toString();
     }

--- a/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/gen/java/org/wso2/carbon/identity/api/server/idp/v1/model/FederatedUserDefinedAuthenticator.java
+++ b/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/gen/java/org/wso2/carbon/identity/api/server/idp/v1/model/FederatedUserDefinedAuthenticator.java
@@ -1,18 +1,20 @@
 /*
-* Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-* http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
+ * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 
 package org.wso2.carbon.identity.api.server.idp.v1.model;
 
@@ -23,7 +25,6 @@ import io.swagger.annotations.ApiModelProperty;
 import java.util.ArrayList;
 import java.util.List;
 import org.wso2.carbon.identity.api.server.idp.v1.model.Endpoint;
-import org.wso2.carbon.identity.api.server.idp.v1.model.Property;
 import javax.validation.constraints.*;
 
 
@@ -32,7 +33,7 @@ import java.util.Objects;
 import javax.validation.Valid;
 import javax.xml.bind.annotation.*;
 
-public class FederatedAuthenticator  {
+public class FederatedUserDefinedAuthenticator  {
   
     private String authenticatorId;
     private String name;
@@ -42,7 +43,7 @@ public class FederatedAuthenticator  {
 @XmlEnum(String.class)
 public enum DefinedByEnum {
 
-    @XmlEnumValue("SYSTEM") SYSTEM(String.valueOf("SYSTEM")), @XmlEnumValue("USER") USER(String.valueOf("USER"));
+    @XmlEnumValue("USER") USER(String.valueOf("USER"));
 
 
     private String value;
@@ -74,19 +75,17 @@ public enum DefinedByEnum {
     private Boolean isDefault = false;
     private List<String> tags = null;
 
-    private List<Property> properties = null;
-
     private Endpoint endpoint;
 
     /**
     **/
-    public FederatedAuthenticator authenticatorId(String authenticatorId) {
+    public FederatedUserDefinedAuthenticator authenticatorId(String authenticatorId) {
 
         this.authenticatorId = authenticatorId;
         return this;
     }
     
-    @ApiModelProperty(example = "U0FNTDJBdXRoZW50aWNhdG9y", required = true, value = "")
+    @ApiModelProperty(example = "Y3VzdG9tQXV0aGVudGljYXRvcg", required = true, value = "")
     @JsonProperty("authenticatorId")
     @Valid
     @NotNull(message = "Property authenticatorId cannot be null.")
@@ -100,13 +99,13 @@ public enum DefinedByEnum {
 
     /**
     **/
-    public FederatedAuthenticator name(String name) {
+    public FederatedUserDefinedAuthenticator name(String name) {
 
         this.name = name;
         return this;
     }
     
-    @ApiModelProperty(example = "SAML2Authenticator", value = "")
+    @ApiModelProperty(example = "customAuthenticator", value = "")
     @JsonProperty("name")
     @Valid
     public String getName() {
@@ -118,7 +117,7 @@ public enum DefinedByEnum {
 
     /**
     **/
-    public FederatedAuthenticator isEnabled(Boolean isEnabled) {
+    public FederatedUserDefinedAuthenticator isEnabled(Boolean isEnabled) {
 
         this.isEnabled = isEnabled;
         return this;
@@ -136,7 +135,7 @@ public enum DefinedByEnum {
 
     /**
     **/
-    public FederatedAuthenticator definedBy(DefinedByEnum definedBy) {
+    public FederatedUserDefinedAuthenticator definedBy(DefinedByEnum definedBy) {
 
         this.definedBy = definedBy;
         return this;
@@ -154,7 +153,7 @@ public enum DefinedByEnum {
 
     /**
     **/
-    public FederatedAuthenticator isDefault(Boolean isDefault) {
+    public FederatedUserDefinedAuthenticator isDefault(Boolean isDefault) {
 
         this.isDefault = isDefault;
         return this;
@@ -172,13 +171,13 @@ public enum DefinedByEnum {
 
     /**
     **/
-    public FederatedAuthenticator tags(List<String> tags) {
+    public FederatedUserDefinedAuthenticator tags(List<String> tags) {
 
         this.tags = tags;
         return this;
     }
     
-    @ApiModelProperty(example = "[\"Social Login\",\"OIDC\"]", value = "")
+    @ApiModelProperty(example = "[\"Custom\"]", value = "")
     @JsonProperty("tags")
     @Valid
     public List<String> getTags() {
@@ -188,7 +187,7 @@ public enum DefinedByEnum {
         this.tags = tags;
     }
 
-    public FederatedAuthenticator addTagsItem(String tagsItem) {
+    public FederatedUserDefinedAuthenticator addTagsItem(String tagsItem) {
         if (this.tags == null) {
             this.tags = new ArrayList<>();
         }
@@ -198,33 +197,7 @@ public enum DefinedByEnum {
 
         /**
     **/
-    public FederatedAuthenticator properties(List<Property> properties) {
-
-        this.properties = properties;
-        return this;
-    }
-    
-    @ApiModelProperty(value = "")
-    @JsonProperty("properties")
-    @Valid
-    public List<Property> getProperties() {
-        return properties;
-    }
-    public void setProperties(List<Property> properties) {
-        this.properties = properties;
-    }
-
-    public FederatedAuthenticator addPropertiesItem(Property propertiesItem) {
-        if (this.properties == null) {
-            this.properties = new ArrayList<>();
-        }
-        this.properties.add(propertiesItem);
-        return this;
-    }
-
-        /**
-    **/
-    public FederatedAuthenticator endpoint(Endpoint endpoint) {
+    public FederatedUserDefinedAuthenticator endpoint(Endpoint endpoint) {
 
         this.endpoint = endpoint;
         return this;
@@ -251,27 +224,26 @@ public enum DefinedByEnum {
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        FederatedAuthenticator federatedAuthenticator = (FederatedAuthenticator) o;
-        return Objects.equals(this.authenticatorId, federatedAuthenticator.authenticatorId) &&
-            Objects.equals(this.name, federatedAuthenticator.name) &&
-            Objects.equals(this.isEnabled, federatedAuthenticator.isEnabled) &&
-            Objects.equals(this.definedBy, federatedAuthenticator.definedBy) &&
-            Objects.equals(this.isDefault, federatedAuthenticator.isDefault) &&
-            Objects.equals(this.tags, federatedAuthenticator.tags) &&
-            Objects.equals(this.properties, federatedAuthenticator.properties) &&
-            Objects.equals(this.endpoint, federatedAuthenticator.endpoint);
+        FederatedUserDefinedAuthenticator federatedUserDefinedAuthenticator = (FederatedUserDefinedAuthenticator) o;
+        return Objects.equals(this.authenticatorId, federatedUserDefinedAuthenticator.authenticatorId) &&
+            Objects.equals(this.name, federatedUserDefinedAuthenticator.name) &&
+            Objects.equals(this.isEnabled, federatedUserDefinedAuthenticator.isEnabled) &&
+            Objects.equals(this.definedBy, federatedUserDefinedAuthenticator.definedBy) &&
+            Objects.equals(this.isDefault, federatedUserDefinedAuthenticator.isDefault) &&
+            Objects.equals(this.tags, federatedUserDefinedAuthenticator.tags) &&
+            Objects.equals(this.endpoint, federatedUserDefinedAuthenticator.endpoint);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(authenticatorId, name, isEnabled, definedBy, isDefault, tags, properties, endpoint);
+        return Objects.hash(authenticatorId, name, isEnabled, definedBy, isDefault, tags, endpoint);
     }
 
     @Override
     public String toString() {
 
         StringBuilder sb = new StringBuilder();
-        sb.append("class FederatedAuthenticator {\n");
+        sb.append("class FederatedUserDefinedAuthenticator {\n");
         
         sb.append("    authenticatorId: ").append(toIndentedString(authenticatorId)).append("\n");
         sb.append("    name: ").append(toIndentedString(name)).append("\n");
@@ -279,7 +251,6 @@ public enum DefinedByEnum {
         sb.append("    definedBy: ").append(toIndentedString(definedBy)).append("\n");
         sb.append("    isDefault: ").append(toIndentedString(isDefault)).append("\n");
         sb.append("    tags: ").append(toIndentedString(tags)).append("\n");
-        sb.append("    properties: ").append(toIndentedString(properties)).append("\n");
         sb.append("    endpoint: ").append(toIndentedString(endpoint)).append("\n");
         sb.append("}");
         return sb.toString();

--- a/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/gen/java/org/wso2/carbon/identity/api/server/idp/v1/model/FederatedUserDefinedAuthenticatorPUTRequest.java
+++ b/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/gen/java/org/wso2/carbon/identity/api/server/idp/v1/model/FederatedUserDefinedAuthenticatorPUTRequest.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.idp.v1.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import org.wso2.carbon.identity.api.server.idp.v1.model.Endpoint;
+import javax.validation.constraints.*;
+
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+import javax.validation.Valid;
+import javax.xml.bind.annotation.*;
+
+public class FederatedUserDefinedAuthenticatorPUTRequest  {
+  
+    private String authenticatorId;
+    private Boolean isEnabled = false;
+    private Boolean isDefault = false;
+    private Endpoint endpoint;
+
+    /**
+    **/
+    public FederatedUserDefinedAuthenticatorPUTRequest authenticatorId(String authenticatorId) {
+
+        this.authenticatorId = authenticatorId;
+        return this;
+    }
+    
+    @ApiModelProperty(value = "")
+    @JsonProperty("authenticatorId")
+    @Valid
+    public String getAuthenticatorId() {
+        return authenticatorId;
+    }
+    public void setAuthenticatorId(String authenticatorId) {
+        this.authenticatorId = authenticatorId;
+    }
+
+    /**
+    **/
+    public FederatedUserDefinedAuthenticatorPUTRequest isEnabled(Boolean isEnabled) {
+
+        this.isEnabled = isEnabled;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "true", value = "")
+    @JsonProperty("isEnabled")
+    @Valid
+    public Boolean getIsEnabled() {
+        return isEnabled;
+    }
+    public void setIsEnabled(Boolean isEnabled) {
+        this.isEnabled = isEnabled;
+    }
+
+    /**
+    **/
+    public FederatedUserDefinedAuthenticatorPUTRequest isDefault(Boolean isDefault) {
+
+        this.isDefault = isDefault;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "false", value = "")
+    @JsonProperty("isDefault")
+    @Valid
+    public Boolean getIsDefault() {
+        return isDefault;
+    }
+    public void setIsDefault(Boolean isDefault) {
+        this.isDefault = isDefault;
+    }
+
+    /**
+    **/
+    public FederatedUserDefinedAuthenticatorPUTRequest endpoint(Endpoint endpoint) {
+
+        this.endpoint = endpoint;
+        return this;
+    }
+    
+    @ApiModelProperty(value = "")
+    @JsonProperty("endpoint")
+    @Valid
+    public Endpoint getEndpoint() {
+        return endpoint;
+    }
+    public void setEndpoint(Endpoint endpoint) {
+        this.endpoint = endpoint;
+    }
+
+
+
+    @Override
+    public boolean equals(java.lang.Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        FederatedUserDefinedAuthenticatorPUTRequest federatedUserDefinedAuthenticatorPUTRequest = (FederatedUserDefinedAuthenticatorPUTRequest) o;
+        return Objects.equals(this.authenticatorId, federatedUserDefinedAuthenticatorPUTRequest.authenticatorId) &&
+            Objects.equals(this.isEnabled, federatedUserDefinedAuthenticatorPUTRequest.isEnabled) &&
+            Objects.equals(this.isDefault, federatedUserDefinedAuthenticatorPUTRequest.isDefault) &&
+            Objects.equals(this.endpoint, federatedUserDefinedAuthenticatorPUTRequest.endpoint);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(authenticatorId, isEnabled, isDefault, endpoint);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class FederatedUserDefinedAuthenticatorPUTRequest {\n");
+        
+        sb.append("    authenticatorId: ").append(toIndentedString(authenticatorId)).append("\n");
+        sb.append("    isEnabled: ").append(toIndentedString(isEnabled)).append("\n");
+        sb.append("    isDefault: ").append(toIndentedString(isDefault)).append("\n");
+        sb.append("    endpoint: ").append(toIndentedString(endpoint)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+    * Convert the given object to string with each line indented by 4 spaces
+    * (except the first line).
+    */
+    private String toIndentedString(java.lang.Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}
+

--- a/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/gen/java/org/wso2/carbon/identity/api/server/idp/v1/model/MetaFederatedAuthenticator.java
+++ b/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/gen/java/org/wso2/carbon/identity/api/server/idp/v1/model/MetaFederatedAuthenticator.java
@@ -22,7 +22,6 @@ import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import java.util.ArrayList;
 import java.util.List;
-import org.wso2.carbon.identity.api.server.idp.v1.model.Endpoint;
 import org.wso2.carbon.identity.api.server.idp.v1.model.MetaProperty;
 import javax.validation.constraints.*;
 
@@ -75,7 +74,6 @@ public enum DefinedByEnum {
 
     private List<MetaProperty> properties = null;
 
-    private Endpoint endpoint;
 
     /**
     **/
@@ -201,25 +199,7 @@ public enum DefinedByEnum {
         return this;
     }
 
-        /**
-    **/
-    public MetaFederatedAuthenticator endpoint(Endpoint endpoint) {
-
-        this.endpoint = endpoint;
-        return this;
-    }
     
-    @ApiModelProperty(value = "")
-    @JsonProperty("endpoint")
-    @Valid
-    public Endpoint getEndpoint() {
-        return endpoint;
-    }
-    public void setEndpoint(Endpoint endpoint) {
-        this.endpoint = endpoint;
-    }
-
-
 
     @Override
     public boolean equals(java.lang.Object o) {
@@ -236,13 +216,12 @@ public enum DefinedByEnum {
             Objects.equals(this.displayName, metaFederatedAuthenticator.displayName) &&
             Objects.equals(this.definedBy, metaFederatedAuthenticator.definedBy) &&
             Objects.equals(this.tags, metaFederatedAuthenticator.tags) &&
-            Objects.equals(this.properties, metaFederatedAuthenticator.properties) &&
-            Objects.equals(this.endpoint, metaFederatedAuthenticator.endpoint);
+            Objects.equals(this.properties, metaFederatedAuthenticator.properties);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(authenticatorId, name, displayName, definedBy, tags, properties, endpoint);
+        return Objects.hash(authenticatorId, name, displayName, definedBy, tags, properties);
     }
 
     @Override
@@ -257,7 +236,6 @@ public enum DefinedByEnum {
         sb.append("    definedBy: ").append(toIndentedString(definedBy)).append("\n");
         sb.append("    tags: ").append(toIndentedString(tags)).append("\n");
         sb.append("    properties: ").append(toIndentedString(properties)).append("\n");
-        sb.append("    endpoint: ").append(toIndentedString(endpoint)).append("\n");
         sb.append("}");
         return sb.toString();
     }

--- a/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/gen/java/org/wso2/carbon/identity/api/server/idp/v1/model/MetaFederatedAuthenticator.java
+++ b/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/gen/java/org/wso2/carbon/identity/api/server/idp/v1/model/MetaFederatedAuthenticator.java
@@ -22,6 +22,7 @@ import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import java.util.ArrayList;
 import java.util.List;
+import org.wso2.carbon.identity.api.server.idp.v1.model.Endpoint;
 import org.wso2.carbon.identity.api.server.idp.v1.model.MetaProperty;
 import javax.validation.constraints.*;
 
@@ -74,6 +75,7 @@ public enum DefinedByEnum {
 
     private List<MetaProperty> properties = null;
 
+    private Endpoint endpoint;
 
     /**
     **/
@@ -199,7 +201,25 @@ public enum DefinedByEnum {
         return this;
     }
 
+        /**
+    **/
+    public MetaFederatedAuthenticator endpoint(Endpoint endpoint) {
+
+        this.endpoint = endpoint;
+        return this;
+    }
     
+    @ApiModelProperty(value = "")
+    @JsonProperty("endpoint")
+    @Valid
+    public Endpoint getEndpoint() {
+        return endpoint;
+    }
+    public void setEndpoint(Endpoint endpoint) {
+        this.endpoint = endpoint;
+    }
+
+
 
     @Override
     public boolean equals(java.lang.Object o) {
@@ -216,12 +236,13 @@ public enum DefinedByEnum {
             Objects.equals(this.displayName, metaFederatedAuthenticator.displayName) &&
             Objects.equals(this.definedBy, metaFederatedAuthenticator.definedBy) &&
             Objects.equals(this.tags, metaFederatedAuthenticator.tags) &&
-            Objects.equals(this.properties, metaFederatedAuthenticator.properties);
+            Objects.equals(this.properties, metaFederatedAuthenticator.properties) &&
+            Objects.equals(this.endpoint, metaFederatedAuthenticator.endpoint);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(authenticatorId, name, displayName, definedBy, tags, properties);
+        return Objects.hash(authenticatorId, name, displayName, definedBy, tags, properties, endpoint);
     }
 
     @Override
@@ -236,6 +257,7 @@ public enum DefinedByEnum {
         sb.append("    definedBy: ").append(toIndentedString(definedBy)).append("\n");
         sb.append("    tags: ").append(toIndentedString(tags)).append("\n");
         sb.append("    properties: ").append(toIndentedString(properties)).append("\n");
+        sb.append("    endpoint: ").append(toIndentedString(endpoint)).append("\n");
         sb.append("}");
         return sb.toString();
     }

--- a/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/main/java/org/wso2/carbon/identity/api/server/idp/v1/core/ServerIdpManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/main/java/org/wso2/carbon/identity/api/server/idp/v1/core/ServerIdpManagementService.java
@@ -1699,6 +1699,7 @@ public class ServerIdpManagementService {
         String authenticatorId = base64URLEncode(authenticatorConfig.getName());
         metaFederatedAuthenticator.setName(authenticatorConfig.getName());
         metaFederatedAuthenticator.setAuthenticatorId(authenticatorId);
+        metaFederatedAuthenticator.setDefinedBy(MetaFederatedAuthenticatorListItem.DefinedByEnum.SYSTEM);
         FederatedAuthenticatorConfig federatedAuthenticatorConfig = ApplicationAuthenticatorService.getInstance()
                 .getFederatedAuthenticatorByName(authenticatorConfig.getName());
         if (federatedAuthenticatorConfig != null) {
@@ -1727,6 +1728,7 @@ public class ServerIdpManagementService {
                 metaFederatedAuthenticator.setTags(Arrays.asList(tags));
             }
         }
+        metaFederatedAuthenticator.setDefinedBy(MetaFederatedAuthenticator.DefinedByEnum.SYSTEM);
         Property[] properties = authenticatorConfig.getProperties();
         List<MetaProperty> metaProperties = Arrays.stream(properties).map(propertyToExternalMeta).collect(Collectors
                 .toList());

--- a/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/main/java/org/wso2/carbon/identity/api/server/idp/v1/core/ServerIdpManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/main/java/org/wso2/carbon/identity/api/server/idp/v1/core/ServerIdpManagementService.java
@@ -596,6 +596,8 @@ public class ServerIdpManagementService {
                     listItem.setAuthenticatorId(fedAuthId);
                     listItem.setName(config.getName());
                     listItem.setIsEnabled(config.isEnabled());
+                    listItem.setDefinedBy(
+                            FederatedAuthenticatorListItem.DefinedByEnum.valueOf(config.getDefinedByType().toString()));
                     FederatedAuthenticatorConfig federatedAuthenticatorConfig =
                             ApplicationAuthenticatorService.getInstance().getFederatedAuthenticatorByName(
                                     config.getName());

--- a/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/main/java/org/wso2/carbon/identity/api/server/idp/v1/core/ServerIdpManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/main/java/org/wso2/carbon/identity/api/server/idp/v1/core/ServerIdpManagementService.java
@@ -1779,6 +1779,10 @@ public class ServerIdpManagementService {
                 } else {
                     definedByType = resolveDefinedByTypeToUpdateFederatedAuthenticator(authenticatorName);
                 }
+                if (definedByType == DefinedByType.USER && federatedAuthenticators.size() > 1) {
+                    throw handleException(Response.Status.BAD_REQUEST,
+                            Constants.ErrorMessage.ERROR_COED_MULTIPLE_USER_DEFINED_AUTHENTICATORS_FOUND, null);
+                }
                 FederatedAuthenticatorConfig authConfig = FederatedAuthenticatorConfigBuilderFactory.build(
                         authenticator, authenticatorName, definedByType);
 

--- a/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/main/java/org/wso2/carbon/identity/api/server/idp/v1/impl/FederatedAuthenticatorConfigBuilderFactory.java
+++ b/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/main/java/org/wso2/carbon/identity/api/server/idp/v1/impl/FederatedAuthenticatorConfigBuilderFactory.java
@@ -42,6 +42,7 @@ import java.util.Arrays;
 import java.util.Base64;
 import java.util.List;
 import java.util.Map;
+import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -184,17 +185,22 @@ public class FederatedAuthenticatorConfigBuilderFactory {
 
         validateUserDefinedFederatedAuthenticatorModel(config);
 
-        UserDefinedFederatedAuthenticatorConfig authConfig = new UserDefinedFederatedAuthenticatorConfig();
-        UserDefinedAuthenticatorEndpointConfig.UserDefinedAuthenticatorEndpointConfigBuilder endpointConfigBuilder =
-                new UserDefinedAuthenticatorEndpointConfig.UserDefinedAuthenticatorEndpointConfigBuilder();
-        endpointConfigBuilder.uri(config.endpoint.getUri());
-        endpointConfigBuilder.authenticationType(config.endpoint.getAuthentication().getType().toString());
-        endpointConfigBuilder.authenticationProperties(config.endpoint.getAuthentication().getProperties()
-                .entrySet().stream().collect(Collectors.toMap(
-                        Map.Entry::getKey, entry -> entry.getValue().toString())));
-        authConfig.setEndpointConfig(endpointConfigBuilder.build());
+        try {
+            UserDefinedFederatedAuthenticatorConfig authConfig = new UserDefinedFederatedAuthenticatorConfig();
+            UserDefinedAuthenticatorEndpointConfig.UserDefinedAuthenticatorEndpointConfigBuilder endpointConfigBuilder =
+                    new UserDefinedAuthenticatorEndpointConfig.UserDefinedAuthenticatorEndpointConfigBuilder();
+            endpointConfigBuilder.uri(config.endpoint.getUri());
+            endpointConfigBuilder.authenticationType(config.endpoint.getAuthentication().getType().toString());
+            endpointConfigBuilder.authenticationProperties(config.endpoint.getAuthentication().getProperties()
+                    .entrySet().stream().collect(Collectors.toMap(
+                            Map.Entry::getKey, entry -> entry.getValue().toString())));
+            authConfig.setEndpointConfig(endpointConfigBuilder.build());
 
-        return authConfig;
+            return authConfig;
+        } catch (NoSuchElementException e) {
+            throw new IdentityProviderManagementClientException(Constants.ErrorMessage
+                    .ERROR_CODE_INVALID_INPUT.getCode(), e.getMessage());
+        }
     }
 
     private static void validateUserDefinedFederatedAuthenticatorModel(Config config)

--- a/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/main/java/org/wso2/carbon/identity/api/server/idp/v1/impl/FederatedAuthenticatorConfigBuilderFactory.java
+++ b/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/main/java/org/wso2/carbon/identity/api/server/idp/v1/impl/FederatedAuthenticatorConfigBuilderFactory.java
@@ -18,74 +18,178 @@
 
 package org.wso2.carbon.identity.api.server.idp.v1.impl;
 
+import org.apache.commons.lang.ArrayUtils;
+import org.apache.commons.lang.StringUtils;
 import org.wso2.carbon.identity.api.server.idp.common.Constants;
+import org.wso2.carbon.identity.api.server.idp.common.IdentityProviderServiceHolder;
+import org.wso2.carbon.identity.api.server.idp.v1.model.AuthenticationType;
 import org.wso2.carbon.identity.api.server.idp.v1.model.Endpoint;
+import org.wso2.carbon.identity.api.server.idp.v1.model.FederatedAuthenticator;
+import org.wso2.carbon.identity.api.server.idp.v1.model.FederatedAuthenticatorPUTRequest;
+import org.wso2.carbon.identity.application.common.ApplicationAuthenticatorService;
 import org.wso2.carbon.identity.application.common.model.FederatedAuthenticatorConfig;
 import org.wso2.carbon.identity.application.common.model.Property;
 import org.wso2.carbon.identity.application.common.model.UserDefinedAuthenticatorEndpointConfig;
 import org.wso2.carbon.identity.application.common.model.UserDefinedFederatedAuthenticatorConfig;
+import org.wso2.carbon.identity.application.common.util.IdentityApplicationConstants;
 import org.wso2.carbon.identity.base.AuthenticatorPropertyConstants.DefinedByType;
 import org.wso2.carbon.idp.mgt.IdentityProviderManagementClientException;
+import org.wso2.carbon.idp.mgt.IdentityProviderManagementException;
+import org.wso2.carbon.idp.mgt.IdentityProviderManagementServerException;
 
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Base64;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import static org.wso2.carbon.identity.api.server.idp.common.Constants.GOOGLE_PRIVATE_KEY;
+
 /**
- * The factory class for creating instances of FederatedAuthenticatorConfig depending on the definedBy type.
- * Returns FederatedAuthenticatorConfig for SYSTEM types and UserDefinedFederatedAuthenticatorConfig for USER types.
+ * The factory class for building federated authenticator configuration related models.
  */
 public class FederatedAuthenticatorConfigBuilderFactory {
 
-    private static FederatedAuthenticatorConfig createFederatedAuthenticatorConfig(Builder builder)
-            throws IdentityProviderManagementClientException {
+    /**
+     * Builds a FederatedAuthenticatorConfig instance based on the definedBy type for the
+     * given FederatedAuthenticatorPUTRequest.
+     *
+     * @param authenticator FederatedAuthenticatorPUTRequest instance.
+     * @param definedByType DefinedByType of the authenticator.
+     * @return FederatedAuthenticatorConfig instance.
+     * @throws IdentityProviderManagementClientException If an error occurs while building
+     *                                                   the FederatedAuthenticatorConfig.
+     */
+    public static FederatedAuthenticatorConfig build(FederatedAuthenticatorPUTRequest authenticator, String 
+            authenticatorName, DefinedByType definedByType) throws IdentityProviderManagementClientException {
 
-        FederatedAuthenticatorConfig config;
-        if (DefinedByType.SYSTEM == builder.definedByType) {
-            config = createSystemDefinedFederatedAuthenticator(builder);
-        } else {
-            config = createUserDefinedFederatedAuthenticator(builder);
+        List<Property> properties = Optional.ofNullable(authenticator.getProperties())
+                .map(props -> props.stream().map(propertyToInternal).collect(Collectors.toList()))
+                .orElse(null);
+        FederatedAuthenticatorConfigBuilderFactory.Config config =
+                new FederatedAuthenticatorConfigBuilderFactory.Config(authenticatorName,
+                        getDisplayNameOfAuthenticator(authenticatorName),
+                        authenticator.getEndpoint(), properties, authenticator.getIsEnabled(), definedByType);
+        return FederatedAuthenticatorConfigBuilderFactory.createFederatedAuthenticatorConfig(config);
+    }
+
+    /**
+     * Builds a FederatedAuthenticatorConfig instance based on the definedBy type for the given FederatedAuthenticator.
+     *
+     * @param authenticator FederatedAuthenticator instance.
+     * @param definedByType DefinedByType of the authenticator.
+     * @return FederatedAuthenticator instance.
+     * @throws IdentityProviderManagementClientException    If an error occurs while building the
+     *                                                      FederatedAuthenticatorConfig.
+     */
+    public static FederatedAuthenticatorConfig build(FederatedAuthenticator authenticator, String
+            authenticatorName, DefinedByType definedByType) throws IdentityProviderManagementClientException {
+
+        List<Property> properties = Optional.ofNullable(authenticator.getProperties())
+                .map(props -> props.stream().map(propertyToInternal).collect(Collectors.toList()))
+                .orElse(null);
+        FederatedAuthenticatorConfigBuilderFactory.Config config =
+                new FederatedAuthenticatorConfigBuilderFactory.Config(authenticatorName,
+                        getDisplayNameOfAuthenticator(authenticatorName),
+                        authenticator.getEndpoint(), properties, authenticator.getIsEnabled(), definedByType);
+
+        return FederatedAuthenticatorConfigBuilderFactory.createFederatedAuthenticatorConfig(config);
+    }
+
+    /**
+     * Builds a FederatedAuthenticatorConfig instance based on the definedBy type for the given
+     * FederatedAuthenticatorConfig.
+     *
+     * @param config     FederatedAuthenticatorConfig instance.
+     * @return FederatedAuthenticator instance.
+     * @throws IdentityProviderManagementServerException    If an error occurs while building the
+     *                                                      FederatedAuthenticator.
+     */
+    public static FederatedAuthenticator build(FederatedAuthenticatorConfig config)
+            throws IdentityProviderManagementServerException {
+
+        FederatedAuthenticator federatedAuthenticator = new FederatedAuthenticator();
+
+        federatedAuthenticator.setName(config.getName());
+        federatedAuthenticator.setIsEnabled(config.isEnabled());
+
+        FederatedAuthenticatorConfig federatedAuthenticatorConfig =
+                ApplicationAuthenticatorService.getInstance().getFederatedAuthenticatorByName(
+                        config.getName());
+        if (federatedAuthenticatorConfig != null) {
+            String[] tags = federatedAuthenticatorConfig.getTags();
+            if (ArrayUtils.isNotEmpty(tags)) {
+                federatedAuthenticator.setTags(Arrays.asList(tags));
+            }
         }
 
-        config.setName(builder.authenticatorName);
-        config.setDisplayName(builder.displayName);
-        config.setEnabled(builder.isEnabled);
+        if (DefinedByType.SYSTEM == config.getDefinedByType()) {
+            federatedAuthenticator.setDefinedBy(FederatedAuthenticator.DefinedByEnum.SYSTEM);
+            List<org.wso2.carbon.identity.api.server.idp.v1.model.Property> properties =
+                    Arrays.stream(config.getProperties()).map(propertyToExternal).collect(Collectors.toList());
+            federatedAuthenticator.setProperties(properties);
+        } else {
+            federatedAuthenticator.setDefinedBy(FederatedAuthenticator.DefinedByEnum.USER);
+            resolveEndpointConfiguration(federatedAuthenticator, config);
+        }
 
-        return config;
+        return federatedAuthenticator;
+    }
+    
+    private static FederatedAuthenticatorConfig createFederatedAuthenticatorConfig(Config config)
+            throws IdentityProviderManagementClientException {
+
+        FederatedAuthenticatorConfig federatedAuthenticatorConfig;
+        if (DefinedByType.SYSTEM == config.definedByType) {
+            federatedAuthenticatorConfig = createSystemDefinedFederatedAuthenticator(config);
+        } else {
+            federatedAuthenticatorConfig = createUserDefinedFederatedAuthenticator(config);
+        }
+
+        federatedAuthenticatorConfig.setName(config.authenticatorName);
+        federatedAuthenticatorConfig.setDisplayName(config.displayName);
+        federatedAuthenticatorConfig.setEnabled(config.isEnabled);
+
+        return federatedAuthenticatorConfig;
     }
 
     private static FederatedAuthenticatorConfig createSystemDefinedFederatedAuthenticator(
-            Builder builder) throws IdentityProviderManagementClientException {
+            Config config) throws IdentityProviderManagementClientException {
 
-        validateSystemDefinedFederatedAuthenticatorModel(builder);
+        validateSystemDefinedFederatedAuthenticatorModel(config);
         FederatedAuthenticatorConfig authConfig = new FederatedAuthenticatorConfig();
         authConfig.setDefinedByType(DefinedByType.SYSTEM);
-        authConfig.setProperties(builder.properties.toArray(new Property[0]));
+        authConfig.setProperties(config.properties.toArray(new Property[0]));
         return authConfig;
     }
 
-    private static void validateSystemDefinedFederatedAuthenticatorModel(Builder builder)
+    private static void validateSystemDefinedFederatedAuthenticatorModel(Config config)
             throws IdentityProviderManagementClientException {
 
         // The System-defined authenticator configs must not have endpoint configurations; throw an error if they do.
-        if (builder.endpoint != null) {
+        if (config.endpoint != null) {
             Constants.ErrorMessage error = Constants.ErrorMessage.ERROR_CODE_ENDPOINT_PROVIDED_FOR_SYSTEM_AUTH;
             throw new IdentityProviderManagementClientException(error.getCode(), String.format(error.getDescription(),
-                    builder.authenticatorName));
+                    config.authenticatorName));
         }
+
+        validateAuthenticatorProperties(config.authenticatorName, config.properties);
     }
 
-    private static UserDefinedFederatedAuthenticatorConfig createUserDefinedFederatedAuthenticator(Builder builder)
+    private static UserDefinedFederatedAuthenticatorConfig createUserDefinedFederatedAuthenticator(Config config)
             throws IdentityProviderManagementClientException {
 
-        validateUserDefinedFederatedAuthenticatorModel(builder);
+        validateUserDefinedFederatedAuthenticatorModel(config);
 
         UserDefinedFederatedAuthenticatorConfig authConfig = new UserDefinedFederatedAuthenticatorConfig();
         UserDefinedAuthenticatorEndpointConfig.UserDefinedAuthenticatorEndpointConfigBuilder endpointConfigBuilder =
                 new UserDefinedAuthenticatorEndpointConfig.UserDefinedAuthenticatorEndpointConfigBuilder();
-        endpointConfigBuilder.uri(builder.endpoint.getUri());
-        endpointConfigBuilder.authenticationType(builder.endpoint.getAuthentication().getType().toString());
-        endpointConfigBuilder.authenticationProperties(builder.endpoint.getAuthentication().getProperties()
+        endpointConfigBuilder.uri(config.endpoint.getUri());
+        endpointConfigBuilder.authenticationType(config.endpoint.getAuthentication().getType().toString());
+        endpointConfigBuilder.authenticationProperties(config.endpoint.getAuthentication().getProperties()
                 .entrySet().stream().collect(Collectors.toMap(
                         Map.Entry::getKey, entry -> entry.getValue().toString())));
         authConfig.setEndpointConfig(endpointConfigBuilder.build());
@@ -93,74 +197,238 @@ public class FederatedAuthenticatorConfigBuilderFactory {
         return authConfig;
     }
 
-    private static void validateUserDefinedFederatedAuthenticatorModel(Builder builder)
+    private static void validateUserDefinedFederatedAuthenticatorModel(Config config)
             throws IdentityProviderManagementClientException {
 
         // The User-defined authenticator configs must not have properties configurations; throw an error if they do.
-        if (builder.properties != null) {
+        if (config.properties != null) {
             Constants.ErrorMessage error = Constants.ErrorMessage.ERROR_CODE_PROPERTIES_PROVIDED_FOR_USER_AUTH;
             throw new IdentityProviderManagementClientException(error.getCode(),
-                    String.format(error.getDescription(), builder.authenticatorName));
+                    String.format(error.getDescription(), config.authenticatorName));
         }
 
         // The User-defined authenticator configs must have endpoint configurations; throw an error if they don't.
-        if (builder.endpoint == null) {
+        if (config.endpoint == null) {
             Constants.ErrorMessage error = Constants.ErrorMessage.ERROR_CODE_NO_ENDPOINT_PROVIDED;
             throw new IdentityProviderManagementClientException(error.getCode(),
-                    String.format(error.getDescription(), builder.authenticatorName));
+                    String.format(error.getDescription(), config.authenticatorName));
+        }
+    }
+
+    private static void validateAuthenticatorProperties(String authenticatorName, List<Property> properties)
+            throws IdentityProviderManagementClientException {
+
+        if (properties == null) {
+            return;
+        }
+
+        if (IdentityApplicationConstants.Authenticator.SAML2SSO.FED_AUTH_NAME.equals(authenticatorName)) {
+            validateSamlMetadata(properties);
+        }
+        if (IdentityApplicationConstants.Authenticator.OIDC.FED_AUTH_NAME.equals(authenticatorName)) {
+            validateDuplicateOpenIDConnectScopes(properties);
+            validateDefaultOpenIDConnectScopes(properties);
+        }
+
+        if (!areAllDistinct(properties)) {
+            Constants.ErrorMessage error = Constants.ErrorMessage.ERROR_CODE_INVALID_INPUT;
+            throw new IdentityProviderManagementClientException(error.getCode(), error.getDescription());
         }
     }
 
     /**
-     * Builder class to build FederatedAuthenticatorConfig.
+     * If selectMode property is set as saml metadata file configuration mode, this function validates whether a
+     * valid base-64 encoded SAML metadata file content is provided with the property key 'meta_data_saml'. If found,
+     * it will decode the file content and update the value of 'meta_data_saml' property with decoded content.
+     *
+     * @param samlAuthenticatorProperties Authenticator properties of SAML authenticator.
      */
-    public static class Builder {
-        private DefinedByType definedByType;
-        private String authenticatorName;
-        private String displayName;
-        private Endpoint endpoint;
-        private List<Property> properties;
-        private Boolean isEnabled;
+    private static void validateSamlMetadata(List<Property> samlAuthenticatorProperties)
+            throws IdentityProviderManagementClientException {
 
-        public Builder definedByType(DefinedByType definedByType) {
+        if (samlAuthenticatorProperties != null) {
+            for (Property property : samlAuthenticatorProperties) {
 
-            this.definedByType = definedByType;
-            return this;
+                if (Constants.SELECT_MODE.equals(property.getName()) &&
+                        Constants.SELECT_MODE_METADATA.equals(property.getValue())) {
+                    // SAML metadata file configuration has been selected. Hence we need to validate whether valid SAML
+                    // metadata (property with key = 'meta_data_saml') is sent.
+
+                    boolean validMetadataFound = false;
+                    String encodedData = null;
+                    int positionOfMetadataKey = -1;
+
+                    for (int i = 0; i < samlAuthenticatorProperties.size(); i++) {
+                        if (Constants.META_DATA_SAML.equals(samlAuthenticatorProperties.get(i).getName()) &&
+                                StringUtils.isNotBlank
+                                        (samlAuthenticatorProperties.get(i).getValue())) {
+                            validMetadataFound = true;
+                            encodedData = samlAuthenticatorProperties.get(i).getValue();
+                            positionOfMetadataKey = i;
+                            break;
+                        }
+                    }
+                    if (validMetadataFound) {
+                        String metadata = new String(Base64.getDecoder().decode(encodedData), (StandardCharsets.UTF_8));
+                        // Add decoded data to property list.
+                        Property metadataProperty = samlAuthenticatorProperties.get(positionOfMetadataKey);
+                        metadataProperty.setValue(metadata);
+                        samlAuthenticatorProperties.set(positionOfMetadataKey, metadataProperty);
+                    } else {
+                        Constants.ErrorMessage error = Constants.ErrorMessage.ERROR_CODE_INVALID_SAML_METADATA;
+                        throw new IdentityProviderManagementClientException(error.getCode(), error.getDescription());
+                    }
+                }
+            }
         }
+    }
 
-        public Builder authenticatorName(String authenticatorName) {
+    /**
+     * Verify if scopes have not been set in both Scopes field and Additional Query Parameters field
+     *
+     * @param oidcAuthenticatorProperties Authenticator properties of OIDC authenticator.
+     */
+    private static void validateDuplicateOpenIDConnectScopes(List<Property> oidcAuthenticatorProperties)
+            throws IdentityProviderManagementClientException {
+
+        if (oidcAuthenticatorProperties != null) {
+            boolean scopesFieldFilled = false;
+            boolean queryParamsScopesFilled = false;
+            for (Property oidcAuthenticatorProperty : oidcAuthenticatorProperties) {
+                if (IdentityApplicationConstants.Authenticator.OIDC.SCOPES.equals(oidcAuthenticatorProperty.getName())
+                        && StringUtils.isNotBlank(oidcAuthenticatorProperty.getValue())) {
+                    scopesFieldFilled = true;
+                }
+                if (IdentityApplicationConstants.Authenticator.OIDC.QUERY_PARAMS.equals
+                        (oidcAuthenticatorProperty.getName())
+                        && oidcAuthenticatorProperty.getValue().contains("scope=")) {
+                    queryParamsScopesFilled = true;
+                }
+            }
+            if (scopesFieldFilled && queryParamsScopesFilled) {
+                Constants.ErrorMessage error = Constants.ErrorMessage.ERROR_CODE_DUPLICATE_OIDC_SCOPES;
+                throw new IdentityProviderManagementClientException(error.getCode(), error.getDescription());
+            }
+        }
+    }
+
+    /**
+     * Verify if scopes contain `openid`.
+     *
+     * @param oidcAuthenticatorProperties Authenticator properties of OIDC authenticator.
+     */
+    private static void validateDefaultOpenIDConnectScopes(List<Property> oidcAuthenticatorProperties)
+            throws IdentityProviderManagementClientException {
+
+        if (oidcAuthenticatorProperties != null) {
+            for (Property oidcAuthenticatorProperty : oidcAuthenticatorProperties) {
+                if (IdentityApplicationConstants.Authenticator.OIDC.SCOPES.equals(
+                        oidcAuthenticatorProperty.getName())) {
+                    String scopes = oidcAuthenticatorProperty.getValue();
+                    if (StringUtils.isNotBlank(scopes) && !scopes.contains("openid")) {
+                        Constants.ErrorMessage error = Constants.ErrorMessage.ERROR_CODE_INVALID_OIDC_SCOPES;
+                        throw new IdentityProviderManagementClientException(error.getCode(), error.getDescription());
+                    }
+                }
+            }
+        }
+    }
+
+    static boolean areAllDistinct(List<Property> properties) {
+        return properties.stream()
+                .map(Property::getName)
+                .distinct().count() == properties.size();
+    }
+
+    private static Function<org.wso2.carbon.identity.api.server.idp.v1.model.Property, Property> propertyToInternal
+            = apiProperty -> {
+
+        Property property = new Property();
+        property.setName(apiProperty.getKey());
+        property.setValue(apiProperty.getValue());
+        if (StringUtils.equals(GOOGLE_PRIVATE_KEY, apiProperty.getKey())) {
+            property.setType(IdentityApplicationConstants.ConfigElements.PROPERTY_TYPE_BLOB);
+        }
+        return property;
+    };
+
+    private static Function<Property, org.wso2.carbon.identity.api.server.idp.v1.model.Property> propertyToExternal
+            = property -> {
+
+        org.wso2.carbon.identity.api.server.idp.v1.model.Property apiProperty = new org.wso2.carbon.identity.api
+                .server.idp.v1.model.Property();
+        apiProperty.setKey(property.getName());
+        apiProperty.setValue(property.getValue());
+        return apiProperty;
+    };
+
+    /**
+     * Returns the 'DisplayName' property of the federated authenticator identified by authenticator name.
+     *
+     * @param authenticatorName Federated authenticator name.
+     * @return Display name of authenticator.
+     */
+    private static String getDisplayNameOfAuthenticator(String authenticatorName)
+            throws IdentityProviderManagementClientException {
+
+        try {
+            FederatedAuthenticatorConfig[] authenticatorConfigs =
+                    IdentityProviderServiceHolder.getIdentityProviderManager()
+                            .getAllFederatedAuthenticators();
+            for (FederatedAuthenticatorConfig config : authenticatorConfigs) {
+
+                if (StringUtils.equals(config.getName(), authenticatorName)) {
+                    return config.getDisplayName();
+                }
+            }
+        } catch (IdentityProviderManagementException e) {
+            Constants.ErrorMessage error = Constants.ErrorMessage.ERROR_CODE_ERROR_ADDING_IDP;
+            throw new IdentityProviderManagementClientException(error.getCode(), error.getDescription());
+        }
+        return null;
+    }
+
+    private static void resolveEndpointConfiguration(FederatedAuthenticator authenticator,
+             FederatedAuthenticatorConfig config) throws IdentityProviderManagementServerException {
+
+        try {
+            UserDefinedFederatedAuthenticatorConfig userDefinedConfig =
+                    (UserDefinedFederatedAuthenticatorConfig) config;
+            UserDefinedAuthenticatorEndpointConfig endpointConfig = userDefinedConfig.getEndpointConfig();
+
+            AuthenticationType authenticationType = new AuthenticationType();
+            authenticationType.setType(AuthenticationType.TypeEnum.fromValue(endpointConfig.getEndpointConfig()
+                    .getAuthentication().getType().toString()));
+
+            Endpoint endpoint = new Endpoint();
+            endpoint.setUri(endpointConfig.getEndpointConfig().getUri());
+            authenticator.setEndpoint(endpoint);
+        } catch (ClassCastException e) {
+            throw new IdentityProviderManagementServerException(String.format("Error occurred while resolving" +
+                    " endpoint configuration of the authenticator %s.", authenticator.getName()), e);
+        }
+    }
+
+    /**
+     * Config class to build FederatedAuthenticatorConfig.
+     */
+    public static class Config {
+        private final DefinedByType definedByType;
+        private final String authenticatorName;
+        private final String displayName;
+        private final Endpoint endpoint;
+        private final List<Property> properties;
+        private final Boolean isEnabled;
+
+        public Config(String authenticatorName, String displayName, Endpoint endpoint,
+                      List<Property> properties, Boolean isEnabled, DefinedByType definedByType) {
 
             this.authenticatorName = authenticatorName;
-            return this;
-        }
-
-        public Builder displayName(String displayName) {
-
             this.displayName = displayName;
-            return this;
-        }
-
-        public Builder endpoint(Endpoint endpoint) {
-
             this.endpoint = endpoint;
-            return this;
-        }
-
-        public Builder properties(List<Property> properties) {
-
             this.properties = properties;
-            return this;
-        }
-
-        public Builder enabled(Boolean enabled) {
-
-            isEnabled = enabled;
-            return this;
-        }
-
-        public FederatedAuthenticatorConfig build() throws IdentityProviderManagementClientException {
-
-            return FederatedAuthenticatorConfigBuilderFactory.createFederatedAuthenticatorConfig(this);
+            this.isEnabled = isEnabled;
+            this.definedByType = definedByType;
         }
     }
 }

--- a/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/main/java/org/wso2/carbon/identity/api/server/idp/v1/impl/FederatedAuthenticatorConfigBuilderFactory.java
+++ b/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/main/java/org/wso2/carbon/identity/api/server/idp/v1/impl/FederatedAuthenticatorConfigBuilderFactory.java
@@ -405,9 +405,11 @@ public class FederatedAuthenticatorConfigBuilderFactory {
             AuthenticationType authenticationType = new AuthenticationType();
             authenticationType.setType(AuthenticationType.TypeEnum.fromValue(endpointConfig.getEndpointConfig()
                     .getAuthentication().getType().toString()));
+            authenticationType.setProperties(null);
 
             Endpoint endpoint = new Endpoint();
             endpoint.setUri(endpointConfig.getEndpointConfig().getUri());
+            endpoint.setAuthentication(authenticationType);
             authenticator.setEndpoint(endpoint);
         } catch (ClassCastException e) {
             throw new IdentityProviderManagementServerException(String.format("Error occurred while resolving" +

--- a/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/main/java/org/wso2/carbon/identity/api/server/idp/v1/impl/FederatedAuthenticatorConfigBuilderFactory.java
+++ b/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/main/java/org/wso2/carbon/identity/api/server/idp/v1/impl/FederatedAuthenticatorConfigBuilderFactory.java
@@ -20,7 +20,6 @@ package org.wso2.carbon.identity.api.server.idp.v1.impl;
 
 import org.wso2.carbon.identity.api.server.idp.common.Constants;
 import org.wso2.carbon.identity.api.server.idp.v1.model.Endpoint;
-import org.wso2.carbon.identity.application.common.ApplicationAuthenticatorService;
 import org.wso2.carbon.identity.application.common.model.FederatedAuthenticatorConfig;
 import org.wso2.carbon.identity.application.common.model.Property;
 import org.wso2.carbon.identity.application.common.model.UserDefinedAuthenticatorEndpointConfig;
@@ -42,7 +41,7 @@ public class FederatedAuthenticatorConfigBuilderFactory {
             throws IdentityProviderManagementClientException {
 
         FederatedAuthenticatorConfig config;
-        if (DefinedByType.SYSTEM.toString().equals(builder.definedByType)) {
+        if (DefinedByType.SYSTEM == builder.definedByType) {
             config = createSystemDefinedFederatedAuthenticator(builder);
         } else {
             config = createUserDefinedFederatedAuthenticator(builder);
@@ -74,14 +73,6 @@ public class FederatedAuthenticatorConfigBuilderFactory {
             throw new IdentityProviderManagementClientException(error.getCode(), String.format(error.getDescription(),
                     builder.authenticatorName));
         }
-
-        // Check if there is an authenticator registered in the system for the given authenticator ID.
-        if (ApplicationAuthenticatorService.getInstance()
-                .getFederatedAuthenticatorByName(builder.authenticatorName) == null) {
-            Constants.ErrorMessage error = Constants.ErrorMessage.ERROR_CODE_NO_SYSTEM_AUTHENTICATOR_FOUND;
-            throw new IdentityProviderManagementClientException(error.getCode(),
-                    String.format(error.getDescription(), builder.authenticatorName));
-        }
     }
 
     private static UserDefinedFederatedAuthenticatorConfig createUserDefinedFederatedAuthenticator(Builder builder)
@@ -106,7 +97,7 @@ public class FederatedAuthenticatorConfigBuilderFactory {
             throws IdentityProviderManagementClientException {
 
         // The User-defined authenticator configs must not have properties configurations; throw an error if they do.
-        if (builder.properties == null || !builder.properties.isEmpty()) {
+        if (builder.properties != null) {
             Constants.ErrorMessage error = Constants.ErrorMessage.ERROR_CODE_PROPERTIES_PROVIDED_FOR_USER_AUTH;
             throw new IdentityProviderManagementClientException(error.getCode(),
                     String.format(error.getDescription(), builder.authenticatorName));
@@ -124,14 +115,14 @@ public class FederatedAuthenticatorConfigBuilderFactory {
      * Builder class to build FederatedAuthenticatorConfig.
      */
     public static class Builder {
-        private String definedByType;
+        private DefinedByType definedByType;
         private String authenticatorName;
         private String displayName;
         private Endpoint endpoint;
         private List<Property> properties;
         private Boolean isEnabled;
 
-        public Builder definedByType(String definedByType) {
+        public Builder definedByType(DefinedByType definedByType) {
 
             this.definedByType = definedByType;
             return this;

--- a/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/main/java/org/wso2/carbon/identity/api/server/idp/v1/impl/FederatedAuthenticatorConfigBuilderFactory.java
+++ b/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/main/java/org/wso2/carbon/identity/api/server/idp/v1/impl/FederatedAuthenticatorConfigBuilderFactory.java
@@ -1,0 +1,175 @@
+/*
+ * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.idp.v1.impl;
+
+import org.wso2.carbon.identity.api.server.idp.common.Constants;
+import org.wso2.carbon.identity.api.server.idp.v1.model.Endpoint;
+import org.wso2.carbon.identity.application.common.ApplicationAuthenticatorService;
+import org.wso2.carbon.identity.application.common.model.FederatedAuthenticatorConfig;
+import org.wso2.carbon.identity.application.common.model.Property;
+import org.wso2.carbon.identity.application.common.model.UserDefinedAuthenticatorEndpointConfig;
+import org.wso2.carbon.identity.application.common.model.UserDefinedFederatedAuthenticatorConfig;
+import org.wso2.carbon.identity.base.AuthenticatorPropertyConstants.DefinedByType;
+import org.wso2.carbon.idp.mgt.IdentityProviderManagementClientException;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * The factory class for creating instances of FederatedAuthenticatorConfig depending on the definedBy type.
+ * Returns FederatedAuthenticatorConfig for SYSTEM types and UserDefinedFederatedAuthenticatorConfig for USER types.
+ */
+public class FederatedAuthenticatorConfigBuilderFactory {
+
+    private static FederatedAuthenticatorConfig createFederatedAuthenticatorConfig(Builder builder)
+            throws IdentityProviderManagementClientException {
+
+        FederatedAuthenticatorConfig config;
+        if (DefinedByType.SYSTEM.toString().equals(builder.definedByType)) {
+            config = createSystemDefinedFederatedAuthenticator(builder);
+        } else {
+            config = createUserDefinedFederatedAuthenticator(builder);
+        }
+
+        config.setName(builder.authenticatorName);
+        config.setDisplayName(builder.displayName);
+        config.setEnabled(builder.isEnabled);
+
+        return config;
+    }
+
+    private static FederatedAuthenticatorConfig createSystemDefinedFederatedAuthenticator(
+            Builder builder) throws IdentityProviderManagementClientException {
+
+        validateSystemDefinedFederatedAuthenticatorModel(builder);
+        FederatedAuthenticatorConfig authConfig = new FederatedAuthenticatorConfig();
+        authConfig.setDefinedByType(DefinedByType.SYSTEM);
+        authConfig.setProperties(builder.properties.toArray(new Property[0]));
+        return authConfig;
+    }
+
+    private static void validateSystemDefinedFederatedAuthenticatorModel(Builder builder)
+            throws IdentityProviderManagementClientException {
+
+        // The System-defined authenticator configs must not have endpoint configurations; throw an error if they do.
+        if (builder.endpoint != null) {
+            Constants.ErrorMessage error = Constants.ErrorMessage.ERROR_CODE_ENDPOINT_PROVIDED_FOR_SYSTEM_AUTH;
+            throw new IdentityProviderManagementClientException(error.getCode(), String.format(error.getDescription(),
+                    builder.authenticatorName));
+        }
+
+        // Check if there is an authenticator registered in the system for the given authenticator ID.
+        if (ApplicationAuthenticatorService.getInstance()
+                .getFederatedAuthenticatorByName(builder.authenticatorName) == null) {
+            Constants.ErrorMessage error = Constants.ErrorMessage.ERROR_CODE_NO_SYSTEM_AUTHENTICATOR_FOUND;
+            throw new IdentityProviderManagementClientException(error.getCode(),
+                    String.format(error.getDescription(), builder.authenticatorName));
+        }
+    }
+
+    private static UserDefinedFederatedAuthenticatorConfig createUserDefinedFederatedAuthenticator(Builder builder)
+            throws IdentityProviderManagementClientException {
+
+        validateUserDefinedFederatedAuthenticatorModel(builder);
+
+        UserDefinedFederatedAuthenticatorConfig authConfig = new UserDefinedFederatedAuthenticatorConfig();
+        UserDefinedAuthenticatorEndpointConfig.UserDefinedAuthenticatorEndpointConfigBuilder endpointConfigBuilder =
+                new UserDefinedAuthenticatorEndpointConfig.UserDefinedAuthenticatorEndpointConfigBuilder();
+        endpointConfigBuilder.uri(builder.endpoint.getUri());
+        endpointConfigBuilder.authenticationType(builder.endpoint.getAuthentication().getType().toString());
+        endpointConfigBuilder.authenticationProperties(builder.endpoint.getAuthentication().getProperties()
+                .entrySet().stream().collect(Collectors.toMap(
+                        Map.Entry::getKey, entry -> entry.getValue().toString())));
+        authConfig.setEndpointConfig(endpointConfigBuilder.build());
+
+        return authConfig;
+    }
+
+    private static void validateUserDefinedFederatedAuthenticatorModel(Builder builder)
+            throws IdentityProviderManagementClientException {
+
+        // The User-defined authenticator configs must not have properties configurations; throw an error if they do.
+        if (builder.properties == null || !builder.properties.isEmpty()) {
+            Constants.ErrorMessage error = Constants.ErrorMessage.ERROR_CODE_PROPERTIES_PROVIDED_FOR_USER_AUTH;
+            throw new IdentityProviderManagementClientException(error.getCode(),
+                    String.format(error.getDescription(), builder.authenticatorName));
+        }
+
+        // The User-defined authenticator configs must have endpoint configurations; throw an error if they don't.
+        if (builder.endpoint == null) {
+            Constants.ErrorMessage error = Constants.ErrorMessage.ERROR_CODE_NO_ENDPOINT_PROVIDED;
+            throw new IdentityProviderManagementClientException(error.getCode(),
+                    String.format(error.getDescription(), builder.authenticatorName));
+        }
+    }
+
+    /**
+     * Builder class to build FederatedAuthenticatorConfig.
+     */
+    public static class Builder {
+        private String definedByType;
+        private String authenticatorName;
+        private String displayName;
+        private Endpoint endpoint;
+        private List<Property> properties;
+        private Boolean isEnabled;
+
+        public Builder definedByType(String definedByType) {
+
+            this.definedByType = definedByType;
+            return this;
+        }
+
+        public Builder authenticatorName(String authenticatorName) {
+
+            this.authenticatorName = authenticatorName;
+            return this;
+        }
+
+        public Builder displayName(String displayName) {
+
+            this.displayName = displayName;
+            return this;
+        }
+
+        public Builder endpoint(Endpoint endpoint) {
+
+            this.endpoint = endpoint;
+            return this;
+        }
+
+        public Builder properties(List<Property> properties) {
+
+            this.properties = properties;
+            return this;
+        }
+
+        public Builder enabled(Boolean enabled) {
+
+            isEnabled = enabled;
+            return this;
+        }
+
+        public FederatedAuthenticatorConfig build() throws IdentityProviderManagementClientException {
+
+            return FederatedAuthenticatorConfigBuilderFactory.createFederatedAuthenticatorConfig(this);
+        }
+    }
+}

--- a/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/main/java/org/wso2/carbon/identity/api/server/idp/v1/impl/FederatedAuthenticatorConfigBuilderFactory.java
+++ b/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/main/java/org/wso2/carbon/identity/api/server/idp/v1/impl/FederatedAuthenticatorConfigBuilderFactory.java
@@ -197,7 +197,7 @@ public class FederatedAuthenticatorConfigBuilderFactory {
             authConfig.setEndpointConfig(endpointConfigBuilder.build());
 
             return authConfig;
-        } catch (NoSuchElementException e) {
+        } catch (NoSuchElementException | IllegalArgumentException e) {
             throw new IdentityProviderManagementClientException(Constants.ErrorMessage
                     .ERROR_CODE_INVALID_INPUT.getCode(), e.getMessage());
         }

--- a/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/main/resources/idp.yaml
+++ b/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/main/resources/idp.yaml
@@ -2895,7 +2895,6 @@ components:
       type: object
       required:
         - type
-        - properties
       properties:
         type:
           type: string

--- a/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/main/resources/idp.yaml
+++ b/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/main/resources/idp.yaml
@@ -2825,7 +2825,6 @@ components:
           items:
             $ref: '#/components/schemas/MetaProperty'
         endpoint:
-          endpoint:
           $ref: '#/components/schemas/Endpoint'
     FederatedAuthenticatorRequest:
       type: object
@@ -2884,6 +2883,9 @@ components:
           $ref: '#/components/schemas/Endpoint'
     Endpoint:
       type: object
+      required:
+        - uri
+        - authentication
       properties:
         uri:
           type: string

--- a/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/main/resources/idp.yaml
+++ b/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/main/resources/idp.yaml
@@ -2824,6 +2824,9 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/MetaProperty'
+        endpoint:
+          endpoint:
+          $ref: '#/components/schemas/Endpoint'
     FederatedAuthenticatorRequest:
       type: object
       required:
@@ -2877,6 +2880,37 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/Property'
+        endpoint:
+          $ref: '#/components/schemas/Endpoint'
+    Endpoint:
+      type: object
+      properties:
+        uri:
+          type: string
+          example: https://abc.com/token
+          pattern: '^https?://.+'
+        authentication:
+          $ref: '#/components/schemas/AuthenticationType'
+    AuthenticationType:
+      type: object
+      required:
+        - type
+        - properties
+      properties:
+        type:
+          type: string
+          enum:
+            - NONE
+            - BEARER
+            - API_KEY
+            - BASIC
+          example: BASIC
+        properties:
+          type: object
+          additionalProperties: true
+          example:
+            username: "auth_username"
+            password: "auth_password"
     FederatedAuthenticatorPUTRequest:
       type: object
       properties:
@@ -2905,6 +2939,8 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/Property'
+        endpoint:
+          $ref: '#/components/schemas/Endpoint'
     FederatedAuthenticatorListResponse:
       type: object
       properties:

--- a/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/main/resources/idp.yaml
+++ b/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/main/resources/idp.yaml
@@ -2824,8 +2824,6 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/MetaProperty'
-        endpoint:
-          $ref: '#/components/schemas/Endpoint'
     FederatedAuthenticatorRequest:
       type: object
       required:

--- a/pom.xml
+++ b/pom.xml
@@ -809,7 +809,7 @@
         <maven.buildnumber.plugin.version>1.4</maven.buildnumber.plugin.version>
         <org.apache.felix.annotations.version>1.2.4</org.apache.felix.annotations.version>
         <identity.governance.version>1.11.11</identity.governance.version>
-        <carbon.identity.framework.version>7.5.117</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.5.121-SNAPSHOT</carbon.identity.framework.version>
         <maven.findbugsplugin.version>3.0.5</maven.findbugsplugin.version>
         <findsecbugs-plugin.version>1.12.0</findsecbugs-plugin.version>
         <maven.checkstyleplugin.excludes>**/gen/**/*</maven.checkstyleplugin.excludes>

--- a/pom.xml
+++ b/pom.xml
@@ -821,7 +821,7 @@
         <maven.buildnumber.plugin.version>1.4</maven.buildnumber.plugin.version>
         <org.apache.felix.annotations.version>1.2.4</org.apache.felix.annotations.version>
         <identity.governance.version>1.11.11</identity.governance.version>
-        <carbon.identity.framework.version>7.7.12</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.7.16</carbon.identity.framework.version>
         <maven.findbugsplugin.version>3.0.5</maven.findbugsplugin.version>
         <findsecbugs-plugin.version>1.12.0</findsecbugs-plugin.version>
         <maven.checkstyleplugin.excludes>**/gen/**/*</maven.checkstyleplugin.excludes>


### PR DESCRIPTION
Issue: 
- https://github.com/wso2/product-is/issues/21216

This PR introduces improvements to the following APIs for managing user-defined federated authenticators:
- /identity-providers: Updated the request body for the PUT request to accept both authenticator configuration models.
- /identity-providers/{identity-provider-id}/federated-authenticators: Updated the request body for the PUT request to accept both authenticator configuration models.
- /identity-providers/{identity-provider-id}/federated-authenticators/{federated-authenticator-id}: Updated the response and request bodies for both GET and PUT requests to accommodate both models.

Service layer PR:
- https://github.com/wso2/carbon-identity-framework/pull/6105