### PR TITLE
Introduce Organization Handle to Management API

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/application/management/v1/BasicOrganizationResponse.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/application/management/v1/BasicOrganizationResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -34,6 +34,7 @@ public class BasicOrganizationResponse  {
   
     private String id;
     private String name;
+    private String orgHandle;
 
 @XmlType(name="StatusEnum")
 @XmlEnum(String.class)
@@ -112,6 +113,26 @@ public enum StatusEnum {
 
     /**
     **/
+    public BasicOrganizationResponse orgHandle(String orgHandle) {
+
+        this.orgHandle = orgHandle;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "abcbuilders", required = true, value = "")
+    @JsonProperty("orgHandle")
+    @Valid
+    @NotNull(message = "Property orgHandle cannot be null.")
+
+    public String getOrgHandle() {
+        return orgHandle;
+    }
+    public void setOrgHandle(String orgHandle) {
+        this.orgHandle = orgHandle;
+    }
+
+    /**
+    **/
     public BasicOrganizationResponse status(StatusEnum status) {
 
         this.status = status;
@@ -164,13 +185,14 @@ public enum StatusEnum {
         BasicOrganizationResponse basicOrganizationResponse = (BasicOrganizationResponse) o;
         return Objects.equals(this.id, basicOrganizationResponse.id) &&
             Objects.equals(this.name, basicOrganizationResponse.name) &&
+            Objects.equals(this.orgHandle, basicOrganizationResponse.orgHandle) &&
             Objects.equals(this.status, basicOrganizationResponse.status) &&
             Objects.equals(this.ref, basicOrganizationResponse.ref);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, name, status, ref);
+        return Objects.hash(id, name, orgHandle, status, ref);
     }
 
     @Override
@@ -181,6 +203,7 @@ public enum StatusEnum {
         
         sb.append("    id: ").append(toIndentedString(id)).append("\n");
         sb.append("    name: ").append(toIndentedString(name)).append("\n");
+        sb.append("    orgHandle: ").append(toIndentedString(orgHandle)).append("\n");
         sb.append("    status: ").append(toIndentedString(status)).append("\n");
         sb.append("    ref: ").append(toIndentedString(ref)).append("\n");
         sb.append("}");

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/ServerApplicationSharingService.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/ServerApplicationSharingService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2024-2025, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/ServerApplicationSharingService.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/ServerApplicationSharingService.java
@@ -178,6 +178,7 @@ public class ServerApplicationSharingService {
         for (BasicOrganization org : organizations) {
             BasicOrganizationResponse basicOrganizationResponse =
                     new BasicOrganizationResponse().id(org.getId()).name(org.getName())
+                            .orgHandle(org.getOrganizationHandle())
                             .ref(buildOrganizationURL(org.getId()).toString());
             response.addOrganizationsItem(basicOrganizationResponse);
         }

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/resources/applications.yaml
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/resources/applications.yaml
@@ -4431,6 +4431,7 @@ components:
       required:
         - id
         - name
+        - orgHandle
         - status
         - ref
       properties:
@@ -4440,6 +4441,9 @@ components:
         name:
           type: string
           example: 'ABC Builders'
+        orgHandle:
+          type: string
+          example: 'abcbuilders'
         status:
           type: string
           enum: [ ACTIVE, DISABLED ]

--- a/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/management/v1/OrganizationsApi.java
+++ b/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/management/v1/OrganizationsApi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -23,16 +23,17 @@ import org.apache.cxf.jaxrs.ext.multipart.Multipart;
 import java.io.InputStream;
 import java.util.List;
 
-import org.wso2.carbon.identity.api.server.organization.management.v1.factories.OrganizationsApiServiceFactory;
 import org.wso2.carbon.identity.api.server.organization.management.v1.model.ApplicationSharePOSTRequest;
 import org.wso2.carbon.identity.api.server.organization.management.v1.model.Error;
 import org.wso2.carbon.identity.api.server.organization.management.v1.model.GetOrganizationResponse;
 import java.util.List;
 import org.wso2.carbon.identity.api.server.organization.management.v1.model.MetaAttributesResponse;
+import org.wso2.carbon.identity.api.server.organization.management.v1.model.OrganizationCheckResponse;
 import org.wso2.carbon.identity.api.server.organization.management.v1.model.OrganizationDiscoveryAttributes;
 import org.wso2.carbon.identity.api.server.organization.management.v1.model.OrganizationDiscoveryCheckPOSTRequest;
 import org.wso2.carbon.identity.api.server.organization.management.v1.model.OrganizationDiscoveryCheckPOSTResponse;
 import org.wso2.carbon.identity.api.server.organization.management.v1.model.OrganizationDiscoveryPostRequest;
+import org.wso2.carbon.identity.api.server.organization.management.v1.model.OrganizationHandleCheckPOSTRequest;
 import org.wso2.carbon.identity.api.server.organization.management.v1.model.OrganizationMetadata;
 import org.wso2.carbon.identity.api.server.organization.management.v1.model.OrganizationNameCheckPOSTRequest;
 import org.wso2.carbon.identity.api.server.organization.management.v1.model.OrganizationNameCheckPOSTResponse;
@@ -44,6 +45,8 @@ import org.wso2.carbon.identity.api.server.organization.management.v1.model.Orga
 import org.wso2.carbon.identity.api.server.organization.management.v1.model.OrganizationsResponse;
 import org.wso2.carbon.identity.api.server.organization.management.v1.model.SharedApplicationsResponse;
 import org.wso2.carbon.identity.api.server.organization.management.v1.model.SharedOrganizationsResponse;
+import org.wso2.carbon.identity.api.server.organization.management.v1.OrganizationsApiService;
+import org.wso2.carbon.identity.api.server.organization.management.v1.factories.OrganizationsApiServiceFactory;
 
 import javax.validation.Valid;
 import javax.ws.rs.*;
@@ -131,7 +134,7 @@ public class OrganizationsApi  {
         @ApiResponse(code = 403, message = "Access forbidden.", response = Void.class),
         @ApiResponse(code = 500, message = "Internal server error.", response = Error.class)
     })
-    public Response organizationDiscoveryPost(@ApiParam(value = "This represents the organization discovery attributes to be added." ,required=true) @Valid @NotNull(message = "Request body organizationDiscoveryPostRequest cannot be null.") OrganizationDiscoveryPostRequest organizationDiscoveryPostRequest) {
+    public Response organizationDiscoveryPost(@ApiParam(value = "This represents the organization discovery attributes to be added." ,required=true) @Valid OrganizationDiscoveryPostRequest organizationDiscoveryPostRequest) {
 
         return delegate.organizationDiscoveryPost(organizationDiscoveryPostRequest );
     }
@@ -179,6 +182,30 @@ public class OrganizationsApi  {
     public Response organizationPost(@ApiParam(value = "This represents the organization to be added." ,required=true) @Valid OrganizationPOSTRequest organizationPOSTRequest) {
 
         return delegate.organizationPost(organizationPOSTRequest );
+    }
+
+    @Valid
+    @POST
+    @Path("/check-handle")
+    @Consumes({ "application/json" })
+    @Produces({ "application/json" })
+    @ApiOperation(value = "Check organization with given handle exist among the organizations hierarchy.", notes = "This API is used to check whether organization with particular handle exist or not.", response = OrganizationCheckResponse.class, authorizations = {
+        @Authorization(value = "BasicAuth"),
+        @Authorization(value = "OAuth2", scopes = {
+            
+        })
+    }, tags={ "Organization", })
+    @ApiResponses(value = { 
+        @ApiResponse(code = 200, message = "Successful response", response = OrganizationCheckResponse.class),
+        @ApiResponse(code = 404, message = "Requested resource is not found.", response = Error.class),
+        @ApiResponse(code = 400, message = "Invalid input in the request.", response = Error.class),
+        @ApiResponse(code = 401, message = "Authentication information is missing or invalid.", response = Void.class),
+        @ApiResponse(code = 403, message = "Access forbidden.", response = Void.class),
+        @ApiResponse(code = 500, message = "Internal server error.", response = Error.class)
+    })
+    public Response organizationsCheckHandlePost(@ApiParam(value = "OrganizationHandleCheckPOSTRequest object containing the organization handle." ,required=true) @Valid OrganizationHandleCheckPOSTRequest organizationHandleCheckPOSTRequest) {
+
+        return delegate.organizationsCheckHandlePost(organizationHandleCheckPOSTRequest );
     }
 
     @Valid
@@ -234,7 +261,7 @@ public class OrganizationsApi  {
     
     
     @Produces({ "application/json" })
-    @ApiOperation(value = "Retrieve organizations created for this tenant which matches the defined search criteria, if any.", notes = "This API is used to search and retrieve organizations created for this tenant.  Organizations can be filtered by id, name, description, created, lastModified, status, parentId, and meta attributes.         Supported operators: \"eq\" (equals), \"co\" (contains), \"sw\" (starts with), \"ew\" (ends with), \"ge\" (greater than or equals), \"le\" (less than or equals), \"gt\" (greater than), \"lt\" (less than)  Multiple attributes can be combined using the \"and\" operator.  Examples:   - filter=name+eq+ABC Builders   - filter=attributes.Country+eq+Sri Lanka  <b>Scope(Permission) required:</b> `internal_organization_view` ", response = OrganizationsResponse.class, authorizations = {
+    @ApiOperation(value = "Retrieve organizations created for this tenant which matches the defined search criteria, if any.", notes = "This API is used to search and retrieve organizations created for this tenant.  Organizations can be filtered by id, name, description, created, lastModified, status, parentId, and meta attributes.   Supported operators: \"eq\" (equals), \"co\" (contains), \"sw\" (starts with), \"ew\" (ends with), \"ge\" (greater than or equals), \"le\" (less than or equals), \"gt\" (greater than), \"lt\" (less than)  Multiple attributes can be combined using the \"and\" operator.  Examples:   - filter=name+eq+ABC Builders   - filter=attributes.Country+eq+Sri Lanka  <b>Scope(Permission) required:</b> `internal_organization_view` ", response = OrganizationsResponse.class, authorizations = {
         @Authorization(value = "BasicAuth"),
         @Authorization(value = "OAuth2", scopes = {
             

--- a/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/management/v1/OrganizationsApiService.java
+++ b/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/management/v1/OrganizationsApiService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -29,10 +29,12 @@ import org.wso2.carbon.identity.api.server.organization.management.v1.model.Erro
 import org.wso2.carbon.identity.api.server.organization.management.v1.model.GetOrganizationResponse;
 import java.util.List;
 import org.wso2.carbon.identity.api.server.organization.management.v1.model.MetaAttributesResponse;
+import org.wso2.carbon.identity.api.server.organization.management.v1.model.OrganizationCheckResponse;
 import org.wso2.carbon.identity.api.server.organization.management.v1.model.OrganizationDiscoveryAttributes;
 import org.wso2.carbon.identity.api.server.organization.management.v1.model.OrganizationDiscoveryCheckPOSTRequest;
 import org.wso2.carbon.identity.api.server.organization.management.v1.model.OrganizationDiscoveryCheckPOSTResponse;
 import org.wso2.carbon.identity.api.server.organization.management.v1.model.OrganizationDiscoveryPostRequest;
+import org.wso2.carbon.identity.api.server.organization.management.v1.model.OrganizationHandleCheckPOSTRequest;
 import org.wso2.carbon.identity.api.server.organization.management.v1.model.OrganizationMetadata;
 import org.wso2.carbon.identity.api.server.organization.management.v1.model.OrganizationNameCheckPOSTRequest;
 import org.wso2.carbon.identity.api.server.organization.management.v1.model.OrganizationNameCheckPOSTResponse;
@@ -58,6 +60,8 @@ public interface OrganizationsApiService {
       public Response organizationMetadataGet();
 
       public Response organizationPost(OrganizationPOSTRequest organizationPOSTRequest);
+
+      public Response organizationsCheckHandlePost(OrganizationHandleCheckPOSTRequest organizationHandleCheckPOSTRequest);
 
       public Response organizationsCheckNamePost(OrganizationNameCheckPOSTRequest organizationNameCheckPOSTRequest);
 

--- a/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/management/v1/model/BasicOrganizationResponse.java
+++ b/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/management/v1/model/BasicOrganizationResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -37,6 +37,7 @@ public class BasicOrganizationResponse  {
   
     private String id;
     private String name;
+    private String orgHandle;
 
 @XmlType(name="StatusEnum")
 @XmlEnum(String.class)
@@ -113,6 +114,26 @@ public enum StatusEnum {
     }
     public void setName(String name) {
         this.name = name;
+    }
+
+    /**
+    **/
+    public BasicOrganizationResponse orgHandle(String orgHandle) {
+
+        this.orgHandle = orgHandle;
+        return this;
+    }
+
+    @ApiModelProperty(example = "abcbuilders", required = true, value = "")
+    @JsonProperty("orgHandle")
+    @Valid
+    @NotNull(message = "Property orgHandle cannot be null.")
+
+    public String getOrgHandle() {
+        return orgHandle;
+    }
+    public void setOrgHandle(String orgHandle) {
+        this.orgHandle = orgHandle;
     }
 
     /**
@@ -195,6 +216,7 @@ public enum StatusEnum {
         BasicOrganizationResponse basicOrganizationResponse = (BasicOrganizationResponse) o;
         return Objects.equals(this.id, basicOrganizationResponse.id) &&
             Objects.equals(this.name, basicOrganizationResponse.name) &&
+            Objects.equals(this.orgHandle, basicOrganizationResponse.orgHandle) &&
             Objects.equals(this.status, basicOrganizationResponse.status) &&
             Objects.equals(this.ref, basicOrganizationResponse.ref) &&
             Objects.equals(this.attributes, basicOrganizationResponse.attributes);
@@ -202,7 +224,7 @@ public enum StatusEnum {
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, name, status, ref, attributes);
+        return Objects.hash(id, name, orgHandle, status, ref, attributes);
     }
 
     @Override
@@ -213,6 +235,7 @@ public enum StatusEnum {
         
         sb.append("    id: ").append(toIndentedString(id)).append("\n");
         sb.append("    name: ").append(toIndentedString(name)).append("\n");
+        sb.append("    orgHandle: ").append(toIndentedString(orgHandle)).append("\n");
         sb.append("    status: ").append(toIndentedString(status)).append("\n");
         sb.append("    ref: ").append(toIndentedString(ref)).append("\n");
         sb.append("    attributes: ").append(toIndentedString(attributes)).append("\n");

--- a/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/management/v1/model/GetOrganizationResponse.java
+++ b/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/management/v1/model/GetOrganizationResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -38,6 +38,7 @@ public class GetOrganizationResponse  {
   
     private String id;
     private String name;
+    private String orgHandle;
     private String description;
 
 @XmlType(name="StatusEnum")
@@ -153,6 +154,26 @@ public enum TypeEnum {
     }
     public void setName(String name) {
         this.name = name;
+    }
+
+    /**
+    **/
+    public GetOrganizationResponse orgHandle(String orgHandle) {
+
+        this.orgHandle = orgHandle;
+        return this;
+    }
+
+    @ApiModelProperty(example = "abcbuilders", required = true, value = "")
+    @JsonProperty("orgHandle")
+    @Valid
+    @NotNull(message = "Property orgHandle cannot be null.")
+
+    public String getOrgHandle() {
+        return orgHandle;
+    }
+    public void setOrgHandle(String orgHandle) {
+        this.orgHandle = orgHandle;
     }
 
     /**
@@ -337,6 +358,7 @@ public enum TypeEnum {
         GetOrganizationResponse getOrganizationResponse = (GetOrganizationResponse) o;
         return Objects.equals(this.id, getOrganizationResponse.id) &&
             Objects.equals(this.name, getOrganizationResponse.name) &&
+            Objects.equals(this.orgHandle, getOrganizationResponse.orgHandle) &&
             Objects.equals(this.description, getOrganizationResponse.description) &&
             Objects.equals(this.status, getOrganizationResponse.status) &&
             Objects.equals(this.created, getOrganizationResponse.created) &&
@@ -349,7 +371,7 @@ public enum TypeEnum {
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, name, description, status, created, lastModified, type, parent, attributes, permissions);
+        return Objects.hash(id, name, orgHandle, description, status, created, lastModified, type, parent, attributes, permissions);
     }
 
     @Override
@@ -360,6 +382,7 @@ public enum TypeEnum {
         
         sb.append("    id: ").append(toIndentedString(id)).append("\n");
         sb.append("    name: ").append(toIndentedString(name)).append("\n");
+        sb.append("    orgHandle: ").append(toIndentedString(orgHandle)).append("\n");
         sb.append("    description: ").append(toIndentedString(description)).append("\n");
         sb.append("    status: ").append(toIndentedString(status)).append("\n");
         sb.append("    created: ").append(toIndentedString(created)).append("\n");

--- a/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/management/v1/model/OrganizationCheckResponse.java
+++ b/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/management/v1/model/OrganizationCheckResponse.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.organization.management.v1.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import javax.validation.constraints.*;
+
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+import javax.validation.Valid;
+import javax.xml.bind.annotation.*;
+
+public class OrganizationCheckResponse  {
+  
+    private Boolean available;
+
+    /**
+    **/
+    public OrganizationCheckResponse available(Boolean available) {
+
+        this.available = available;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "true", value = "")
+    @JsonProperty("available")
+    @Valid
+    public Boolean getAvailable() {
+        return available;
+    }
+    public void setAvailable(Boolean available) {
+        this.available = available;
+    }
+
+
+
+    @Override
+    public boolean equals(java.lang.Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OrganizationCheckResponse organizationCheckResponse = (OrganizationCheckResponse) o;
+        return Objects.equals(this.available, organizationCheckResponse.available);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(available);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OrganizationCheckResponse {\n");
+        
+        sb.append("    available: ").append(toIndentedString(available)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+    * Convert the given object to string with each line indented by 4 spaces
+    * (except the first line).
+    */
+    private String toIndentedString(java.lang.Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}
+

--- a/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/management/v1/model/OrganizationDiscoveryResponse.java
+++ b/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/management/v1/model/OrganizationDiscoveryResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -37,6 +37,7 @@ public class OrganizationDiscoveryResponse  {
   
     private String organizationId;
     private String organizationName;
+    private String orgHandle;
     private List<DiscoveryAttribute> attributes = new ArrayList<>();
 
 
@@ -83,6 +84,27 @@ public class OrganizationDiscoveryResponse  {
     }
 
     /**
+    * The handle of the organization.
+    **/
+    public OrganizationDiscoveryResponse orgHandle(String orgHandle) {
+
+        this.orgHandle = orgHandle;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "abcbuilders", required = true, value = "The handle of the organization.")
+    @JsonProperty("orgHandle")
+    @Valid
+    @NotNull(message = "Property orgHandle cannot be null.")
+
+    public String getOrgHandle() {
+        return orgHandle;
+    }
+    public void setOrgHandle(String orgHandle) {
+        this.orgHandle = orgHandle;
+    }
+
+    /**
     **/
     public OrganizationDiscoveryResponse attributes(List<DiscoveryAttribute> attributes) {
 
@@ -121,12 +143,13 @@ public class OrganizationDiscoveryResponse  {
         OrganizationDiscoveryResponse organizationDiscoveryResponse = (OrganizationDiscoveryResponse) o;
         return Objects.equals(this.organizationId, organizationDiscoveryResponse.organizationId) &&
             Objects.equals(this.organizationName, organizationDiscoveryResponse.organizationName) &&
+            Objects.equals(this.orgHandle, organizationDiscoveryResponse.orgHandle) &&
             Objects.equals(this.attributes, organizationDiscoveryResponse.attributes);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(organizationId, organizationName, attributes);
+        return Objects.hash(organizationId, organizationName, orgHandle, attributes);
     }
 
     @Override
@@ -137,6 +160,7 @@ public class OrganizationDiscoveryResponse  {
         
         sb.append("    organizationId: ").append(toIndentedString(organizationId)).append("\n");
         sb.append("    organizationName: ").append(toIndentedString(organizationName)).append("\n");
+        sb.append("    orgHandle: ").append(toIndentedString(orgHandle)).append("\n");
         sb.append("    attributes: ").append(toIndentedString(attributes)).append("\n");
         sb.append("}");
         return sb.toString();

--- a/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/management/v1/model/OrganizationHandleCheckPOSTRequest.java
+++ b/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/management/v1/model/OrganizationHandleCheckPOSTRequest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.organization.management.v1.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import javax.validation.constraints.*;
+
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+import javax.validation.Valid;
+import javax.xml.bind.annotation.*;
+
+public class OrganizationHandleCheckPOSTRequest  {
+  
+    private String orgHandle;
+
+    /**
+    **/
+    public OrganizationHandleCheckPOSTRequest orgHandle(String orgHandle) {
+
+        this.orgHandle = orgHandle;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "abcbuilders", value = "")
+    @JsonProperty("orgHandle")
+    @Valid
+    public String getOrgHandle() {
+        return orgHandle;
+    }
+    public void setOrgHandle(String orgHandle) {
+        this.orgHandle = orgHandle;
+    }
+
+
+
+    @Override
+    public boolean equals(java.lang.Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OrganizationHandleCheckPOSTRequest organizationHandleCheckPOSTRequest = (OrganizationHandleCheckPOSTRequest) o;
+        return Objects.equals(this.orgHandle, organizationHandleCheckPOSTRequest.orgHandle);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(orgHandle);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OrganizationHandleCheckPOSTRequest {\n");
+        
+        sb.append("    orgHandle: ").append(toIndentedString(orgHandle)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+    * Convert the given object to string with each line indented by 4 spaces
+    * (except the first line).
+    */
+    private String toIndentedString(java.lang.Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}
+

--- a/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/management/v1/model/OrganizationMetadata.java
+++ b/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/management/v1/model/OrganizationMetadata.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -39,6 +39,7 @@ public class OrganizationMetadata  {
   
     private String id;
     private String name;
+    private String orgHandle;
     private String description;
 
 @XmlType(name="StatusEnum")
@@ -156,6 +157,26 @@ public enum TypeEnum {
     }
     public void setName(String name) {
         this.name = name;
+    }
+
+    /**
+    **/
+    public OrganizationMetadata orgHandle(String orgHandle) {
+
+        this.orgHandle = orgHandle;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "abcbuilders", required = true, value = "")
+    @JsonProperty("orgHandle")
+    @Valid
+    @NotNull(message = "Property orgHandle cannot be null.")
+
+    public String getOrgHandle() {
+        return orgHandle;
+    }
+    public void setOrgHandle(String orgHandle) {
+        this.orgHandle = orgHandle;
     }
 
     /**
@@ -366,6 +387,7 @@ public enum TypeEnum {
         OrganizationMetadata organizationMetadata = (OrganizationMetadata) o;
         return Objects.equals(this.id, organizationMetadata.id) &&
             Objects.equals(this.name, organizationMetadata.name) &&
+            Objects.equals(this.orgHandle, organizationMetadata.orgHandle) &&
             Objects.equals(this.description, organizationMetadata.description) &&
             Objects.equals(this.status, organizationMetadata.status) &&
             Objects.equals(this.created, organizationMetadata.created) &&
@@ -379,7 +401,7 @@ public enum TypeEnum {
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, name, description, status, created, lastModified, type, parent, attributes, permissions, discoveryAttributes);
+        return Objects.hash(id, name, orgHandle, description, status, created, lastModified, type, parent, attributes, permissions, discoveryAttributes);
     }
 
     @Override
@@ -390,6 +412,7 @@ public enum TypeEnum {
         
         sb.append("    id: ").append(toIndentedString(id)).append("\n");
         sb.append("    name: ").append(toIndentedString(name)).append("\n");
+        sb.append("    orgHandle: ").append(toIndentedString(orgHandle)).append("\n");
         sb.append("    description: ").append(toIndentedString(description)).append("\n");
         sb.append("    status: ").append(toIndentedString(status)).append("\n");
         sb.append("    created: ").append(toIndentedString(created)).append("\n");

--- a/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/management/v1/model/OrganizationPOSTRequest.java
+++ b/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/management/v1/model/OrganizationPOSTRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -36,6 +36,7 @@ import javax.xml.bind.annotation.*;
 public class OrganizationPOSTRequest  {
   
     private String name;
+    private String orgHandle;
     private String description;
 
 @XmlType(name="TypeEnum")
@@ -93,6 +94,24 @@ public enum TypeEnum {
     }
     public void setName(String name) {
         this.name = name;
+    }
+
+    /**
+    **/
+    public OrganizationPOSTRequest orgHandle(String orgHandle) {
+
+        this.orgHandle = orgHandle;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "abcbuilders", value = "")
+    @JsonProperty("orgHandle")
+    @Valid
+    public String getOrgHandle() {
+        return orgHandle;
+    }
+    public void setOrgHandle(String orgHandle) {
+        this.orgHandle = orgHandle;
     }
 
     /**
@@ -189,6 +208,7 @@ public enum TypeEnum {
         }
         OrganizationPOSTRequest organizationPOSTRequest = (OrganizationPOSTRequest) o;
         return Objects.equals(this.name, organizationPOSTRequest.name) &&
+            Objects.equals(this.orgHandle, organizationPOSTRequest.orgHandle) &&
             Objects.equals(this.description, organizationPOSTRequest.description) &&
             Objects.equals(this.type, organizationPOSTRequest.type) &&
             Objects.equals(this.parentId, organizationPOSTRequest.parentId) &&
@@ -197,7 +217,7 @@ public enum TypeEnum {
 
     @Override
     public int hashCode() {
-        return Objects.hash(name, description, type, parentId, attributes);
+        return Objects.hash(name, orgHandle, description, type, parentId, attributes);
     }
 
     @Override
@@ -207,6 +227,7 @@ public enum TypeEnum {
         sb.append("class OrganizationPOSTRequest {\n");
         
         sb.append("    name: ").append(toIndentedString(name)).append("\n");
+        sb.append("    orgHandle: ").append(toIndentedString(orgHandle)).append("\n");
         sb.append("    description: ").append(toIndentedString(description)).append("\n");
         sb.append("    type: ").append(toIndentedString(type)).append("\n");
         sb.append("    parentId: ").append(toIndentedString(parentId)).append("\n");

--- a/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/management/v1/model/OrganizationPUTRequest.java
+++ b/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/management/v1/model/OrganizationPUTRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -36,6 +36,7 @@ import javax.xml.bind.annotation.*;
 public class OrganizationPUTRequest  {
   
     private String name;
+    private String organizationHandle;
     private String description;
 
 @XmlType(name="StatusEnum")
@@ -92,6 +93,24 @@ public enum StatusEnum {
     }
     public void setName(String name) {
         this.name = name;
+    }
+
+    /**
+    **/
+    public OrganizationPUTRequest organizationHandle(String organizationHandle) {
+
+        this.organizationHandle = organizationHandle;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "abcbuilders", value = "")
+    @JsonProperty("organizationHandle")
+    @Valid
+    public String getOrganizationHandle() {
+        return organizationHandle;
+    }
+    public void setOrganizationHandle(String organizationHandle) {
+        this.organizationHandle = organizationHandle;
     }
 
     /**
@@ -171,6 +190,7 @@ public enum StatusEnum {
         }
         OrganizationPUTRequest organizationPUTRequest = (OrganizationPUTRequest) o;
         return Objects.equals(this.name, organizationPUTRequest.name) &&
+            Objects.equals(this.organizationHandle, organizationPUTRequest.organizationHandle) &&
             Objects.equals(this.description, organizationPUTRequest.description) &&
             Objects.equals(this.status, organizationPUTRequest.status) &&
             Objects.equals(this.attributes, organizationPUTRequest.attributes);
@@ -178,7 +198,7 @@ public enum StatusEnum {
 
     @Override
     public int hashCode() {
-        return Objects.hash(name, description, status, attributes);
+        return Objects.hash(name, organizationHandle, description, status, attributes);
     }
 
     @Override
@@ -188,6 +208,7 @@ public enum StatusEnum {
         sb.append("class OrganizationPUTRequest {\n");
         
         sb.append("    name: ").append(toIndentedString(name)).append("\n");
+        sb.append("    organizationHandle: ").append(toIndentedString(organizationHandle)).append("\n");
         sb.append("    description: ").append(toIndentedString(description)).append("\n");
         sb.append("    status: ").append(toIndentedString(status)).append("\n");
         sb.append("    attributes: ").append(toIndentedString(attributes)).append("\n");

--- a/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/management/v1/model/OrganizationPUTRequest.java
+++ b/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/management/v1/model/OrganizationPUTRequest.java
@@ -36,7 +36,6 @@ import javax.xml.bind.annotation.*;
 public class OrganizationPUTRequest  {
   
     private String name;
-    private String organizationHandle;
     private String description;
 
 @XmlType(name="StatusEnum")
@@ -93,24 +92,6 @@ public enum StatusEnum {
     }
     public void setName(String name) {
         this.name = name;
-    }
-
-    /**
-    **/
-    public OrganizationPUTRequest organizationHandle(String organizationHandle) {
-
-        this.organizationHandle = organizationHandle;
-        return this;
-    }
-    
-    @ApiModelProperty(example = "abcbuilders", value = "")
-    @JsonProperty("organizationHandle")
-    @Valid
-    public String getOrganizationHandle() {
-        return organizationHandle;
-    }
-    public void setOrganizationHandle(String organizationHandle) {
-        this.organizationHandle = organizationHandle;
     }
 
     /**
@@ -190,7 +171,6 @@ public enum StatusEnum {
         }
         OrganizationPUTRequest organizationPUTRequest = (OrganizationPUTRequest) o;
         return Objects.equals(this.name, organizationPUTRequest.name) &&
-            Objects.equals(this.organizationHandle, organizationPUTRequest.organizationHandle) &&
             Objects.equals(this.description, organizationPUTRequest.description) &&
             Objects.equals(this.status, organizationPUTRequest.status) &&
             Objects.equals(this.attributes, organizationPUTRequest.attributes);
@@ -198,7 +178,7 @@ public enum StatusEnum {
 
     @Override
     public int hashCode() {
-        return Objects.hash(name, organizationHandle, description, status, attributes);
+        return Objects.hash(name, description, status, attributes);
     }
 
     @Override
@@ -208,7 +188,6 @@ public enum StatusEnum {
         sb.append("class OrganizationPUTRequest {\n");
         
         sb.append("    name: ").append(toIndentedString(name)).append("\n");
-        sb.append("    organizationHandle: ").append(toIndentedString(organizationHandle)).append("\n");
         sb.append("    description: ").append(toIndentedString(description)).append("\n");
         sb.append("    status: ").append(toIndentedString(status)).append("\n");
         sb.append("    attributes: ").append(toIndentedString(attributes)).append("\n");

--- a/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/management/v1/model/OrganizationResponse.java
+++ b/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/management/v1/model/OrganizationResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -38,6 +38,7 @@ public class OrganizationResponse  {
   
     private String id;
     private String name;
+    private String orgHandle;
     private String description;
 
 @XmlType(name="StatusEnum")
@@ -151,6 +152,26 @@ public enum TypeEnum {
     }
     public void setName(String name) {
         this.name = name;
+    }
+
+    /**
+    **/
+    public OrganizationResponse orgHandle(String orgHandle) {
+
+        this.orgHandle = orgHandle;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "abcbuilders", required = true, value = "")
+    @JsonProperty("orgHandle")
+    @Valid
+    @NotNull(message = "Property orgHandle cannot be null.")
+
+    public String getOrgHandle() {
+        return orgHandle;
+    }
+    public void setOrgHandle(String orgHandle) {
+        this.orgHandle = orgHandle;
     }
 
     /**
@@ -309,6 +330,7 @@ public enum TypeEnum {
         OrganizationResponse organizationResponse = (OrganizationResponse) o;
         return Objects.equals(this.id, organizationResponse.id) &&
             Objects.equals(this.name, organizationResponse.name) &&
+            Objects.equals(this.orgHandle, organizationResponse.orgHandle) &&
             Objects.equals(this.description, organizationResponse.description) &&
             Objects.equals(this.status, organizationResponse.status) &&
             Objects.equals(this.created, organizationResponse.created) &&
@@ -320,7 +342,7 @@ public enum TypeEnum {
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, name, description, status, created, lastModified, type, parent, attributes);
+        return Objects.hash(id, name, orgHandle, description, status, created, lastModified, type, parent, attributes);
     }
 
     @Override
@@ -331,6 +353,7 @@ public enum TypeEnum {
         
         sb.append("    id: ").append(toIndentedString(id)).append("\n");
         sb.append("    name: ").append(toIndentedString(name)).append("\n");
+        sb.append("    orgHandle: ").append(toIndentedString(orgHandle)).append("\n");
         sb.append("    description: ").append(toIndentedString(description)).append("\n");
         sb.append("    status: ").append(toIndentedString(status)).append("\n");
         sb.append("    created: ").append(toIndentedString(created)).append("\n");

--- a/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.v1/src/main/java/org/wso2/carbon/identity/api/server/organization/management/v1/impl/OrganizationsApiServiceImpl.java
+++ b/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.v1/src/main/java/org/wso2/carbon/identity/api/server/organization/management/v1/impl/OrganizationsApiServiceImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2023-2025, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except

--- a/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.v1/src/main/java/org/wso2/carbon/identity/api/server/organization/management/v1/impl/OrganizationsApiServiceImpl.java
+++ b/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.v1/src/main/java/org/wso2/carbon/identity/api/server/organization/management/v1/impl/OrganizationsApiServiceImpl.java
@@ -24,6 +24,7 @@ import org.wso2.carbon.identity.api.server.organization.management.v1.model.Appl
 import org.wso2.carbon.identity.api.server.organization.management.v1.model.OrganizationDiscoveryAttributes;
 import org.wso2.carbon.identity.api.server.organization.management.v1.model.OrganizationDiscoveryCheckPOSTRequest;
 import org.wso2.carbon.identity.api.server.organization.management.v1.model.OrganizationDiscoveryPostRequest;
+import org.wso2.carbon.identity.api.server.organization.management.v1.model.OrganizationHandleCheckPOSTRequest;
 import org.wso2.carbon.identity.api.server.organization.management.v1.model.OrganizationNameCheckPOSTRequest;
 import org.wso2.carbon.identity.api.server.organization.management.v1.model.OrganizationPOSTRequest;
 import org.wso2.carbon.identity.api.server.organization.management.v1.model.OrganizationPUTRequest;
@@ -184,6 +185,13 @@ public class OrganizationsApiServiceImpl implements OrganizationsApiService {
     public Response organizationsCheckNamePost(OrganizationNameCheckPOSTRequest organizationNameCheckPOSTRequest) {
 
         return organizationManagementService.checkOrganizationName(organizationNameCheckPOSTRequest.getName());
+    }
+
+    @Override
+    public Response organizationsCheckHandlePost(
+            OrganizationHandleCheckPOSTRequest organizationHandleCheckPOSTRequest) {
+
+        return organizationManagementService.checkOrganizationHandle(organizationHandleCheckPOSTRequest.getOrgHandle());
     }
 
     @Override

--- a/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.v1/src/main/resources/org.wso2.carbon.identity.organization.management.yaml
+++ b/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.v1/src/main/resources/org.wso2.carbon.identity.organization.management.yaml
@@ -64,7 +64,7 @@ paths:
         This API is used to search and retrieve organizations created for this tenant.
         
         Organizations can be filtered by id, name, description, created, lastModified, status, parentId, and meta attributes. 
-              
+        
         Supported operators: "eq" (equals), "co" (contains), "sw" (starts with), "ew" (ends with), "ge" (greater than or equals), "le" (less than or equals), "gt" (greater than), "lt" (less than)
         
         Multiple attributes can be combined using the "and" operator.
@@ -121,6 +121,37 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/OrganizationNameCheckPOSTResponse'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '500':
+          $ref: '#/components/responses/ServerError'
+      tags:
+        - Organization
+  /organizations/check-handle:
+    post:
+      summary: Check organization with given handle exist among the organizations hierarchy.
+      description: This API is used to check whether organization with particular handle exist or not.
+      operationId: organizationsCheckHandlePost
+      requestBody:
+        description: OrganizationHandleCheckPOSTRequest object containing the organization handle.
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrganizationHandleCheckPOSTRequest'
+        required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrganizationCheckResponse'
         '404':
           $ref: '#/components/responses/NotFound'
         '400':
@@ -898,6 +929,9 @@ components:
         name:
           type: string
           example: "ABC Builders"
+        orgHandle:
+          type: string
+          example: "abcbuilders"
         description:
           type: string
           example: "Building constructions"
@@ -952,7 +986,19 @@ components:
         name:
           type: string
           example: "ABC Builders"
+    OrganizationHandleCheckPOSTRequest:
+      type: object
+      properties:
+        orgHandle:
+          type: string
+          example: "abcbuilders"
     OrganizationNameCheckPOSTResponse:
+      type: object
+      properties:
+        available:
+          type: boolean
+          example: true
+    OrganizationCheckResponse:
       type: object
       properties:
         available:
@@ -983,9 +1029,9 @@ components:
                 "href": "/o/10084a8d-113f-4211-a0d5-efe36b082211/api/server/v1/organizations?limit=10&filter=name+co+der&next=MjAyMS0xMi0yMSAwNToxODozMS4wMDQzNDg=",
                 "rel": "next",
               },  {
-                "href": "/o/10084a8d-113f-4211-a0d5-efe36b082211/api/server/v1/organizations?limit=10&filter=name+co+der&before=MjAyMS0xMi0yMSAwNToxODozMS4wMDQzNDg=",
-                "rel": "previous",
-              }
+              "href": "/o/10084a8d-113f-4211-a0d5-efe36b082211/api/server/v1/organizations?limit=10&filter=name+co+der&before=MjAyMS0xMi0yMSAwNToxODozMS4wMDQzNDg=",
+              "rel": "previous",
+            }
             ]
         organizations:
           type: array
@@ -1007,6 +1053,7 @@ components:
       required:
         - id
         - name
+        - orgHandle
         - status
         - ref
       properties:
@@ -1016,6 +1063,9 @@ components:
         name:
           type: string
           example: 'ABC Builders'
+        orgHandle:
+          type: string
+          example: 'abcbuilders'
         status:
           type: string
           enum: [ ACTIVE, DISABLED ]
@@ -1032,6 +1082,7 @@ components:
       required:
         - id
         - name
+        - orgHandle
         - status
         - created
         - lastModified
@@ -1043,6 +1094,9 @@ components:
         name:
           type: string
           example: 'ABC Builders'
+        orgHandle:
+          type: string
+          example: 'abcbuilders'
         description:
           type: string
           example: 'Building constructions'
@@ -1073,6 +1127,7 @@ components:
       required:
         - id
         - name
+        - orgHandle
         - status
         - created
         - lastModified
@@ -1084,6 +1139,9 @@ components:
         name:
           type: string
           example: 'ABC Builders'
+        orgHandle:
+          type: string
+          example: 'abcbuilders'
         description:
           type: string
           example: 'Building constructions'
@@ -1126,9 +1184,9 @@ components:
                 "href": "/o/api/server/v1/organizations/meta-attributes?limit=10&recursive=false&filter=attributes+co+C&after=MjAyMS0xMi0yMSAwNToxODozMS4wMDQzNDg=",
                 "rel": "next",
               },  {
-                "href": "/o/api/server/v1/organizations/meta-attributes?limit=10&recursive=false&filter=attributes+co+C&before=MjAyMS0xMi0yMSAwNToxODozMS4wMDQzNDg=",
-                "rel": "previous",
-              }
+              "href": "/o/api/server/v1/organizations/meta-attributes?limit=10&recursive=false&filter=attributes+co+C&before=MjAyMS0xMi0yMSAwNToxODozMS4wMDQzNDg=",
+              "rel": "previous",
+            }
             ]
         attributes:
           type: array
@@ -1273,9 +1331,9 @@ components:
                 "href": "/o/10084a8d-113f-4211-a0d5-efe36b082211/api/server/v1/organizations/discovery?filter=attributes.type+eq+emailDomain&limit=10&offset=50",
                 "rel": "next",
               },  {
-                "href": "/o/10084a8d-113f-4211-a0d5-efe36b082211/api/server/v1/organizations/discovery?filter=attributes.type+eq+emailDomain&limit=10&offset=30",
-                "rel": "previous",
-              }
+              "href": "/o/10084a8d-113f-4211-a0d5-efe36b082211/api/server/v1/organizations/discovery?filter=attributes.type+eq+emailDomain&limit=10&offset=30",
+              "rel": "previous",
+            }
             ]
         organizations:
           type: array
@@ -1286,6 +1344,7 @@ components:
       required:
         - organizationId
         - organizationName
+        - orgHandle
         - attributes
       properties:
         organizationId:
@@ -1296,6 +1355,10 @@ components:
           type: string
           description: The name of the organization.
           example: 'ABC Builders'
+        orgHandle:
+          type: string
+          description: The handle of the organization.
+          example: 'abcbuilders'
         attributes:
           type: array
           items:
@@ -1326,6 +1389,7 @@ components:
       required:
         - id
         - name
+        - orgHandle
         - status
         - created
         - lastModified
@@ -1337,6 +1401,9 @@ components:
         name:
           type: string
           example: 'ABC Builders'
+        orgHandle:
+          type: string
+          example: 'abcbuilders'
         description:
           type: string
           example: 'Building constructions'

--- a/components/org.wso2.carbon.identity.api.server.tenant.management/org.wso2.carbon.identity.api.server.tenant.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/tenant/management/v1/model/ChannelVerifiedTenantModel.java
+++ b/components/org.wso2.carbon.identity.api.server.tenant.management/org.wso2.carbon.identity.api.server.tenant.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/tenant/management/v1/model/ChannelVerifiedTenantModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -36,11 +36,31 @@ import javax.xml.bind.annotation.*;
 
 public class ChannelVerifiedTenantModel  {
   
+    private String name;
     private String domain;
     private String code;
     private Purpose purpose;
     private List<Owner> owners = new ArrayList<>();
 
+
+    /**
+    * Name of the tenant.
+    **/
+    public ChannelVerifiedTenantModel name(String name) {
+
+        this.name = name;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "ABC Builders", value = "Name of the tenant.")
+    @JsonProperty("name")
+    @Valid
+    public String getName() {
+        return name;
+    }
+    public void setName(String name) {
+        this.name = name;
+    }
 
     /**
     * Tenant domain of the tenant.
@@ -51,7 +71,7 @@ public class ChannelVerifiedTenantModel  {
         return this;
     }
     
-    @ApiModelProperty(example = "wso2.com", required = true, value = "Tenant domain of the tenant.")
+    @ApiModelProperty(example = "abc.com", required = true, value = "Tenant domain of the tenant.")
     @JsonProperty("domain")
     @Valid
     @NotNull(message = "Property domain cannot be null.")
@@ -139,7 +159,8 @@ public class ChannelVerifiedTenantModel  {
             return false;
         }
         ChannelVerifiedTenantModel channelVerifiedTenantModel = (ChannelVerifiedTenantModel) o;
-        return Objects.equals(this.domain, channelVerifiedTenantModel.domain) &&
+        return Objects.equals(this.name, channelVerifiedTenantModel.name) &&
+            Objects.equals(this.domain, channelVerifiedTenantModel.domain) &&
             Objects.equals(this.code, channelVerifiedTenantModel.code) &&
             Objects.equals(this.purpose, channelVerifiedTenantModel.purpose) &&
             Objects.equals(this.owners, channelVerifiedTenantModel.owners);
@@ -147,7 +168,7 @@ public class ChannelVerifiedTenantModel  {
 
     @Override
     public int hashCode() {
-        return Objects.hash(domain, code, purpose, owners);
+        return Objects.hash(name, domain, code, purpose, owners);
     }
 
     @Override
@@ -156,6 +177,7 @@ public class ChannelVerifiedTenantModel  {
         StringBuilder sb = new StringBuilder();
         sb.append("class ChannelVerifiedTenantModel {\n");
         
+        sb.append("    name: ").append(toIndentedString(name)).append("\n");
         sb.append("    domain: ").append(toIndentedString(domain)).append("\n");
         sb.append("    code: ").append(toIndentedString(code)).append("\n");
         sb.append("    purpose: ").append(toIndentedString(purpose)).append("\n");

--- a/components/org.wso2.carbon.identity.api.server.tenant.management/org.wso2.carbon.identity.api.server.tenant.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/tenant/management/v1/model/TenantListItem.java
+++ b/components/org.wso2.carbon.identity.api.server.tenant.management/org.wso2.carbon.identity.api.server.tenant.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/tenant/management/v1/model/TenantListItem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -37,6 +37,7 @@ import javax.xml.bind.annotation.*;
 public class TenantListItem  {
   
     private String id;
+    private String name;
     private String domain;
     private List<OwnerResponse> owners = null;
 
@@ -61,6 +62,25 @@ public class TenantListItem  {
     }
     public void setId(String id) {
         this.id = id;
+    }
+
+    /**
+    * Name of the tenant.
+    **/
+    public TenantListItem name(String name) {
+
+        this.name = name;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "ABC Builders", value = "Name of the tenant.")
+    @JsonProperty("name")
+    @Valid
+    public String getName() {
+        return name;
+    }
+    public void setName(String name) {
+        this.name = name;
     }
 
     /**
@@ -177,6 +197,7 @@ public class TenantListItem  {
         }
         TenantListItem tenantListItem = (TenantListItem) o;
         return Objects.equals(this.id, tenantListItem.id) &&
+            Objects.equals(this.name, tenantListItem.name) &&
             Objects.equals(this.domain, tenantListItem.domain) &&
             Objects.equals(this.owners, tenantListItem.owners) &&
             Objects.equals(this.createdDate, tenantListItem.createdDate) &&
@@ -186,7 +207,7 @@ public class TenantListItem  {
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, domain, owners, createdDate, lifecycleStatus, region);
+        return Objects.hash(id, name, domain, owners, createdDate, lifecycleStatus, region);
     }
 
     @Override
@@ -196,6 +217,7 @@ public class TenantListItem  {
         sb.append("class TenantListItem {\n");
         
         sb.append("    id: ").append(toIndentedString(id)).append("\n");
+        sb.append("    name: ").append(toIndentedString(name)).append("\n");
         sb.append("    domain: ").append(toIndentedString(domain)).append("\n");
         sb.append("    owners: ").append(toIndentedString(owners)).append("\n");
         sb.append("    createdDate: ").append(toIndentedString(createdDate)).append("\n");

--- a/components/org.wso2.carbon.identity.api.server.tenant.management/org.wso2.carbon.identity.api.server.tenant.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/tenant/management/v1/model/TenantModel.java
+++ b/components/org.wso2.carbon.identity.api.server.tenant.management/org.wso2.carbon.identity.api.server.tenant.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/tenant/management/v1/model/TenantModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -35,9 +35,29 @@ import javax.xml.bind.annotation.*;
 
 public class TenantModel  {
   
+    private String name;
     private String domain;
     private List<Owner> owners = new ArrayList<>();
 
+
+    /**
+    * Name of the tenant.
+    **/
+    public TenantModel name(String name) {
+
+        this.name = name;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "ABC Builders", value = "Name of the tenant.")
+    @JsonProperty("name")
+    @Valid
+    public String getName() {
+        return name;
+    }
+    public void setName(String name) {
+        this.name = name;
+    }
 
     /**
     * Tenant domain of the tenant.
@@ -48,7 +68,7 @@ public class TenantModel  {
         return this;
     }
     
-    @ApiModelProperty(example = "wso2.com", required = true, value = "Tenant domain of the tenant.")
+    @ApiModelProperty(example = "abc.com", required = true, value = "Tenant domain of the tenant.")
     @JsonProperty("domain")
     @Valid
     @NotNull(message = "Property domain cannot be null.")
@@ -97,13 +117,14 @@ public class TenantModel  {
             return false;
         }
         TenantModel tenantModel = (TenantModel) o;
-        return Objects.equals(this.domain, tenantModel.domain) &&
+        return Objects.equals(this.name, tenantModel.name) &&
+            Objects.equals(this.domain, tenantModel.domain) &&
             Objects.equals(this.owners, tenantModel.owners);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(domain, owners);
+        return Objects.hash(name, domain, owners);
     }
 
     @Override
@@ -112,6 +133,7 @@ public class TenantModel  {
         StringBuilder sb = new StringBuilder();
         sb.append("class TenantModel {\n");
         
+        sb.append("    name: ").append(toIndentedString(name)).append("\n");
         sb.append("    domain: ").append(toIndentedString(domain)).append("\n");
         sb.append("    owners: ").append(toIndentedString(owners)).append("\n");
         sb.append("}");

--- a/components/org.wso2.carbon.identity.api.server.tenant.management/org.wso2.carbon.identity.api.server.tenant.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/tenant/management/v1/model/TenantResponseModel.java
+++ b/components/org.wso2.carbon.identity.api.server.tenant.management/org.wso2.carbon.identity.api.server.tenant.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/tenant/management/v1/model/TenantResponseModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -37,6 +37,7 @@ import javax.xml.bind.annotation.*;
 public class TenantResponseModel  {
   
     private String id;
+    private String name;
     private String domain;
     private List<OwnerResponse> owners = null;
 
@@ -61,6 +62,25 @@ public class TenantResponseModel  {
     }
     public void setId(String id) {
         this.id = id;
+    }
+
+    /**
+    * Name of the tenant.
+    **/
+    public TenantResponseModel name(String name) {
+
+        this.name = name;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "ABC Builders", value = "Name of the tenant.")
+    @JsonProperty("name")
+    @Valid
+    public String getName() {
+        return name;
+    }
+    public void setName(String name) {
+        this.name = name;
     }
 
     /**
@@ -177,6 +197,7 @@ public class TenantResponseModel  {
         }
         TenantResponseModel tenantResponseModel = (TenantResponseModel) o;
         return Objects.equals(this.id, tenantResponseModel.id) &&
+            Objects.equals(this.name, tenantResponseModel.name) &&
             Objects.equals(this.domain, tenantResponseModel.domain) &&
             Objects.equals(this.owners, tenantResponseModel.owners) &&
             Objects.equals(this.createdDate, tenantResponseModel.createdDate) &&
@@ -186,7 +207,7 @@ public class TenantResponseModel  {
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, domain, owners, createdDate, lifecycleStatus, region);
+        return Objects.hash(id, name, domain, owners, createdDate, lifecycleStatus, region);
     }
 
     @Override
@@ -196,6 +217,7 @@ public class TenantResponseModel  {
         sb.append("class TenantResponseModel {\n");
         
         sb.append("    id: ").append(toIndentedString(id)).append("\n");
+        sb.append("    name: ").append(toIndentedString(name)).append("\n");
         sb.append("    domain: ").append(toIndentedString(domain)).append("\n");
         sb.append("    owners: ").append(toIndentedString(owners)).append("\n");
         sb.append("    createdDate: ").append(toIndentedString(createdDate)).append("\n");

--- a/components/org.wso2.carbon.identity.api.server.tenant.management/org.wso2.carbon.identity.api.server.tenant.management.v1/src/main/java/org/wso2/carbon/identity/api/server/tenant/management/v1/core/ServerTenantManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.tenant.management/org.wso2.carbon.identity.api.server.tenant.management.v1/src/main/java/org/wso2/carbon/identity/api/server/tenant/management/v1/core/ServerTenantManagementService.java
@@ -354,6 +354,7 @@ public class ServerTenantManagementService {
         TenantResponseModel tenantResponseModel = new TenantResponseModel();
         tenantResponseModel.setCreatedDate(getISOFormatDate(tenant.getCreatedDate()));
         tenantResponseModel.setDomain(tenant.getDomain());
+        tenantResponseModel.setName(tenant.getName());
         tenantResponseModel.setId(tenant.getTenantUniqueID());
         tenantResponseModel.setLifecycleStatus(getLifeCycleStatus(tenant.isActive()));
         tenantResponseModel.setOwners(getOwnerResponses(tenant));
@@ -365,6 +366,7 @@ public class ServerTenantManagementService {
         Tenant tenant = new Tenant();
         tenant.setActive(true);
         tenant.setDomain(tenantModel.getDomain());
+        tenant.setName(tenantModel.getName());
         if (tenantModel.getOwners() != null) {
             tenant.setAdminName(tenantModel.getOwners().get(0).getUsername());
             tenant.setAdminFirstName(tenantModel.getOwners().get(0).getFirstname());
@@ -430,6 +432,7 @@ public class ServerTenantManagementService {
             listItem.setLifecycleStatus(getLifeCycleStatus(tenant.isActive()));
             listItem.setCreatedDate(getISOFormatDate(tenant.getCreatedDate()));
             listItem.setDomain(tenant.getDomain());
+            listItem.setName(tenant.getName());
             listItem.setId(tenant.getTenantUniqueID());
             listItem.setOwners(getOwnerResponses(tenant));
 
@@ -667,6 +670,7 @@ public class ServerTenantManagementService {
 
         tenant.setActive(true);
         tenant.setDomain(StringUtils.lowerCase(channelVerifiedTenantModel.getDomain()));
+        tenant.setName(channelVerifiedTenantModel.getName());
         if (channelVerifiedTenantModel.getOwners() != null && channelVerifiedTenantModel.getOwners().size() > 0
                 && channelVerifiedTenantModel.getOwners().get(0) != null) {
             tenant.setAdminName(channelVerifiedTenantModel.getOwners().get(0).getEmail());

--- a/components/org.wso2.carbon.identity.api.server.tenant.management/org.wso2.carbon.identity.api.server.tenant.management.v1/src/main/resources/tenant-management.yaml
+++ b/components/org.wso2.carbon.identity.api.server.tenant.management/org.wso2.carbon.identity.api.server.tenant.management.v1/src/main/resources/tenant-management.yaml
@@ -383,46 +383,46 @@ paths:
         '500':
           $ref: '#/components/responses/ServerError'
   '/tenants/{tenant-id}/metadata':
-      delete:
-        tags:
-          - Tenants
-        summary: |
-          Delete tenant's metadata by ID
-        operationId: deleteTenantMetadata
-        description: |
-          This API provides the capability to delete the tenant meta data(tenant specific data like tenant domain,
-          tenant owner details). <br>
-            <b>Permission required:</b> <br>
-                * /permission/protected/manage/modify/tenants <br>
-            <b>Scope required:</b> <br>
-                * internal_modify_tenants
-        parameters:
-          - $ref: '#/components/parameters/tenantIdPathParam'
-        responses:
-          '204':
-            description: Successfully Deleted
-          '400':
-            description: Bad Request
-            content:
-              application/json:
-                schema:
-                  $ref: '#/components/schemas/Error'
-          '401':
-            description: Unauthorized
-          '403':
-            description: Forbidden
-          '404':
-            description: Not Found
-            content:
-              application/json:
-                schema:
-                  $ref: '#/components/schemas/Error'
-          '500':
-            description: Server Error
-            content:
-              application/json:
-                schema:
-                  $ref: '#/components/schemas/Error'
+    delete:
+      tags:
+        - Tenants
+      summary: |
+        Delete tenant's metadata by ID
+      operationId: deleteTenantMetadata
+      description: |
+        This API provides the capability to delete the tenant meta data(tenant specific data like tenant domain,
+        tenant owner details). <br>
+          <b>Permission required:</b> <br>
+              * /permission/protected/manage/modify/tenants <br>
+          <b>Scope required:</b> <br>
+              * internal_modify_tenants
+      parameters:
+        - $ref: '#/components/parameters/tenantIdPathParam'
+      responses:
+        '204':
+          description: Successfully Deleted
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '500':
+          description: Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
 
 servers:
   - url: 'https://localhost:9443/api/server/v1'
@@ -442,7 +442,7 @@ components:
       required: true
       description: owner id
       schema:
-          type: string
+        type: string
     tenantDomainPathParam:
       in: path
       name: tenant-domain
@@ -566,9 +566,13 @@ components:
         - domain
         - owners
       properties:
+        name:
+          type: string
+          example: "ABC Builders"
+          description: Name of the tenant.
         domain:
           type: string
-          example: wso2.com
+          example: abc.com
           description: Tenant domain of the tenant.
         owners:
           type: array
@@ -582,9 +586,13 @@ components:
         - owners
         - code
       properties:
+        name:
+          type: string
+          example: "ABC Builders"
+          description: Name of the tenant.
         domain:
           type: string
-          example: wso2.com
+          example: abc.com
           description: Tenant domain of the tenant.
         code:
           type: string
@@ -604,6 +612,10 @@ components:
           type: string
           example: "123e4567-e89b-12d3-a456-556642440000"
           description: tenant id of the tenant owner.
+        name:
+          type: string
+          example: "ABC Builders"
+          description: Name of the tenant.
         domain:
           type: string
           example: abc.com
@@ -643,13 +655,13 @@ components:
             $ref: '#/components/schemas/Link'
           example:
             [
-                {
-                    "href": "/api/server/v1/tenants?offset=50&limit=10",
-                    "rel": "next",
-                },  {
-                    "href": "/api/server/v1/tenants?offset=30&limit=10",
-                    "rel": "previous",
-                }
+              {
+                "href": "/api/server/v1/tenants?offset=50&limit=10",
+                "rel": "next",
+              },  {
+              "href": "/api/server/v1/tenants?offset=30&limit=10",
+              "rel": "previous",
+            }
             ]
         tenants:
           type: array
@@ -663,6 +675,10 @@ components:
           type: string
           example: "123e4567-e89b-12d3-a456-556642440000"
           description: tenant id of the tenant owner.
+        name:
+          type: string
+          example: "ABC Builders"
+          description: Name of the tenant.
         domain:
           type: string
           example: abc.com

--- a/pom.xml
+++ b/pom.xml
@@ -898,7 +898,7 @@
         <identity.x509Certificate.validation.version>1.1.19</identity.x509Certificate.validation.version>
         <commons.beanutils.version>1.9.4</commons.beanutils.version>
         <mavan.findbugsplugin.exclude.file>findbugs-exclude-filter.xml</mavan.findbugsplugin.exclude.file>
-        <carbon.kernel.version>4.10.25</carbon.kernel.version>
+        <carbon.kernel.version>4.10.48</carbon.kernel.version>
         <carbon.multitenancy.version>4.11.31</carbon.multitenancy.version>
         <org.wso2.carbon.identity.remotefetch.version>0.7.12</org.wso2.carbon.identity.remotefetch.version>
         <org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.version>2.5.18</org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.version>
@@ -913,13 +913,13 @@
         <identity.verification.version>1.0.15</identity.verification.version>
 
         <!-- Organization management core Version -->
-        <org.wso2.carbon.identity.organization.management.core.version>1.1.20
+        <org.wso2.carbon.identity.organization.management.core.version>1.1.29
         </org.wso2.carbon.identity.organization.management.core.version>
         <org.wso2.carbon.identity.organization.management.core.version.range>[1.0.0, 2.0.0)
         </org.wso2.carbon.identity.organization.management.core.version.range>
 
         <!-- Organization management service Version -->
-        <org.wso2.carbon.identity.organization.management.version>1.4.87
+        <org.wso2.carbon.identity.organization.management.version>1.4.137
         </org.wso2.carbon.identity.organization.management.version>
 
         <!-- Unit test versions -->


### PR DESCRIPTION
## Purpose
$subject

**Merge in order:**

- https://github.com/wso2/identity-organization-management-core/pull/172
- https://github.com/wso2/carbon-commons/pull/513
- https://github.com/wso2/carbon-kernel/pull/4276
- https://github.com/wso2-extensions/identity-organization-management/pull/500
- https://github.com/wso2/carbon-multitenancy/pull/290
- https://github.com/wso2/carbon-identity-framework/pull/6685
- https://github.com/wso2/identity-api-server/pull/862
- https://github.com/wso2/identity-api-user/pull/263

## Goals

The new field will store the tenant domain as the value. This would lead to:

- Root organizations: The unique identifier, to act on, instead of the display name.
- Sub organizations: A human-readable tenant domain.

## Approach

The following APIs will be affected:

1. /organization PATCH/POST/PUT responses
2. /organization GET
3. /organizations GET
4. /organizations/discovery GET
5. /organizations/metadata GET

Please check: https://github.com/wso2/product-is/issues/23526#issuecomment-2739373089

## Related PRs
- https://github.com/wso2/identity-organization-management-core/pull/172

## Related Issues: 

- https://github.com/wso2/product-is/issues/23526