### PR TITLE
Use SharedType.toString() in populateUserSharedOrganizationsResponse

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.organization.user.sharing.management/org.wso2.carbon.identity.api.server.organization.user.sharing.management.v1/src/main/java/org/wso2/carbon/identity/api/server/organization/user/sharing/management/v1/core/UsersApiServiceCore.java
+++ b/components/org.wso2.carbon.identity.api.server.organization.user.sharing.management/org.wso2.carbon.identity.api.server.organization.user.sharing.management.v1/src/main/java/org/wso2/carbon/identity/api/server/organization/user/sharing/management/v1/core/UsersApiServiceCore.java
@@ -372,7 +372,7 @@ public class UsersApiServiceCore {
                                     resultOrgDetail.getOrganizationId())
                             .orgName(resultOrgDetail.getOrganizationName())
                             .sharedUserId(resultOrgDetail.getSharedUserId())
-                            .sharedType(resultOrgDetail.getSharedType())
+                            .sharedType(resultOrgDetail.getSharedType().toString())
                             .rolesRef(resultOrgDetail.getRolesRef());
             responseOrgs.add(org);
         }

--- a/pom.xml
+++ b/pom.xml
@@ -878,7 +878,7 @@
         </org.wso2.carbon.identity.organization.management.core.version.range>
 
         <!-- Organization management service Version -->
-        <org.wso2.carbon.identity.organization.management.version>1.4.80
+        <org.wso2.carbon.identity.organization.management.version>1.4.87
         </org.wso2.carbon.identity.organization.management.version>
 
         <!-- Unit test versions -->


### PR DESCRIPTION
## Purpose
> Ensure sharedType is correctly serialized as a String in `UserSharedOrganizationsResponseSharedOrganizations`, following the enum update in [Refactor SharedType Enum and Update Usage in UserAssociation and ResponseOrgDetailsDO #22689](https://github.com/wso2/product-is/issues/22689).

## Goals
> - Align with the changes from [Refactor SharedType Enum and Update Usage in UserAssociation and ResponseOrgDetailsDO #22689](https://github.com/wso2/product-is/issues/22689).
> - Prevent type mismatches when handling sharedType.
> - Maintain consistency in response serialization.

## Approach
> Updated `populateUserSharedOrganizationsResponse` to call `toString()` on `SharedType` before assigning it to sharedType.