### PR TITLE
Fix endpointConfig being list.

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/gen/java/org/wso2/carbon/identity/api/server/configs/v1/model/Authenticator.java
+++ b/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/gen/java/org/wso2/carbon/identity/api/server/configs/v1/model/Authenticator.java
@@ -112,8 +112,7 @@ public enum TypeEnum {
 
     private List<AuthenticatorProperty> properties = null;
 
-    private List<Endpoint> endpoint = null;
-
+    private Endpoint endpoint;
 
     /**
     **/
@@ -317,7 +316,7 @@ public enum TypeEnum {
 
         /**
     **/
-    public Authenticator endpoint(List<Endpoint> endpoint) {
+    public Authenticator endpoint(Endpoint endpoint) {
 
         this.endpoint = endpoint;
         return this;
@@ -326,22 +325,14 @@ public enum TypeEnum {
     @ApiModelProperty(value = "")
     @JsonProperty("endpoint")
     @Valid
-    public List<Endpoint> getEndpoint() {
+    public Endpoint getEndpoint() {
         return endpoint;
     }
-    public void setEndpoint(List<Endpoint> endpoint) {
+    public void setEndpoint(Endpoint endpoint) {
         this.endpoint = endpoint;
     }
 
-    public Authenticator addEndpointItem(Endpoint endpointItem) {
-        if (this.endpoint == null) {
-            this.endpoint = new ArrayList<>();
-        }
-        this.endpoint.add(endpointItem);
-        return this;
-    }
 
-    
 
     @Override
     public boolean equals(java.lang.Object o) {

--- a/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/main/java/org/wso2/carbon/identity/api/server/configs/v1/core/ServerConfigManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/main/java/org/wso2/carbon/identity/api/server/configs/v1/core/ServerConfigManagementService.java
@@ -848,7 +848,7 @@ public class ServerConfigManagementService {
         UserDefinedAuthenticatorEndpointConfig endpointConfig = config.getEndpointConfig();
         Endpoint endpoint = new Endpoint();
         endpoint.setUri(endpointConfig.getAuthenticatorEndpointUri());
-        authenticator.addEndpointItem(endpoint);
+        authenticator.endpoint(endpoint);
     }
 
     private void setAuthenticatorProperties(LocalAuthenticatorConfig config, Authenticator authenticator) {

--- a/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/main/resources/configs.yaml
+++ b/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/main/resources/configs.yaml
@@ -1255,8 +1255,6 @@ components:
           items:
             $ref: '#/components/schemas/AuthenticatorProperty'
         endpoint:
-          type: array
-          items:
             $ref: '#/components/schemas/Endpoint'
       required:
         - name


### PR DESCRIPTION
Issue:
- https://github.com/wso2/product-is/issues/22459

The endpoint configs returning for user defined local authenticators from the `config\authenticators` is currently returning as a list. It must be an object.