### PR TITLE
Provide the first class support for the multi valued property

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.claim.management/org.wso2.carbon.identity.api.server.claim.management.common/src/main/java/org/wso2/carbon/identity/api/server/claim/management/common/Constant.java
+++ b/components/org.wso2.carbon.identity.api.server.claim.management/org.wso2.carbon.identity.api.server.claim.management.common/src/main/java/org/wso2/carbon/identity/api/server/claim/management/common/Constant.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) (2019-2023), WSO2 LLC. (http://www.wso2.org).
+ * Copyright (c) (2019-2025), WSO2 LLC. (http://www.wso2.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -290,6 +290,7 @@ public class Constant {
     public static final String PROP_REG_EX = "RegEx";
     public static final String PROP_REQUIRED = "Required";
     public static final String PROP_SUPPORTED_BY_DEFAULT = "SupportedByDefault";
+    public static final String PROP_MULTI_VALUED = "multiValued";
     public static final String PROP_UNIQUENESS_SCOPE = "UniquenessScope";
     public static final String PROP_PROFILES_PREFIX = "Profiles.";
     public static final String PROP_EXCLUDED_USER_STORES = "ExcludedUserStores";

--- a/components/org.wso2.carbon.identity.api.server.claim.management/org.wso2.carbon.identity.rest.api.server.claim.management.v1/src/gen/java/org/wso2/carbon/identity/rest/api/server/claim/management/v1/dto/LocalClaimReqDTO.java
+++ b/components/org.wso2.carbon.identity.api.server.claim.management/org.wso2.carbon.identity.rest.api.server.claim.management.v1/src/gen/java/org/wso2/carbon/identity/rest/api/server/claim/management/v1/dto/LocalClaimReqDTO.java
@@ -63,6 +63,9 @@ public class LocalClaimReqDTO {
     @Valid 
     private Boolean supportedByDefault = null;
 
+    @Valid
+    private Boolean multiValued = null;
+
     public enum UniquenessScopeEnum {
          NONE,  WITHIN_USERSTORE,  ACROSS_USERSTORES, 
     };
@@ -183,6 +186,18 @@ public class LocalClaimReqDTO {
     }
 
     /**
+     * Specifies if the claim can hold multiple values.
+     **/
+    @ApiModelProperty(value = "Specifies if the claim can hold multiple values.")
+    @JsonProperty("multiValued")
+    public Boolean getMultiValued() {
+        return multiValued;
+    }
+    public void setMultiValued(Boolean multiValued) {
+        this.multiValued = multiValued;
+    }
+
+    /**
     * Specifies the scope of uniqueness validation for the claim value.
     **/
     @ApiModelProperty(value = "Specifies the scope of uniqueness validation for the claim value.")
@@ -257,6 +272,7 @@ public class LocalClaimReqDTO {
         sb.append("    regEx: ").append(regEx).append("\n");
         sb.append("    required: ").append(required).append("\n");
         sb.append("    supportedByDefault: ").append(supportedByDefault).append("\n");
+        sb.append("    multiValued: ").append(multiValued).append("\n");
         sb.append("    uniquenessScope: ").append(uniquenessScope).append("\n");
         sb.append("    sharedProfileValueResolvingMethod: ").append(sharedProfileValueResolvingMethod).append("\n");
         sb.append("    attributeMapping: ").append(attributeMapping).append("\n");

--- a/components/org.wso2.carbon.identity.api.server.claim.management/org.wso2.carbon.identity.rest.api.server.claim.management.v1/src/gen/java/org/wso2/carbon/identity/rest/api/server/claim/management/v1/dto/LocalClaimResDTO.java
+++ b/components/org.wso2.carbon.identity.api.server.claim.management/org.wso2.carbon.identity.rest.api.server.claim.management.v1/src/gen/java/org/wso2/carbon/identity/rest/api/server/claim/management/v1/dto/LocalClaimResDTO.java
@@ -68,6 +68,9 @@ public class LocalClaimResDTO extends ClaimResDTO {
     @Valid 
     private Boolean supportedByDefault = null;
 
+    @Valid
+    private Boolean multiValued = null;
+
     public enum UniquenessScopeEnum {
          NONE,  WITHIN_USERSTORE,  ACROSS_USERSTORES, 
     };
@@ -210,6 +213,18 @@ public class LocalClaimResDTO extends ClaimResDTO {
     }
 
     /**
+     * Specifies if the claim can hold multiple values.
+     **/
+    @ApiModelProperty(value = "Specifies if the claim can hold multiple values.")
+    @JsonProperty("multiValued")
+    public Boolean getMultiValued() {
+        return multiValued;
+    }
+    public void setMultiValued(Boolean multiValued) {
+        this.multiValued = multiValued;
+    }
+
+    /**
     * Specifies the scope of uniqueness validation for the claim value.
     **/
     @ApiModelProperty(value = "Specifies the scope of uniqueness validation for the claim value.")
@@ -288,6 +303,7 @@ public class LocalClaimResDTO extends ClaimResDTO {
         sb.append("    regEx: ").append(regEx).append("\n");
         sb.append("    required: ").append(required).append("\n");
         sb.append("    supportedByDefault: ").append(supportedByDefault).append("\n");
+        sb.append("    multiValued: ").append(multiValued).append("\n");
         sb.append("    uniquenessScope: ").append(uniquenessScope).append("\n");
         sb.append("    sharedProfileValueResolvingMethod: ").append(sharedProfileValueResolvingMethod).append("\n");
         sb.append("    attributeMapping: ").append(attributeMapping).append("\n");

--- a/components/org.wso2.carbon.identity.api.server.claim.management/org.wso2.carbon.identity.rest.api.server.claim.management.v1/src/main/java/org/wso2/carbon/identity/rest/api/server/claim/management/v1/core/ServerClaimManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.claim.management/org.wso2.carbon.identity.rest.api.server.claim.management.v1/src/main/java/org/wso2/carbon/identity/rest/api/server/claim/management/v1/core/ServerClaimManagementService.java
@@ -1174,7 +1174,8 @@ public class ServerClaimManagementService {
         claimProperties.put(PROP_READ_ONLY, String.valueOf(localClaimReqDTO.getReadOnly()));
         claimProperties.put(PROP_REQUIRED, String.valueOf(localClaimReqDTO.getRequired()));
         claimProperties.put(PROP_SUPPORTED_BY_DEFAULT, String.valueOf(localClaimReqDTO.getSupportedByDefault()));
-        claimProperties.put(PROP_MULTI_VALUED, String.valueOf(localClaimReqDTO.getMultiValued()));
+        claimProperties.put(PROP_MULTI_VALUED, localClaimReqDTO.getMultiValued() == null ? FALSE :
+                String.valueOf(localClaimReqDTO.getMultiValued()));
 
         claimProperties.putAll(propertiesToMap(localClaimReqDTO.getProperties()));
 
@@ -1745,5 +1746,6 @@ public class ServerClaimManagementService {
         localClaim.getClaimProperties().putIfAbsent(PROP_READ_ONLY, FALSE);
         localClaim.getClaimProperties().putIfAbsent(PROP_REQUIRED, FALSE);
         localClaim.getClaimProperties().putIfAbsent(PROP_SUPPORTED_BY_DEFAULT, FALSE);
+        localClaim.getClaimProperties().putIfAbsent(PROP_MULTI_VALUED, FALSE);
     }
 }

--- a/components/org.wso2.carbon.identity.api.server.claim.management/org.wso2.carbon.identity.rest.api.server.claim.management.v1/src/main/java/org/wso2/carbon/identity/rest/api/server/claim/management/v1/core/ServerClaimManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.claim.management/org.wso2.carbon.identity.rest.api.server.claim.management.v1/src/main/java/org/wso2/carbon/identity/rest/api/server/claim/management/v1/core/ServerClaimManagementService.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) (2019-2023), WSO2 LLC. (http://www.wso2.org).
+ *  Copyright (c) (2019-2025), WSO2 LLC. (http://www.wso2.org).
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -136,6 +136,7 @@ import static org.wso2.carbon.identity.api.server.claim.management.common.Consta
 import static org.wso2.carbon.identity.api.server.claim.management.common.Constant.PROP_DESCRIPTION;
 import static org.wso2.carbon.identity.api.server.claim.management.common.Constant.PROP_DISPLAY_NAME;
 import static org.wso2.carbon.identity.api.server.claim.management.common.Constant.PROP_DISPLAY_ORDER;
+import static org.wso2.carbon.identity.api.server.claim.management.common.Constant.PROP_MULTI_VALUED;
 import static org.wso2.carbon.identity.api.server.claim.management.common.Constant.PROP_PROFILES_PREFIX;
 import static org.wso2.carbon.identity.api.server.claim.management.common.Constant.PROP_READ_ONLY;
 import static org.wso2.carbon.identity.api.server.claim.management.common.Constant.PROP_REG_EX;
@@ -1029,6 +1030,7 @@ public class ServerClaimManagementService {
         }
         localClaimResDTO.setRequired(Boolean.valueOf(claimProperties.remove(PROP_REQUIRED)));
         localClaimResDTO.setSupportedByDefault(Boolean.valueOf(claimProperties.remove(PROP_SUPPORTED_BY_DEFAULT)));
+        localClaimResDTO.setMultiValued(Boolean.valueOf(claimProperties.remove(PROP_MULTI_VALUED)));
 
         String uniquenessScope = claimProperties.remove(PROP_UNIQUENESS_SCOPE);
         if (StringUtils.isNotBlank(uniquenessScope)) {
@@ -1172,6 +1174,8 @@ public class ServerClaimManagementService {
         claimProperties.put(PROP_READ_ONLY, String.valueOf(localClaimReqDTO.getReadOnly()));
         claimProperties.put(PROP_REQUIRED, String.valueOf(localClaimReqDTO.getRequired()));
         claimProperties.put(PROP_SUPPORTED_BY_DEFAULT, String.valueOf(localClaimReqDTO.getSupportedByDefault()));
+        claimProperties.put(PROP_MULTI_VALUED, String.valueOf(localClaimReqDTO.getMultiValued()));
+
         claimProperties.putAll(propertiesToMap(localClaimReqDTO.getProperties()));
 
         List<AttributeMapping> attributeMappings = new ArrayList<>();

--- a/components/org.wso2.carbon.identity.api.server.claim.management/org.wso2.carbon.identity.rest.api.server.claim.management.v1/src/main/java/org/wso2/carbon/identity/rest/api/server/claim/management/v1/model/ClaimDialectConfiguration.java
+++ b/components/org.wso2.carbon.identity.api.server.claim.management/org.wso2.carbon.identity.rest.api.server.claim.management.v1/src/main/java/org/wso2/carbon/identity/rest/api/server/claim/management/v1/model/ClaimDialectConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2023-2025, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -107,6 +107,7 @@ public class ClaimDialectConfiguration extends ClaimDialectResDTO {
                 localClaimReqDTO.setRegEx(localClaimResDTO.getRegEx());
                 localClaimReqDTO.setRequired(localClaimResDTO.getRequired());
                 localClaimReqDTO.setSupportedByDefault(localClaimResDTO.getSupportedByDefault());
+                localClaimReqDTO.setMultiValued(localClaimResDTO.getMultiValued());
                 localClaimReqDTO.setAttributeMapping(localClaimResDTO.getAttributeMapping());
                 localClaimReqDTO.setProperties(localClaimResDTO.getProperties());
                 localClaimReqDTOList.add(localClaimReqDTO);

--- a/components/org.wso2.carbon.identity.api.server.claim.management/org.wso2.carbon.identity.rest.api.server.claim.management.v1/src/main/resources/claim-management.yaml
+++ b/components/org.wso2.carbon.identity.api.server.claim.management/org.wso2.carbon.identity.rest.api.server.claim.management.v1/src/main/resources/claim-management.yaml
@@ -736,6 +736,10 @@ definitions:
         type: boolean
         description: Specifies if the claim will be prompted during user registration and displayed on the user profile.
         example: true
+      multiValued:
+        type: boolean
+        description: Specifies if the claim can hold multiple values or not.
+        example: true
       uniquenessScope:
         type: string
         description: Specifies the scope of uniqueness validation for the claim value.
@@ -813,6 +817,10 @@ definitions:
           supportedByDefault:
             type: boolean
             description: Specifies if the claim will be prompted during user registration and displayed on the user profile.
+            example: true
+          multiValued:
+            type: boolean
+            description: Specifies if the claim can hold multiple values.
             example: true
           uniquenessScope:
             type: string


### PR DESCRIPTION
## Purpose

Introduce the `multiValued` property as a first class property of the claim.

```
{
    "claimURI": "http://wso2.org/claims/abc",
    "displayName": "abc",
    "displayOrder": 0,
    "readOnly": false,
    "regEx": "",
    "required": false,
    "supportedByDefault": false,
    "multiValued": true,
    "properties": [
        {
            "key": "USER_CUSTOM_ATTRIBUTE",
            "value": "TRUE"
        }
    ],
    "attributeMapping": [
        {
            "mappedAttribute": "abc",
            "userstore": "PRIMARY"
        }
    ]
}
```

<br>
<br>
Note: From the Claims API, all the first class and other properties are treated as claim properties. Hence even it is set as first class or as an additional property, it can't be distinguished. Hence only show as a first class parameter.



https://github.com/user-attachments/assets/fdb957e1-924e-4f98-9ab0-34592ddb6a9f


### Related Issues
- https://github.com/wso2/product-is/issues/23547
