### PR TITLE
Add UniquenessScope as a first class property for claim management

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.claim.management/org.wso2.carbon.identity.api.server.claim.management.common/src/main/java/org/wso2/carbon/identity/api/server/claim/management/common/Constant.java
+++ b/components/org.wso2.carbon.identity.api.server.claim.management/org.wso2.carbon.identity.api.server.claim.management.common/src/main/java/org/wso2/carbon/identity/api/server/claim/management/common/Constant.java
@@ -278,4 +278,5 @@ public class Constant {
     public static final String PROP_REG_EX = "RegEx";
     public static final String PROP_REQUIRED = "Required";
     public static final String PROP_SUPPORTED_BY_DEFAULT = "SupportedByDefault";
+    public static final String PROP_UNIQUENESS_SCOPE = "UniquenessScope";
 }

--- a/components/org.wso2.carbon.identity.api.server.claim.management/org.wso2.carbon.identity.rest.api.server.claim.management.v1/src/gen/java/org/wso2/carbon/identity/rest/api/server/claim/management/v1/dto/LocalClaimReqDTO.java
+++ b/components/org.wso2.carbon.identity.api.server.claim.management/org.wso2.carbon.identity.rest.api.server.claim.management.v1/src/gen/java/org/wso2/carbon/identity/rest/api/server/claim/management/v1/dto/LocalClaimReqDTO.java
@@ -60,6 +60,12 @@ public class LocalClaimReqDTO {
     @Valid 
     private Boolean supportedByDefault = null;
 
+    public enum UniquenessScopeEnum {
+         NONE,  WITHIN_USERSTORE,  ACROSS_USERSTORES, 
+    };
+    @Valid 
+    private UniquenessScopeEnum uniquenessScope = null;
+
     @Valid 
     @NotNull(message = "Property attributeMapping cannot be null.") 
     private List<AttributeMappingDTO> attributeMapping = new ArrayList<AttributeMappingDTO>();
@@ -164,6 +170,18 @@ public class LocalClaimReqDTO {
     }
 
     /**
+    * Specifies the scope of uniqueness validation for the claim value.
+    **/
+    @ApiModelProperty(value = "Specifies the scope of uniqueness validation for the claim value.")
+    @JsonProperty("uniquenessScope")
+    public UniquenessScopeEnum getUniquenessScope() {
+        return uniquenessScope;
+    }
+    public void setUniquenessScope(UniquenessScopeEnum uniquenessScope) {
+        this.uniquenessScope = uniquenessScope;
+    }
+
+    /**
     * Userstore attribute mappings.
     **/
     @ApiModelProperty(required = true, value = "Userstore attribute mappings.")
@@ -201,6 +219,7 @@ public class LocalClaimReqDTO {
         sb.append("    regEx: ").append(regEx).append("\n");
         sb.append("    required: ").append(required).append("\n");
         sb.append("    supportedByDefault: ").append(supportedByDefault).append("\n");
+        sb.append("    uniquenessScope: ").append(uniquenessScope).append("\n");
         sb.append("    attributeMapping: ").append(attributeMapping).append("\n");
         sb.append("    properties: ").append(properties).append("\n");
         

--- a/components/org.wso2.carbon.identity.api.server.claim.management/org.wso2.carbon.identity.rest.api.server.claim.management.v1/src/gen/java/org/wso2/carbon/identity/rest/api/server/claim/management/v1/dto/LocalClaimResDTO.java
+++ b/components/org.wso2.carbon.identity.api.server.claim.management/org.wso2.carbon.identity.rest.api.server.claim.management.v1/src/gen/java/org/wso2/carbon/identity/rest/api/server/claim/management/v1/dto/LocalClaimResDTO.java
@@ -20,6 +20,7 @@ import io.swagger.annotations.ApiModel;
 import java.util.ArrayList;
 import java.util.List;
 import org.wso2.carbon.identity.rest.api.server.claim.management.v1.dto.AttributeMappingDTO;
+import org.wso2.carbon.identity.rest.api.server.claim.management.v1.dto.ClaimResDTO;
 import org.wso2.carbon.identity.rest.api.server.claim.management.v1.dto.PropertyDTO;
 import io.swagger.annotations.*;
 import com.fasterxml.jackson.annotation.*;
@@ -63,6 +64,12 @@ public class LocalClaimResDTO extends ClaimResDTO {
 
     @Valid 
     private Boolean supportedByDefault = null;
+
+    public enum UniquenessScopeEnum {
+         NONE,  WITHIN_USERSTORE,  ACROSS_USERSTORES, 
+    };
+    @Valid 
+    private UniquenessScopeEnum uniquenessScope = null;
 
     @Valid 
     private List<AttributeMappingDTO> attributeMapping = new ArrayList<AttributeMappingDTO>();
@@ -191,6 +198,18 @@ public class LocalClaimResDTO extends ClaimResDTO {
     }
 
     /**
+    * Specifies the scope of uniqueness validation for the claim value.
+    **/
+    @ApiModelProperty(value = "Specifies the scope of uniqueness validation for the claim value.")
+    @JsonProperty("uniquenessScope")
+    public UniquenessScopeEnum getUniquenessScope() {
+        return uniquenessScope;
+    }
+    public void setUniquenessScope(UniquenessScopeEnum uniquenessScope) {
+        this.uniquenessScope = uniquenessScope;
+    }
+
+    /**
     * Userstore attribute mappings.
     **/
     @ApiModelProperty(value = "Userstore attribute mappings.")
@@ -231,6 +250,7 @@ public class LocalClaimResDTO extends ClaimResDTO {
         sb.append("    regEx: ").append(regEx).append("\n");
         sb.append("    required: ").append(required).append("\n");
         sb.append("    supportedByDefault: ").append(supportedByDefault).append("\n");
+        sb.append("    uniquenessScope: ").append(uniquenessScope).append("\n");
         sb.append("    attributeMapping: ").append(attributeMapping).append("\n");
         sb.append("    properties: ").append(properties).append("\n");
         

--- a/components/org.wso2.carbon.identity.api.server.claim.management/org.wso2.carbon.identity.rest.api.server.claim.management.v1/src/main/java/org/wso2/carbon/identity/rest/api/server/claim/management/v1/core/ServerClaimManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.claim.management/org.wso2.carbon.identity.rest.api.server.claim.management.v1/src/main/java/org/wso2/carbon/identity/rest/api/server/claim/management/v1/core/ServerClaimManagementService.java
@@ -130,6 +130,7 @@ import static org.wso2.carbon.identity.api.server.claim.management.common.Consta
 import static org.wso2.carbon.identity.api.server.claim.management.common.Constant.PROP_REG_EX;
 import static org.wso2.carbon.identity.api.server.claim.management.common.Constant.PROP_REQUIRED;
 import static org.wso2.carbon.identity.api.server.claim.management.common.Constant.PROP_SUPPORTED_BY_DEFAULT;
+import static org.wso2.carbon.identity.api.server.claim.management.common.Constant.PROP_UNIQUENESS_SCOPE;
 import static org.wso2.carbon.identity.api.server.common.Constants.JSON_FILE_EXTENSION;
 import static org.wso2.carbon.identity.api.server.common.Constants.MEDIA_TYPE_JSON;
 import static org.wso2.carbon.identity.api.server.common.Constants.MEDIA_TYPE_XML;
@@ -994,6 +995,15 @@ public class ServerClaimManagementService {
         localClaimResDTO.setRequired(Boolean.valueOf(claimProperties.remove(PROP_REQUIRED)));
         localClaimResDTO.setSupportedByDefault(Boolean.valueOf(claimProperties.remove(PROP_SUPPORTED_BY_DEFAULT)));
 
+        String uniquenessScope = claimProperties.remove(PROP_UNIQUENESS_SCOPE);
+        if (StringUtils.isNotBlank(uniquenessScope)) {
+            try {
+                localClaimResDTO.setUniquenessScope(LocalClaimResDTO.UniquenessScopeEnum.valueOf(uniquenessScope));
+            } catch (IllegalArgumentException e) {
+                localClaimResDTO.setUniquenessScope(LocalClaimResDTO.UniquenessScopeEnum.NONE);
+            }
+        }
+
         List<AttributeMappingDTO> attributeMappingDTOs = new ArrayList<>();
         for (AttributeMapping attributeMapping : localClaim.getMappedAttributes()) {
             AttributeMappingDTO attributeMappingDTO = new AttributeMappingDTO();
@@ -1040,6 +1050,10 @@ public class ServerClaimManagementService {
             claimProperties.put(PROP_DISPLAY_ORDER, String.valueOf(localClaimReqDTO.getDisplayOrder()));
         } else {
             claimProperties.put(PROP_DISPLAY_ORDER, "0");
+        }
+
+        if (localClaimReqDTO.getUniquenessScope() != null) {
+            claimProperties.put(PROP_UNIQUENESS_SCOPE, localClaimReqDTO.getUniquenessScope().toString());
         }
 
         claimProperties.put(PROP_READ_ONLY, String.valueOf(localClaimReqDTO.getReadOnly()));

--- a/components/org.wso2.carbon.identity.api.server.claim.management/org.wso2.carbon.identity.rest.api.server.claim.management.v1/src/main/resources/claim-management.yaml
+++ b/components/org.wso2.carbon.identity.api.server.claim.management/org.wso2.carbon.identity.rest.api.server.claim.management.v1/src/main/resources/claim-management.yaml
@@ -736,6 +736,14 @@ definitions:
         type: boolean
         description: Specifies if the claim will be prompted during user registration and displayed on the user profile.
         example: true
+      uniquenessScope:
+        type: string
+        description: Specifies the scope of uniqueness validation for the claim value.
+        enum:
+          - NONE
+          - WITHIN_USERSTORE
+          - ACROSS_USERSTORES
+        example: "NONE"
       attributeMapping:
         type: array
         description: Userstore attribute mappings.
@@ -796,6 +804,14 @@ definitions:
             type: boolean
             description: Specifies if the claim will be prompted during user registration and displayed on the user profile.
             example: true
+          uniquenessScope:
+            type: string
+            description: Specifies the scope of uniqueness validation for the claim value.
+            enum:
+              - NONE
+              - WITHIN_USERSTORE
+              - ACROSS_USERSTORES
+            example: "NONE"
           attributeMapping:
             type: array
             description: Userstore attribute mappings.

--- a/pom.xml
+++ b/pom.xml
@@ -809,7 +809,7 @@
         <maven.buildnumber.plugin.version>1.4</maven.buildnumber.plugin.version>
         <org.apache.felix.annotations.version>1.2.4</org.apache.felix.annotations.version>
         <identity.governance.version>1.11.11</identity.governance.version>
-        <carbon.identity.framework.version>7.5.117</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.7.24</carbon.identity.framework.version>
         <maven.findbugsplugin.version>3.0.5</maven.findbugsplugin.version>
         <findsecbugs-plugin.version>1.12.0</findsecbugs-plugin.version>
         <maven.checkstyleplugin.excludes>**/gen/**/*</maven.checkstyleplugin.excludes>


### PR DESCRIPTION
## Purpose

Add UniquenessScope as a first class property for claim management. Note that this property is implemented in an optional manner.

### To be merged after :
- https://github.com/wso2/carbon-identity-framework/pull/6113

### Related PR : 
- https://github.com/wso2/identity-apps/pull/7106




