### PR TITLE
Improve hybrid flow to handle multiple values

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/functions/application/inbound/oauth2/ApiModelToOAuthConsumerApp.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/functions/application/inbound/oauth2/ApiModelToOAuthConsumerApp.java
@@ -16,7 +16,6 @@
 package org.wso2.carbon.identity.api.server.application.management.v1.core.functions.application.inbound.oauth2;
 
 import org.apache.commons.collections.CollectionUtils;
-import org.apache.commons.lang.ArrayUtils;
 import org.apache.commons.lang.StringUtils;
 import org.wso2.carbon.identity.api.server.application.management.common.ApplicationManagementConstants;
 import org.wso2.carbon.identity.api.server.application.management.v1.AccessTokenConfiguration;
@@ -37,8 +36,12 @@ import org.wso2.carbon.identity.api.server.common.error.ErrorResponse;
 import org.wso2.carbon.identity.oauth.common.OAuthConstants;
 import org.wso2.carbon.identity.oauth.dto.OAuthConsumerAppDTO;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 import javax.ws.rs.core.Response;
 
@@ -201,9 +204,11 @@ public class ApiModelToOAuthConsumerApp implements ApiModelToOAuthConsumerAppFun
     private void validateHybridFlowResponseType(OAuthConsumerAppDTO consumerAppDTO,
                                                 HybridFlowConfiguration hybridFlowResponseType) {
 
-        String[] allowedResponseTypes = {ApplicationManagementConstants.CODE_TOKEN,
-                                         ApplicationManagementConstants.CODE_IDTOKEN,
-                                         ApplicationManagementConstants.CODE_IDTOKEN_TOKEN};
+        Set<String> allowedResponseTypesSet = new HashSet<>(Arrays.asList(
+                ApplicationManagementConstants.CODE_TOKEN,
+                ApplicationManagementConstants.CODE_IDTOKEN,
+                ApplicationManagementConstants.CODE_IDTOKEN_TOKEN
+        ));
 
         if (StringUtils.isBlank(hybridFlowResponseType.getResponseType())) {
             throw new APIError(Response.Status.BAD_REQUEST,
@@ -215,7 +220,10 @@ public class ApiModelToOAuthConsumerApp implements ApiModelToOAuthConsumerAppFun
                                     .Hybrid_FLOW_RESPONSE_TYPE_NOT_FOUND.getDescription()).build());
         }
 
-        if (!ArrayUtils.contains(allowedResponseTypes, hybridFlowResponseType.getResponseType())) {
+        List<String> hybridFlowResponseTypes =
+                new ArrayList<>(Arrays.asList(hybridFlowResponseType.getResponseType().split(",")));
+
+        if (!allowedResponseTypesSet.containsAll(hybridFlowResponseTypes)) {
             throw new APIError(Response.Status.BAD_REQUEST,
                     new ErrorResponse.Builder().withCode(ApplicationManagementConstants.ErrorMessage
                                     .Hybrid_FLOW_RESPONSE_TYPE_INCORRECT.getCode())

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/resources/applications.yaml
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/resources/applications.yaml
@@ -3676,10 +3676,13 @@ components:
       properties:
         enable:
           type: boolean
+          description: "Indicates whether the hybrid flow is enabled."
           example: true
         responseType:
           type: string
-          example: code id_token
+          description: "Specifies the allowed response types for the hybrid flow, provided as a comma-separated string. 
+          The supported combinations are: 'code token', 'code id_token token', and 'code id_token'."
+          example: code id_token,code token
     AccessTokenConfiguration:
       type: object
       properties:


### PR DESCRIPTION
## Purpose
Issue: https://github.com/wso2/product-is/issues/21140

OAuth PR: https://github.com/wso2-extensions/identity-inbound-auth-oauth/pull/2677

Now the allowed response types for the hybrid flow, provided as a comma-separated string. The supported combinations are: 'code token', 'code id_token token', and 'code id_token'.