### PR TITLE
Improve error description for input validation fail

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/main/java/org/wso2/carbon/identity/api/server/idp/v1/impl/FederatedAuthenticatorConfigBuilderFactory.java
+++ b/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/main/java/org/wso2/carbon/identity/api/server/idp/v1/impl/FederatedAuthenticatorConfigBuilderFactory.java
@@ -235,7 +235,8 @@ public class FederatedAuthenticatorConfigBuilderFactory {
         if (!areAllDistinct(properties)) {
             Constants.ErrorMessage error = Constants.ErrorMessage.ERROR_CODE_INVALID_INPUT;
             throw new IdentityProviderManagementClientException(error.getCode(), error.getMessage(),
-                    error.getDescription());
+                    String.format(error.getDescription(), " Duplicate properties are found in " +
+                            "the request."));
         }
     }
 


### PR DESCRIPTION
Related PR:
- https://github.com/wso2/identity-api-server/pull/735

With refactoring done with https://github.com/wso2/identity-api-server/pull/735, the required data for the description of the ERROR_CODE_INVALID_INPUT expection is missing. With this PR, the existing error description will be perserved. 
