### PR TITLE
Improve /configs/authenticator endpoint.

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.authenticators/org.wso2.carbon.identity.api.server.authenticators.v1/src/main/java/org/wso2/carbon/identity/api/server/authenticators/v1/impl/LocalAuthenticatorConfigBuilderFactory.java
+++ b/components/org.wso2.carbon.identity.api.server.authenticators/org.wso2.carbon.identity.api.server.authenticators.v1/src/main/java/org/wso2/carbon/identity/api/server/authenticators/v1/impl/LocalAuthenticatorConfigBuilderFactory.java
@@ -59,6 +59,8 @@ public class LocalAuthenticatorConfigBuilderFactory {
         authenticator.setName(config.getName());
         authenticator.setId(authenticatorId);
         authenticator.setDisplayName(config.getDisplayName());
+        authenticator.setImage(config.getImageUrl());
+        authenticator.description(config.getDescription());
         authenticator.setIsEnabled(config.isEnabled());
         authenticator.setDefinedBy(Authenticator.DefinedByEnum.USER);
         authenticator.setType(Authenticator.TypeEnum.LOCAL);
@@ -87,6 +89,8 @@ public class LocalAuthenticatorConfigBuilderFactory {
                 AuthenticatorPropertyConstants.AuthenticationType.valueOf(authenticationType));
         authConfig.setName(config.getName());
         authConfig.setDisplayName(config.getDisplayName());
+        authConfig.setImageUrl(config.getImage());
+        authConfig.setDescription(config.getDescription());
         authConfig.setEnabled(config.getIsEnabled());
         authConfig.setEndpointConfig(buildEndpointConfig(config.getEndpoint()));
 
@@ -108,6 +112,8 @@ public class LocalAuthenticatorConfigBuilderFactory {
                 resolveAuthenticationType(existingConfig));
         authConfig.setName(existingConfig.getName());
         authConfig.setDisplayName(config.getDisplayName());
+        authConfig.setImageUrl(config.getImage());
+        authConfig.setDescription(config.getDescription());
         authConfig.setEnabled(config.getIsEnabled());
         authConfig.setEndpointConfig(buildEndpointConfig(config.getEndpoint()));
 

--- a/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/gen/java/org/wso2/carbon/identity/api/server/configs/v1/model/Authenticator.java
+++ b/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/gen/java/org/wso2/carbon/identity/api/server/configs/v1/model/Authenticator.java
@@ -37,6 +37,8 @@ public class Authenticator  {
     private String id;
     private String name;
     private String displayName;
+    private String description;
+    private String image;
     private Boolean isEnabled = true;
 
 @XmlType(name="DefinedByEnum")
@@ -169,6 +171,42 @@ public enum TypeEnum {
     }
     public void setDisplayName(String displayName) {
         this.displayName = displayName;
+    }
+
+    /**
+    **/
+    public Authenticator description(String description) {
+
+        this.description = description;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "Description for local authenticator configuration.", value = "")
+    @JsonProperty("description")
+    @Valid
+    public String getDescription() {
+        return description;
+    }
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    /**
+    **/
+    public Authenticator image(String image) {
+
+        this.image = image;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "https://example.com/logo/my-logo.png", value = "")
+    @JsonProperty("image")
+    @Valid
+    public String getImage() {
+        return image;
+    }
+    public void setImage(String image) {
+        this.image = image;
     }
 
     /**
@@ -318,6 +356,8 @@ public enum TypeEnum {
         return Objects.equals(this.id, authenticator.id) &&
             Objects.equals(this.name, authenticator.name) &&
             Objects.equals(this.displayName, authenticator.displayName) &&
+            Objects.equals(this.description, authenticator.description) &&
+            Objects.equals(this.image, authenticator.image) &&
             Objects.equals(this.isEnabled, authenticator.isEnabled) &&
             Objects.equals(this.definedBy, authenticator.definedBy) &&
             Objects.equals(this.type, authenticator.type) &&
@@ -328,7 +368,7 @@ public enum TypeEnum {
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, name, displayName, isEnabled, definedBy, type, tags, properties, endpoint);
+        return Objects.hash(id, name, displayName, description, image, isEnabled, definedBy, type, tags, properties, endpoint);
     }
 
     @Override
@@ -340,6 +380,8 @@ public enum TypeEnum {
         sb.append("    id: ").append(toIndentedString(id)).append("\n");
         sb.append("    name: ").append(toIndentedString(name)).append("\n");
         sb.append("    displayName: ").append(toIndentedString(displayName)).append("\n");
+        sb.append("    description: ").append(toIndentedString(description)).append("\n");
+        sb.append("    image: ").append(toIndentedString(image)).append("\n");
         sb.append("    isEnabled: ").append(toIndentedString(isEnabled)).append("\n");
         sb.append("    definedBy: ").append(toIndentedString(definedBy)).append("\n");
         sb.append("    type: ").append(toIndentedString(type)).append("\n");

--- a/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/gen/java/org/wso2/carbon/identity/api/server/configs/v1/model/AuthenticatorListItem.java
+++ b/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/gen/java/org/wso2/carbon/identity/api/server/configs/v1/model/AuthenticatorListItem.java
@@ -35,6 +35,8 @@ public class AuthenticatorListItem  {
     private String id;
     private String name;
     private String displayName;
+    private String description;
+    private String image;
     private Boolean isEnabled = true;
 
 @XmlType(name="DefinedByEnum")
@@ -164,6 +166,42 @@ public enum TypeEnum {
 
     /**
     **/
+    public AuthenticatorListItem description(String description) {
+
+        this.description = description;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "Description for local authenticator configuration.", value = "")
+    @JsonProperty("description")
+    @Valid
+    public String getDescription() {
+        return description;
+    }
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    /**
+    **/
+    public AuthenticatorListItem image(String image) {
+
+        this.image = image;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "https://example.com/logo/my-logo.png", value = "")
+    @JsonProperty("image")
+    @Valid
+    public String getImage() {
+        return image;
+    }
+    public void setImage(String image) {
+        this.image = image;
+    }
+
+    /**
+    **/
     public AuthenticatorListItem isEnabled(Boolean isEnabled) {
 
         this.isEnabled = isEnabled;
@@ -275,6 +313,8 @@ public enum TypeEnum {
         return Objects.equals(this.id, authenticatorListItem.id) &&
             Objects.equals(this.name, authenticatorListItem.name) &&
             Objects.equals(this.displayName, authenticatorListItem.displayName) &&
+            Objects.equals(this.description, authenticatorListItem.description) &&
+            Objects.equals(this.image, authenticatorListItem.image) &&
             Objects.equals(this.isEnabled, authenticatorListItem.isEnabled) &&
             Objects.equals(this.definedBy, authenticatorListItem.definedBy) &&
             Objects.equals(this.type, authenticatorListItem.type) &&
@@ -284,7 +324,7 @@ public enum TypeEnum {
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, name, displayName, isEnabled, definedBy, type, tags, self);
+        return Objects.hash(id, name, displayName, description, image, isEnabled, definedBy, type, tags, self);
     }
 
     @Override
@@ -296,6 +336,8 @@ public enum TypeEnum {
         sb.append("    id: ").append(toIndentedString(id)).append("\n");
         sb.append("    name: ").append(toIndentedString(name)).append("\n");
         sb.append("    displayName: ").append(toIndentedString(displayName)).append("\n");
+        sb.append("    description: ").append(toIndentedString(description)).append("\n");
+        sb.append("    image: ").append(toIndentedString(image)).append("\n");
         sb.append("    isEnabled: ").append(toIndentedString(isEnabled)).append("\n");
         sb.append("    definedBy: ").append(toIndentedString(definedBy)).append("\n");
         sb.append("    type: ").append(toIndentedString(type)).append("\n");

--- a/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/main/java/org/wso2/carbon/identity/api/server/configs/v1/core/ServerConfigManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/main/java/org/wso2/carbon/identity/api/server/configs/v1/core/ServerConfigManagementService.java
@@ -712,6 +712,11 @@ public class ServerConfigManagementService {
                 authenticatorListItem.setType(AuthenticatorListItem.TypeEnum.LOCAL);
                 authenticatorListItem.setDefinedBy(
                         AuthenticatorListItem.DefinedByEnum.valueOf(config.getDefinedByType().toString()));
+                if (AuthenticatorPropertyConstants.DefinedByType.USER == config.getDefinedByType()) {
+                    UserDefinedLocalAuthenticatorConfig userDefinedConfig = (UserDefinedLocalAuthenticatorConfig) config;
+                    authenticatorListItem.setImage(userDefinedConfig.getImageUrl());
+                    authenticatorListItem.setDescription(userDefinedConfig.getDescription());
+                }
                 String[] tags = config.getTags();
                 if (ArrayUtils.isNotEmpty(tags)) {
                     authenticatorListItem.setTags(Arrays.asList(tags));
@@ -784,15 +789,16 @@ public class ServerConfigManagementService {
         if (config instanceof RequestPathAuthenticatorConfig) {
             authenticator.setType(Authenticator.TypeEnum.REQUEST_PATH);
             authenticator.setDefinedBy(Authenticator.DefinedByEnum.SYSTEM);
-            setAuthenticatorProperties(config, authenticator);
         } else {
             authenticator.setType(Authenticator.TypeEnum.LOCAL);
             if (AuthenticatorPropertyConstants.DefinedByType.USER == config.getDefinedByType()) {
                 authenticator.setDefinedBy(Authenticator.DefinedByEnum.USER);
-                resolveEndpointConfiguration(authenticator, config);
+                UserDefinedLocalAuthenticatorConfig userDefinedConfig = (UserDefinedLocalAuthenticatorConfig) config;
+                authenticator.setImage(userDefinedConfig.getImageUrl());
+                authenticator.setDescription(userDefinedConfig.getDescription());
+                resolveEndpointConfiguration(authenticator, userDefinedConfig);
             } else {
                 authenticator.setDefinedBy(Authenticator.DefinedByEnum.SYSTEM);
-                setAuthenticatorProperties(config, authenticator);
             }
         }
         String[] tags = config.getTags();
@@ -802,12 +808,11 @@ public class ServerConfigManagementService {
         return authenticator;
     }
 
-    private void resolveEndpointConfiguration(Authenticator authenticator, LocalAuthenticatorConfig config)
+    private void resolveEndpointConfiguration(Authenticator authenticator, UserDefinedLocalAuthenticatorConfig config)
             throws IdentityApplicationManagementServerException {
 
         try {
-            UserDefinedLocalAuthenticatorConfig userDefinedConfig = (UserDefinedLocalAuthenticatorConfig) config;
-            UserDefinedAuthenticatorEndpointConfig endpointConfig = userDefinedConfig.getEndpointConfig();
+            UserDefinedAuthenticatorEndpointConfig endpointConfig = config.getEndpointConfig();
 
             AuthenticationType authenticationType = new AuthenticationType();
             authenticationType.setType(AuthenticationType.TypeEnum.fromValue(

--- a/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/main/resources/configs.yaml
+++ b/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/main/resources/configs.yaml
@@ -1183,6 +1183,12 @@ components:
         displayName:
           type: string
           example: basic
+        description:
+          type: string
+          example: "Description for local authenticator configuration."
+        image:
+          type: string
+          example: "https://example.com/logo/my-logo.png"
         isEnabled:
           type: boolean
           default: true
@@ -1219,6 +1225,12 @@ components:
         displayName:
           type: string
           example: basic
+        description:
+          type: string
+          example: "Description for local authenticator configuration."
+        image:
+          type: string
+          example: "https://example.com/logo/my-logo.png"
         isEnabled:
           type: boolean
           default: true


### PR DESCRIPTION
Issue:
- https://github.com/wso2/product-is/issues/22273

Currently there is no way to configure image_url and description of the user defined local authenticators. The federated authenticators, those can be configured for the assocaited identity providers. This PR is to provide support for that for user defined local authenticators.

Related PRs:
- https://github.com/wso2/carbon-identity-framework/pull/6296