### PR TITLE
[UX] Sort api resource collection by Display name

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.api.resource/org.wso2.carbon.identity.api.server.api.resource.v1/src/main/java/org/wso2/carbon/identity/api/server/api/resource/v1/core/ServerAPIResourceCollectionManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.api.resource/org.wso2.carbon.identity.api.server.api.resource.v1/src/main/java/org/wso2/carbon/identity/api/server/api/resource/v1/core/ServerAPIResourceCollectionManagementService.java
@@ -42,6 +42,7 @@ import org.wso2.carbon.identity.application.common.model.Scope;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -91,6 +92,8 @@ public class ServerAPIResourceCollectionManagementService {
             }
             apiResourceCollectionListResponse.setTotalResults(apiResourceCollectionSearchResult.getTotalCount());
             apiResourceCollectionListResponse.setApiResourceCollections(apiResourceCollections.stream()
+                    .sorted(Comparator.comparing(APIResourceCollection::getDisplayName,
+                            Comparator.nullsFirst(String.CASE_INSENSITIVE_ORDER)))
                     .map(apiResourceCollection -> buildAPIResourceCollectionListItem(apiResourceCollection,
                             CollectionUtils.isNotEmpty(requestedAttributeList))).collect(Collectors.toList()));
         } catch (APIResourceCollectionMgtException e) {


### PR DESCRIPTION
## Purpose
Public Issue: https://github.com/wso2/product-is/issues/22903
Sort API resource by display name for UX and added a null check if display name is null. But as per design display name shouldn't be null.


Modify Existing Role
https://github.com/user-attachments/assets/82509b14-dc02-4acc-8fcb-65dd35aa1bd7

Add New Role
https://github.com/user-attachments/assets/0ffcdab1-fe7b-4620-90cd-6eda3c33adae

Root Org Permission
<img width="941" alt="Screenshot 2025-02-11 at 12 42 07" src="https://github.com/user-attachments/assets/f5165691-fe86-4a11-8354-ba3df64704e6" />

Org Permission
<img width="941" alt="Screenshot 2025-02-11 at 12 42 15" src="https://github.com/user-attachments/assets/484f2832-2735-498b-88f9-4f3f07525749" />

