### PR TITLE
Improve error codes for user defined local authenticator mgt

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.authenticators/org.wso2.carbon.identity.api.server.authenticators.common/src/main/java/org/wso2/carbon/identity/api/server/authenticators/common/Constants.java
+++ b/components/org.wso2.carbon.identity.api.server.authenticators/org.wso2.carbon.identity.api.server.authenticators.common/src/main/java/org/wso2/carbon/identity/api/server/authenticators/common/Constants.java
@@ -71,10 +71,6 @@ public class Constants {
                 "Filter needs to be in the format <attribute>+<operation>+<value>. Eg: tag+eq+2FA"),
         ERROR_CODE_UNSUPPORTED_FILTER_ATTRIBUTE("60002", "Unsupported filter attribute.",
                 "The filter attribute '%s' is not supported."),
-        ERROR_CODE_INVALID_ENDPOINT_CONFIG("60003", "Invalid endpoint configuration provided.",
-                "Invalid endpoint configuration is provided for the authenticator %s."),
-        ERROR_CODE_ERROR_AUTHENTICATOR_NOT_FOUND("60004", "Authenticator not found.",
-                "Authenticator not found by the given name: %s."),
 
         ERROR_CODE_ERROR_LISTING_AUTHENTICATORS("65001", "Unable to list the existing authenticators.",
                 "Server encountered an error while listing the authenticators."),

