### PR TITLE
Add validation for endpoint authentication properties in authenticator create flows

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.action.management/org.wso2.carbon.identity.api.server.action.management.v1/src/main/java/org/wso2/carbon/identity/api/server/action/management/v1/util/ActionMapperUtil.java
+++ b/components/org.wso2.carbon.identity.api.server.action.management/org.wso2.carbon.identity.api.server.action.management.v1/src/main/java/org/wso2/carbon/identity/api/server/action/management/v1/util/ActionMapperUtil.java
@@ -61,7 +61,7 @@ public class ActionMapperUtil {
             throws ActionMgtException {
 
         Authentication authentication = ActionMapperUtil.buildAuthentication(
-                Authentication.Type.valueOf(actionModel.getEndpoint().getAuthentication().getType().toString()),
+                Authentication.Type.valueOfName(actionModel.getEndpoint().getAuthentication().getType().toString()),
                 actionModel.getEndpoint().getAuthentication().getProperties());
 
         ActionRule actionRule = null;
@@ -97,7 +97,7 @@ public class ActionMapperUtil {
 
             Authentication authentication = null;
             if (actionUpdateModel.getEndpoint().getAuthentication() != null) {
-                authentication = buildAuthentication(Authentication.Type.valueOf(actionUpdateModel.getEndpoint()
+                authentication = buildAuthentication(Authentication.Type.valueOfName(actionUpdateModel.getEndpoint()
                                 .getAuthentication().getType().toString()),
                         actionUpdateModel.getEndpoint().getAuthentication().getProperties());
             }

--- a/components/org.wso2.carbon.identity.api.server.authenticators/org.wso2.carbon.identity.api.server.authenticators.v1/src/main/java/org/wso2/carbon/identity/api/server/authenticators/v1/impl/LocalAuthenticatorConfigBuilderFactory.java
+++ b/components/org.wso2.carbon.identity.api.server.authenticators/org.wso2.carbon.identity.api.server.authenticators.v1/src/main/java/org/wso2/carbon/identity/api/server/authenticators/v1/impl/LocalAuthenticatorConfigBuilderFactory.java
@@ -92,6 +92,7 @@ public class LocalAuthenticatorConfigBuilderFactory {
         authConfig.setImageUrl(config.getImage());
         authConfig.setDescription(config.getDescription());
         authConfig.setEnabled(config.getIsEnabled());
+        validateEndpointAuthProperties(config.getEndpoint());
         authConfig.setEndpointConfig(buildEndpointConfig(config.getEndpoint()));
 
         return authConfig;
@@ -145,6 +146,16 @@ public class LocalAuthenticatorConfigBuilderFactory {
             return AuthenticatorPropertyConstants.AuthenticationType.VERIFICATION;
         } else {
             return AuthenticatorPropertyConstants.AuthenticationType.IDENTIFICATION;
+        }
+    }
+
+    private static void validateEndpointAuthProperties(Endpoint endpoint) throws AuthenticatorMgtClientException {
+
+        if (endpoint.getAuthentication().getProperties() == null ||
+                endpoint.getAuthentication().getProperties().isEmpty()) {
+            AuthenticatorMgtError error = AuthenticatorMgtError.ERROR_CODE_INVALID_ENDPOINT_CONFIG;
+            throw new AuthenticatorMgtClientException(error.getCode(), error.getMessage(),
+                    "Authentication properties are not provided");
         }
     }
 }

--- a/components/org.wso2.carbon.identity.api.server.authenticators/org.wso2.carbon.identity.api.server.authenticators.v1/src/main/java/org/wso2/carbon/identity/api/server/authenticators/v1/impl/LocalAuthenticatorConfigBuilderFactory.java
+++ b/components/org.wso2.carbon.identity.api.server.authenticators/org.wso2.carbon.identity.api.server.authenticators.v1/src/main/java/org/wso2/carbon/identity/api/server/authenticators/v1/impl/LocalAuthenticatorConfigBuilderFactory.java
@@ -81,6 +81,7 @@ public class LocalAuthenticatorConfigBuilderFactory {
     public static UserDefinedLocalAuthenticatorConfig build(UserDefinedLocalAuthenticatorCreation config)
             throws AuthenticatorMgtClientException {
 
+        validateUserDefinedLocalAuthenticatorConfig(config);
         String authenticationType = AuthenticatorPropertyConstants.AuthenticationType.IDENTIFICATION.toString();
         if (config.getAuthenticationType() != null) {
             authenticationType = config.getAuthenticationType().toString();
@@ -92,7 +93,6 @@ public class LocalAuthenticatorConfigBuilderFactory {
         authConfig.setImageUrl(config.getImage());
         authConfig.setDescription(config.getDescription());
         authConfig.setEnabled(config.getIsEnabled());
-        validateEndpointAuthProperties(config.getEndpoint());
         authConfig.setEndpointConfig(buildEndpointConfig(config.getEndpoint()));
 
         return authConfig;
@@ -149,13 +149,15 @@ public class LocalAuthenticatorConfigBuilderFactory {
         }
     }
 
-    private static void validateEndpointAuthProperties(Endpoint endpoint) throws AuthenticatorMgtClientException {
+    private static void validateUserDefinedLocalAuthenticatorConfig(UserDefinedLocalAuthenticatorCreation config)
+            throws AuthenticatorMgtClientException {
 
-        if (endpoint.getAuthentication().getProperties() == null ||
-                endpoint.getAuthentication().getProperties().isEmpty()) {
+        if (config.getEndpoint().getAuthentication().getProperties() == null ||
+                config.getEndpoint().getAuthentication().getProperties().isEmpty()) {
             AuthenticatorMgtError error = AuthenticatorMgtError.ERROR_CODE_INVALID_ENDPOINT_CONFIG;
             throw new AuthenticatorMgtClientException(error.getCode(), error.getMessage(),
-                    "Authentication properties are not provided");
+                    "Endpoint authentication properties must be provided for user defined local authenticator: "
+                            + config.getName());
         }
     }
 }

--- a/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/main/java/org/wso2/carbon/identity/api/server/idp/v1/core/ServerIdpManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/main/java/org/wso2/carbon/identity/api/server/idp/v1/core/ServerIdpManagementService.java
@@ -2765,7 +2765,7 @@ public class ServerIdpManagementService {
          If the authenticator config is present in the ApplicationAuthenticatorService list, return its type,
          if not return USER. */
         FederatedAuthenticatorConfig authenticatorConfig = ApplicationAuthenticatorService.getInstance()
-                .getFederatedAuthenticatorByName(authenticatorName, "test");
+                .getFederatedAuthenticatorByName(authenticatorName);
         if (authenticatorConfig != null) {
             return DefinedByType.valueOf(authenticatorConfig.getDefinedByType().toString());
         }

--- a/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/main/java/org/wso2/carbon/identity/api/server/idp/v1/core/ServerIdpManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/main/java/org/wso2/carbon/identity/api/server/idp/v1/core/ServerIdpManagementService.java
@@ -2765,7 +2765,7 @@ public class ServerIdpManagementService {
          If the authenticator config is present in the ApplicationAuthenticatorService list, return its type,
          if not return USER. */
         FederatedAuthenticatorConfig authenticatorConfig = ApplicationAuthenticatorService.getInstance()
-                .getFederatedAuthenticatorByName(authenticatorName);
+                .getFederatedAuthenticatorByName(authenticatorName, "test");
         if (authenticatorConfig != null) {
             return DefinedByType.valueOf(authenticatorConfig.getDefinedByType().toString());
         }

--- a/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/main/java/org/wso2/carbon/identity/api/server/idp/v1/impl/FederatedAuthenticatorConfigBuilderFactory.java
+++ b/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/main/java/org/wso2/carbon/identity/api/server/idp/v1/impl/FederatedAuthenticatorConfigBuilderFactory.java
@@ -256,7 +256,8 @@ public class FederatedAuthenticatorConfigBuilderFactory {
             throw new IdentityProviderManagementClientException(
                     Constants.ErrorMessage.ERROR_CODE_INVALID_INPUT.getCode(),
                     Constants.ErrorMessage.ERROR_CODE_INVALID_INPUT.getMessage(),
-                    "Authenticator endpoint authentication properties are not provided");
+                    "Endpoint authentication properties must be provided for user defined federated authenticator: "
+                            + config.authenticatorName);
         }
     }
 

--- a/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/main/java/org/wso2/carbon/identity/api/server/idp/v1/impl/FederatedAuthenticatorConfigBuilderFactory.java
+++ b/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/main/java/org/wso2/carbon/identity/api/server/idp/v1/impl/FederatedAuthenticatorConfigBuilderFactory.java
@@ -82,7 +82,7 @@ public class FederatedAuthenticatorConfigBuilderFactory {
                         getDisplayNameOfAuthenticator(authenticatorName),
                         authenticator.getEndpoint(), properties, authenticator.getIsEnabled(), definedByType);
 
-        validateFederatedAuthenticatorConfigForPUTRequest(config);
+        validateFederatedAuthenticatorConfigForUpdateRequest(config);
         return FederatedAuthenticatorConfigBuilderFactory.createFederatedAuthenticatorConfig(config);
     }
 
@@ -107,7 +107,7 @@ public class FederatedAuthenticatorConfigBuilderFactory {
                         getDisplayNameOfAuthenticator(authenticatorName),
                         authenticator.getEndpoint(), properties, authenticator.getIsEnabled(), definedByType);
 
-        validateFederatedAuthenticatorConfig(config);
+        validateFederatedAuthenticatorConfigForCreateRequest(config);
         return FederatedAuthenticatorConfigBuilderFactory.createFederatedAuthenticatorConfig(config);
     }
 
@@ -237,20 +237,20 @@ public class FederatedAuthenticatorConfigBuilderFactory {
         }
     }
 
-    private static void validateFederatedAuthenticatorConfig(Config config)
+    private static void validateFederatedAuthenticatorConfigForCreateRequest(Config config)
             throws IdentityProviderManagementClientException {
 
         if (config.definedByType == DefinedByType.SYSTEM) {
             validateSystemDefinedFederatedAuthenticatorModel(config);
         } else {
-            validateUserDefinedFederatedAuthenticatorModel(config);
+            validateUserDefinedFederatedAuthenticatorModelForCreateRequest(config);
         }
     }
 
-    private static void validateUserDefinedFederatedAuthenticatorModel(Config config)
+    private static void validateUserDefinedFederatedAuthenticatorModelForCreateRequest(Config config)
             throws IdentityProviderManagementClientException {
 
-        validateUserDefinedFederatedAuthenticatorModelForPUTRequest(config);
+        validateUserDefinedFederatedAuthenticatorModelForUpdateRequest(config);
         if (config.endpoint.getAuthentication().getProperties() == null ||
                 config.endpoint.getAuthentication().getProperties().isEmpty()) {
             throw new IdentityProviderManagementClientException(
@@ -261,17 +261,17 @@ public class FederatedAuthenticatorConfigBuilderFactory {
         }
     }
 
-    private static void validateFederatedAuthenticatorConfigForPUTRequest(Config config)
+    private static void validateFederatedAuthenticatorConfigForUpdateRequest(Config config)
             throws IdentityProviderManagementClientException {
 
         if (config.definedByType == DefinedByType.SYSTEM) {
             validateSystemDefinedFederatedAuthenticatorModel(config);
         } else {
-            validateUserDefinedFederatedAuthenticatorModelForPUTRequest(config);
+            validateUserDefinedFederatedAuthenticatorModelForUpdateRequest(config);
         }
     }
 
-    private static void validateUserDefinedFederatedAuthenticatorModelForPUTRequest(Config config)
+    private static void validateUserDefinedFederatedAuthenticatorModelForUpdateRequest(Config config)
             throws IdentityProviderManagementClientException {
 
         // The User-defined authenticator configs must not have properties configurations; throw an error if they do.

--- a/pom.xml
+++ b/pom.xml
@@ -848,7 +848,7 @@
         <maven.buildnumber.plugin.version>1.4</maven.buildnumber.plugin.version>
         <org.apache.felix.annotations.version>1.2.4</org.apache.felix.annotations.version>
         <identity.governance.version>1.11.27</identity.governance.version>
-        <carbon.identity.framework.version>7.7.180</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.7.184</carbon.identity.framework.version>
         <maven.findbugsplugin.version>3.0.5</maven.findbugsplugin.version>
         <findsecbugs-plugin.version>1.12.0</findsecbugs-plugin.version>
         <maven.checkstyleplugin.excludes>**/gen/**/*</maven.checkstyleplugin.excludes>

--- a/pom.xml
+++ b/pom.xml
@@ -848,7 +848,7 @@
         <maven.buildnumber.plugin.version>1.4</maven.buildnumber.plugin.version>
         <org.apache.felix.annotations.version>1.2.4</org.apache.felix.annotations.version>
         <identity.governance.version>1.11.27</identity.governance.version>
-        <carbon.identity.framework.version>7.7.184</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.7.185</carbon.identity.framework.version>
         <maven.findbugsplugin.version>3.0.5</maven.findbugsplugin.version>
         <findsecbugs-plugin.version>1.12.0</findsecbugs-plugin.version>
         <maven.checkstyleplugin.excludes>**/gen/**/*</maven.checkstyleplugin.excludes>


### PR DESCRIPTION
## Purpose
> This will add validations on the endpoint authentication properties on authenticator and federated-authenticator create flows, as authentication properties is a required attribute

Depends on : https://github.com/wso2/carbon-identity-framework/pull/6424

## Related Issue
- https://github.com/wso2/product-is/issues/22564