### PR TITLE
Fix not properly returning error messages and error discriptions for idp mgt

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/main/java/org/wso2/carbon/identity/api/server/idp/v1/core/ServerIdpManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/main/java/org/wso2/carbon/identity/api/server/idp/v1/core/ServerIdpManagementService.java
@@ -3262,6 +3262,10 @@ public class ServerIdpManagementService {
                 errorResponse = getErrorBuilder(errorEnum, data).build(log, e.getMessage());
             }
             errorResponse.setDescription(e.getMessage());
+            IdentityProviderManagementClientException clientException = (IdentityProviderManagementClientException) e;
+            if (StringUtils.isNotEmpty(clientException.getDescription())) {
+                errorResponse.setDescription(clientException.getDescription());
+            }
             status = Response.Status.BAD_REQUEST;
         } else if (e instanceof IdentityProviderManagementServerException) {
             if (e.getErrorCode() != null) {

--- a/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/main/java/org/wso2/carbon/identity/api/server/idp/v1/impl/FederatedAuthenticatorConfigBuilderFactory.java
+++ b/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/main/java/org/wso2/carbon/identity/api/server/idp/v1/impl/FederatedAuthenticatorConfigBuilderFactory.java
@@ -173,8 +173,8 @@ public class FederatedAuthenticatorConfigBuilderFactory {
         // The System-defined authenticator configs must not have endpoint configurations; throw an error if they do.
         if (config.endpoint != null) {
             Constants.ErrorMessage error = Constants.ErrorMessage.ERROR_CODE_ENDPOINT_PROVIDED_FOR_SYSTEM_AUTH;
-            throw new IdentityProviderManagementClientException(error.getCode(), String.format(error.getDescription(),
-                    config.authenticatorName));
+            throw new IdentityProviderManagementClientException(error.getCode(), error.getMessage(),
+                    String.format(error.getDescription(), config.authenticatorName));
         }
 
         validateAuthenticatorProperties(config.authenticatorName, config.properties);
@@ -199,7 +199,8 @@ public class FederatedAuthenticatorConfigBuilderFactory {
             return authConfig;
         } catch (NoSuchElementException | IllegalArgumentException e) {
             throw new IdentityProviderManagementClientException(Constants.ErrorMessage
-                    .ERROR_CODE_INVALID_INPUT.getCode(), e.getMessage());
+                    .ERROR_CODE_INVALID_INPUT.getCode(), Constants.ErrorMessage.ERROR_CODE_INVALID_INPUT.getMessage(),
+                    e.getMessage());
         }
     }
 
@@ -209,14 +210,14 @@ public class FederatedAuthenticatorConfigBuilderFactory {
         // The User-defined authenticator configs must not have properties configurations; throw an error if they do.
         if (config.properties != null) {
             Constants.ErrorMessage error = Constants.ErrorMessage.ERROR_CODE_PROPERTIES_PROVIDED_FOR_USER_AUTH;
-            throw new IdentityProviderManagementClientException(error.getCode(),
+            throw new IdentityProviderManagementClientException(error.getCode(), error.getMessage(),
                     String.format(error.getDescription(), config.authenticatorName));
         }
 
         // The User-defined authenticator configs must have endpoint configurations; throw an error if they don't.
         if (config.endpoint == null) {
             Constants.ErrorMessage error = Constants.ErrorMessage.ERROR_CODE_NO_ENDPOINT_PROVIDED;
-            throw new IdentityProviderManagementClientException(error.getCode(),
+            throw new IdentityProviderManagementClientException(error.getCode(), error.getMessage(),
                     String.format(error.getDescription(), config.authenticatorName));
         }
     }
@@ -238,7 +239,8 @@ public class FederatedAuthenticatorConfigBuilderFactory {
 
         if (!areAllDistinct(properties)) {
             Constants.ErrorMessage error = Constants.ErrorMessage.ERROR_CODE_INVALID_INPUT;
-            throw new IdentityProviderManagementClientException(error.getCode(), error.getDescription());
+            throw new IdentityProviderManagementClientException(error.getCode(), error.getMessage(),
+                    error.getDescription());
         }
     }
 
@@ -282,7 +284,8 @@ public class FederatedAuthenticatorConfigBuilderFactory {
                         samlAuthenticatorProperties.set(positionOfMetadataKey, metadataProperty);
                     } else {
                         Constants.ErrorMessage error = Constants.ErrorMessage.ERROR_CODE_INVALID_SAML_METADATA;
-                        throw new IdentityProviderManagementClientException(error.getCode(), error.getDescription());
+                        throw new IdentityProviderManagementClientException(error.getCode(), error.getMessage(),
+                                error.getDescription());
                     }
                 }
             }
@@ -313,7 +316,8 @@ public class FederatedAuthenticatorConfigBuilderFactory {
             }
             if (scopesFieldFilled && queryParamsScopesFilled) {
                 Constants.ErrorMessage error = Constants.ErrorMessage.ERROR_CODE_DUPLICATE_OIDC_SCOPES;
-                throw new IdentityProviderManagementClientException(error.getCode(), error.getDescription());
+                throw new IdentityProviderManagementClientException(error.getCode(), error.getMessage(),
+                        error.getDescription());
             }
         }
     }
@@ -333,7 +337,8 @@ public class FederatedAuthenticatorConfigBuilderFactory {
                     String scopes = oidcAuthenticatorProperty.getValue();
                     if (StringUtils.isNotBlank(scopes) && !scopes.contains("openid")) {
                         Constants.ErrorMessage error = Constants.ErrorMessage.ERROR_CODE_INVALID_OIDC_SCOPES;
-                        throw new IdentityProviderManagementClientException(error.getCode(), error.getDescription());
+                        throw new IdentityProviderManagementClientException(error.getCode(), error.getMessage(),
+                                error.getDescription());
                     }
                 }
             }
@@ -389,7 +394,8 @@ public class FederatedAuthenticatorConfigBuilderFactory {
             }
         } catch (IdentityProviderManagementException e) {
             Constants.ErrorMessage error = Constants.ErrorMessage.ERROR_CODE_ERROR_ADDING_IDP;
-            throw new IdentityProviderManagementClientException(error.getCode(), error.getDescription());
+            throw new IdentityProviderManagementClientException(error.getCode(), error.getMessage(),
+                    error.getDescription());
         }
         return null;
     }

--- a/pom.xml
+++ b/pom.xml
@@ -821,7 +821,7 @@
         <maven.buildnumber.plugin.version>1.4</maven.buildnumber.plugin.version>
         <org.apache.felix.annotations.version>1.2.4</org.apache.felix.annotations.version>
         <identity.governance.version>1.11.11</identity.governance.version>
-        <carbon.identity.framework.version>7.7.16</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.7.18</carbon.identity.framework.version>
         <maven.findbugsplugin.version>3.0.5</maven.findbugsplugin.version>
         <findsecbugs-plugin.version>1.12.0</findsecbugs-plugin.version>
         <maven.checkstyleplugin.excludes>**/gen/**/*</maven.checkstyleplugin.excludes>


### PR DESCRIPTION
Related PR:
- https://github.com/wso2/identity-api-server/pull/735

Previously used handleException() which use errorMessage when building API error. Fix using by `error.getMessge()` instead of `error.getDescription()`.