--- a/components/org.wso2.carbon.identity.api.server.authenticators/org.wso2.carbon.identity.api.server.authenticators.v1/src/main/java/org/wso2/carbon/identity/api/server/authenticators/v1/core/ServerAuthenticatorManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.authenticators/org.wso2.carbon.identity.api.server.authenticators.v1/src/main/java/org/wso2/carbon/identity/api/server/authenticators/v1/core/ServerAuthenticatorManagementService.java
@@ -1018,7 +1018,7 @@ public class ServerAuthenticatorManagementService {
                 .withMessage(e.getMessage())
                 .withDescription(e.getDescription());
         Response.Status status = null;
-        if (responseStatus != null && responseStatus[0] != null) {
+        if (ArrayUtils.isNotEmpty(responseStatus)) {
             status = responseStatus[0];
         }
         ErrorResponse errorResponse;

--- a/components/org.wso2.carbon.identity.api.server.authenticators/org.wso2.carbon.identity.api.server.authenticators.v1/src/main/java/org/wso2/carbon/identity/api/server/authenticators/v1/core/ServerAuthenticatorManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.authenticators/org.wso2.carbon.identity.api.server.authenticators.v1/src/main/java/org/wso2/carbon/identity/api/server/authenticators/v1/core/ServerAuthenticatorManagementService.java
@@ -49,6 +49,7 @@ import org.wso2.carbon.identity.application.common.model.IdentityProvider;
 import org.wso2.carbon.identity.application.common.model.LocalAuthenticatorConfig;
 import org.wso2.carbon.identity.application.common.model.RequestPathAuthenticatorConfig;
 import org.wso2.carbon.identity.application.common.model.UserDefinedLocalAuthenticatorConfig;
+import org.wso2.carbon.identity.application.common.util.AuthenticatorMgtExceptionBuilder.AuthenticatorMgtError;
 import org.wso2.carbon.identity.base.AuthenticatorPropertyConstants.DefinedByType;
 import org.wso2.carbon.identity.base.IdentityException;
 import org.wso2.carbon.identity.core.model.ExpressionNode;
@@ -259,8 +260,10 @@ public class ServerAuthenticatorManagementService {
             LocalAuthenticatorConfig existingAuthenticator = getApplicationAuthenticatorService()
                     .getLocalAuthenticatorByName(authenticatorName, tenantDomain);
             if (existingAuthenticator == null) {
-                throw handleException(Response.Status.NOT_FOUND,
-                        Constants.ErrorMessage.ERROR_CODE_ERROR_AUTHENTICATOR_NOT_FOUND, authenticatorName);
+                AuthenticatorMgtError error = AuthenticatorMgtError.ERROR_CODE_ERROR_AUTHENTICATOR_NOT_FOUND;
+                throw handleAuthenticatorException(new AuthenticatorMgtClientException(error.getCode(),
+                                error.getMessage(), String.format(error.getMessage(), authenticatorName)),
+                        Response.Status.NOT_FOUND);
             }
             UserDefinedLocalAuthenticatorConfig updatedConfig = getApplicationAuthenticatorService()
                     .updateUserDefinedLocalAuthenticator(
@@ -993,13 +996,16 @@ public class ServerAuthenticatorManagementService {
      * @param e         IdentityProviderManagementException.
      * @return APIError.
      */
-    private APIError handleAuthenticatorException(AuthenticatorMgtException e) {
+    private APIError handleAuthenticatorException(AuthenticatorMgtException e, Response.Status... responseStatus) {
 
         ErrorResponse errorResponse = new ErrorResponse.Builder()
                 .withCode(e.getErrorCode())
                 .withMessage(e.getMessage())
                 .withDescription(e.getDescription()).build();
-        Response.Status status;
+        Response.Status status = null;
+        if (responseStatus != null && responseStatus[0] != null) {
+            status = responseStatus[0];
+        }
 
         if (e instanceof AuthenticatorMgtClientException) {
             if (e.getErrorCode() != null) {
@@ -1010,7 +1016,9 @@ public class ServerAuthenticatorManagementService {
                 errorResponse.setCode(errorCode);
             }
             errorResponse.setDescription(e.getDescription());
-            status = Response.Status.BAD_REQUEST;
+            if (status == null) {
+                status = Response.Status.BAD_REQUEST;
+            }
         } else if (e instanceof AuthenticatorMgtServerException) {
             if (e.getErrorCode() != null) {
                 String errorCode = e.getErrorCode();

--- a/components/org.wso2.carbon.identity.api.server.authenticators/org.wso2.carbon.identity.api.server.authenticators.v1/src/main/java/org/wso2/carbon/identity/api/server/authenticators/v1/impl/LocalAuthenticatorConfigBuilderFactory.java
+++ b/components/org.wso2.carbon.identity.api.server.authenticators/org.wso2.carbon.identity.api.server.authenticators.v1/src/main/java/org/wso2/carbon/identity/api/server/authenticators/v1/impl/LocalAuthenticatorConfigBuilderFactory.java
@@ -18,7 +18,6 @@
 
 package org.wso2.carbon.identity.api.server.authenticators.v1.impl;
 
-import org.wso2.carbon.identity.api.server.authenticators.common.Constants;
 import org.wso2.carbon.identity.api.server.authenticators.v1.model.Authenticator;
 import org.wso2.carbon.identity.api.server.authenticators.v1.model.Endpoint;
 import org.wso2.carbon.identity.api.server.authenticators.v1.model.UserDefinedLocalAuthenticatorCreation;
@@ -28,6 +27,7 @@ import org.wso2.carbon.identity.application.common.exception.AuthenticatorMgtCli
 import org.wso2.carbon.identity.application.common.model.LocalAuthenticatorConfig;
 import org.wso2.carbon.identity.application.common.model.UserDefinedAuthenticatorEndpointConfig;
 import org.wso2.carbon.identity.application.common.model.UserDefinedLocalAuthenticatorConfig;
+import org.wso2.carbon.identity.application.common.util.AuthenticatorMgtExceptionBuilder.AuthenticatorMgtError;
 import org.wso2.carbon.identity.base.AuthenticatorPropertyConstants;
 
 import java.util.Arrays;
@@ -36,7 +36,6 @@ import java.util.NoSuchElementException;
 import java.util.stream.Collectors;
 
 import static org.wso2.carbon.identity.api.server.authenticators.common.Constants.CONFIGS_AUTHENTICATOR_PATH_COMPONENT;
-import static org.wso2.carbon.identity.api.server.authenticators.common.Constants.ErrorMessage.ERROR_CODE_INVALID_ENDPOINT_CONFIG;
 import static org.wso2.carbon.identity.api.server.common.Constants.V1_API_PATH_COMPONENT;
 import static org.wso2.carbon.identity.api.server.common.Util.base64URLEncode;
 
@@ -128,7 +127,7 @@ public class LocalAuthenticatorConfigBuilderFactory {
                             Map.Entry::getKey, entry -> entry.getValue().toString())));
             return endpointConfigBuilder.build();
         } catch (NoSuchElementException | IllegalArgumentException e) {
-            Constants.ErrorMessage error = ERROR_CODE_INVALID_ENDPOINT_CONFIG;
+            AuthenticatorMgtError error = AuthenticatorMgtError.ERROR_CODE_INVALID_ENDPOINT_CONFIG;
             throw new AuthenticatorMgtClientException(error.getCode(), error.getMessage(), e.getMessage());
         }
     }

--- a/pom.xml
+++ b/pom.xml
@@ -821,7 +821,7 @@
         <maven.buildnumber.plugin.version>1.4</maven.buildnumber.plugin.version>
         <org.apache.felix.annotations.version>1.2.4</org.apache.felix.annotations.version>
         <identity.governance.version>1.11.21</identity.governance.version>
-        <carbon.identity.framework.version>7.7.41</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.7.66</carbon.identity.framework.version>
         <maven.findbugsplugin.version>3.0.5</maven.findbugsplugin.version>
         <findsecbugs-plugin.version>1.12.0</findsecbugs-plugin.version>
         <maven.checkstyleplugin.excludes>**/gen/**/*</maven.checkstyleplugin.excludes>


### PR DESCRIPTION
Issue: 
- https://github.com/wso2/product-is/issues/22050

Improve code base to throw error constants from framework, instead error constants from API server.