### PR TITLE
Modify getActionsByActionType API response

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.action.management/org.wso2.carbon.identity.api.server.action.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/action/management/v1/ActionBasicResponse.java
+++ b/components/org.wso2.carbon.identity.api.server.action.management/org.wso2.carbon.identity.api.server.action.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/action/management/v1/ActionBasicResponse.java
@@ -22,7 +22,10 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import java.util.ArrayList;
+import java.util.List;
 import org.wso2.carbon.identity.api.server.action.management.v1.ActionType;
+import org.wso2.carbon.identity.api.server.action.management.v1.Link;
 import javax.validation.constraints.*;
 
 
@@ -71,6 +74,8 @@ public enum StatusEnum {
 }
 
     private StatusEnum status;
+    private List<Link> links = null;
+
 
     /**
     **/
@@ -162,7 +167,33 @@ public enum StatusEnum {
         this.status = status;
     }
 
+    /**
+    **/
+    public ActionBasicResponse links(List<Link> links) {
 
+        this.links = links;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "[{\"href\":\"/t/wso2.com/api/server/v1/actions/preIssueAccessToken/24f64d17-9824-4e28-8413-de45728d8e84\",\"method\":\"GET\",\"rel\":\"self\"}]", value = "")
+    @JsonProperty("links")
+    @Valid
+    public List<Link> getLinks() {
+        return links;
+    }
+    public void setLinks(List<Link> links) {
+        this.links = links;
+    }
+
+    public ActionBasicResponse addLinksItem(Link linksItem) {
+        if (this.links == null) {
+            this.links = new ArrayList<Link>();
+        }
+        this.links.add(linksItem);
+        return this;
+    }
+
+    
 
     @Override
     public boolean equals(java.lang.Object o) {
@@ -178,12 +209,13 @@ public enum StatusEnum {
             Objects.equals(this.type, actionBasicResponse.type) &&
             Objects.equals(this.name, actionBasicResponse.name) &&
             Objects.equals(this.description, actionBasicResponse.description) &&
-            Objects.equals(this.status, actionBasicResponse.status);
+            Objects.equals(this.status, actionBasicResponse.status) &&
+            Objects.equals(this.links, actionBasicResponse.links);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, type, name, description, status);
+        return Objects.hash(id, type, name, description, status, links);
     }
 
     @Override
@@ -197,6 +229,7 @@ public enum StatusEnum {
         sb.append("    name: ").append(toIndentedString(name)).append("\n");
         sb.append("    description: ").append(toIndentedString(description)).append("\n");
         sb.append("    status: ").append(toIndentedString(status)).append("\n");
+        sb.append("    links: ").append(toIndentedString(links)).append("\n");
         sb.append("}");
         return sb.toString();
     }

