### PR TITLE
Fix Missing Required Field Validation in User Sharing APIs to Prevent NPE and Internal Server Errors

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.organization.user.sharing.management/org.wso2.carbon.identity.api.server.organization.user.sharing.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/user/sharing/management/v1/factories/UsersApiServiceFactory.java
+++ b/components/org.wso2.carbon.identity.api.server.organization.user.sharing.management/org.wso2.carbon.identity.api.server.organization.user.sharing.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/user/sharing/management/v1/factories/UsersApiServiceFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -23,15 +23,10 @@ import org.wso2.carbon.identity.api.server.organization.user.sharing.management.
 
 public class UsersApiServiceFactory {
 
-   private static final UsersApiService SERVICE = new UsersApiServiceImpl();
+   private final static UsersApiService service = new UsersApiServiceImpl();
 
-   /**
-    * Get UsersApiService.
-    *
-    * @return UsersApiService.
-    */
-   public static UsersApiService getUsersApi() {
-
-      return SERVICE;
+   public static UsersApiService getUsersApi()
+   {
+      return service;
    }
 }

--- a/components/org.wso2.carbon.identity.api.server.organization.user.sharing.management/org.wso2.carbon.identity.api.server.organization.user.sharing.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/user/sharing/management/v1/model/UserShareRequestBody.java
+++ b/components/org.wso2.carbon.identity.api.server.organization.user.sharing.management/org.wso2.carbon.identity.api.server.organization.user.sharing.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/user/sharing/management/v1/model/UserShareRequestBody.java
@@ -40,7 +40,7 @@ import javax.xml.bind.annotation.*;
 public class UserShareRequestBody  {
   
     private UserShareRequestBodyUserCriteria userCriteria;
-    private List<UserShareRequestBodyOrganizations> organizations = null;
+    private List<UserShareRequestBodyOrganizations> organizations = new ArrayList<>();
 
 
     /**
@@ -51,9 +51,11 @@ public class UserShareRequestBody  {
         return this;
     }
     
-    @ApiModelProperty(value = "")
+    @ApiModelProperty(required = true, value = "")
     @JsonProperty("userCriteria")
     @Valid
+    @NotNull(message = "Property userCriteria cannot be null.")
+
     public UserShareRequestBodyUserCriteria getUserCriteria() {
         return userCriteria;
     }
@@ -70,9 +72,11 @@ public class UserShareRequestBody  {
         return this;
     }
     
-    @ApiModelProperty(value = "List of organizations specifying sharing scope and roles.")
+    @ApiModelProperty(required = true, value = "List of organizations specifying sharing scope and roles.")
     @JsonProperty("organizations")
     @Valid
+    @NotNull(message = "Property organizations cannot be null.")
+
     public List<UserShareRequestBodyOrganizations> getOrganizations() {
         return organizations;
     }
@@ -81,9 +85,6 @@ public class UserShareRequestBody  {
     }
 
     public UserShareRequestBody addOrganizationsItem(UserShareRequestBodyOrganizations organizationsItem) {
-        if (this.organizations == null) {
-            this.organizations = new ArrayList<>();
-        }
         this.organizations.add(organizationsItem);
         return this;
     }

--- a/components/org.wso2.carbon.identity.api.server.organization.user.sharing.management/org.wso2.carbon.identity.api.server.organization.user.sharing.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/user/sharing/management/v1/model/UserShareRequestBodyOrganizations.java
+++ b/components/org.wso2.carbon.identity.api.server.organization.user.sharing.management/org.wso2.carbon.identity.api.server.organization.user.sharing.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/user/sharing/management/v1/model/UserShareRequestBodyOrganizations.java
@@ -82,9 +82,11 @@ public enum PolicyEnum {
         return this;
     }
     
-    @ApiModelProperty(value = "The ID of the organization to share the users with.")
+    @ApiModelProperty(required = true, value = "The ID of the organization to share the users with.")
     @JsonProperty("orgId")
     @Valid
+    @NotNull(message = "Property orgId cannot be null.")
+
     public String getOrgId() {
         return orgId;
     }
@@ -101,9 +103,11 @@ public enum PolicyEnum {
         return this;
     }
     
-    @ApiModelProperty(value = "The scope of sharing for this organization.")
+    @ApiModelProperty(required = true, value = "The scope of sharing for this organization.")
     @JsonProperty("policy")
     @Valid
+    @NotNull(message = "Property policy cannot be null.")
+
     public PolicyEnum getPolicy() {
         return policy;
     }

--- a/components/org.wso2.carbon.identity.api.server.organization.user.sharing.management/org.wso2.carbon.identity.api.server.organization.user.sharing.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/user/sharing/management/v1/model/UserShareWithAllRequestBody.java
+++ b/components/org.wso2.carbon.identity.api.server.organization.user.sharing.management/org.wso2.carbon.identity.api.server.organization.user.sharing.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/user/sharing/management/v1/model/UserShareWithAllRequestBody.java
@@ -85,9 +85,11 @@ public enum PolicyEnum {
         return this;
     }
     
-    @ApiModelProperty(value = "")
+    @ApiModelProperty(required = true, value = "")
     @JsonProperty("userCriteria")
     @Valid
+    @NotNull(message = "Property userCriteria cannot be null.")
+
     public UserShareRequestBodyUserCriteria getUserCriteria() {
         return userCriteria;
     }
@@ -104,9 +106,11 @@ public enum PolicyEnum {
         return this;
     }
     
-    @ApiModelProperty(value = "A policy to specify the sharing scope.")
+    @ApiModelProperty(required = true, value = "A policy to specify the sharing scope.")
     @JsonProperty("policy")
     @Valid
+    @NotNull(message = "Property policy cannot be null.")
+
     public PolicyEnum getPolicy() {
         return policy;
     }

--- a/components/org.wso2.carbon.identity.api.server.organization.user.sharing.management/org.wso2.carbon.identity.api.server.organization.user.sharing.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/user/sharing/management/v1/model/UserUnshareRequestBody.java
+++ b/components/org.wso2.carbon.identity.api.server.organization.user.sharing.management/org.wso2.carbon.identity.api.server.organization.user.sharing.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/user/sharing/management/v1/model/UserUnshareRequestBody.java
@@ -39,7 +39,7 @@ import javax.xml.bind.annotation.*;
 public class UserUnshareRequestBody  {
   
     private UserUnshareRequestBodyUserCriteria userCriteria;
-    private List<String> organizations = null;
+    private List<String> organizations = new ArrayList<>();
 
 
     /**
@@ -50,9 +50,11 @@ public class UserUnshareRequestBody  {
         return this;
     }
     
-    @ApiModelProperty(value = "")
+    @ApiModelProperty(required = true, value = "")
     @JsonProperty("userCriteria")
     @Valid
+    @NotNull(message = "Property userCriteria cannot be null.")
+
     public UserUnshareRequestBodyUserCriteria getUserCriteria() {
         return userCriteria;
     }
@@ -69,9 +71,11 @@ public class UserUnshareRequestBody  {
         return this;
     }
     
-    @ApiModelProperty(value = "List of organization IDs from which the users should be unshared.")
+    @ApiModelProperty(required = true, value = "List of organization IDs from which the users should be unshared.")
     @JsonProperty("organizations")
     @Valid
+    @NotNull(message = "Property organizations cannot be null.")
+
     public List<String> getOrganizations() {
         return organizations;
     }
@@ -80,9 +84,6 @@ public class UserUnshareRequestBody  {
     }
 
     public UserUnshareRequestBody addOrganizationsItem(String organizationsItem) {
-        if (this.organizations == null) {
-            this.organizations = new ArrayList<>();
-        }
         this.organizations.add(organizationsItem);
         return this;
     }

--- a/components/org.wso2.carbon.identity.api.server.organization.user.sharing.management/org.wso2.carbon.identity.api.server.organization.user.sharing.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/user/sharing/management/v1/model/UserUnshareWithAllRequestBody.java
+++ b/components/org.wso2.carbon.identity.api.server.organization.user.sharing.management/org.wso2.carbon.identity.api.server.organization.user.sharing.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/user/sharing/management/v1/model/UserUnshareWithAllRequestBody.java
@@ -46,9 +46,11 @@ public class UserUnshareWithAllRequestBody  {
         return this;
     }
     
-    @ApiModelProperty(value = "")
+    @ApiModelProperty(required = true, value = "")
     @JsonProperty("userCriteria")
     @Valid
+    @NotNull(message = "Property userCriteria cannot be null.")
+
     public UserUnshareRequestBodyUserCriteria getUserCriteria() {
         return userCriteria;
     }

--- a/components/org.wso2.carbon.identity.api.server.organization.user.sharing.management/org.wso2.carbon.identity.api.server.organization.user.sharing.management.v1/src/main/resources/organization-user-share.yaml
+++ b/components/org.wso2.carbon.identity.api.server.organization.user.sharing.management/org.wso2.carbon.identity.api.server.organization.user.sharing.management.v1/src/main/resources/organization-user-share.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 info:
   version: 1.0.2
-  title: 'User Share API Definition'
+  title: 'User Sharing API Definition'
   description: |-
     This API provides organization administrators with the ability to manage user access across child organizations. It supports operations to share users with specific or all child organizations, retrieve shared access details, and remove shared access as needed. The API also includes features for paginated retrieval of organizations and roles associated with shared users.
   contact:
@@ -346,6 +346,9 @@ components:
       description: |
         The request body for sharing users with multiple child organizations.
         Includes a list of users, organizations, sharing scope as policy, and roles.
+      required:
+        - userCriteria
+        - organizations
       properties:
         userCriteria:
           type: object
@@ -362,6 +365,9 @@ components:
           description: List of organizations specifying sharing scope and roles.
           items:
             type: object
+            required:
+              - orgId
+              - policy
             properties:
               orgId:
                 type: string
@@ -400,6 +406,9 @@ components:
       description: |
         Process a request to share users with all organizations. 
         The payload contains the roles applicable across all organizations and a policy that defines the scope of sharing.
+      required:
+        - userCriteria
+        - policy
       properties:
         userCriteria:
           type: object
@@ -441,6 +450,9 @@ components:
       description: |
         The request body for unsharing users from multiple organizations.
         Includes a list of user IDs and a list of organization IDs.
+      required:
+        - userCriteria
+        - organizations
       properties:
         userCriteria:
           type: object
@@ -471,6 +483,8 @@ components:
       description: |
         The request body for unsharing users from all organizations.
         Includes a list of user IDs.
+      required:
+        - userCriteria
       properties:
         userCriteria:
           type: object


### PR DESCRIPTION
## Purpose
Previously, required fields were not enforced in the API definition, allowing requests with missing values to reach the service layer. This resulted in `NullPointerException` (NPE) errors, causing a `500 Internal Server Error` instead of a proper client error. The issue affected both selective user sharing/unsharing and general user sharing/unsharing, leading to unexpected failures when required attributes were missing.

## Goals
This fix ensures that all mandatory fields are properly enforced at the API definition level, preventing invalid requests from being processed. Instead of an unhandled server error, the API now responds with a 400 Bad Request error when required fields are missing, improving error handling and user experience.

#### Example:
**Invalid Request: (Missing `userCriteria` in selective user share)**
```
curl --location 'https://localhost:9443/t/carbon.super/api/server/v1/users/share' \
--header 'Authorization: Basic YWRtaW46YWRtaW4=' \
--header 'Content-Type: application/json' \
--data '{
    "organizations": [
        {
            "orgId": "10e7ab37-de5c-4908-abdd-552bfbe4858a",
            "policy": "SELECTED_ORG_ONLY",
            "roles": [
                {
                    "displayName": "app-role-1",
                    "audience": {
                        "display": "App1",
                        "type": "application"
                    }
                }
            ]
        }
    ]
}'

```
**Error Response:**
```
{
    "code": "UE-10000",
    "message": "Invalid Request",
    "description": "Property userCriteria cannot be null.",
    "traceId": "0f739e92-67ae-498f-bce8-6b2f2bf2366c"
}
```

## Approach
The following fields have now been explicitly marked as required in the OpenAPI definition to prevent null values from causing internal server errors:

- Selective User Sharing (/users/share)
  - userCriteria
  - organizations
    - orgId
    - policy
- General User Sharing (/users/share-all)
  - userCriteria
  - policy
- Selective User Unsharing (/users/unshare)
  - userCriteria
  - organizations
- General User Unsharing (/users/unshare-all)
  - userCriteria

These changes ensure that missing values now trigger a client-side validation error (400 Bad Request) rather than an unexpected server-side failure (500 Internal Server Error), improving both API reliability and user feedback.

---

## Related Issue
product-is issue: [Selective user sharing cause for NPE if organizations key is missing in the payload #22598](https://github.com/wso2/product-is/issues/22598)