### PR TITLE
Add tags in the idp authenticator responses.

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/main/java/org/wso2/carbon/identity/api/server/idp/v1/core/ServerIdpManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/main/java/org/wso2/carbon/identity/api/server/idp/v1/core/ServerIdpManagementService.java
@@ -588,33 +588,10 @@ public class ServerIdpManagementService {
             listResponse = new FederatedAuthenticatorListResponse();
             FederatedAuthenticatorConfig[] fedAuthConfigs = idP.getFederatedAuthenticatorConfigs();
             if (fedAuthConfigs != null) {
-                List<FederatedAuthenticatorListItem> fedAuthList = new ArrayList<>();
-                String defaultAuthenticator = null;
-                for (FederatedAuthenticatorConfig config : fedAuthConfigs) {
-                    String fedAuthId = base64URLEncode(config.getName());
-                    FederatedAuthenticatorListItem listItem = new FederatedAuthenticatorListItem();
-                    listItem.setAuthenticatorId(fedAuthId);
-                    listItem.setName(config.getName());
-                    listItem.setIsEnabled(config.isEnabled());
-                    listItem.setDefinedBy(
-                            FederatedAuthenticatorListItem.DefinedByEnum.valueOf(config.getDefinedByType().toString()));
-                    FederatedAuthenticatorConfig federatedAuthenticatorConfig =
-                            ApplicationAuthenticatorService.getInstance().getFederatedAuthenticatorByName(
-                                    config.getName());
-                    if (federatedAuthenticatorConfig != null) {
-                        String[] tags = federatedAuthenticatorConfig.getTags();
-                        if (ArrayUtils.isNotEmpty(tags)) {
-                            listItem.setTags(Arrays.asList(tags));
-                        }
-                    }
-                    listItem.setSelf(
-                            ContextLoader.buildURIForBody(String.format(V1_API_PATH_COMPONENT + IDP_PATH_COMPONENT +
-                                    "/%s/federated-authenticators/%s", idpId, fedAuthId)).toString());
-                    fedAuthList.add(listItem);
-                    if (idP.getDefaultAuthenticatorConfig() != null) {
-                        defaultAuthenticator = base64URLEncode(idP.getDefaultAuthenticatorConfig().getName());
-                    }
-                }
+                List<FederatedAuthenticatorListItem> fedAuthList = FederatedAuthenticatorConfigBuilderFactory.build(
+                        fedAuthConfigs, idP.getResourceId());
+                String defaultAuthenticator = (idP.getDefaultAuthenticatorConfig() != null ? base64URLEncode(idP
+                        .getDefaultAuthenticatorConfig().getName()) : null);
                 listResponse.setDefaultAuthenticatorId(defaultAuthenticator);
                 listResponse.setAuthenticators(fedAuthList);
             }
@@ -2428,30 +2405,8 @@ public class ServerIdpManagementService {
 
         FederatedAuthenticatorConfig[] fedAuthConfigs = idp.getFederatedAuthenticatorConfigs();
         FederatedAuthenticatorListResponse fedAuthIDPResponse = new FederatedAuthenticatorListResponse();
-        List<FederatedAuthenticatorListItem> authenticators = new ArrayList<>();
-        for (FederatedAuthenticatorConfig fedAuthConfig : fedAuthConfigs) {
-            FederatedAuthenticatorListItem fedAuthListItem = new FederatedAuthenticatorListItem();
-            fedAuthListItem.setAuthenticatorId(base64URLEncode(fedAuthConfig.getName()));
-            fedAuthListItem.setName(fedAuthConfig.getName());
-            fedAuthListItem.setIsEnabled(fedAuthConfig.isEnabled());
-            fedAuthListItem.setDefinedBy(FederatedAuthenticatorListItem.DefinedByEnum.valueOf(
-                    fedAuthConfig.getDefinedByType().toString()));
-            FederatedAuthenticatorConfig federatedAuthenticatorConfig =
-                    ApplicationAuthenticatorService.getInstance().getFederatedAuthenticatorByName(
-                            fedAuthConfig.getName());
-            if (federatedAuthenticatorConfig != null) {
-                String[] tags = federatedAuthenticatorConfig.getTags();
-                if (ArrayUtils.isNotEmpty(tags)) {
-                    fedAuthListItem.setTags(Arrays.asList(tags));
-                }
-            }
-            fedAuthListItem.setSelf(
-                    ContextLoader.buildURIForBody(String.format(V1_API_PATH_COMPONENT + IDP_PATH_COMPONENT +
-                                    "/%s/federated-authenticators/%s", idp.getResourceId(),
-                            base64URLEncode(fedAuthConfig.getName())))
-                            .toString());
-            authenticators.add(fedAuthListItem);
-        }
+        List<FederatedAuthenticatorListItem> authenticators =
+                FederatedAuthenticatorConfigBuilderFactory.build(fedAuthConfigs, idp.getResourceId());
         fedAuthIDPResponse.setDefaultAuthenticatorId(idp.getDefaultAuthenticatorConfig() != null ? base64URLEncode(idp
                 .getDefaultAuthenticatorConfig().getName()) : null);
         fedAuthIDPResponse.setAuthenticators(authenticators);

--- a/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/main/java/org/wso2/carbon/identity/api/server/idp/v1/impl/FederatedAuthenticatorConfigBuilderFactory.java
+++ b/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/main/java/org/wso2/carbon/identity/api/server/idp/v1/impl/FederatedAuthenticatorConfigBuilderFactory.java
@@ -20,11 +20,13 @@ package org.wso2.carbon.identity.api.server.idp.v1.impl;
 
 import org.apache.commons.lang.ArrayUtils;
 import org.apache.commons.lang.StringUtils;
+import org.wso2.carbon.identity.api.server.common.ContextLoader;
 import org.wso2.carbon.identity.api.server.idp.common.Constants;
 import org.wso2.carbon.identity.api.server.idp.common.IdentityProviderServiceHolder;
 import org.wso2.carbon.identity.api.server.idp.v1.model.AuthenticationType;
 import org.wso2.carbon.identity.api.server.idp.v1.model.Endpoint;
 import org.wso2.carbon.identity.api.server.idp.v1.model.FederatedAuthenticator;
+import org.wso2.carbon.identity.api.server.idp.v1.model.FederatedAuthenticatorListItem;
 import org.wso2.carbon.identity.api.server.idp.v1.model.FederatedAuthenticatorPUTRequest;
 import org.wso2.carbon.identity.application.common.ApplicationAuthenticatorService;
 import org.wso2.carbon.identity.application.common.model.FederatedAuthenticatorConfig;
@@ -38,6 +40,7 @@ import org.wso2.carbon.idp.mgt.IdentityProviderManagementException;
 import org.wso2.carbon.idp.mgt.IdentityProviderManagementServerException;
 
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Base64;
 import java.util.List;
@@ -47,7 +50,10 @@ import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import static org.wso2.carbon.identity.api.server.common.Constants.V1_API_PATH_COMPONENT;
+import static org.wso2.carbon.identity.api.server.common.Util.base64URLEncode;
 import static org.wso2.carbon.identity.api.server.idp.common.Constants.GOOGLE_PRIVATE_KEY;
+import static org.wso2.carbon.identity.api.server.idp.common.Constants.IDP_PATH_COMPONENT;
 
 /**
  * The factory class for building federated authenticator configuration related models.
@@ -118,15 +124,9 @@ public class FederatedAuthenticatorConfigBuilderFactory {
 
         federatedAuthenticator.setName(config.getName());
         federatedAuthenticator.setIsEnabled(config.isEnabled());
-
-        FederatedAuthenticatorConfig federatedAuthenticatorConfig =
-                ApplicationAuthenticatorService.getInstance().getFederatedAuthenticatorByName(
-                        config.getName());
-        if (federatedAuthenticatorConfig != null) {
-            String[] tags = federatedAuthenticatorConfig.getTags();
-            if (ArrayUtils.isNotEmpty(tags)) {
-                federatedAuthenticator.setTags(Arrays.asList(tags));
-            }
+        String[] tags = resolveAuthenticatorTags(config);
+        if (ArrayUtils.isNotEmpty(tags)) {
+            federatedAuthenticator.setTags(Arrays.asList(tags));
         }
 
         if (DefinedByType.SYSTEM == config.getDefinedByType()) {
@@ -140,6 +140,37 @@ public class FederatedAuthenticatorConfigBuilderFactory {
         }
 
         return federatedAuthenticator;
+    }
+
+    /**
+     * Builds a list of FederatedAuthenticatorListItem instances based on the given array of
+     * FederatedAuthenticatorConfig.
+     *
+     * @param fedAuthConfigs Array of FederatedAuthenticatorConfig instances.
+     * @return List of FederatedAuthenticatorListItem instances.
+     */
+    public static List<FederatedAuthenticatorListItem> build(FederatedAuthenticatorConfig[] fedAuthConfigs,
+                                                             String idpResourceId) {
+
+        List<FederatedAuthenticatorListItem> authenticators = new ArrayList<>();
+        for (FederatedAuthenticatorConfig config : fedAuthConfigs) {
+            FederatedAuthenticatorListItem authenticatorListItem = new FederatedAuthenticatorListItem();
+            authenticatorListItem.setAuthenticatorId(base64URLEncode(config.getName()));
+            authenticatorListItem.setName(config.getName());
+            authenticatorListItem.setIsEnabled(config.isEnabled());
+            authenticatorListItem.definedBy(FederatedAuthenticatorListItem.DefinedByEnum.valueOf(
+                    config.getDefinedByType().toString()));
+            String[] tags = resolveAuthenticatorTags(config);
+            if (ArrayUtils.isNotEmpty(tags)) {
+                authenticatorListItem.setTags(Arrays.asList(tags));
+            }
+            authenticatorListItem.setSelf(ContextLoader.buildURIForBody(String.format(V1_API_PATH_COMPONENT +
+                     IDP_PATH_COMPONENT + "/%s/federated-authenticators/%s", idpResourceId,
+                                    base64URLEncode(config.getName()))).toString());
+            authenticators.add(authenticatorListItem);
+        }
+
+        return authenticators;
     }
     
     private static FederatedAuthenticatorConfig createFederatedAuthenticatorConfig(Config config)
@@ -433,6 +464,23 @@ public class FederatedAuthenticatorConfigBuilderFactory {
             throw new IdentityProviderManagementServerException(String.format("Error occurred while resolving" +
                     " endpoint configuration of the authenticator %s.", authenticator.getName()), e);
         }
+    }
+
+    private static String[] resolveAuthenticatorTags(FederatedAuthenticatorConfig config) {
+
+        /* If the authenticator is defined by the user, return the tags of the authenticator config. Otherwise, return
+        the tags of the system registered federated authenticator template.
+         */
+        if (DefinedByType.USER == config.getDefinedByType()) {
+            return config.getTags();
+
+        }
+        FederatedAuthenticatorConfig federatedAuthenticatorConfig =
+                ApplicationAuthenticatorService.getInstance().getFederatedAuthenticatorByName(config.getName());
+        if (federatedAuthenticatorConfig != null) {
+            return federatedAuthenticatorConfig.getTags();
+        }
+        return new String[0];
     }
 
     /**

--- a/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/main/java/org/wso2/carbon/identity/api/server/idp/v1/impl/FederatedAuthenticatorConfigBuilderFactory.java
+++ b/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/main/java/org/wso2/carbon/identity/api/server/idp/v1/impl/FederatedAuthenticatorConfigBuilderFactory.java
@@ -18,6 +18,7 @@
 
 package org.wso2.carbon.identity.api.server.idp.v1.impl;
 
+import org.apache.commons.lang.ArrayUtils;
 import org.apache.commons.lang.StringUtils;
 import org.wso2.carbon.identity.api.server.common.ContextLoader;
 import org.wso2.carbon.identity.api.server.idp.common.Constants;
@@ -123,9 +124,9 @@ public class FederatedAuthenticatorConfigBuilderFactory {
 
         federatedAuthenticator.setName(config.getName());
         federatedAuthenticator.setIsEnabled(config.isEnabled());
-        List<String> tags = resolveAuthenticatorTags(config);
-        if (tags.isEmpty()) {
-            federatedAuthenticator.setTags(tags);
+        String[] tags = resolveAuthenticatorTags(config);
+        if (ArrayUtils.isNotEmpty(tags)) {
+            federatedAuthenticator.setTags(Arrays.asList(tags));
         }
 
         if (DefinedByType.SYSTEM == config.getDefinedByType()) {
@@ -160,9 +161,9 @@ public class FederatedAuthenticatorConfigBuilderFactory {
             authenticatorListItem.setIsEnabled(config.isEnabled());
             authenticatorListItem.definedBy(FederatedAuthenticatorListItem.DefinedByEnum.valueOf(
                     config.getDefinedByType().toString()));
-            List<String> tags = resolveAuthenticatorTags(config);
-            if (tags.isEmpty()) {
-                authenticatorListItem.setTags(tags);
+            String[] tags = resolveAuthenticatorTags(config);
+            if (ArrayUtils.isNotEmpty(tags)) {
+                authenticatorListItem.setTags(Arrays.asList(tags));
             }
             authenticatorListItem.setSelf(ContextLoader.buildURIForBody(String.format(V1_API_PATH_COMPONENT +
                      IDP_PATH_COMPONENT + "/%s/federated-authenticators/%s", idpResourceId,
@@ -466,19 +467,18 @@ public class FederatedAuthenticatorConfigBuilderFactory {
         }
     }
 
-    private static List<String> resolveAuthenticatorTags(FederatedAuthenticatorConfig config) {
+    private static String[] resolveAuthenticatorTags(FederatedAuthenticatorConfig config) {
 
         /* If the authenticator is defined by the user, return the tags of the authenticator config. Otherwise, return
         the tags of the system registered federated authenticator template.
          */
         if (DefinedByType.USER == config.getDefinedByType()) {
-            return Arrays.asList(config.getTags());
+            return config.getTags();
         }
-
         FederatedAuthenticatorConfig federatedAuthenticatorConfig =
                 ApplicationAuthenticatorService.getInstance().getFederatedAuthenticatorByName(config.getName());
-        return federatedAuthenticatorConfig != null ? Arrays.asList(federatedAuthenticatorConfig.getTags())
-                : new ArrayList<>();
+        return federatedAuthenticatorConfig != null ? federatedAuthenticatorConfig.getTags()
+                : new String[0];
     }
 
     /**


### PR DESCRIPTION
Issue:
- https://github.com/wso2/product-is/issues/21998

Following changes are added with this PR:
1. Fix the issue of missing tags in the user defined federated authenticators.
2. Improve the `FederatedAuthenticatorConfigBuilderFactory` class to build list of `FederatedAuthenticatorListItem` where authenticators will be list with basic info.

Integration tests: https://github.com/wso2/product-is/pull/22002/