--- a/components/org.wso2.carbon.identity.api.server.action.management/org.wso2.carbon.identity.api.server.action.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/action/management/v1/ActionsApi.java
+++ b/components/org.wso2.carbon.identity.api.server.action.management/org.wso2.carbon.identity.api.server.action.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/action/management/v1/ActionsApi.java
@@ -199,14 +199,14 @@ public class ActionsApi  {
     @Path("/{actionType}")
     
     @Produces({ "application/json" })
-    @ApiOperation(value = "List action ", notes = "This API provides the capability to retrieve the action by action type.<br>   <b>Scope required:</b> <br>       * internal_action_mgt_view ", response = ActionResponse.class, responseContainer = "List", authorizations = {
+    @ApiOperation(value = "List action ", notes = "This API provides the capability to retrieve the action by action type.<br>   <b>Scope required:</b> <br>       * internal_action_mgt_view ", response = ActionBasicResponse.class, responseContainer = "List", authorizations = {
         @Authorization(value = "BasicAuth"),
         @Authorization(value = "OAuth2", scopes = {
             
         })
     }, tags={ "Actions", })
     @ApiResponses(value = { 
-        @ApiResponse(code = 200, message = "OK", response = ActionResponse.class, responseContainer = "List"),
+        @ApiResponse(code = 200, message = "OK", response = ActionBasicResponse.class, responseContainer = "List"),
         @ApiResponse(code = 400, message = "Bad Request", response = Error.class),
         @ApiResponse(code = 401, message = "Unauthorized", response = Void.class),
         @ApiResponse(code = 403, message = "Forbidden", response = Void.class),

--- a/components/org.wso2.carbon.identity.api.server.action.management/org.wso2.carbon.identity.api.server.action.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/action/management/v1/Link.java
+++ b/components/org.wso2.carbon.identity.api.server.action.management/org.wso2.carbon.identity.api.server.action.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/action/management/v1/Link.java
@@ -1,0 +1,176 @@
+/*
+ * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.action.management.v1;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import javax.validation.constraints.*;
+
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+import javax.validation.Valid;
+import javax.xml.bind.annotation.*;
+
+public class Link  {
+  
+    private String href;
+
+@XmlType(name="MethodEnum")
+@XmlEnum(String.class)
+public enum MethodEnum {
+
+    @XmlEnumValue("GET") GET(String.valueOf("GET"));
+
+
+    private String value;
+
+    MethodEnum(String v) {
+        value = v;
+    }
+
+    public String value() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    public static MethodEnum fromValue(String value) {
+        for (MethodEnum b : MethodEnum.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
+}
+
+    private MethodEnum method;
+    private String rel;
+
+    /**
+    * Url of the endpoint.
+    **/
+    public Link href(String href) {
+
+        this.href = href;
+        return this;
+    }
+    
+    @ApiModelProperty(value = "Url of the endpoint.")
+    @JsonProperty("href")
+    @Valid
+    public String getHref() {
+        return href;
+    }
+    public void setHref(String href) {
+        this.href = href;
+    }
+
+    /**
+    * Http method.
+    **/
+    public Link method(MethodEnum method) {
+
+        this.method = method;
+        return this;
+    }
+    
+    @ApiModelProperty(value = "Http method.")
+    @JsonProperty("method")
+    @Valid
+    public MethodEnum getMethod() {
+        return method;
+    }
+    public void setMethod(MethodEnum method) {
+        this.method = method;
+    }
+
+    /**
+    * Relation to the resource.
+    **/
+    public Link rel(String rel) {
+
+        this.rel = rel;
+        return this;
+    }
+    
+    @ApiModelProperty(value = "Relation to the resource.")
+    @JsonProperty("rel")
+    @Valid
+    public String getRel() {
+        return rel;
+    }
+    public void setRel(String rel) {
+        this.rel = rel;
+    }
+
+
+
+    @Override
+    public boolean equals(java.lang.Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Link link = (Link) o;
+        return Objects.equals(this.href, link.href) &&
+            Objects.equals(this.method, link.method) &&
+            Objects.equals(this.rel, link.rel);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(href, method, rel);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class Link {\n");
+        
+        sb.append("    href: ").append(toIndentedString(href)).append("\n");
+        sb.append("    method: ").append(toIndentedString(method)).append("\n");
+        sb.append("    rel: ").append(toIndentedString(rel)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+    * Convert the given object to string with each line indented by 4 spaces
+    * (except the first line).
+    */
+    private String toIndentedString(java.lang.Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}
+

--- a/components/org.wso2.carbon.identity.api.server.action.management/org.wso2.carbon.identity.api.server.action.management.v1/src/main/java/org/wso2/carbon/identity/api/server/action/management/v1/constants/ActionMgtEndpointConstants.java
+++ b/components/org.wso2.carbon.identity.api.server.action.management/org.wso2.carbon.identity.api.server.action.management.v1/src/main/java/org/wso2/carbon/identity/api/server/action/management/v1/constants/ActionMgtEndpointConstants.java
@@ -28,7 +28,7 @@ public class ActionMgtEndpointConstants {
 
     public static final String ACTION_MANAGEMENT_PREFIX = "ACTION-";
     public static final String ACTION_PATH_COMPONENT = "/actions";
-    public static final String PATH_CONSTANT = "/";
+    public static final String PATH_SEPARATOR = "/";
 
     /**
      * Enum for error messages.

--- a/components/org.wso2.carbon.identity.api.server.action.management/org.wso2.carbon.identity.api.server.action.management.v1/src/main/java/org/wso2/carbon/identity/api/server/action/management/v1/core/ServerActionManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.action.management/org.wso2.carbon.identity.api.server.action.management.v1/src/main/java/org/wso2/carbon/identity/api/server/action/management/v1/core/ServerActionManagementService.java
@@ -35,6 +35,8 @@ import org.wso2.carbon.identity.api.server.action.management.v1.ActionTypesRespo
 import org.wso2.carbon.identity.api.server.action.management.v1.ActionUpdateModel;
 import org.wso2.carbon.identity.api.server.action.management.v1.AuthenticationTypeResponse;
 import org.wso2.carbon.identity.api.server.action.management.v1.EndpointResponse;
+import org.wso2.carbon.identity.api.server.action.management.v1.Link;
+import org.wso2.carbon.identity.api.server.action.management.v1.constants.ActionMgtEndpointConstants;
 import org.wso2.carbon.identity.api.server.action.management.v1.util.ActionMgtEndpointUtil;
 
 import java.util.ArrayList;
@@ -79,7 +81,7 @@ public class ServerActionManagementService {
         }
     }
 
-    public List<ActionResponse> getActionsByActionType(String actionType) {
+    public List<ActionBasicResponse> getActionsByActionType(String actionType) {
 
         try {
             validateActionType(actionType);
@@ -87,11 +89,11 @@ public class ServerActionManagementService {
                     .getActionsByActionType(actionType,
                             CarbonContext.getThreadLocalCarbonContext().getTenantDomain());
 
-            List<ActionResponse> actionResponses = new ArrayList<>();
+            List<ActionBasicResponse> actionBasicResponses = new ArrayList<>();
             for (Action action : actions) {
-                actionResponses.add(buildActionResponse(action));
+                actionBasicResponses.add(buildActionBasicResponse(action));
             }
-            return actionResponses;
+            return actionBasicResponses;
         } catch (ActionMgtException e) {
             throw ActionMgtEndpointUtil.handleActionMgtException(e);
         }
@@ -226,7 +228,26 @@ public class ServerActionManagementService {
                 .type(ActionType.valueOf(activatedAction.getType().toString()))
                 .name(activatedAction.getName())
                 .description(activatedAction.getDescription())
-                .status(ActionBasicResponse.StatusEnum.valueOf(activatedAction.getStatus().toString()));
+                .status(ActionBasicResponse.StatusEnum.valueOf(activatedAction.getStatus().toString()))
+                .links(buildLinks(activatedAction));
+    }
+
+    /**
+     * Build Links for the Action.
+     *
+     * @param activatedAction Action object.
+     * @return List of Links.
+     */
+    private List<Link> buildLinks(Action activatedAction) {
+
+        String baseUrl = ActionMgtEndpointUtil.buildURIForActionType(activatedAction.getType().getActionType());
+
+        List<Link> links = new ArrayList<>();
+        links.add(new Link()
+                .href(baseUrl + ActionMgtEndpointConstants.PATH_SEPARATOR + activatedAction.getId())
+                .rel("self")
+                .method(Link.MethodEnum.GET));
+        return links;
     }
 
     /**

--- a/components/org.wso2.carbon.identity.api.server.action.management/org.wso2.carbon.identity.api.server.action.management.v1/src/main/java/org/wso2/carbon/identity/api/server/action/management/v1/util/ActionMgtEndpointUtil.java
+++ b/components/org.wso2.carbon.identity.api.server.action.management/org.wso2.carbon.identity.api.server.action.management.v1/src/main/java/org/wso2/carbon/identity/api/server/action/management/v1/util/ActionMgtEndpointUtil.java
@@ -33,7 +33,7 @@ import javax.ws.rs.core.Response;
 
 import static org.wso2.carbon.identity.action.management.constant.ActionMgtConstants.ErrorMessages.ERROR_NO_ACTION_CONFIGURED_ON_GIVEN_ACTION_TYPE_AND_ID;
 import static org.wso2.carbon.identity.api.server.action.management.v1.constants.ActionMgtEndpointConstants.ACTION_PATH_COMPONENT;
-import static org.wso2.carbon.identity.api.server.action.management.v1.constants.ActionMgtEndpointConstants.PATH_CONSTANT;
+import static org.wso2.carbon.identity.api.server.action.management.v1.constants.ActionMgtEndpointConstants.PATH_SEPARATOR;
 import static org.wso2.carbon.identity.api.server.common.Constants.ERROR_CODE_DELIMITER;
 
 /**
@@ -43,7 +43,7 @@ public class ActionMgtEndpointUtil {
 
     private static final Log LOG = LogFactory.getLog(ActionMgtEndpointUtil.class);
     private static final String ACTION_TYPE_LINK_FORMAT = Constants.V1_API_PATH_COMPONENT + ACTION_PATH_COMPONENT
-            + PATH_CONSTANT;
+            + PATH_SEPARATOR;
 
     public static String buildURIForActionType(String actionType) {
 

--- a/components/org.wso2.carbon.identity.api.server.action.management/org.wso2.carbon.identity.api.server.action.management.v1/src/main/resources/Actions.yaml
+++ b/components/org.wso2.carbon.identity.api.server.action.management/org.wso2.carbon.identity.api.server.action.management.v1/src/main/resources/Actions.yaml
@@ -596,11 +596,34 @@ components:
           enum:
             - ACTIVE
             - INACTIVE
+        links:
+          type: array
+          items:
+            $ref: '#/components/schemas/Link'
+          example:
+            - href: "/t/wso2.com/api/server/v1/actions/preIssueAccessToken/24f64d17-9824-4e28-8413-de45728d8e84"
+              method: GET
+              rel: self
+
+    Link:
+      type: object
+      properties:
+        href:
+          type: string
+          description: Url of the endpoint.
+        method:
+          type: string
+          enum:
+            - GET
+          description: Http method.
+        rel:
+          type: string
+          description: Relation to the resource.
 
     ActionResponseList:
       type: array
       items:
-        $ref: '#/components/schemas/ActionResponse'
+        $ref: '#/components/schemas/ActionBasicResponse'
 
     ActionTypesResponse:
       type: array


### PR DESCRIPTION
## Purpose
> This PR will change the getActionsByActionType REST API response to be more simplified as there is a separate endpoint to fetch the complete information of an action by action id.

### Previous API Response:

```
[
    {
        "id": "3********************************a",
        "type": "PRE_ISSUE_ACCESS_TOKEN",
        "name": "Access Token Pre Issue",
        "description": "This is the configuration of pre-action for issuing access token.",
        "status": "ACTIVE",
        "endpoint": {
            "uri": "https://myextension.com/token",
            "authentication": {
                "type": "API_KEY"
            }
        }
    }
]
```

### New API Response:

```
[
    {
        "id": "6********************************7",
        "type": "PRE_ISSUE_ACCESS_TOKEN",
        "name": "test",
        "description": "This is the configuration of pre-action for issuing access token.",
        "status": "ACTIVE",
        "links": [
            {
                "href": "/api/server/v1/actions/preIssueAccessToken/6ba8f776-72a5-407f-b0ed-7154b8653d77",
                "method": "GET",
                "rel": "self"
            }
        ]
    }
]
```

## Related Issue:
- https://github.com/wso2/product-is/issues/21869