### PR TITLE
Add notification sender management v2 API

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.notification.sender/org.wso2.carbon.identity.api.server.notification.sender.v2/pom.xml
+++ b/components/org.wso2.carbon.identity.api.server.notification.sender/org.wso2.carbon.identity.api.server.notification.sender.v2/pom.xml
@@ -1,0 +1,166 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2025, WSO2 LLC. (http://www.wso2.org).
+  ~
+  ~ WSO2 LLC. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>org.wso2.carbon.identity.api.server.notification.sender</artifactId>
+        <groupId>org.wso2.carbon.identity.server.api</groupId>
+        <relativePath>../pom.xml</relativePath>
+        <version>1.3.95-SNAPSHOT</version>
+    </parent>
+
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>org.wso2.carbon.identity.api.server.notification.sender.v2</artifactId>
+    <packaging>jar</packaging>
+
+    <build>
+        <plugins>
+<!--                        <plugin>-->
+<!--                            <groupId>org.openapitools</groupId>-->
+<!--                            <artifactId>openapi-generator-maven-plugin</artifactId>-->
+<!--                            <version>4.1.2</version>-->
+<!--                            <executions>-->
+<!--                                <execution>-->
+<!--                                    <goals>-->
+<!--                                        <goal>generate</goal>-->
+<!--                                    </goals>-->
+<!--                                    <configuration>-->
+<!--                                        <inputSpec>${project.basedir}/src/main/resources/notification-sender.yaml</inputSpec>-->
+<!--                                        <generatorName>org.wso2.carbon.codegen.CxfWso2Generator</generatorName>-->
+<!--                                        <configOptions>-->
+<!--                                            <sourceFolder>src/gen/java</sourceFolder>-->
+<!--                                            <apiPackage>org.wso2.carbon.identity.api.server.notification.sender.v2</apiPackage>-->
+<!--                                            <modelPackage>org.wso2.carbon.identity.api.server.notification.sender.v2.model</modelPackage>-->
+<!--                                            <packageName>org.wso2.carbon.identity.api.server.notification.sender.v2</packageName>-->
+<!--                                            <dateLibrary>java8</dateLibrary>-->
+<!--                                            <hideGenerationTimestamp>true</hideGenerationTimestamp>-->
+<!--                                        </configOptions>-->
+<!--                                        <output>.</output>-->
+<!--                                        <skipOverwrite>true</skipOverwrite>-->
+<!--                                    </configuration>-->
+<!--                                </execution>-->
+<!--                            </executions>-->
+<!--                            <dependencies>-->
+<!--                                <dependency>-->
+<!--                                    <groupId>org.openapitools</groupId>-->
+<!--                                    <artifactId>cxf-wso2-openapi-generator</artifactId>-->
+<!--                                    <version>1.0.0</version>-->
+<!--                                </dependency>-->
+<!--                            </dependencies>-->
+<!--                        </plugin>-->
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <version>1.8</version>
+                <executions>
+                    <execution>
+                        <id>add-source</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>add-source</goal>
+                        </goals>
+                        <configuration>
+                            <sources>
+                                <source>src/gen/java</source>
+                            </sources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>${maven.compiler.plugin.version}</version>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.cxf</groupId>
+            <artifactId>cxf-rt-frontend-jaxrs</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.cxf</groupId>
+            <artifactId>cxf-rt-rs-service-description</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>javax.ws.rs</groupId>
+            <artifactId>javax.ws.rs-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.swagger</groupId>
+            <artifactId>swagger-jaxrs</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-databind</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-annotations</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.dataformat</groupId>
+                    <artifactId>jackson-dataformat-yaml</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>javax.ws.rs</groupId>
+                    <artifactId>jsr311-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.google.guava</groupId>
+                    <artifactId>guava</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.jaxrs</groupId>
+            <artifactId>jackson-jaxrs-json-provider</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.server.api</groupId>
+            <artifactId>org.wso2.carbon.identity.api.server.common</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.server.api</groupId>
+            <artifactId>org.wso2.carbon.identity.api.server.notification.sender.common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.event.handler.notification</groupId>
+            <artifactId>org.wso2.carbon.identity.notification.sender.tenant.config</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.multitenancy</groupId>
+            <artifactId>org.wso2.carbon.tenant.mgt</artifactId>
+        </dependency>
+    </dependencies>
+</project>

--- a/components/org.wso2.carbon.identity.api.server.notification.sender/org.wso2.carbon.identity.api.server.notification.sender.v2/pom.xml
+++ b/components/org.wso2.carbon.identity.api.server.notification.sender/org.wso2.carbon.identity.api.server.notification.sender.v2/pom.xml
@@ -22,7 +22,7 @@
         <artifactId>org.wso2.carbon.identity.api.server.notification.sender</artifactId>
         <groupId>org.wso2.carbon.identity.server.api</groupId>
         <relativePath>../pom.xml</relativePath>
-        <version>1.3.95-SNAPSHOT</version>
+        <version>1.3.96-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/components/org.wso2.carbon.identity.api.server.notification.sender/org.wso2.carbon.identity.api.server.notification.sender.v2/src/gen/java/org/wso2/carbon/identity/api/server/notification/sender/v2/NotificationSendersApi.java
+++ b/components/org.wso2.carbon.identity.api.server.notification.sender/org.wso2.carbon.identity.api.server.notification.sender.v2/src/gen/java/org/wso2/carbon/identity/api/server/notification/sender/v2/NotificationSendersApi.java
@@ -1,0 +1,436 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.notification.sender.v2;
+
+import org.apache.cxf.jaxrs.ext.multipart.Attachment;
+import org.apache.cxf.jaxrs.ext.multipart.Multipart;
+import java.io.InputStream;
+import java.util.List;
+
+import org.wso2.carbon.identity.api.server.notification.sender.v2.model.EmailSender;
+import org.wso2.carbon.identity.api.server.notification.sender.v2.model.EmailSenderAdd;
+import org.wso2.carbon.identity.api.server.notification.sender.v2.model.EmailSenderUpdateRequest;
+import org.wso2.carbon.identity.api.server.notification.sender.v2.model.Error;
+import org.wso2.carbon.identity.api.server.notification.sender.v2.model.PushSender;
+import org.wso2.carbon.identity.api.server.notification.sender.v2.model.PushSenderAdd;
+import org.wso2.carbon.identity.api.server.notification.sender.v2.model.PushSenderUpdateRequest;
+import org.wso2.carbon.identity.api.server.notification.sender.v2.model.SMSSender;
+import org.wso2.carbon.identity.api.server.notification.sender.v2.model.SMSSenderAdd;
+import org.wso2.carbon.identity.api.server.notification.sender.v2.model.SMSSenderUpdateRequest;
+import org.wso2.carbon.identity.api.server.notification.sender.v2.NotificationSendersApiService;
+import org.wso2.carbon.identity.api.server.notification.sender.v2.factories.NotificationSendersApiServiceFactory;
+
+import javax.validation.Valid;
+import javax.ws.rs.*;
+import javax.ws.rs.core.Response;
+import io.swagger.annotations.*;
+
+import javax.validation.constraints.*;
+
+@Path("/notification-senders")
+@Api(description = "The notification-senders API")
+
+public class NotificationSendersApi  {
+
+    private final NotificationSendersApiService delegate;
+
+    public NotificationSendersApi() {
+
+        this.delegate = NotificationSendersApiServiceFactory.getNotificationSendersApi();
+    }
+
+    @Valid
+    @POST
+    @Path("/email")
+    @Consumes({ "application/json" })
+    @Produces({ "application/json" })
+    @ApiOperation(value = "Create an email sender", notes = "This API provides the capability to create an email sender.\\n\\nIf the 'name' is not not defined, 'EmailPublisher' is taken as the default name. <br>   <b>Permission required:</b> <br>     * /permission/admin/manage/identity/configmgt/add <br>   <b>Scope required:</b> <br>     * internal_config_mgt_add ", response = EmailSender.class, authorizations = {
+        @Authorization(value = "BasicAuth"),
+        @Authorization(value = "OAuth2", scopes = {
+            
+        })
+    }, tags={ "Email Senders", })
+    @ApiResponses(value = { 
+        @ApiResponse(code = 201, message = "Successful Response", response = EmailSender.class),
+        @ApiResponse(code = 400, message = "Bad Request", response = Error.class),
+        @ApiResponse(code = 401, message = "Unauthorized", response = Void.class),
+        @ApiResponse(code = 403, message = "Forbidden", response = Void.class),
+        @ApiResponse(code = 404, message = "Not Found", response = Error.class),
+        @ApiResponse(code = 405, message = "Method Not Allowed.", response = Error.class),
+        @ApiResponse(code = 409, message = "Conflict", response = Error.class),
+        @ApiResponse(code = 500, message = "Server Error", response = Error.class)
+    })
+    public Response createEmailSender(@ApiParam(value = "" ) @Valid EmailSenderAdd emailSenderAdd) {
+
+        return delegate.createEmailSender(emailSenderAdd );
+    }
+
+    @Valid
+    @POST
+    @Path("/push")
+    @Consumes({ "application/json" })
+    @Produces({ "application/json" })
+    @ApiOperation(value = "Create a push notification sender", notes = "This API provides the capability to create a push notification sender.\\n\\nIf the 'name' is not defined, 'PushPublisher' is taken as the default name. <br>   <b>Permission required:</b> <br>     * /permission/admin/manage/identity/configmgt/add <br>   <b>Scope required:</b> <br>     * internal_config_mgt_add ", response = PushSender.class, authorizations = {
+        @Authorization(value = "BasicAuth"),
+        @Authorization(value = "OAuth2", scopes = {
+            
+        })
+    }, tags={ "Push Notification Senders", })
+    @ApiResponses(value = { 
+        @ApiResponse(code = 201, message = "Successful Response", response = PushSender.class),
+        @ApiResponse(code = 400, message = "Bad Request", response = Error.class),
+        @ApiResponse(code = 401, message = "Unauthorized", response = Void.class),
+        @ApiResponse(code = 403, message = "Forbidden", response = Void.class),
+        @ApiResponse(code = 404, message = "Not Found", response = Error.class),
+        @ApiResponse(code = 405, message = "Method Not Allowed.", response = Error.class),
+        @ApiResponse(code = 409, message = "Conflict", response = Error.class),
+        @ApiResponse(code = 500, message = "Server Error", response = Error.class)
+    })
+    public Response createPushSender(@ApiParam(value = "" ) @Valid PushSenderAdd pushSenderAdd) {
+
+        return delegate.createPushSender(pushSenderAdd );
+    }
+
+    @Valid
+    @POST
+    @Path("/sms")
+    @Consumes({ "application/json" })
+    @Produces({ "application/json" })
+    @ApiOperation(value = "Create a SMS sender", notes = "This API provides the capability to create a SMS sender. If the 'name' is not not defined, 'SMSPublisher' is taken as the default name.<br>   <b>Permission required:</b> <br>     * /permission/admin/manage/identity/configmgt/add <br>   <b>Scope required:</b> <br>     * internal_config_mgt_add ", response = SMSSender.class, authorizations = {
+        @Authorization(value = "BasicAuth"),
+        @Authorization(value = "OAuth2", scopes = {
+            
+        })
+    }, tags={ "SMS Senders", })
+    @ApiResponses(value = { 
+        @ApiResponse(code = 201, message = "Successful Response", response = SMSSender.class),
+        @ApiResponse(code = 400, message = "Bad Request", response = Error.class),
+        @ApiResponse(code = 401, message = "Unauthorized", response = Void.class),
+        @ApiResponse(code = 403, message = "Forbidden", response = Void.class),
+        @ApiResponse(code = 404, message = "Not Found", response = Error.class),
+        @ApiResponse(code = 405, message = "Method Not Allowed.", response = Error.class),
+        @ApiResponse(code = 409, message = "Conflict", response = Error.class),
+        @ApiResponse(code = 500, message = "Server Error", response = Error.class)
+    })
+    public Response createSMSSender(@ApiParam(value = "" ) @Valid SMSSenderAdd smSSenderAdd) {
+
+        return delegate.createSMSSender(smSSenderAdd );
+    }
+
+    @Valid
+    @DELETE
+    @Path("/email/{sender-name}")
+    
+    @Produces({ "application/json" })
+    @ApiOperation(value = "Delete an email sender by name", notes = "This API provides the capability to delete an email sender by name. The URL encoded email sender name is used as sender-name.<br>   <b>Permission required:</b> <br>     * /permission/admin/manage/identity/configmgt/delete <br>   <b>Scope required:</b> <br>     * internal_config_mgt_delete ", response = Void.class, authorizations = {
+        @Authorization(value = "BasicAuth"),
+        @Authorization(value = "OAuth2", scopes = {
+            
+        })
+    }, tags={ "Email Senders", })
+    @ApiResponses(value = { 
+        @ApiResponse(code = 204, message = "No Content", response = Void.class),
+        @ApiResponse(code = 400, message = "Bad Request", response = Error.class),
+        @ApiResponse(code = 401, message = "Unauthorized", response = Void.class),
+        @ApiResponse(code = 403, message = "Forbidden", response = Void.class),
+        @ApiResponse(code = 404, message = "Not Found", response = Error.class),
+        @ApiResponse(code = 405, message = "Method Not Allowed.", response = Error.class),
+        @ApiResponse(code = 500, message = "Server Error", response = Error.class)
+    })
+    public Response deleteEmailSender(@ApiParam(value = "name of the email sender",required=true) @PathParam("sender-name") String senderName) {
+
+        return delegate.deleteEmailSender(senderName );
+    }
+
+    @Valid
+    @DELETE
+    @Path("/push/{sender-name}")
+    
+    @Produces({ "application/json" })
+    @ApiOperation(value = "Delete a push notification sender by name", notes = "This API provides the capability to delete a push notification sender by name. The URL encoded push notification sender name is used as sender-name.<br>   <b>Permission required:</b> <br>     * /permission/admin/manage/identity/configmgt/delete <br>   <b>Scope required:</b> <br>     * internal_config_mgt_delete ", response = Void.class, authorizations = {
+        @Authorization(value = "BasicAuth"),
+        @Authorization(value = "OAuth2", scopes = {
+            
+        })
+    }, tags={ "Push Notification Senders", })
+    @ApiResponses(value = { 
+        @ApiResponse(code = 204, message = "No Content", response = Void.class),
+        @ApiResponse(code = 400, message = "Bad Request", response = Error.class),
+        @ApiResponse(code = 401, message = "Unauthorized", response = Void.class),
+        @ApiResponse(code = 403, message = "Forbidden", response = Void.class),
+        @ApiResponse(code = 404, message = "Not Found", response = Error.class),
+        @ApiResponse(code = 405, message = "Method Not Allowed.", response = Error.class),
+        @ApiResponse(code = 500, message = "Server Error", response = Error.class)
+    })
+    public Response deletePushSender(@ApiParam(value = "name of the email sender",required=true) @PathParam("sender-name") String senderName) {
+
+        return delegate.deletePushSender(senderName );
+    }
+
+    @Valid
+    @DELETE
+    @Path("/sms/{sender-name}")
+    
+    @Produces({ "application/json" })
+    @ApiOperation(value = "Delete a SMS sender by name", notes = "This API provides the capability to delete a SMS sender by name. The URL encoded SMS sender name is used as sender-name.<br>   <b>Permission required:</b> <br>     * /permission/admin/manage/identity/configmgt/delete <br>   <b>Scope required:</b> <br>     * internal_config_mgt_delete ", response = Void.class, authorizations = {
+        @Authorization(value = "BasicAuth"),
+        @Authorization(value = "OAuth2", scopes = {
+            
+        })
+    }, tags={ "SMS Senders", })
+    @ApiResponses(value = { 
+        @ApiResponse(code = 204, message = "No Content", response = Void.class),
+        @ApiResponse(code = 400, message = "Bad Request", response = Error.class),
+        @ApiResponse(code = 401, message = "Unauthorized", response = Void.class),
+        @ApiResponse(code = 403, message = "Forbidden", response = Void.class),
+        @ApiResponse(code = 404, message = "Not Found", response = Error.class),
+        @ApiResponse(code = 405, message = "Method Not Allowed.", response = Error.class),
+        @ApiResponse(code = 500, message = "Server Error", response = Error.class)
+    })
+    public Response deleteSMSSender(@ApiParam(value = "name of the SMS sender",required=true) @PathParam("sender-name") String senderName) {
+
+        return delegate.deleteSMSSender(senderName );
+    }
+
+    @Valid
+    @GET
+    @Path("/email/{sender-name}")
+    
+    @Produces({ "application/json" })
+    @ApiOperation(value = "Retrieve an email sender by name", notes = "This API provides the capability to retrieve an email sender by name. The URL encoded email sender name is used as sender-name.<br>   <b>Permission required:</b> <br>     * /permission/admin/manage/identity/configmgt/view <br>   <b>Scope required:</b> <br>     * internal_config_mgt_view ", response = EmailSender.class, authorizations = {
+        @Authorization(value = "BasicAuth"),
+        @Authorization(value = "OAuth2", scopes = {
+            
+        })
+    }, tags={ "Email Senders", })
+    @ApiResponses(value = { 
+        @ApiResponse(code = 200, message = "Successful Response", response = EmailSender.class),
+        @ApiResponse(code = 400, message = "Bad Request", response = Error.class),
+        @ApiResponse(code = 401, message = "Unauthorized", response = Void.class),
+        @ApiResponse(code = 403, message = "Forbidden", response = Void.class),
+        @ApiResponse(code = 404, message = "Not Found", response = Error.class),
+        @ApiResponse(code = 405, message = "Method Not Allowed.", response = Error.class),
+        @ApiResponse(code = 500, message = "Server Error", response = Error.class)
+    })
+    public Response getEmailSender(@ApiParam(value = "name of the email sender",required=true) @PathParam("sender-name") String senderName) {
+
+        return delegate.getEmailSender(senderName );
+    }
+
+    @Valid
+    @GET
+    @Path("/email")
+    
+    @Produces({ "application/json" })
+    @ApiOperation(value = "Get a list of email senders", notes = "This API provides the capability to retrieve the list of email senders. <br>   <b>Permission required:</b> <br>     * /permission/admin/manage/identity/configmgt/view <br>   <b>Scope required:</b> <br>     * internal_config_mgt_view ", response = EmailSender.class, responseContainer = "List", authorizations = {
+        @Authorization(value = "BasicAuth"),
+        @Authorization(value = "OAuth2", scopes = {
+            
+        })
+    }, tags={ "Email Senders", })
+    @ApiResponses(value = { 
+        @ApiResponse(code = 200, message = "Successful Response", response = EmailSender.class, responseContainer = "List"),
+        @ApiResponse(code = 400, message = "Bad Request", response = Error.class),
+        @ApiResponse(code = 401, message = "Unauthorized", response = Void.class),
+        @ApiResponse(code = 403, message = "Forbidden", response = Void.class),
+        @ApiResponse(code = 404, message = "Not Found", response = Error.class),
+        @ApiResponse(code = 405, message = "Method Not Allowed.", response = Error.class),
+        @ApiResponse(code = 500, message = "Server Error", response = Error.class)
+    })
+    public Response getEmailSenders() {
+
+        return delegate.getEmailSenders();
+    }
+
+    @Valid
+    @GET
+    @Path("/push/{sender-name}")
+    
+    @Produces({ "application/json" })
+    @ApiOperation(value = "Retrieve a push notification sender by name", notes = "This API provides the capability to retrieve a push notification sender by name. The URL encoded push notification sender name is used as sender-name.<br>   <b>Permission required:</b> <br>     * /permission/admin/manage/identity/configmgt/view <br>   <b>Scope required:</b> <br>     * internal_config_mgt_view ", response = PushSender.class, authorizations = {
+        @Authorization(value = "BasicAuth"),
+        @Authorization(value = "OAuth2", scopes = {
+            
+        })
+    }, tags={ "Push Notification Senders", })
+    @ApiResponses(value = { 
+        @ApiResponse(code = 200, message = "Successful Response", response = PushSender.class),
+        @ApiResponse(code = 400, message = "Bad Request", response = Error.class),
+        @ApiResponse(code = 401, message = "Unauthorized", response = Void.class),
+        @ApiResponse(code = 403, message = "Forbidden", response = Void.class),
+        @ApiResponse(code = 404, message = "Not Found", response = Error.class),
+        @ApiResponse(code = 405, message = "Method Not Allowed.", response = Error.class),
+        @ApiResponse(code = 500, message = "Server Error", response = Error.class)
+    })
+    public Response getPushSender(@ApiParam(value = "name of the push notification sender",required=true) @PathParam("sender-name") String senderName) {
+
+        return delegate.getPushSender(senderName );
+    }
+
+    @Valid
+    @GET
+    @Path("/push")
+    
+    @Produces({ "application/json" })
+    @ApiOperation(value = "Get a list of push notification senders", notes = "This API provides the capability to retrieve the list of push notification senders. <br>   <b>Permission required:</b> <br>     * /permission/admin/manage/identity/configmgt/view <br>   <b>Scope required:</b> <br>     * internal_config_mgt_view ", response = PushSender.class, responseContainer = "List", authorizations = {
+        @Authorization(value = "BasicAuth"),
+        @Authorization(value = "OAuth2", scopes = {
+            
+        })
+    }, tags={ "Push Notification Senders", })
+    @ApiResponses(value = { 
+        @ApiResponse(code = 200, message = "Successful response", response = PushSender.class, responseContainer = "List"),
+        @ApiResponse(code = 400, message = "Bad Request", response = Error.class),
+        @ApiResponse(code = 401, message = "Unauthorized", response = Void.class),
+        @ApiResponse(code = 403, message = "Forbidden", response = Void.class),
+        @ApiResponse(code = 404, message = "Not Found", response = Error.class),
+        @ApiResponse(code = 405, message = "Method Not Allowed.", response = Error.class),
+        @ApiResponse(code = 500, message = "Server Error", response = Error.class)
+    })
+    public Response getPushSenders() {
+
+        return delegate.getPushSenders();
+    }
+
+    @Valid
+    @GET
+    @Path("/sms/{sender-name}")
+    
+    @Produces({ "application/json" })
+    @ApiOperation(value = "Get a SMS sender by name", notes = "This API provides the capability to retrieve a SMS notification sender by name. The URL encoded SMS sender name is used as sender-name.<br>   <b>Permission required:</b> <br>     * /permission/admin/manage/identity/configmgt/view <br>   <b>Scope required:</b> <br>     * internal_config_mgt_view ", response = SMSSender.class, authorizations = {
+        @Authorization(value = "BasicAuth"),
+        @Authorization(value = "OAuth2", scopes = {
+            
+        })
+    }, tags={ "SMS Senders", })
+    @ApiResponses(value = { 
+        @ApiResponse(code = 200, message = "Successful response", response = SMSSender.class),
+        @ApiResponse(code = 400, message = "Bad Request", response = Error.class),
+        @ApiResponse(code = 401, message = "Unauthorized", response = Void.class),
+        @ApiResponse(code = 403, message = "Forbidden", response = Void.class),
+        @ApiResponse(code = 404, message = "Not Found", response = Error.class),
+        @ApiResponse(code = 405, message = "Method Not Allowed.", response = Error.class),
+        @ApiResponse(code = 500, message = "Server Error", response = Error.class)
+    })
+    public Response getSMSSender(@ApiParam(value = "name of the SMS sender",required=true) @PathParam("sender-name") String senderName) {
+
+        return delegate.getSMSSender(senderName );
+    }
+
+    @Valid
+    @GET
+    @Path("/sms")
+    
+    @Produces({ "application/json" })
+    @ApiOperation(value = "Get a list of SMS senders", notes = "This API provides the capability to retrieve a list of SMS notification senders.<br>   <b>Permission required:</b> <br>     * /permission/admin/manage/identity/configmgt/view <br>   <b>Scope required:</b> <br>     * internal_config_mgt_view ", response = SMSSender.class, responseContainer = "List", authorizations = {
+        @Authorization(value = "BasicAuth"),
+        @Authorization(value = "OAuth2", scopes = {
+            
+        })
+    }, tags={ "SMS Senders", })
+    @ApiResponses(value = { 
+        @ApiResponse(code = 200, message = "Successful response", response = SMSSender.class, responseContainer = "List"),
+        @ApiResponse(code = 400, message = "Bad Request", response = Error.class),
+        @ApiResponse(code = 401, message = "Unauthorized", response = Void.class),
+        @ApiResponse(code = 403, message = "Forbidden", response = Void.class),
+        @ApiResponse(code = 404, message = "Not Found", response = Error.class),
+        @ApiResponse(code = 405, message = "Method Not Allowed.", response = Error.class),
+        @ApiResponse(code = 500, message = "Server Error", response = Error.class)
+    })
+    public Response getSMSSenders() {
+
+        return delegate.getSMSSenders();
+    }
+
+    @Valid
+    @PUT
+    @Path("/email/{sender-name}")
+    @Consumes({ "application/json" })
+    @Produces({ "application/json" })
+    @ApiOperation(value = "Update an email sender", notes = "This API provides the capability to update an email sender by name. The URL encoded email sender name is used as sender-name.<br>   <b>Permission required:</b> <br>     * /permission/admin/manage/identity/configmgt/update <br>   <b>Scope required:</b> <br>     * internal_config_mgt_update ", response = EmailSender.class, authorizations = {
+        @Authorization(value = "BasicAuth"),
+        @Authorization(value = "OAuth2", scopes = {
+            
+        })
+    }, tags={ "Email Senders", })
+    @ApiResponses(value = { 
+        @ApiResponse(code = 200, message = "Successful Response", response = EmailSender.class),
+        @ApiResponse(code = 400, message = "Bad Request", response = Error.class),
+        @ApiResponse(code = 401, message = "Unauthorized", response = Void.class),
+        @ApiResponse(code = 403, message = "Forbidden", response = Void.class),
+        @ApiResponse(code = 404, message = "Not Found", response = Error.class),
+        @ApiResponse(code = 405, message = "Method Not Allowed.", response = Error.class),
+        @ApiResponse(code = 500, message = "Server Error", response = Error.class)
+    })
+    public Response updateEmailSender(@ApiParam(value = "name of the email sender",required=true) @PathParam("sender-name") String senderName, @ApiParam(value = "" ,required=true) @Valid EmailSenderUpdateRequest emailSenderUpdateRequest) {
+
+        return delegate.updateEmailSender(senderName,  emailSenderUpdateRequest );
+    }
+
+    @Valid
+    @PUT
+    @Path("/push/{sender-name}")
+    @Consumes({ "application/json" })
+    @Produces({ "application/json" })
+    @ApiOperation(value = "Update a push notification sender", notes = "This API provides the capability to update a push notification sender by name. The URL encoded push notification sender name is used as sender-name.<br>   <b>Permission required:</b> <br>     * /permission/admin/manage/identity/configmgt/update <br>   <b>Scope required:</b> <br>     * internal_config_mgt_update ", response = PushSender.class, authorizations = {
+        @Authorization(value = "BasicAuth"),
+        @Authorization(value = "OAuth2", scopes = {
+            
+        })
+    }, tags={ "Push Notification Senders", })
+    @ApiResponses(value = { 
+        @ApiResponse(code = 200, message = "Successful Response", response = PushSender.class),
+        @ApiResponse(code = 400, message = "Bad Request", response = Error.class),
+        @ApiResponse(code = 401, message = "Unauthorized", response = Void.class),
+        @ApiResponse(code = 403, message = "Forbidden", response = Void.class),
+        @ApiResponse(code = 404, message = "Not Found", response = Error.class),
+        @ApiResponse(code = 405, message = "Method Not Allowed.", response = Error.class),
+        @ApiResponse(code = 500, message = "Server Error", response = Error.class)
+    })
+    public Response updatePushSender(@ApiParam(value = "name of the push notification sender",required=true) @PathParam("sender-name") String senderName, @ApiParam(value = "" ,required=true) @Valid PushSenderUpdateRequest pushSenderUpdateRequest) {
+
+        return delegate.updatePushSender(senderName,  pushSenderUpdateRequest );
+    }
+
+    @Valid
+    @PUT
+    @Path("/sms/{sender-name}")
+    @Consumes({ "application/json" })
+    @Produces({ "application/json" })
+    @ApiOperation(value = "Update a SMS sender", notes = "This API provides the capability to update a SMS Sender. The URL encoded SMS sender name is used as sender-name.<br>   <b>Permission required:</b> <br>     * /permission/admin/manage/identity/configmgt/update <br>   <b>Scope required:</b> <br>     * internal_config_mgt_update ", response = SMSSender.class, authorizations = {
+        @Authorization(value = "BasicAuth"),
+        @Authorization(value = "OAuth2", scopes = {
+            
+        })
+    }, tags={ "SMS Senders" })
+    @ApiResponses(value = { 
+        @ApiResponse(code = 200, message = "Successful response", response = SMSSender.class),
+        @ApiResponse(code = 400, message = "Bad Request", response = Error.class),
+        @ApiResponse(code = 401, message = "Unauthorized", response = Void.class),
+        @ApiResponse(code = 403, message = "Forbidden", response = Void.class),
+        @ApiResponse(code = 404, message = "Not Found", response = Error.class),
+        @ApiResponse(code = 405, message = "Method Not Allowed.", response = Error.class),
+        @ApiResponse(code = 500, message = "Server Error", response = Error.class)
+    })
+    public Response updateSMSSender(@ApiParam(value = "name of the SMS sender",required=true) @PathParam("sender-name") String senderName, @ApiParam(value = "" ,required=true) @Valid SMSSenderUpdateRequest smSSenderUpdateRequest) {
+
+        return delegate.updateSMSSender(senderName,  smSSenderUpdateRequest );
+    }
+
+}

--- a/components/org.wso2.carbon.identity.api.server.notification.sender/org.wso2.carbon.identity.api.server.notification.sender.v2/src/gen/java/org/wso2/carbon/identity/api/server/notification/sender/v2/NotificationSendersApi.java
+++ b/components/org.wso2.carbon.identity.api.server.notification.sender/org.wso2.carbon.identity.api.server.notification.sender.v2/src/gen/java/org/wso2/carbon/identity/api/server/notification/sender/v2/NotificationSendersApi.java
@@ -60,7 +60,7 @@ public class NotificationSendersApi  {
     @Path("/email")
     @Consumes({ "application/json" })
     @Produces({ "application/json" })
-    @ApiOperation(value = "Create an email sender", notes = "This API provides the capability to create an email sender.\\n\\nIf the 'name' is not not defined, 'EmailPublisher' is taken as the default name. <br>   <b>Permission required:</b> <br>     * /permission/admin/manage/identity/configmgt/add <br>   <b>Scope required:</b> <br>     * internal_config_mgt_add ", response = EmailSender.class, authorizations = {
+    @ApiOperation(value = "Create an email sender", notes = "This API provides the capability to create an email sender.\\n\\nIf 'name' is not defined, 'EmailPublisher' is used as the default name. <br>   <b>Permission required:</b> <br>     * /permission/admin/manage/identity/configmgt/add <br>   <b>Scope required:</b> <br>     * internal_config_mgt_add ", response = EmailSender.class, authorizations = {
         @Authorization(value = "BasicAuth"),
         @Authorization(value = "OAuth2", scopes = {
             

--- a/components/org.wso2.carbon.identity.api.server.notification.sender/org.wso2.carbon.identity.api.server.notification.sender.v2/src/gen/java/org/wso2/carbon/identity/api/server/notification/sender/v2/NotificationSendersApiService.java
+++ b/components/org.wso2.carbon.identity.api.server.notification.sender/org.wso2.carbon.identity.api.server.notification.sender.v2/src/gen/java/org/wso2/carbon/identity/api/server/notification/sender/v2/NotificationSendersApiService.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.notification.sender.v2;
+
+import org.wso2.carbon.identity.api.server.notification.sender.v2.*;
+import org.wso2.carbon.identity.api.server.notification.sender.v2.model.*;
+import org.apache.cxf.jaxrs.ext.multipart.Attachment;
+import org.apache.cxf.jaxrs.ext.multipart.Multipart;
+import java.io.InputStream;
+import java.util.List;
+import org.wso2.carbon.identity.api.server.notification.sender.v2.model.EmailSender;
+import org.wso2.carbon.identity.api.server.notification.sender.v2.model.EmailSenderAdd;
+import org.wso2.carbon.identity.api.server.notification.sender.v2.model.EmailSenderUpdateRequest;
+import org.wso2.carbon.identity.api.server.notification.sender.v2.model.Error;
+import org.wso2.carbon.identity.api.server.notification.sender.v2.model.PushSender;
+import org.wso2.carbon.identity.api.server.notification.sender.v2.model.PushSenderAdd;
+import org.wso2.carbon.identity.api.server.notification.sender.v2.model.PushSenderUpdateRequest;
+import org.wso2.carbon.identity.api.server.notification.sender.v2.model.SMSSender;
+import org.wso2.carbon.identity.api.server.notification.sender.v2.model.SMSSenderAdd;
+import org.wso2.carbon.identity.api.server.notification.sender.v2.model.SMSSenderUpdateRequest;
+import javax.ws.rs.core.Response;
+
+
+public interface NotificationSendersApiService {
+
+      public Response createEmailSender(EmailSenderAdd emailSenderAdd);
+
+      public Response createPushSender(PushSenderAdd pushSenderAdd);
+
+      public Response createSMSSender(SMSSenderAdd smSSenderAdd);
+
+      public Response deleteEmailSender(String senderName);
+
+      public Response deletePushSender(String senderName);
+
+      public Response deleteSMSSender(String senderName);
+
+      public Response getEmailSender(String senderName);
+
+      public Response getEmailSenders();
+
+      public Response getPushSender(String senderName);
+
+      public Response getPushSenders();
+
+      public Response getSMSSender(String senderName);
+
+      public Response getSMSSenders();
+
+      public Response updateEmailSender(String senderName, EmailSenderUpdateRequest emailSenderUpdateRequest);
+
+      public Response updatePushSender(String senderName, PushSenderUpdateRequest pushSenderUpdateRequest);
+
+      public Response updateSMSSender(String senderName, SMSSenderUpdateRequest smSSenderUpdateRequest);
+}

--- a/components/org.wso2.carbon.identity.api.server.notification.sender/org.wso2.carbon.identity.api.server.notification.sender.v2/src/gen/java/org/wso2/carbon/identity/api/server/notification/sender/v2/factories/NotificationSendersApiServiceFactory.java
+++ b/components/org.wso2.carbon.identity.api.server.notification.sender/org.wso2.carbon.identity.api.server.notification.sender.v2/src/gen/java/org/wso2/carbon/identity/api/server/notification/sender/v2/factories/NotificationSendersApiServiceFactory.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.notification.sender.v2.factories;
+
+import org.wso2.carbon.identity.api.server.notification.sender.v2.NotificationSendersApiService;
+import org.wso2.carbon.identity.api.server.notification.sender.v2.impl.NotificationSendersApiServiceImpl;
+
+public class NotificationSendersApiServiceFactory {
+
+   private final static NotificationSendersApiService SERVICE = new NotificationSendersApiServiceImpl();
+
+   public static NotificationSendersApiService getNotificationSendersApi() {
+
+      return SERVICE;
+   }
+}

--- a/components/org.wso2.carbon.identity.api.server.notification.sender/org.wso2.carbon.identity.api.server.notification.sender.v2/src/gen/java/org/wso2/carbon/identity/api/server/notification/sender/v2/model/EmailSender.java
+++ b/components/org.wso2.carbon.identity.api.server.notification.sender/org.wso2.carbon.identity.api.server.notification.sender.v2/src/gen/java/org/wso2/carbon/identity/api/server/notification/sender/v2/model/EmailSender.java
@@ -1,0 +1,219 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.notification.sender.v2.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import java.util.ArrayList;
+import java.util.List;
+import org.wso2.carbon.identity.api.server.notification.sender.v2.model.Properties;
+import javax.validation.constraints.*;
+
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+import javax.validation.Valid;
+import javax.xml.bind.annotation.*;
+
+public class EmailSender  {
+  
+    private String name;
+    private String smtpServerHost;
+    private Integer smtpPort;
+    private String fromAddress;
+    private String authType;
+    private List<Properties> properties = null;
+
+
+    /**
+    **/
+    public EmailSender name(String name) {
+
+        this.name = name;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "EmailPublisher", required = true, value = "")
+    @JsonProperty("name")
+    @Valid
+    @NotNull(message = "Property name cannot be null.")
+
+    public String getName() {
+        return name;
+    }
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    /**
+    **/
+    public EmailSender smtpServerHost(String smtpServerHost) {
+
+        this.smtpServerHost = smtpServerHost;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "smtp.gmail.com", value = "")
+    @JsonProperty("smtpServerHost")
+    @Valid
+    public String getSmtpServerHost() {
+        return smtpServerHost;
+    }
+    public void setSmtpServerHost(String smtpServerHost) {
+        this.smtpServerHost = smtpServerHost;
+    }
+
+    /**
+    **/
+    public EmailSender smtpPort(Integer smtpPort) {
+
+        this.smtpPort = smtpPort;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "587", value = "")
+    @JsonProperty("smtpPort")
+    @Valid
+    public Integer getSmtpPort() {
+        return smtpPort;
+    }
+    public void setSmtpPort(Integer smtpPort) {
+        this.smtpPort = smtpPort;
+    }
+
+    /**
+    **/
+    public EmailSender fromAddress(String fromAddress) {
+
+        this.fromAddress = fromAddress;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "iam@gmail.com", required = true, value = "")
+    @JsonProperty("fromAddress")
+    @Valid
+    @NotNull(message = "Property fromAddress cannot be null.")
+
+    public String getFromAddress() {
+        return fromAddress;
+    }
+    public void setFromAddress(String fromAddress) {
+        this.fromAddress = fromAddress;
+    }
+
+    /**
+    **/
+    public EmailSender authType(String authType) {
+
+        this.authType = authType;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "BASIC", value = "")
+    @JsonProperty("authType")
+    @Valid
+    public String getAuthType() {
+        return authType;
+    }
+    public void setAuthType(String authType) {
+        this.authType = authType;
+    }
+
+    /**
+    **/
+    public EmailSender properties(List<Properties> properties) {
+
+        this.properties = properties;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "[{\"key\":\"mail.smtp.starttls.enable\",\"value\":true},{\"key\":\"userName\",\"value\":\"iam\"},{\"key\":\"password\",\"value\":\"iam123\"}]", value = "")
+    @JsonProperty("properties")
+    @Valid
+    public List<Properties> getProperties() {
+        return properties;
+    }
+    public void setProperties(List<Properties> properties) {
+        this.properties = properties;
+    }
+
+    public EmailSender addPropertiesItem(Properties propertiesItem) {
+        if (this.properties == null) {
+            this.properties = new ArrayList<>();
+        }
+        this.properties.add(propertiesItem);
+        return this;
+    }
+
+    
+
+    @Override
+    public boolean equals(java.lang.Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        EmailSender emailSender = (EmailSender) o;
+        return Objects.equals(this.name, emailSender.name) &&
+            Objects.equals(this.smtpServerHost, emailSender.smtpServerHost) &&
+            Objects.equals(this.smtpPort, emailSender.smtpPort) &&
+            Objects.equals(this.fromAddress, emailSender.fromAddress) &&
+            Objects.equals(this.authType, emailSender.authType) &&
+            Objects.equals(this.properties, emailSender.properties);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, smtpServerHost, smtpPort, fromAddress, authType, properties);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class EmailSender {\n");
+        
+        sb.append("    name: ").append(toIndentedString(name)).append("\n");
+        sb.append("    smtpServerHost: ").append(toIndentedString(smtpServerHost)).append("\n");
+        sb.append("    smtpPort: ").append(toIndentedString(smtpPort)).append("\n");
+        sb.append("    fromAddress: ").append(toIndentedString(fromAddress)).append("\n");
+        sb.append("    authType: ").append(toIndentedString(authType)).append("\n");
+        sb.append("    properties: ").append(toIndentedString(properties)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+    * Convert the given object to string with each line indented by 4 spaces
+    * (except the first line).
+    */
+    private String toIndentedString(java.lang.Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}
+

--- a/components/org.wso2.carbon.identity.api.server.notification.sender/org.wso2.carbon.identity.api.server.notification.sender.v2/src/gen/java/org/wso2/carbon/identity/api/server/notification/sender/v2/model/EmailSenderAdd.java
+++ b/components/org.wso2.carbon.identity.api.server.notification.sender/org.wso2.carbon.identity.api.server.notification.sender.v2/src/gen/java/org/wso2/carbon/identity/api/server/notification/sender/v2/model/EmailSenderAdd.java
@@ -1,0 +1,217 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.notification.sender.v2.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import java.util.ArrayList;
+import java.util.List;
+import org.wso2.carbon.identity.api.server.notification.sender.v2.model.Properties;
+import javax.validation.constraints.*;
+
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+import javax.validation.Valid;
+import javax.xml.bind.annotation.*;
+
+public class EmailSenderAdd  {
+  
+    private String name;
+    private String smtpServerHost;
+    private Integer smtpPort;
+    private String fromAddress;
+    private String authType;
+    private List<Properties> properties = null;
+
+
+    /**
+    **/
+    public EmailSenderAdd name(String name) {
+
+        this.name = name;
+        return this;
+    }
+    
+    @ApiModelProperty(value = "")
+    @JsonProperty("name")
+    @Valid
+    public String getName() {
+        return name;
+    }
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    /**
+    **/
+    public EmailSenderAdd smtpServerHost(String smtpServerHost) {
+
+        this.smtpServerHost = smtpServerHost;
+        return this;
+    }
+    
+    @ApiModelProperty(value = "")
+    @JsonProperty("smtpServerHost")
+    @Valid
+    public String getSmtpServerHost() {
+        return smtpServerHost;
+    }
+    public void setSmtpServerHost(String smtpServerHost) {
+        this.smtpServerHost = smtpServerHost;
+    }
+
+    /**
+    **/
+    public EmailSenderAdd smtpPort(Integer smtpPort) {
+
+        this.smtpPort = smtpPort;
+        return this;
+    }
+    
+    @ApiModelProperty(value = "")
+    @JsonProperty("smtpPort")
+    @Valid
+    public Integer getSmtpPort() {
+        return smtpPort;
+    }
+    public void setSmtpPort(Integer smtpPort) {
+        this.smtpPort = smtpPort;
+    }
+
+    /**
+    **/
+    public EmailSenderAdd fromAddress(String fromAddress) {
+
+        this.fromAddress = fromAddress;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "iam@gmail.com", required = true, value = "")
+    @JsonProperty("fromAddress")
+    @Valid
+    @NotNull(message = "Property fromAddress cannot be null.")
+
+    public String getFromAddress() {
+        return fromAddress;
+    }
+    public void setFromAddress(String fromAddress) {
+        this.fromAddress = fromAddress;
+    }
+
+    /**
+    **/
+    public EmailSenderAdd authType(String authType) {
+
+        this.authType = authType;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "BASIC", value = "")
+    @JsonProperty("authType")
+    @Valid
+    public String getAuthType() {
+        return authType;
+    }
+    public void setAuthType(String authType) {
+        this.authType = authType;
+    }
+
+    /**
+    **/
+    public EmailSenderAdd properties(List<Properties> properties) {
+
+        this.properties = properties;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "[{\"key\":\"body.scope\",\"value\":\"true\"},{\"key\":\"mail.smtp.starttls.enable\",\"value\":true},{\"key\":\"userName\",\"value\":\"iam\"},{\"key\":\"password\",\"value\":\"iam123\"}]", value = "")
+    @JsonProperty("properties")
+    @Valid
+    public List<Properties> getProperties() {
+        return properties;
+    }
+    public void setProperties(List<Properties> properties) {
+        this.properties = properties;
+    }
+
+    public EmailSenderAdd addPropertiesItem(Properties propertiesItem) {
+        if (this.properties == null) {
+            this.properties = new ArrayList<>();
+        }
+        this.properties.add(propertiesItem);
+        return this;
+    }
+
+    
+
+    @Override
+    public boolean equals(java.lang.Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        EmailSenderAdd emailSenderAdd = (EmailSenderAdd) o;
+        return Objects.equals(this.name, emailSenderAdd.name) &&
+            Objects.equals(this.smtpServerHost, emailSenderAdd.smtpServerHost) &&
+            Objects.equals(this.smtpPort, emailSenderAdd.smtpPort) &&
+            Objects.equals(this.fromAddress, emailSenderAdd.fromAddress) &&
+            Objects.equals(this.authType, emailSenderAdd.authType) &&
+            Objects.equals(this.properties, emailSenderAdd.properties);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, smtpServerHost, smtpPort, fromAddress, authType, properties);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class EmailSenderAdd {\n");
+        
+        sb.append("    name: ").append(toIndentedString(name)).append("\n");
+        sb.append("    smtpServerHost: ").append(toIndentedString(smtpServerHost)).append("\n");
+        sb.append("    smtpPort: ").append(toIndentedString(smtpPort)).append("\n");
+        sb.append("    fromAddress: ").append(toIndentedString(fromAddress)).append("\n");
+        sb.append("    authType: ").append(toIndentedString(authType)).append("\n");
+        sb.append("    properties: ").append(toIndentedString(properties)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+    * Convert the given object to string with each line indented by 4 spaces
+    * (except the first line).
+    */
+    private String toIndentedString(java.lang.Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}
+

--- a/components/org.wso2.carbon.identity.api.server.notification.sender/org.wso2.carbon.identity.api.server.notification.sender.v2/src/gen/java/org/wso2/carbon/identity/api/server/notification/sender/v2/model/EmailSenderUpdateRequest.java
+++ b/components/org.wso2.carbon.identity.api.server.notification.sender/org.wso2.carbon.identity.api.server.notification.sender.v2/src/gen/java/org/wso2/carbon/identity/api/server/notification/sender/v2/model/EmailSenderUpdateRequest.java
@@ -1,0 +1,196 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.notification.sender.v2.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import java.util.ArrayList;
+import java.util.List;
+import org.wso2.carbon.identity.api.server.notification.sender.v2.model.Properties;
+import javax.validation.constraints.*;
+
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+import javax.validation.Valid;
+import javax.xml.bind.annotation.*;
+
+public class EmailSenderUpdateRequest  {
+  
+    private String smtpServerHost;
+    private Integer smtpPort;
+    private String fromAddress;
+    private String authType;
+    private List<Properties> properties = null;
+
+
+    /**
+    **/
+    public EmailSenderUpdateRequest smtpServerHost(String smtpServerHost) {
+
+        this.smtpServerHost = smtpServerHost;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "smtp.gmail.com", value = "")
+    @JsonProperty("smtpServerHost")
+    @Valid
+    public String getSmtpServerHost() {
+        return smtpServerHost;
+    }
+    public void setSmtpServerHost(String smtpServerHost) {
+        this.smtpServerHost = smtpServerHost;
+    }
+
+    /**
+    **/
+    public EmailSenderUpdateRequest smtpPort(Integer smtpPort) {
+
+        this.smtpPort = smtpPort;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "587", value = "")
+    @JsonProperty("smtpPort")
+    @Valid
+    public Integer getSmtpPort() {
+        return smtpPort;
+    }
+    public void setSmtpPort(Integer smtpPort) {
+        this.smtpPort = smtpPort;
+    }
+
+    /**
+    **/
+    public EmailSenderUpdateRequest fromAddress(String fromAddress) {
+
+        this.fromAddress = fromAddress;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "iam@gmail.com", required = true, value = "")
+    @JsonProperty("fromAddress")
+    @Valid
+    @NotNull(message = "Property fromAddress cannot be null.")
+
+    public String getFromAddress() {
+        return fromAddress;
+    }
+    public void setFromAddress(String fromAddress) {
+        this.fromAddress = fromAddress;
+    }
+
+    /**
+    **/
+    public EmailSenderUpdateRequest authType(String authType) {
+
+        this.authType = authType;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "BASIC", value = "")
+    @JsonProperty("authType")
+    @Valid
+    public String getAuthType() {
+        return authType;
+    }
+    public void setAuthType(String authType) {
+        this.authType = authType;
+    }
+
+    /**
+    **/
+    public EmailSenderUpdateRequest properties(List<Properties> properties) {
+
+        this.properties = properties;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "[{\"key\":\"body.scope\",\"value\":\"true\"},{\"key\":\"mail.smtp.starttls.enable\",\"value\":true},{\"key\":\"userName\",\"value\":\"iam\"},{\"key\":\"password\",\"value\":\"iam123\"}]", value = "")
+    @JsonProperty("properties")
+    @Valid
+    public List<Properties> getProperties() {
+        return properties;
+    }
+    public void setProperties(List<Properties> properties) {
+        this.properties = properties;
+    }
+
+    public EmailSenderUpdateRequest addPropertiesItem(Properties propertiesItem) {
+        if (this.properties == null) {
+            this.properties = new ArrayList<>();
+        }
+        this.properties.add(propertiesItem);
+        return this;
+    }
+
+    
+
+    @Override
+    public boolean equals(java.lang.Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        EmailSenderUpdateRequest emailSenderUpdateRequest = (EmailSenderUpdateRequest) o;
+        return Objects.equals(this.smtpServerHost, emailSenderUpdateRequest.smtpServerHost) &&
+            Objects.equals(this.smtpPort, emailSenderUpdateRequest.smtpPort) &&
+            Objects.equals(this.fromAddress, emailSenderUpdateRequest.fromAddress) &&
+            Objects.equals(this.authType, emailSenderUpdateRequest.authType) &&
+            Objects.equals(this.properties, emailSenderUpdateRequest.properties);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(smtpServerHost, smtpPort, fromAddress, authType, properties);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class EmailSenderUpdateRequest {\n");
+        
+        sb.append("    smtpServerHost: ").append(toIndentedString(smtpServerHost)).append("\n");
+        sb.append("    smtpPort: ").append(toIndentedString(smtpPort)).append("\n");
+        sb.append("    fromAddress: ").append(toIndentedString(fromAddress)).append("\n");
+        sb.append("    authType: ").append(toIndentedString(authType)).append("\n");
+        sb.append("    properties: ").append(toIndentedString(properties)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+    * Convert the given object to string with each line indented by 4 spaces
+    * (except the first line).
+    */
+    private String toIndentedString(java.lang.Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}
+

--- a/components/org.wso2.carbon.identity.api.server.notification.sender/org.wso2.carbon.identity.api.server.notification.sender.v2/src/gen/java/org/wso2/carbon/identity/api/server/notification/sender/v2/model/Error.java
+++ b/components/org.wso2.carbon.identity.api.server.notification.sender/org.wso2.carbon.identity.api.server.notification.sender.v2/src/gen/java/org/wso2/carbon/identity/api/server/notification/sender/v2/model/Error.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.notification.sender.v2.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import javax.validation.constraints.*;
+
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+import javax.validation.Valid;
+import javax.xml.bind.annotation.*;
+
+public class Error  {
+  
+    private String code;
+    private String message;
+    private String description;
+    private String traceId;
+
+    /**
+    **/
+    public Error code(String code) {
+
+        this.code = code;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "NSM-00000", value = "")
+    @JsonProperty("code")
+    @Valid
+    public String getCode() {
+        return code;
+    }
+    public void setCode(String code) {
+        this.code = code;
+    }
+
+    /**
+    **/
+    public Error message(String message) {
+
+        this.message = message;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "Some Error Message", value = "")
+    @JsonProperty("message")
+    @Valid
+    public String getMessage() {
+        return message;
+    }
+    public void setMessage(String message) {
+        this.message = message;
+    }
+
+    /**
+    **/
+    public Error description(String description) {
+
+        this.description = description;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "Some Error Description", value = "")
+    @JsonProperty("description")
+    @Valid
+    public String getDescription() {
+        return description;
+    }
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    /**
+    **/
+    public Error traceId(String traceId) {
+
+        this.traceId = traceId;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "e0fbcfeb-3617-43c4-8dd0-7b7d38e13047", value = "")
+    @JsonProperty("traceId")
+    @Valid
+    public String getTraceId() {
+        return traceId;
+    }
+    public void setTraceId(String traceId) {
+        this.traceId = traceId;
+    }
+
+
+
+    @Override
+    public boolean equals(java.lang.Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Error error = (Error) o;
+        return Objects.equals(this.code, error.code) &&
+            Objects.equals(this.message, error.message) &&
+            Objects.equals(this.description, error.description) &&
+            Objects.equals(this.traceId, error.traceId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(code, message, description, traceId);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class Error {\n");
+        
+        sb.append("    code: ").append(toIndentedString(code)).append("\n");
+        sb.append("    message: ").append(toIndentedString(message)).append("\n");
+        sb.append("    description: ").append(toIndentedString(description)).append("\n");
+        sb.append("    traceId: ").append(toIndentedString(traceId)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+    * Convert the given object to string with each line indented by 4 spaces
+    * (except the first line).
+    */
+    private String toIndentedString(java.lang.Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}
+

--- a/components/org.wso2.carbon.identity.api.server.notification.sender/org.wso2.carbon.identity.api.server.notification.sender.v2/src/gen/java/org/wso2/carbon/identity/api/server/notification/sender/v2/model/Properties.java
+++ b/components/org.wso2.carbon.identity.api.server.notification.sender/org.wso2.carbon.identity.api.server.notification.sender.v2/src/gen/java/org/wso2/carbon/identity/api/server/notification/sender/v2/model/Properties.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.notification.sender.v2.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import javax.validation.constraints.*;
+
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+import javax.validation.Valid;
+import javax.xml.bind.annotation.*;
+
+public class Properties  {
+  
+    private String key;
+    private String value;
+
+    /**
+    **/
+    public Properties key(String key) {
+
+        this.key = key;
+        return this;
+    }
+    
+    @ApiModelProperty(required = true, value = "")
+    @JsonProperty("key")
+    @Valid
+    @NotNull(message = "Property key cannot be null.")
+
+    public String getKey() {
+        return key;
+    }
+    public void setKey(String key) {
+        this.key = key;
+    }
+
+    /**
+    **/
+    public Properties value(String value) {
+
+        this.value = value;
+        return this;
+    }
+    
+    @ApiModelProperty(required = true, value = "")
+    @JsonProperty("value")
+    @Valid
+    @NotNull(message = "Property value cannot be null.")
+
+    public String getValue() {
+        return value;
+    }
+    public void setValue(String value) {
+        this.value = value;
+    }
+
+
+
+    @Override
+    public boolean equals(java.lang.Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Properties properties = (Properties) o;
+        return Objects.equals(this.key, properties.key) &&
+            Objects.equals(this.value, properties.value);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(key, value);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class Properties {\n");
+        
+        sb.append("    key: ").append(toIndentedString(key)).append("\n");
+        sb.append("    value: ").append(toIndentedString(value)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+    * Convert the given object to string with each line indented by 4 spaces
+    * (except the first line).
+    */
+    private String toIndentedString(java.lang.Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}
+

--- a/components/org.wso2.carbon.identity.api.server.notification.sender/org.wso2.carbon.identity.api.server.notification.sender.v2/src/gen/java/org/wso2/carbon/identity/api/server/notification/sender/v2/model/PushSender.java
+++ b/components/org.wso2.carbon.identity.api.server.notification.sender/org.wso2.carbon.identity.api.server.notification.sender.v2/src/gen/java/org/wso2/carbon/identity/api/server/notification/sender/v2/model/PushSender.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.notification.sender.v2.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import java.util.ArrayList;
+import java.util.List;
+import org.wso2.carbon.identity.api.server.notification.sender.v2.model.Properties;
+import javax.validation.constraints.*;
+
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+import javax.validation.Valid;
+import javax.xml.bind.annotation.*;
+
+public class PushSender  {
+  
+    private String name;
+    private String provider;
+    private List<Properties> properties = null;
+
+
+    /**
+    **/
+    public PushSender name(String name) {
+
+        this.name = name;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "PushPublisher", required = true, value = "")
+    @JsonProperty("name")
+    @Valid
+    @NotNull(message = "Property name cannot be null.")
+
+    public String getName() {
+        return name;
+    }
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    /**
+    **/
+    public PushSender provider(String provider) {
+
+        this.provider = provider;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "fcm", required = true, value = "")
+    @JsonProperty("provider")
+    @Valid
+    @NotNull(message = "Property provider cannot be null.")
+
+    public String getProvider() {
+        return provider;
+    }
+    public void setProvider(String provider) {
+        this.provider = provider;
+    }
+
+    /**
+    **/
+    public PushSender properties(List<Properties> properties) {
+
+        this.properties = properties;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "[{\"key\":\"fcm.serviceAccount\",\"value\":\"jsonString\"},{\"key\":\"aws.keyId\",\"value\":\"sampleKeyId\"}]", value = "")
+    @JsonProperty("properties")
+    @Valid
+    public List<Properties> getProperties() {
+        return properties;
+    }
+    public void setProperties(List<Properties> properties) {
+        this.properties = properties;
+    }
+
+    public PushSender addPropertiesItem(Properties propertiesItem) {
+        if (this.properties == null) {
+            this.properties = new ArrayList<>();
+        }
+        this.properties.add(propertiesItem);
+        return this;
+    }
+
+    
+
+    @Override
+    public boolean equals(java.lang.Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        PushSender pushSender = (PushSender) o;
+        return Objects.equals(this.name, pushSender.name) &&
+            Objects.equals(this.provider, pushSender.provider) &&
+            Objects.equals(this.properties, pushSender.properties);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, provider, properties);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class PushSender {\n");
+        
+        sb.append("    name: ").append(toIndentedString(name)).append("\n");
+        sb.append("    provider: ").append(toIndentedString(provider)).append("\n");
+        sb.append("    properties: ").append(toIndentedString(properties)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+    * Convert the given object to string with each line indented by 4 spaces
+    * (except the first line).
+    */
+    private String toIndentedString(java.lang.Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}
+

--- a/components/org.wso2.carbon.identity.api.server.notification.sender/org.wso2.carbon.identity.api.server.notification.sender.v2/src/gen/java/org/wso2/carbon/identity/api/server/notification/sender/v2/model/PushSenderAdd.java
+++ b/components/org.wso2.carbon.identity.api.server.notification.sender/org.wso2.carbon.identity.api.server.notification.sender.v2/src/gen/java/org/wso2/carbon/identity/api/server/notification/sender/v2/model/PushSenderAdd.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.notification.sender.v2.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import java.util.ArrayList;
+import java.util.List;
+import org.wso2.carbon.identity.api.server.notification.sender.v2.model.Properties;
+import javax.validation.constraints.*;
+
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+import javax.validation.Valid;
+import javax.xml.bind.annotation.*;
+
+public class PushSenderAdd  {
+  
+    private String name;
+    private String provider;
+    private List<Properties> properties = new ArrayList<>();
+
+
+    /**
+    **/
+    public PushSenderAdd name(String name) {
+
+        this.name = name;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "PushPublisher", value = "")
+    @JsonProperty("name")
+    @Valid
+    public String getName() {
+        return name;
+    }
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    /**
+    **/
+    public PushSenderAdd provider(String provider) {
+
+        this.provider = provider;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "fcm", required = true, value = "")
+    @JsonProperty("provider")
+    @Valid
+    @NotNull(message = "Property provider cannot be null.")
+
+    public String getProvider() {
+        return provider;
+    }
+    public void setProvider(String provider) {
+        this.provider = provider;
+    }
+
+    /**
+    **/
+    public PushSenderAdd properties(List<Properties> properties) {
+
+        this.properties = properties;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "[{\"key\":\"fcm.serviceAccount\",\"value\":\"jsonString\"},{\"key\":\"aws.keyId\",\"value\":\"sampleKeyId\"}]", required = true, value = "")
+    @JsonProperty("properties")
+    @Valid
+    @NotNull(message = "Property properties cannot be null.")
+
+    public List<Properties> getProperties() {
+        return properties;
+    }
+    public void setProperties(List<Properties> properties) {
+        this.properties = properties;
+    }
+
+    public PushSenderAdd addPropertiesItem(Properties propertiesItem) {
+        this.properties.add(propertiesItem);
+        return this;
+    }
+
+    
+
+    @Override
+    public boolean equals(java.lang.Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        PushSenderAdd pushSenderAdd = (PushSenderAdd) o;
+        return Objects.equals(this.name, pushSenderAdd.name) &&
+            Objects.equals(this.provider, pushSenderAdd.provider) &&
+            Objects.equals(this.properties, pushSenderAdd.properties);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, provider, properties);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class PushSenderAdd {\n");
+        
+        sb.append("    name: ").append(toIndentedString(name)).append("\n");
+        sb.append("    provider: ").append(toIndentedString(provider)).append("\n");
+        sb.append("    properties: ").append(toIndentedString(properties)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+    * Convert the given object to string with each line indented by 4 spaces
+    * (except the first line).
+    */
+    private String toIndentedString(java.lang.Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}
+

--- a/components/org.wso2.carbon.identity.api.server.notification.sender/org.wso2.carbon.identity.api.server.notification.sender.v2/src/gen/java/org/wso2/carbon/identity/api/server/notification/sender/v2/model/PushSenderUpdateRequest.java
+++ b/components/org.wso2.carbon.identity.api.server.notification.sender/org.wso2.carbon.identity.api.server.notification.sender.v2/src/gen/java/org/wso2/carbon/identity/api/server/notification/sender/v2/model/PushSenderUpdateRequest.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.notification.sender.v2.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import java.util.ArrayList;
+import java.util.List;
+import org.wso2.carbon.identity.api.server.notification.sender.v2.model.Properties;
+import javax.validation.constraints.*;
+
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+import javax.validation.Valid;
+import javax.xml.bind.annotation.*;
+
+public class PushSenderUpdateRequest  {
+  
+    private String provider;
+    private List<Properties> properties = new ArrayList<>();
+
+
+    /**
+    **/
+    public PushSenderUpdateRequest provider(String provider) {
+
+        this.provider = provider;
+        return this;
+    }
+    
+    @ApiModelProperty(required = true, value = "")
+    @JsonProperty("provider")
+    @Valid
+    @NotNull(message = "Property provider cannot be null.")
+
+    public String getProvider() {
+        return provider;
+    }
+    public void setProvider(String provider) {
+        this.provider = provider;
+    }
+
+    /**
+    **/
+    public PushSenderUpdateRequest properties(List<Properties> properties) {
+
+        this.properties = properties;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "[{\"key\":\"fcm.serviceAccount\",\"value\":\"jsonString\"},{\"key\":\"aws.keyId\",\"value\":\"sampleKeyId\"}]", required = true, value = "")
+    @JsonProperty("properties")
+    @Valid
+    @NotNull(message = "Property properties cannot be null.")
+
+    public List<Properties> getProperties() {
+        return properties;
+    }
+    public void setProperties(List<Properties> properties) {
+        this.properties = properties;
+    }
+
+    public PushSenderUpdateRequest addPropertiesItem(Properties propertiesItem) {
+        this.properties.add(propertiesItem);
+        return this;
+    }
+
+    
+
+    @Override
+    public boolean equals(java.lang.Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        PushSenderUpdateRequest pushSenderUpdateRequest = (PushSenderUpdateRequest) o;
+        return Objects.equals(this.provider, pushSenderUpdateRequest.provider) &&
+            Objects.equals(this.properties, pushSenderUpdateRequest.properties);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(provider, properties);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class PushSenderUpdateRequest {\n");
+        
+        sb.append("    provider: ").append(toIndentedString(provider)).append("\n");
+        sb.append("    properties: ").append(toIndentedString(properties)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+    * Convert the given object to string with each line indented by 4 spaces
+    * (except the first line).
+    */
+    private String toIndentedString(java.lang.Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}
+

--- a/components/org.wso2.carbon.identity.api.server.notification.sender/org.wso2.carbon.identity.api.server.notification.sender.v2/src/gen/java/org/wso2/carbon/identity/api/server/notification/sender/v2/model/SMSSender.java
+++ b/components/org.wso2.carbon.identity.api.server.notification.sender/org.wso2.carbon.identity.api.server.notification.sender.v2/src/gen/java/org/wso2/carbon/identity/api/server/notification/sender/v2/model/SMSSender.java
@@ -1,0 +1,298 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.notification.sender.v2.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import java.util.ArrayList;
+import java.util.List;
+import org.wso2.carbon.identity.api.server.notification.sender.v2.model.Properties;
+import javax.validation.constraints.*;
+
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+import javax.validation.Valid;
+import javax.xml.bind.annotation.*;
+
+public class SMSSender  {
+  
+    private String name;
+    private String provider;
+    private String providerURL;
+    private String key;
+    private String secret;
+    private String sender;
+
+@XmlType(name="ContentTypeEnum")
+@XmlEnum(String.class)
+public enum ContentTypeEnum {
+
+    @XmlEnumValue("JSON") JSON(String.valueOf("JSON")), @XmlEnumValue("FORM") FORM(String.valueOf("FORM"));
+
+
+    private String value;
+
+    ContentTypeEnum(String v) {
+        value = v;
+    }
+
+    public String value() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    public static ContentTypeEnum fromValue(String value) {
+        for (ContentTypeEnum b : ContentTypeEnum.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
+}
+
+    private ContentTypeEnum contentType;
+    private List<Properties> properties = null;
+
+
+    /**
+    **/
+    public SMSSender name(String name) {
+
+        this.name = name;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "SMSPublisher", required = true, value = "")
+    @JsonProperty("name")
+    @Valid
+    @NotNull(message = "Property name cannot be null.")
+
+    public String getName() {
+        return name;
+    }
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    /**
+    **/
+    public SMSSender provider(String provider) {
+
+        this.provider = provider;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "NEXMO", required = true, value = "")
+    @JsonProperty("provider")
+    @Valid
+    @NotNull(message = "Property provider cannot be null.")
+
+    public String getProvider() {
+        return provider;
+    }
+    public void setProvider(String provider) {
+        this.provider = provider;
+    }
+
+    /**
+    **/
+    public SMSSender providerURL(String providerURL) {
+
+        this.providerURL = providerURL;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "https://rest.nexmo.com/sms/json", required = true, value = "")
+    @JsonProperty("providerURL")
+    @Valid
+    @NotNull(message = "Property providerURL cannot be null.")
+
+    public String getProviderURL() {
+        return providerURL;
+    }
+    public void setProviderURL(String providerURL) {
+        this.providerURL = providerURL;
+    }
+
+    /**
+    **/
+    public SMSSender key(String key) {
+
+        this.key = key;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "123**45", value = "")
+    @JsonProperty("key")
+    @Valid
+    public String getKey() {
+        return key;
+    }
+    public void setKey(String key) {
+        this.key = key;
+    }
+
+    /**
+    **/
+    public SMSSender secret(String secret) {
+
+        this.secret = secret;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "5tg**ssd", value = "")
+    @JsonProperty("secret")
+    @Valid
+    public String getSecret() {
+        return secret;
+    }
+    public void setSecret(String secret) {
+        this.secret = secret;
+    }
+
+    /**
+    **/
+    public SMSSender sender(String sender) {
+
+        this.sender = sender;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "+94 775563324", value = "")
+    @JsonProperty("sender")
+    @Valid
+    public String getSender() {
+        return sender;
+    }
+    public void setSender(String sender) {
+        this.sender = sender;
+    }
+
+    /**
+    **/
+    public SMSSender contentType(ContentTypeEnum contentType) {
+
+        this.contentType = contentType;
+        return this;
+    }
+    
+    @ApiModelProperty(required = true, value = "")
+    @JsonProperty("contentType")
+    @Valid
+    @NotNull(message = "Property contentType cannot be null.")
+
+    public ContentTypeEnum getContentType() {
+        return contentType;
+    }
+    public void setContentType(ContentTypeEnum contentType) {
+        this.contentType = contentType;
+    }
+
+    /**
+    **/
+    public SMSSender properties(List<Properties> properties) {
+
+        this.properties = properties;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "[{\"key\":\"body.scope\",\"value\":\"internal\"},{\"key\":\"http.headers\",\"value\":\"X-Version: 1, Authorization: bearer ,Accept: application/json ,Content-Type: application/json\"}]", value = "")
+    @JsonProperty("properties")
+    @Valid
+    public List<Properties> getProperties() {
+        return properties;
+    }
+    public void setProperties(List<Properties> properties) {
+        this.properties = properties;
+    }
+
+    public SMSSender addPropertiesItem(Properties propertiesItem) {
+        if (this.properties == null) {
+            this.properties = new ArrayList<>();
+        }
+        this.properties.add(propertiesItem);
+        return this;
+    }
+
+    
+
+    @Override
+    public boolean equals(java.lang.Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        SMSSender smSSender = (SMSSender) o;
+        return Objects.equals(this.name, smSSender.name) &&
+            Objects.equals(this.provider, smSSender.provider) &&
+            Objects.equals(this.providerURL, smSSender.providerURL) &&
+            Objects.equals(this.key, smSSender.key) &&
+            Objects.equals(this.secret, smSSender.secret) &&
+            Objects.equals(this.sender, smSSender.sender) &&
+            Objects.equals(this.contentType, smSSender.contentType) &&
+            Objects.equals(this.properties, smSSender.properties);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, provider, providerURL, key, secret, sender, contentType, properties);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class SMSSender {\n");
+        
+        sb.append("    name: ").append(toIndentedString(name)).append("\n");
+        sb.append("    provider: ").append(toIndentedString(provider)).append("\n");
+        sb.append("    providerURL: ").append(toIndentedString(providerURL)).append("\n");
+        sb.append("    key: ").append(toIndentedString(key)).append("\n");
+        sb.append("    secret: ").append(toIndentedString(secret)).append("\n");
+        sb.append("    sender: ").append(toIndentedString(sender)).append("\n");
+        sb.append("    contentType: ").append(toIndentedString(contentType)).append("\n");
+        sb.append("    properties: ").append(toIndentedString(properties)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+    * Convert the given object to string with each line indented by 4 spaces
+    * (except the first line).
+    */
+    private String toIndentedString(java.lang.Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}
+

--- a/components/org.wso2.carbon.identity.api.server.notification.sender/org.wso2.carbon.identity.api.server.notification.sender.v2/src/gen/java/org/wso2/carbon/identity/api/server/notification/sender/v2/model/SMSSenderAdd.java
+++ b/components/org.wso2.carbon.identity.api.server.notification.sender/org.wso2.carbon.identity.api.server.notification.sender.v2/src/gen/java/org/wso2/carbon/identity/api/server/notification/sender/v2/model/SMSSenderAdd.java
@@ -1,0 +1,294 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.notification.sender.v2.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import java.util.ArrayList;
+import java.util.List;
+import org.wso2.carbon.identity.api.server.notification.sender.v2.model.Properties;
+import javax.validation.constraints.*;
+
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+import javax.validation.Valid;
+import javax.xml.bind.annotation.*;
+
+public class SMSSenderAdd  {
+  
+    private String name;
+    private String provider;
+    private String providerURL;
+    private String key;
+    private String secret;
+    private String sender;
+
+@XmlType(name="ContentTypeEnum")
+@XmlEnum(String.class)
+public enum ContentTypeEnum {
+
+    @XmlEnumValue("JSON") JSON(String.valueOf("JSON")), @XmlEnumValue("FORM") FORM(String.valueOf("FORM"));
+
+
+    private String value;
+
+    ContentTypeEnum(String v) {
+        value = v;
+    }
+
+    public String value() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    public static ContentTypeEnum fromValue(String value) {
+        for (ContentTypeEnum b : ContentTypeEnum.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
+}
+
+    private ContentTypeEnum contentType;
+    private List<Properties> properties = null;
+
+
+    /**
+    **/
+    public SMSSenderAdd name(String name) {
+
+        this.name = name;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "SMSPublisher", value = "")
+    @JsonProperty("name")
+    @Valid
+    public String getName() {
+        return name;
+    }
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    /**
+    **/
+    public SMSSenderAdd provider(String provider) {
+
+        this.provider = provider;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "NEXMO", required = true, value = "")
+    @JsonProperty("provider")
+    @Valid
+    @NotNull(message = "Property provider cannot be null.")
+
+    public String getProvider() {
+        return provider;
+    }
+    public void setProvider(String provider) {
+        this.provider = provider;
+    }
+
+    /**
+    **/
+    public SMSSenderAdd providerURL(String providerURL) {
+
+        this.providerURL = providerURL;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "https://rest.nexmo.com/sms/json", value = "")
+    @JsonProperty("providerURL")
+    @Valid
+    public String getProviderURL() {
+        return providerURL;
+    }
+    public void setProviderURL(String providerURL) {
+        this.providerURL = providerURL;
+    }
+
+    /**
+    **/
+    public SMSSenderAdd key(String key) {
+
+        this.key = key;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "123**45", value = "")
+    @JsonProperty("key")
+    @Valid
+    public String getKey() {
+        return key;
+    }
+    public void setKey(String key) {
+        this.key = key;
+    }
+
+    /**
+    **/
+    public SMSSenderAdd secret(String secret) {
+
+        this.secret = secret;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "5tg**ssd", value = "")
+    @JsonProperty("secret")
+    @Valid
+    public String getSecret() {
+        return secret;
+    }
+    public void setSecret(String secret) {
+        this.secret = secret;
+    }
+
+    /**
+    **/
+    public SMSSenderAdd sender(String sender) {
+
+        this.sender = sender;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "+94 775563324", value = "")
+    @JsonProperty("sender")
+    @Valid
+    public String getSender() {
+        return sender;
+    }
+    public void setSender(String sender) {
+        this.sender = sender;
+    }
+
+    /**
+    **/
+    public SMSSenderAdd contentType(ContentTypeEnum contentType) {
+
+        this.contentType = contentType;
+        return this;
+    }
+    
+    @ApiModelProperty(required = true, value = "")
+    @JsonProperty("contentType")
+    @Valid
+    @NotNull(message = "Property contentType cannot be null.")
+
+    public ContentTypeEnum getContentType() {
+        return contentType;
+    }
+    public void setContentType(ContentTypeEnum contentType) {
+        this.contentType = contentType;
+    }
+
+    /**
+    **/
+    public SMSSenderAdd properties(List<Properties> properties) {
+
+        this.properties = properties;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "[{\"key\":\"http.headers\",\"value\":\"X-Version: 1, Authorization: bearer ,Accept: application/json ,Content-Type: application/json\"}]", value = "")
+    @JsonProperty("properties")
+    @Valid
+    public List<Properties> getProperties() {
+        return properties;
+    }
+    public void setProperties(List<Properties> properties) {
+        this.properties = properties;
+    }
+
+    public SMSSenderAdd addPropertiesItem(Properties propertiesItem) {
+        if (this.properties == null) {
+            this.properties = new ArrayList<>();
+        }
+        this.properties.add(propertiesItem);
+        return this;
+    }
+
+    
+
+    @Override
+    public boolean equals(java.lang.Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        SMSSenderAdd smSSenderAdd = (SMSSenderAdd) o;
+        return Objects.equals(this.name, smSSenderAdd.name) &&
+            Objects.equals(this.provider, smSSenderAdd.provider) &&
+            Objects.equals(this.providerURL, smSSenderAdd.providerURL) &&
+            Objects.equals(this.key, smSSenderAdd.key) &&
+            Objects.equals(this.secret, smSSenderAdd.secret) &&
+            Objects.equals(this.sender, smSSenderAdd.sender) &&
+            Objects.equals(this.contentType, smSSenderAdd.contentType) &&
+            Objects.equals(this.properties, smSSenderAdd.properties);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, provider, providerURL, key, secret, sender, contentType, properties);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class SMSSenderAdd {\n");
+        
+        sb.append("    name: ").append(toIndentedString(name)).append("\n");
+        sb.append("    provider: ").append(toIndentedString(provider)).append("\n");
+        sb.append("    providerURL: ").append(toIndentedString(providerURL)).append("\n");
+        sb.append("    key: ").append(toIndentedString(key)).append("\n");
+        sb.append("    secret: ").append(toIndentedString(secret)).append("\n");
+        sb.append("    sender: ").append(toIndentedString(sender)).append("\n");
+        sb.append("    contentType: ").append(toIndentedString(contentType)).append("\n");
+        sb.append("    properties: ").append(toIndentedString(properties)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+    * Convert the given object to string with each line indented by 4 spaces
+    * (except the first line).
+    */
+    private String toIndentedString(java.lang.Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}
+

--- a/components/org.wso2.carbon.identity.api.server.notification.sender/org.wso2.carbon.identity.api.server.notification.sender.v2/src/gen/java/org/wso2/carbon/identity/api/server/notification/sender/v2/model/SMSSenderUpdateRequest.java
+++ b/components/org.wso2.carbon.identity.api.server.notification.sender/org.wso2.carbon.identity.api.server.notification.sender.v2/src/gen/java/org/wso2/carbon/identity/api/server/notification/sender/v2/model/SMSSenderUpdateRequest.java
@@ -1,0 +1,273 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.notification.sender.v2.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import java.util.ArrayList;
+import java.util.List;
+import org.wso2.carbon.identity.api.server.notification.sender.v2.model.Properties;
+import javax.validation.constraints.*;
+
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+import javax.validation.Valid;
+import javax.xml.bind.annotation.*;
+
+public class SMSSenderUpdateRequest  {
+  
+    private String provider;
+    private String providerURL;
+    private String key;
+    private String secret;
+    private String sender;
+
+@XmlType(name="ContentTypeEnum")
+@XmlEnum(String.class)
+public enum ContentTypeEnum {
+
+    @XmlEnumValue("JSON") JSON(String.valueOf("JSON")), @XmlEnumValue("FORM") FORM(String.valueOf("FORM"));
+
+
+    private String value;
+
+    ContentTypeEnum(String v) {
+        value = v;
+    }
+
+    public String value() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    public static ContentTypeEnum fromValue(String value) {
+        for (ContentTypeEnum b : ContentTypeEnum.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
+}
+
+    private ContentTypeEnum contentType;
+    private List<Properties> properties = null;
+
+
+    /**
+    **/
+    public SMSSenderUpdateRequest provider(String provider) {
+
+        this.provider = provider;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "NEXMO", required = true, value = "")
+    @JsonProperty("provider")
+    @Valid
+    @NotNull(message = "Property provider cannot be null.")
+
+    public String getProvider() {
+        return provider;
+    }
+    public void setProvider(String provider) {
+        this.provider = provider;
+    }
+
+    /**
+    **/
+    public SMSSenderUpdateRequest providerURL(String providerURL) {
+
+        this.providerURL = providerURL;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "https://rest.nexmo.com/sms/json", value = "")
+    @JsonProperty("providerURL")
+    @Valid
+    public String getProviderURL() {
+        return providerURL;
+    }
+    public void setProviderURL(String providerURL) {
+        this.providerURL = providerURL;
+    }
+
+    /**
+    **/
+    public SMSSenderUpdateRequest key(String key) {
+
+        this.key = key;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "123**45", value = "")
+    @JsonProperty("key")
+    @Valid
+    public String getKey() {
+        return key;
+    }
+    public void setKey(String key) {
+        this.key = key;
+    }
+
+    /**
+    **/
+    public SMSSenderUpdateRequest secret(String secret) {
+
+        this.secret = secret;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "5tg**ssd", value = "")
+    @JsonProperty("secret")
+    @Valid
+    public String getSecret() {
+        return secret;
+    }
+    public void setSecret(String secret) {
+        this.secret = secret;
+    }
+
+    /**
+    **/
+    public SMSSenderUpdateRequest sender(String sender) {
+
+        this.sender = sender;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "+94 775563324", value = "")
+    @JsonProperty("sender")
+    @Valid
+    public String getSender() {
+        return sender;
+    }
+    public void setSender(String sender) {
+        this.sender = sender;
+    }
+
+    /**
+    **/
+    public SMSSenderUpdateRequest contentType(ContentTypeEnum contentType) {
+
+        this.contentType = contentType;
+        return this;
+    }
+    
+    @ApiModelProperty(required = true, value = "")
+    @JsonProperty("contentType")
+    @Valid
+    @NotNull(message = "Property contentType cannot be null.")
+
+    public ContentTypeEnum getContentType() {
+        return contentType;
+    }
+    public void setContentType(ContentTypeEnum contentType) {
+        this.contentType = contentType;
+    }
+
+    /**
+    **/
+    public SMSSenderUpdateRequest properties(List<Properties> properties) {
+
+        this.properties = properties;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "[{\"key\":\"http.headers\",\"value\":\"X-Version: 1, Authorization: bearer ,Accept: application/json ,Content-Type: application/json\"}]", value = "")
+    @JsonProperty("properties")
+    @Valid
+    public List<Properties> getProperties() {
+        return properties;
+    }
+    public void setProperties(List<Properties> properties) {
+        this.properties = properties;
+    }
+
+    public SMSSenderUpdateRequest addPropertiesItem(Properties propertiesItem) {
+        if (this.properties == null) {
+            this.properties = new ArrayList<>();
+        }
+        this.properties.add(propertiesItem);
+        return this;
+    }
+
+    
+
+    @Override
+    public boolean equals(java.lang.Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        SMSSenderUpdateRequest smSSenderUpdateRequest = (SMSSenderUpdateRequest) o;
+        return Objects.equals(this.provider, smSSenderUpdateRequest.provider) &&
+            Objects.equals(this.providerURL, smSSenderUpdateRequest.providerURL) &&
+            Objects.equals(this.key, smSSenderUpdateRequest.key) &&
+            Objects.equals(this.secret, smSSenderUpdateRequest.secret) &&
+            Objects.equals(this.sender, smSSenderUpdateRequest.sender) &&
+            Objects.equals(this.contentType, smSSenderUpdateRequest.contentType) &&
+            Objects.equals(this.properties, smSSenderUpdateRequest.properties);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(provider, providerURL, key, secret, sender, contentType, properties);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class SMSSenderUpdateRequest {\n");
+        
+        sb.append("    provider: ").append(toIndentedString(provider)).append("\n");
+        sb.append("    providerURL: ").append(toIndentedString(providerURL)).append("\n");
+        sb.append("    key: ").append(toIndentedString(key)).append("\n");
+        sb.append("    secret: ").append(toIndentedString(secret)).append("\n");
+        sb.append("    sender: ").append(toIndentedString(sender)).append("\n");
+        sb.append("    contentType: ").append(toIndentedString(contentType)).append("\n");
+        sb.append("    properties: ").append(toIndentedString(properties)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+    * Convert the given object to string with each line indented by 4 spaces
+    * (except the first line).
+    */
+    private String toIndentedString(java.lang.Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}
+

--- a/components/org.wso2.carbon.identity.api.server.notification.sender/org.wso2.carbon.identity.api.server.notification.sender.v2/src/main/java/org/wso2/carbon/identity/api/server/notification/sender/v2/core/NotificationSenderManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.notification.sender/org.wso2.carbon.identity.api.server.notification.sender.v2/src/main/java/org/wso2/carbon/identity/api/server/notification/sender/v2/core/NotificationSenderManagementService.java
@@ -33,7 +33,6 @@ import org.wso2.carbon.identity.api.server.notification.sender.v2.model.PushSend
 import org.wso2.carbon.identity.api.server.notification.sender.v2.model.SMSSender;
 import org.wso2.carbon.identity.api.server.notification.sender.v2.model.SMSSenderAdd;
 import org.wso2.carbon.identity.api.server.notification.sender.v2.model.SMSSenderUpdateRequest;
-import org.wso2.carbon.identity.notification.sender.tenant.config.NotificationSenderManagementConstants;
 import org.wso2.carbon.identity.notification.sender.tenant.config.dto.EmailSenderDTO;
 import org.wso2.carbon.identity.notification.sender.tenant.config.dto.PushSenderDTO;
 import org.wso2.carbon.identity.notification.sender.tenant.config.dto.SMSSenderDTO;
@@ -46,6 +45,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
+
 import javax.ws.rs.core.Response;
 
 import static org.wso2.carbon.identity.notification.sender.tenant.config.NotificationSenderManagementConstants.CLIENT_ID;
@@ -325,6 +325,7 @@ public class NotificationSenderManagementService {
         emailSender.setAuthType(dto.getAuthType());
         List<Properties> properties = new ArrayList<>();
 
+        // Exclude credentials from the response.
         Set<String> excludedKeys = new HashSet<>(Arrays.asList(PASSWORD, USERNAME, CLIENT_SECRET, CLIENT_ID));
 
         dto.getProperties().forEach((key, value) -> {

--- a/components/org.wso2.carbon.identity.api.server.notification.sender/org.wso2.carbon.identity.api.server.notification.sender.v2/src/main/java/org/wso2/carbon/identity/api/server/notification/sender/v2/core/NotificationSenderManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.notification.sender/org.wso2.carbon.identity.api.server.notification.sender.v2/src/main/java/org/wso2/carbon/identity/api/server/notification/sender/v2/core/NotificationSenderManagementService.java
@@ -1,0 +1,474 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.notification.sender.v2.core;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.identity.api.server.common.error.APIError;
+import org.wso2.carbon.identity.api.server.common.error.ErrorResponse;
+import org.wso2.carbon.identity.api.server.notification.sender.common.NotificationSenderServiceHolder;
+import org.wso2.carbon.identity.api.server.notification.sender.v2.model.EmailSender;
+import org.wso2.carbon.identity.api.server.notification.sender.v2.model.EmailSenderAdd;
+import org.wso2.carbon.identity.api.server.notification.sender.v2.model.EmailSenderUpdateRequest;
+import org.wso2.carbon.identity.api.server.notification.sender.v2.model.Properties;
+import org.wso2.carbon.identity.api.server.notification.sender.v2.model.PushSender;
+import org.wso2.carbon.identity.api.server.notification.sender.v2.model.PushSenderAdd;
+import org.wso2.carbon.identity.api.server.notification.sender.v2.model.PushSenderUpdateRequest;
+import org.wso2.carbon.identity.api.server.notification.sender.v2.model.SMSSender;
+import org.wso2.carbon.identity.api.server.notification.sender.v2.model.SMSSenderAdd;
+import org.wso2.carbon.identity.api.server.notification.sender.v2.model.SMSSenderUpdateRequest;
+import org.wso2.carbon.identity.notification.sender.tenant.config.NotificationSenderManagementConstants;
+import org.wso2.carbon.identity.notification.sender.tenant.config.dto.EmailSenderDTO;
+import org.wso2.carbon.identity.notification.sender.tenant.config.dto.PushSenderDTO;
+import org.wso2.carbon.identity.notification.sender.tenant.config.dto.SMSSenderDTO;
+import org.wso2.carbon.identity.notification.sender.tenant.config.exception.NotificationSenderManagementClientException;
+import org.wso2.carbon.identity.notification.sender.tenant.config.exception.NotificationSenderManagementException;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import javax.ws.rs.core.Response;
+
+import static org.wso2.carbon.identity.notification.sender.tenant.config.NotificationSenderManagementConstants.CLIENT_ID;
+import static org.wso2.carbon.identity.notification.sender.tenant.config.NotificationSenderManagementConstants.CLIENT_SECRET;
+import static org.wso2.carbon.identity.notification.sender.tenant.config.NotificationSenderManagementConstants.ErrorMessage.ERROR_CODE_CONFLICT_PUBLISHER;
+import static org.wso2.carbon.identity.notification.sender.tenant.config.NotificationSenderManagementConstants.ErrorMessage.ERROR_CODE_NO_ACTIVE_PUBLISHERS_FOUND;
+import static org.wso2.carbon.identity.notification.sender.tenant.config.NotificationSenderManagementConstants.ErrorMessage.ERROR_CODE_PUBLISHER_NOT_EXISTS;
+import static org.wso2.carbon.identity.notification.sender.tenant.config.NotificationSenderManagementConstants.PASSWORD;
+import static org.wso2.carbon.identity.notification.sender.tenant.config.NotificationSenderManagementConstants.USERNAME;
+
+/**
+ * Invoke internal OSGi service to perform notification sender management operations.
+ */
+public class NotificationSenderManagementService {
+
+    private final org.wso2.carbon.identity.notification.sender.tenant.config.NotificationSenderManagementService
+            notificationSenderManagementService;
+    private static final Log log = LogFactory.getLog(NotificationSenderManagementService.class);
+
+    public NotificationSenderManagementService(
+            org.wso2.carbon.identity.notification.sender.tenant.config.NotificationSenderManagementService
+                    notificationSenderManagementService) {
+
+        this.notificationSenderManagementService = notificationSenderManagementService;
+    }
+
+    /**
+     * Create an email sender resource with a resource file.
+     *
+     * @param emailSenderAdd Email sender post request.
+     * @return Email sender.
+     */
+    public EmailSender addEmailSender(EmailSenderAdd emailSenderAdd) {
+
+        EmailSenderDTO dto = buildEmailSenderDTO(emailSenderAdd);
+        try {
+            EmailSenderDTO emailSenderDTO = notificationSenderManagementService.addEmailSender(dto);
+            return buildEmailSenderFromDTO(emailSenderDTO);
+        } catch (NotificationSenderManagementException e) {
+            throw handleException(e);
+        }
+    }
+
+    /**
+     * Create a sms sender resource with a resource file.
+     *
+     * @param smsSenderAdd SMS sender post request.
+     * @return SMS sender.
+     */
+    public SMSSender addSMSSender(SMSSenderAdd smsSenderAdd) {
+
+        SMSSenderDTO dto = buildSMSSenderDTO(smsSenderAdd);
+        try {
+            SMSSenderDTO smsSenderDTO = notificationSenderManagementService.addSMSSender(dto);
+            return buildSMSSenderFromDTO(smsSenderDTO);
+        } catch (NotificationSenderManagementException e) {
+            throw handleException(e);
+        }
+    }
+
+    /**
+     * Create a push sender resource with a resource file.
+     *
+     * @param pushSenderAdd Push sender post request.
+     * @return Push sender.
+     */
+    public PushSender addPushSender(PushSenderAdd pushSenderAdd) {
+
+        PushSenderDTO dto = buildPushSenderDTO(pushSenderAdd);
+        try {
+            PushSenderDTO pushSenderDTO = NotificationSenderServiceHolder.getNotificationSenderManagementService()
+                    .addPushSender(dto);
+            return buildPushSenderFromDTO(pushSenderDTO);
+        } catch (NotificationSenderManagementException e) {
+            throw handleException(e);
+        }
+    }
+
+    /**
+     * Delete a SMS/Email sender by name.
+     *
+     * @param notificationSenderName Name of the notification sender.
+     */
+    public void deleteNotificationSender(String notificationSenderName) {
+
+        try {
+            notificationSenderManagementService.deleteNotificationSender(notificationSenderName);
+        } catch (NotificationSenderManagementException e) {
+            throw handleException(e);
+        }
+    }
+
+    /**
+     * Retrieve the email sender details by name.
+     *
+     * @param senderName Email sender's name.
+     * @return Email sender.
+     */
+    public EmailSender getEmailSender(String senderName) {
+
+        try {
+            EmailSenderDTO emailSenderDTO = notificationSenderManagementService.getEmailSender(senderName);
+            return buildEmailSenderFromDTO(emailSenderDTO);
+        } catch (NotificationSenderManagementException e) {
+            throw handleException(e);
+        }
+    }
+
+    /**
+     * Retrieve the sms sender details by name.
+     *
+     * @param senderName SMS sender's name.
+     * @return SMS sender.
+     */
+    public SMSSender getSMSSender(String senderName) {
+
+        try {
+            SMSSenderDTO smsSenderDTO = notificationSenderManagementService.getSMSSender(senderName, false);
+            return buildSMSSenderFromDTO(smsSenderDTO);
+        } catch (NotificationSenderManagementException e) {
+            throw handleException(e);
+        }
+    }
+
+    /**
+     * Retrieve the push sender details by name.
+     *
+     * @param senderName Push sender's name.
+     * @return Push sender.
+     */
+    public PushSender getPushSender(String senderName) {
+
+        try {
+            PushSenderDTO pushSenderDTO = NotificationSenderServiceHolder.getNotificationSenderManagementService()
+                    .getPushSender(senderName, false);
+            return buildPushSenderFromDTO(pushSenderDTO);
+        } catch (NotificationSenderManagementException e) {
+            throw handleException(e);
+        }
+    }
+
+    /**
+     * Retrieve all email senders of the tenant.
+     *
+     * @return Email senders of the tenant.
+     */
+    public List<EmailSender> getEmailSenders() {
+
+        try {
+            List<EmailSenderDTO> emailSenders = notificationSenderManagementService.getEmailSenders();
+            return emailSenders.stream().map(this::buildEmailSenderFromDTO).collect(Collectors.toList());
+        } catch (NotificationSenderManagementException e) {
+            throw handleException(e);
+        }
+    }
+
+    /**
+     * Retrieve all sms senders of the tenant.
+     *
+     * @return SMS senders of the tenant.
+     */
+    public List<SMSSender> getSMSSenders() {
+
+        try {
+            List<SMSSenderDTO> smsSenders = notificationSenderManagementService.getSMSSenders(false);
+            return smsSenders.stream().map(this::buildSMSSenderFromDTO).collect(Collectors.toList());
+        } catch (NotificationSenderManagementException e) {
+            throw handleException(e);
+        }
+    }
+
+    /**
+     * Retrieve all push senders of the tenant.
+     *
+     * @return Push senders of the tenant.
+     */
+    public List<PushSender> getPushSenders() {
+
+        try {
+            List<PushSenderDTO> pushSenders = NotificationSenderServiceHolder.getNotificationSenderManagementService()
+                    .getPushSenders(false);
+            return pushSenders.stream().map(this::buildPushSenderFromDTO).collect(Collectors.toList());
+        } catch (NotificationSenderManagementException e) {
+            throw handleException(e);
+        }
+    }
+
+    /**
+     * Update email sender details by name.
+     *
+     * @param senderName               Email sender's name.
+     * @param emailSenderUpdateRequest Email sender's updated configurations.
+     * @return Updated email sender.
+     */
+    public EmailSender updateEmailSender(String senderName, EmailSenderUpdateRequest emailSenderUpdateRequest) {
+
+        EmailSenderDTO dto = buildEmailSenderDTO(senderName, emailSenderUpdateRequest);
+        try {
+            EmailSenderDTO emailSenderDTO = notificationSenderManagementService.updateEmailSender(dto);
+            return buildEmailSenderFromDTO(emailSenderDTO);
+        } catch (NotificationSenderManagementException e) {
+            throw handleException(e);
+        }
+    }
+
+    /**
+     * Update sms sender details by name.
+     *
+     * @param senderName             SMS sender' name.
+     * @param smsSenderUpdateRequest SMS sender's updated configurations.
+     * @return Updated SMS sender.
+     */
+    public SMSSender updateSMSSender(String senderName, SMSSenderUpdateRequest smsSenderUpdateRequest) {
+
+        SMSSenderDTO dto = buildSMSSenderDTO(senderName, smsSenderUpdateRequest);
+        try {
+            SMSSenderDTO smsSenderDTO = notificationSenderManagementService.updateSMSSender(dto);
+            return buildSMSSenderFromDTO(smsSenderDTO);
+        } catch (NotificationSenderManagementException e) {
+            throw handleException(e);
+        }
+    }
+
+    /**
+     * Update push sender details by name.
+     *
+     * @param senderName               Push sender's name.
+     * @param pushSenderUpdateRequest Push sender's updated configurations.
+     * @return Updated push sender.
+     */
+    public PushSender updatePushSender(String senderName, PushSenderUpdateRequest pushSenderUpdateRequest) {
+
+        PushSenderDTO dto = buildPushSenderDTO(senderName, pushSenderUpdateRequest);
+        try {
+            PushSenderDTO pushSenderDTO = NotificationSenderServiceHolder.getNotificationSenderManagementService()
+                    .updatePushSender(dto);
+            return buildPushSenderFromDTO(pushSenderDTO);
+        } catch (NotificationSenderManagementException e) {
+            throw handleException(e);
+        }
+    }
+
+    private EmailSenderDTO buildEmailSenderDTO(EmailSenderAdd emailSenderAdd) {
+
+        EmailSenderDTO dto = new EmailSenderDTO();
+        dto.setName(emailSenderAdd.getName());
+        dto.setFromAddress(emailSenderAdd.getFromAddress());
+        dto.setSmtpPort(emailSenderAdd.getSmtpPort());
+        dto.setAuthType(emailSenderAdd.getAuthType());
+        dto.setSmtpServerHost(emailSenderAdd.getSmtpServerHost());
+        List<Properties> properties = emailSenderAdd.getProperties();
+        properties.forEach((prop) -> dto.getProperties().put(prop.getKey(), prop.getValue()));
+        return dto;
+    }
+
+
+    private EmailSenderDTO buildEmailSenderDTO(String senderName, EmailSenderUpdateRequest emailSenderUpdateRequest) {
+
+        EmailSenderDTO dto = new EmailSenderDTO();
+        dto.setName(senderName);
+        dto.setFromAddress(emailSenderUpdateRequest.getFromAddress());
+        dto.setSmtpPort(emailSenderUpdateRequest.getSmtpPort());
+        dto.setSmtpServerHost(emailSenderUpdateRequest.getSmtpServerHost());
+        dto.setAuthType(emailSenderUpdateRequest.getAuthType());
+        List<Properties> properties = emailSenderUpdateRequest.getProperties();
+        properties.forEach((prop) -> dto.getProperties().put(prop.getKey(), prop.getValue()));
+        return dto;
+    }
+
+    private EmailSender buildEmailSenderFromDTO(EmailSenderDTO dto) {
+
+        EmailSender emailSender = new EmailSender();
+        emailSender.setName(dto.getName());
+        emailSender.setFromAddress(dto.getFromAddress());
+        emailSender.setSmtpPort(dto.getSmtpPort());
+        emailSender.setSmtpServerHost(dto.getSmtpServerHost());
+        emailSender.setAuthType(dto.getAuthType());
+        List<Properties> properties = new ArrayList<>();
+
+        Set<String> excludedKeys = new HashSet<>(Arrays.asList(PASSWORD, USERNAME, CLIENT_SECRET, CLIENT_ID));
+
+        dto.getProperties().forEach((key, value) -> {
+            if (excludedKeys.contains(key)) {
+                return;
+            }
+            Properties prop = new Properties();
+            prop.setKey(key);
+            prop.setValue(value);
+            properties.add(prop);
+        });
+        emailSender.setProperties(properties);
+        return emailSender;
+    }
+
+    private SMSSenderDTO buildSMSSenderDTO(SMSSenderAdd smsSenderAdd) {
+
+        SMSSenderDTO dto = new SMSSenderDTO();
+        dto.setName(smsSenderAdd.getName());
+        dto.setProvider(smsSenderAdd.getProvider());
+        dto.setProviderURL(smsSenderAdd.getProviderURL());
+        dto.setKey(smsSenderAdd.getKey());
+        dto.setSecret(smsSenderAdd.getSecret());
+        dto.setSender(smsSenderAdd.getSender());
+        dto.setContentType(smsSenderAdd.getContentType().toString());
+        List<Properties> properties = smsSenderAdd.getProperties();
+        if (properties != null) {
+            properties.forEach((prop) -> dto.getProperties().put(prop.getKey(), prop.getValue()));
+        }
+        return dto;
+    }
+
+
+    private SMSSenderDTO buildSMSSenderDTO(String senderName, SMSSenderUpdateRequest smsSenderUpdateRequest) {
+
+        SMSSenderDTO dto = new SMSSenderDTO();
+        dto.setName(senderName);
+        dto.setProvider(smsSenderUpdateRequest.getProvider());
+        dto.setProviderURL(smsSenderUpdateRequest.getProviderURL());
+        dto.setKey(smsSenderUpdateRequest.getKey());
+        dto.setSecret(smsSenderUpdateRequest.getSecret());
+        dto.setSender(smsSenderUpdateRequest.getSender());
+        dto.setContentType(smsSenderUpdateRequest.getContentType().toString());
+        List<Properties> properties = smsSenderUpdateRequest.getProperties();
+        if (properties != null) {
+            properties.forEach((prop) -> dto.getProperties().put(prop.getKey(), prop.getValue()));
+        }
+        return dto;
+    }
+
+    private APIError handleException(NotificationSenderManagementException e) {
+
+        if (e instanceof NotificationSenderManagementClientException) {
+            throw buildClientError(e);
+        }
+        throw buildServerError(e);
+    }
+
+    private SMSSender buildSMSSenderFromDTO(SMSSenderDTO dto) {
+
+        SMSSender smsSender = new SMSSender();
+        smsSender.setName(dto.getName());
+        smsSender.setProvider(dto.getProvider());
+        smsSender.setProviderURL(dto.getProviderURL());
+        smsSender.setKey(dto.getKey());
+        smsSender.setSecret(dto.getSecret());
+        smsSender.setSender(dto.getSender());
+        smsSender.setContentType(SMSSender.ContentTypeEnum.valueOf(dto.getContentType()));
+        List<Properties> properties = new ArrayList<>();
+        dto.getProperties().forEach((key, value) -> {
+            Properties prop = new Properties();
+            prop.setKey(key);
+            prop.setValue(value);
+            properties.add(prop);
+        });
+        smsSender.setProperties(properties);
+        return smsSender;
+    }
+
+    private PushSenderDTO buildPushSenderDTO(PushSenderAdd pushSenderAdd) {
+
+        PushSenderDTO dto = new PushSenderDTO();
+        dto.setName(pushSenderAdd.getName());
+        dto.setProvider(pushSenderAdd.getProvider());
+        List<Properties> properties = pushSenderAdd.getProperties();
+        properties.forEach((prop) -> dto.getProperties().put(prop.getKey(), prop.getValue()));
+        return dto;
+    }
+
+    private PushSenderDTO buildPushSenderDTO(String senderName, PushSenderUpdateRequest pushSenderUpdateRequest) {
+
+        PushSenderDTO dto = new PushSenderDTO();
+        dto.setName(senderName);
+        dto.setProvider(pushSenderUpdateRequest.getProvider());
+        List<Properties> properties = pushSenderUpdateRequest.getProperties();
+        properties.forEach((prop) -> dto.getProperties().put(prop.getKey(), prop.getValue()));
+        return dto;
+    }
+
+    private PushSender buildPushSenderFromDTO(PushSenderDTO dto) {
+
+        PushSender pushSender = new PushSender();
+        pushSender.setName(dto.getName());
+        pushSender.setProvider(dto.getProvider());
+        List<Properties> properties = new ArrayList<>();
+        dto.getProperties().forEach((key, value) -> {
+            Properties prop = new Properties();
+            prop.setKey(key);
+            prop.setValue(value);
+            properties.add(prop);
+        });
+        pushSender.setProperties(properties);
+        return pushSender;
+    }
+
+    private APIError buildServerError(NotificationSenderManagementException e) {
+
+        String errorCode = e.getErrorCode();
+        ErrorResponse errorResponse = new ErrorResponse.Builder()
+                .withCode(errorCode)
+                .withMessage(e.getMessage())
+                .withDescription(e.getDescription())
+                .build(log, e, e.getMessage());
+
+        Response.Status status = Response.Status.INTERNAL_SERVER_ERROR;
+        return new APIError(status, errorResponse);
+    }
+
+    private APIError buildClientError(NotificationSenderManagementException e) {
+
+        String errorCode = e.getErrorCode();
+        ErrorResponse errorResponse = new ErrorResponse.Builder()
+                .withCode(e.getErrorCode())
+                .withMessage(e.getMessage())
+                .withDescription(e.getDescription())
+                .build(log, e.getMessage());
+
+        Response.Status status = Response.Status.BAD_REQUEST;
+        if (ERROR_CODE_NO_ACTIVE_PUBLISHERS_FOUND.getCode().equals(errorCode) ||
+                ERROR_CODE_PUBLISHER_NOT_EXISTS.getCode().equals(errorCode)) {
+            status = Response.Status.NOT_FOUND;
+        } else if (ERROR_CODE_CONFLICT_PUBLISHER.getCode().equals(errorCode)) {
+            status = Response.Status.CONFLICT;
+        }
+        return new APIError(status, errorResponse);
+    }
+}

--- a/components/org.wso2.carbon.identity.api.server.notification.sender/org.wso2.carbon.identity.api.server.notification.sender.v2/src/main/java/org/wso2/carbon/identity/api/server/notification/sender/v2/core/NotificationSenderManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.notification.sender/org.wso2.carbon.identity.api.server.notification.sender.v2/src/main/java/org/wso2/carbon/identity/api/server/notification/sender/v2/core/NotificationSenderManagementService.java
@@ -347,7 +347,7 @@ public class NotificationSenderManagementService {
             return emailSender;
         }
         dto.getProperties().forEach((key, value) -> {
-            if (StringUtils.isBlank(key) || StringUtils.isBlank(value) || excludedKeys.contains(key)) {
+            if (excludedKeys.contains(key) || StringUtils.isBlank(key) || StringUtils.isBlank(value)) {
                 return;
             }
             Properties prop = new Properties();

--- a/components/org.wso2.carbon.identity.api.server.notification.sender/org.wso2.carbon.identity.api.server.notification.sender.v2/src/main/java/org/wso2/carbon/identity/api/server/notification/sender/v2/core/NotificationSenderManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.notification.sender/org.wso2.carbon.identity.api.server.notification.sender.v2/src/main/java/org/wso2/carbon/identity/api/server/notification/sender/v2/core/NotificationSenderManagementService.java
@@ -18,6 +18,7 @@
 
 package org.wso2.carbon.identity.api.server.notification.sender.v2.core;
 
+import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.identity.api.server.common.error.APIError;
@@ -297,7 +298,14 @@ public class NotificationSenderManagementService {
         dto.setAuthType(emailSenderAdd.getAuthType());
         dto.setSmtpServerHost(emailSenderAdd.getSmtpServerHost());
         List<Properties> properties = emailSenderAdd.getProperties();
-        properties.forEach((prop) -> dto.getProperties().put(prop.getKey(), prop.getValue()));
+        if (properties == null) {
+            return dto;
+        }
+        properties.forEach((prop) -> {
+            if (StringUtils.isNotBlank(prop.getKey()) && StringUtils.isNotBlank(prop.getValue())) {
+                dto.getProperties().put(prop.getKey(), prop.getValue());
+            }
+        });
         return dto;
     }
 
@@ -311,7 +319,14 @@ public class NotificationSenderManagementService {
         dto.setSmtpServerHost(emailSenderUpdateRequest.getSmtpServerHost());
         dto.setAuthType(emailSenderUpdateRequest.getAuthType());
         List<Properties> properties = emailSenderUpdateRequest.getProperties();
-        properties.forEach((prop) -> dto.getProperties().put(prop.getKey(), prop.getValue()));
+        if (properties == null) {
+            return dto;
+        }
+        properties.forEach((prop) -> {
+            if (StringUtils.isNotBlank(prop.getKey()) && StringUtils.isNotBlank(prop.getValue())) {
+                dto.getProperties().put(prop.getKey(), prop.getValue());
+            }
+        });
         return dto;
     }
 
@@ -328,8 +343,11 @@ public class NotificationSenderManagementService {
         // Exclude credentials from the response.
         Set<String> excludedKeys = new HashSet<>(Arrays.asList(PASSWORD, USERNAME, CLIENT_SECRET, CLIENT_ID));
 
+        if (dto.getProperties() == null) {
+            return emailSender;
+        }
         dto.getProperties().forEach((key, value) -> {
-            if (excludedKeys.contains(key)) {
+            if (StringUtils.isBlank(key) || StringUtils.isBlank(value) || excludedKeys.contains(key)) {
                 return;
             }
             Properties prop = new Properties();

--- a/components/org.wso2.carbon.identity.api.server.notification.sender/org.wso2.carbon.identity.api.server.notification.sender.v2/src/main/java/org/wso2/carbon/identity/api/server/notification/sender/v2/factories/NotificationSenderManagementServiceFactory.java
+++ b/components/org.wso2.carbon.identity.api.server.notification.sender/org.wso2.carbon.identity.api.server.notification.sender.v2/src/main/java/org/wso2/carbon/identity/api/server/notification/sender/v2/factories/NotificationSenderManagementServiceFactory.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.notification.sender.v2.factories;
+
+import org.wso2.carbon.identity.api.server.notification.sender.common.NotificationSenderServiceHolder;
+import org.wso2.carbon.identity.api.server.notification.sender.v2.core.NotificationSenderManagementService;
+
+/**
+ * Factory class for NotificationSenderManagementService.
+ */
+public class NotificationSenderManagementServiceFactory {
+
+    private static final NotificationSenderManagementService SERVICE;
+
+    static {
+        org.wso2.carbon.identity.notification.sender.tenant.config.NotificationSenderManagementService
+                notificationSenderManagementService = NotificationSenderServiceHolder
+                        .getNotificationSenderManagementService();
+
+        if (notificationSenderManagementService == null) {
+            throw new IllegalStateException("NotificationSenderManagementService is not available from OSGi context.");
+        }
+
+        SERVICE = new NotificationSenderManagementService(notificationSenderManagementService);
+    }
+
+    /**
+     * Get NotificationSenderManagementService service.
+     *
+     * @return NotificationSenderManagementService service.
+     */
+    public static NotificationSenderManagementService getNotificationSenderManagementService() {
+
+        return SERVICE;
+    }
+}

--- a/components/org.wso2.carbon.identity.api.server.notification.sender/org.wso2.carbon.identity.api.server.notification.sender.v2/src/main/java/org/wso2/carbon/identity/api/server/notification/sender/v2/impl/NotificationSendersApiServiceImpl.java
+++ b/components/org.wso2.carbon.identity.api.server.notification.sender/org.wso2.carbon.identity.api.server.notification.sender.v2/src/main/java/org/wso2/carbon/identity/api/server/notification/sender/v2/impl/NotificationSendersApiServiceImpl.java
@@ -1,0 +1,221 @@
+/*
+ * Copyright (c) 2020-2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.notification.sender.v2.impl;
+
+import org.apache.commons.lang.StringUtils;
+import org.wso2.carbon.base.MultitenantConstants;
+import org.wso2.carbon.identity.api.server.common.ContextLoader;
+import org.wso2.carbon.identity.api.server.common.error.APIError;
+import org.wso2.carbon.identity.api.server.common.error.ErrorResponse;
+import org.wso2.carbon.identity.api.server.notification.sender.v2.NotificationSendersApiService;
+import org.wso2.carbon.identity.api.server.notification.sender.v2.core.NotificationSenderManagementService;
+import org.wso2.carbon.identity.api.server.notification.sender.v2.factories.NotificationSenderManagementServiceFactory;
+import org.wso2.carbon.identity.api.server.notification.sender.v2.model.EmailSender;
+import org.wso2.carbon.identity.api.server.notification.sender.v2.model.EmailSenderAdd;
+import org.wso2.carbon.identity.api.server.notification.sender.v2.model.EmailSenderUpdateRequest;
+import org.wso2.carbon.identity.api.server.notification.sender.v2.model.PushSender;
+import org.wso2.carbon.identity.api.server.notification.sender.v2.model.PushSenderAdd;
+import org.wso2.carbon.identity.api.server.notification.sender.v2.model.PushSenderUpdateRequest;
+import org.wso2.carbon.identity.api.server.notification.sender.v2.model.SMSSender;
+import org.wso2.carbon.identity.api.server.notification.sender.v2.model.SMSSenderAdd;
+import org.wso2.carbon.identity.api.server.notification.sender.v2.model.SMSSenderUpdateRequest;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URI;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+
+import javax.ws.rs.core.Response;
+
+import static org.wso2.carbon.identity.api.server.common.Constants.V2_API_PATH_COMPONENT;
+import static org.wso2.carbon.identity.api.server.common.ContextLoader.getTenantDomainFromContext;
+import static org.wso2.carbon.identity.api.server.notification.sender.common.NotificationSenderManagementConstants.EMAIL_PUBLISHER_TYPE;
+import static org.wso2.carbon.identity.api.server.notification.sender.common.NotificationSenderManagementConstants.NOTIFICATION_SENDER_CONTEXT_PATH;
+import static org.wso2.carbon.identity.api.server.notification.sender.common.NotificationSenderManagementConstants.PLUS;
+import static org.wso2.carbon.identity.api.server.notification.sender.common.NotificationSenderManagementConstants.PUSH_PUBLISHER_TYPE;
+import static org.wso2.carbon.identity.api.server.notification.sender.common.NotificationSenderManagementConstants.SMS_PUBLISHER_TYPE;
+import static org.wso2.carbon.identity.api.server.notification.sender.common.NotificationSenderManagementConstants.URL_ENCODED_SPACE;
+
+/**
+ * Implementation of notification senders REST API.
+ */
+public class NotificationSendersApiServiceImpl implements NotificationSendersApiService {
+
+    private final NotificationSenderManagementService notificationSenderManagementService;
+
+    public NotificationSendersApiServiceImpl() {
+
+        try {
+            this.notificationSenderManagementService = NotificationSenderManagementServiceFactory
+                    .getNotificationSenderManagementService();
+        } catch (IllegalStateException e) {
+            throw new RuntimeException("Error occurred while initiating notification sender service.", e);
+        }
+    }
+
+    @Override
+    public Response createEmailSender(EmailSenderAdd emailSenderAdd) {
+
+        if (StringUtils.equals(getTenantDomainFromContext(), MultitenantConstants.SUPER_TENANT_DOMAIN_NAME)) {
+            return Response.status(Response.Status.METHOD_NOT_ALLOWED).build();
+        }
+        EmailSender emailSender = notificationSenderManagementService.addEmailSender(emailSenderAdd);
+        URI location = null;
+        try {
+            location = ContextLoader.buildURIForHeader(
+                    V2_API_PATH_COMPONENT + NOTIFICATION_SENDER_CONTEXT_PATH + "/" + EMAIL_PUBLISHER_TYPE + "/" +
+                            URLEncoder.encode(emailSender.getName(), StandardCharsets.UTF_8.name())
+                                    .replace(PLUS, URL_ENCODED_SPACE));
+        } catch (UnsupportedEncodingException e) {
+            ErrorResponse errorResponse =
+                    new ErrorResponse.Builder().withMessage("Error due to unsupported encoding.").build();
+            throw new APIError(Response.Status.METHOD_NOT_ALLOWED, errorResponse);
+        }
+        return Response.created(location).entity(emailSender).build();
+    }
+
+    @Override
+    public Response createPushSender(PushSenderAdd pushSenderAdd) {
+
+        PushSender pushSender = notificationSenderManagementService.addPushSender(pushSenderAdd);
+        URI location = null;
+        try {
+            location = ContextLoader.buildURIForHeader(
+                    V2_API_PATH_COMPONENT + NOTIFICATION_SENDER_CONTEXT_PATH + "/" + PUSH_PUBLISHER_TYPE + "/" +
+                            URLEncoder.encode(pushSender.getName(), StandardCharsets.UTF_8.name())
+                                    .replace(PLUS, URL_ENCODED_SPACE));
+        } catch (UnsupportedEncodingException e) {
+            ErrorResponse errorResponse =
+                    new ErrorResponse.Builder().withMessage("Error due to unsupported encoding.").build();
+            throw new APIError(Response.Status.METHOD_NOT_ALLOWED, errorResponse);
+        }
+        return Response.created(location).entity(pushSender).build();
+    }
+
+    @Override
+    public Response createSMSSender(SMSSenderAdd smSSenderAdd) {
+
+        SMSSender smsSender = notificationSenderManagementService.addSMSSender(smSSenderAdd);
+        URI location = null;
+        try {
+            location = ContextLoader.buildURIForHeader(
+                    V2_API_PATH_COMPONENT + NOTIFICATION_SENDER_CONTEXT_PATH + "/" + SMS_PUBLISHER_TYPE + "/" +
+                            URLEncoder.encode(smsSender.getName(), StandardCharsets.UTF_8.name())
+                                    .replace(PLUS, URL_ENCODED_SPACE));
+        } catch (UnsupportedEncodingException e) {
+            ErrorResponse errorResponse =
+                    new ErrorResponse.Builder().withMessage("Error due to unsupported encoding.").build();
+            throw new APIError(Response.Status.METHOD_NOT_ALLOWED, errorResponse);
+        }
+        return Response.created(location).entity(smsSender).build();
+    }
+
+    @Override
+    public Response deleteEmailSender(String senderName) {
+
+        if (StringUtils.equals(getTenantDomainFromContext(), MultitenantConstants.SUPER_TENANT_DOMAIN_NAME)) {
+            return Response.status(Response.Status.METHOD_NOT_ALLOWED).build();
+        }
+        notificationSenderManagementService.deleteNotificationSender(senderName);
+        return Response.noContent().build();
+    }
+
+    @Override
+    public Response deletePushSender(String senderName) {
+
+        notificationSenderManagementService.deleteNotificationSender(senderName);
+        return Response.noContent().build();
+    }
+
+    @Override
+    public Response deleteSMSSender(String senderName) {
+
+        notificationSenderManagementService.deleteNotificationSender(senderName);
+        return Response.noContent().build();
+    }
+
+    @Override
+    public Response getEmailSender(String senderName) {
+
+        if (StringUtils.equals(getTenantDomainFromContext(), MultitenantConstants.SUPER_TENANT_DOMAIN_NAME)) {
+            return Response.status(Response.Status.METHOD_NOT_ALLOWED).build();
+        }
+        return Response.ok().entity(notificationSenderManagementService.getEmailSender(senderName)).build();
+    }
+
+    @Override
+    public Response getEmailSenders() {
+
+        if (StringUtils.equals(getTenantDomainFromContext(), MultitenantConstants.SUPER_TENANT_DOMAIN_NAME)) {
+            return Response.status(Response.Status.METHOD_NOT_ALLOWED).build();
+        }
+        return Response.ok().entity(notificationSenderManagementService.getEmailSenders()).build();
+    }
+
+    @Override
+    public Response getPushSender(String senderName) {
+
+        return Response.ok().entity(notificationSenderManagementService.getPushSender(senderName)).build();
+    }
+
+    @Override
+    public Response getPushSenders() {
+
+        return Response.ok().entity(notificationSenderManagementService.getPushSenders()).build();
+    }
+
+    @Override
+    public Response getSMSSender(String senderName) {
+
+        return Response.ok().entity(notificationSenderManagementService.getSMSSender(senderName)).build();
+    }
+
+    @Override
+    public Response getSMSSenders() {
+
+        return Response.ok().entity(notificationSenderManagementService.getSMSSenders()).build();
+    }
+
+    @Override
+    public Response updateEmailSender(String senderName, EmailSenderUpdateRequest emailSenderUpdateRequest) {
+
+        if (StringUtils.equals(getTenantDomainFromContext(), MultitenantConstants.SUPER_TENANT_DOMAIN_NAME)) {
+            return Response.status(Response.Status.METHOD_NOT_ALLOWED).build();
+        }
+        return Response.ok()
+                .entity(notificationSenderManagementService.updateEmailSender(senderName, emailSenderUpdateRequest))
+                .build();
+    }
+
+    @Override
+    public Response updatePushSender(String senderName, PushSenderUpdateRequest pushSenderUpdateRequest) {
+
+        return Response.ok()
+                .entity(notificationSenderManagementService.updatePushSender(senderName, pushSenderUpdateRequest))
+                .build();
+    }
+
+    @Override
+    public Response updateSMSSender(String senderName, SMSSenderUpdateRequest smSSenderUpdateRequest) {
+
+        return Response.ok()
+                .entity(notificationSenderManagementService.updateSMSSender(senderName, smSSenderUpdateRequest))
+                .build();
+    }
+}

--- a/components/org.wso2.carbon.identity.api.server.notification.sender/org.wso2.carbon.identity.api.server.notification.sender.v2/src/main/java/org/wso2/carbon/identity/api/server/notification/sender/v2/impl/NotificationSendersApiServiceImpl.java
+++ b/components/org.wso2.carbon.identity.api.server.notification.sender/org.wso2.carbon.identity.api.server.notification.sender.v2/src/main/java/org/wso2/carbon/identity/api/server/notification/sender/v2/impl/NotificationSendersApiServiceImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2025, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except

--- a/components/org.wso2.carbon.identity.api.server.notification.sender/org.wso2.carbon.identity.api.server.notification.sender.v2/src/main/resources/notification-sender.yaml
+++ b/components/org.wso2.carbon.identity.api.server.notification.sender/org.wso2.carbon.identity.api.server.notification.sender.v2/src/main/resources/notification-sender.yaml
@@ -1,0 +1,1221 @@
+openapi: 3.0.0
+info:
+  title: WSO2 Identity Server - Notification Senders API Definition
+  description: This document specifies a **RESTful API** for **WSO2 Identity Server Notification Senders**
+  contact:
+    name: WSO2
+    url: http://wso2.com/products/identity-server/
+    email: architecture@wso2.org
+  license:
+    name: Apache 2.0
+    url: http://www.apache.org/licenses/LICENSE-2.0.html
+  version: "v2"
+servers:
+  - url: https://localhost:9443/t/{tenant-domain}/api/server/v2
+    variables:
+      tenant-domain:
+        default: carbon.super
+security:
+  - OAuth2: []
+  - BasicAuth: []
+paths:
+  /notification-senders/email:
+    get:
+      tags:
+        - Email Senders
+      summary: Get a list of email senders
+      description: |
+        This API provides the capability to retrieve the list of email senders. <br>
+          <b>Permission required:</b> <br>
+            * /permission/admin/manage/identity/configmgt/view <br>
+          <b>Scope required:</b> <br>
+            * internal_config_mgt_view
+      operationId: getEmailSenders
+      responses:
+        "200":
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EmailProviderList'
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        "401":
+          description: Unauthorized
+        "403":
+          description: Forbidden
+        "404":
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        "405":
+          description: Method Not Allowed.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        "500":
+          description: Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+    post:
+      tags:
+        - Email Senders
+      summary: Create an email sender
+      description: |
+        This API provides the capability to create an email sender.\n\nIf the 'name' is not not defined, 'EmailPublisher' is taken as the default name. <br>
+          <b>Permission required:</b> <br>
+            * /permission/admin/manage/identity/configmgt/add <br>
+          <b>Scope required:</b> <br>
+            * internal_config_mgt_add
+      operationId: createEmailSender
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/EmailSenderAdd'
+            example:
+              fromAddress: iam@gmail.com
+              smtpServerHost: smtp.gmail.com
+              smtpPort: 587
+              authType: BASIC
+              properties:
+                - key: mail.smtp.starttls.enable
+                  value: true
+                - key: userName
+                  value: iam
+                - key: password
+                  value: iam123
+      responses:
+        "201":
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EmailSender'
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        "401":
+          description: Unauthorized
+        "403":
+          description: Forbidden
+        "404":
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        "405":
+          description: Method Not Allowed.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        "409":
+          description: Conflict
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        "500":
+          description: Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+  /notification-senders/email/{sender-name}:
+    get:
+      tags:
+        - Email Senders
+      summary: Retrieve an email sender by name
+      description: |
+        This API provides the capability to retrieve an email sender by name.
+        The URL encoded email sender name is used as sender-name.<br>
+          <b>Permission required:</b> <br>
+            * /permission/admin/manage/identity/configmgt/view <br>
+          <b>Scope required:</b> <br>
+            * internal_config_mgt_view
+      operationId: getEmailSender
+      parameters:
+        - name: sender-name
+          in: path
+          description: name of the email sender
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EmailSender'
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        "401":
+          description: Unauthorized
+        "403":
+          description: Forbidden
+        "404":
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        "405":
+          description: Method Not Allowed.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        "500":
+          description: Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+    put:
+      tags:
+        - Email Senders
+      summary: Update an email sender
+      description: |
+        This API provides the capability to update an email sender by name.
+        The URL encoded email sender name is used as sender-name.<br>
+          <b>Permission required:</b> <br>
+            * /permission/admin/manage/identity/configmgt/update <br>
+          <b>Scope required:</b> <br>
+            * internal_config_mgt_update
+      operationId: updateEmailSender
+      parameters:
+        - name: sender-name
+          in: path
+          description: name of the email sender
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/EmailSenderUpdateRequest'
+            example:
+              fromAddress: iam@gmail.com
+              properties:
+                - key: mail.smtp.starttls.enable
+                  value: true
+        required: true
+      responses:
+        "200":
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EmailSender'
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        "401":
+          description: Unauthorized
+        "403":
+          description: Forbidden
+        "404":
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        "405":
+          description: Method Not Allowed.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        "500":
+          description: Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+    delete:
+      tags:
+        - Email Senders
+      summary: Delete an email sender by name
+      description: |
+        This API provides the capability to delete an email sender by name.
+        The URL encoded email sender name is used as sender-name.<br>
+          <b>Permission required:</b> <br>
+            * /permission/admin/manage/identity/configmgt/delete <br>
+          <b>Scope required:</b> <br>
+            * internal_config_mgt_delete
+      operationId: deleteEmailSender
+      parameters:
+        - name: sender-name
+          in: path
+          description: name of the email sender
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+      responses:
+        "204":
+          description: No Content
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        "401":
+          description: Unauthorized
+        "403":
+          description: Forbidden
+        "404":
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        "405":
+          description: Method Not Allowed.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        "500":
+          description: Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+  /notification-senders/sms:
+    get:
+      tags:
+        - SMS Senders
+      summary: Get a list of SMS senders
+      description: |
+        This API provides the capability to retrieve a list of SMS notification senders.<br>
+          <b>Permission required:</b> <br>
+            * /permission/admin/manage/identity/configmgt/view <br>
+          <b>Scope required:</b> <br>
+            * internal_config_mgt_view
+      operationId: getSMSSenders
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SMSProviderList'
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        "401":
+          description: Unauthorized
+        "403":
+          description: Forbidden
+        "404":
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        "405":
+          description: Method Not Allowed.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        "500":
+          description: Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+    post:
+      tags:
+        - SMS Senders
+      summary: Create a SMS sender
+      description: |
+        This API provides the capability to create a SMS sender.
+        If the 'name' is not not defined, 'SMSPublisher' is taken as the default name.<br>
+          <b>Permission required:</b> <br>
+            * /permission/admin/manage/identity/configmgt/add <br>
+          <b>Scope required:</b> <br>
+            * internal_config_mgt_add
+      operationId: createSMSSender
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SMSSenderAdd'
+            example:
+              provider: NEXMO
+              providerURL: https://rest.nexmo.com/sms/json
+              key: 123**45
+              secret: 5tg**ssd
+              sender: +94 775563324
+              type : json
+              properties:
+                - key: body.scope
+                  value: "internal"
+                - key: http.headers
+                  value: "X-Version: 1, Authorization: bearer ,Accept: application/json ,Content-Type: application/json"
+      responses:
+        "201":
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SMSSender'
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        "401":
+          description: Unauthorized
+        "403":
+          description: Forbidden
+        "404":
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        "405":
+          description: Method Not Allowed.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        "409":
+          description: Conflict
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        "500":
+          description: Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+  /notification-senders/sms/{sender-name}:
+    get:
+      tags:
+        - SMS Senders
+      summary: Get a SMS sender by name
+      description: |
+        This API provides the capability to retrieve a SMS notification sender by name.
+        The URL encoded SMS sender name is used as sender-name.<br>
+          <b>Permission required:</b> <br>
+            * /permission/admin/manage/identity/configmgt/view <br>
+          <b>Scope required:</b> <br>
+            * internal_config_mgt_view
+      operationId: getSMSSender
+      parameters:
+        - name: sender-name
+          in: path
+          description: name of the SMS sender
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SMSSender'
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        "401":
+          description: Unauthorized
+        "403":
+          description: Forbidden
+        "404":
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        "405":
+          description: Method Not Allowed.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        "500":
+          description: Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+    put:
+      tags:
+        - SMS Senders
+      summary: Update a SMS sender
+      description: |
+        This API provides the capability to update a SMS Sender.
+        The URL encoded SMS sender name is used as sender-name.<br>
+          <b>Permission required:</b> <br>
+            * /permission/admin/manage/identity/configmgt/update <br>
+          <b>Scope required:</b> <br>
+            * internal_config_mgt_update
+      operationId: updateSMSSender
+      parameters:
+        - name: sender-name
+          in: path
+          description: name of the SMS sender
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SMSSenderUpdateRequest'
+            example:
+              provider: NEXMO
+              providerURL: https://rest.nexmo.com/sms/json
+              key: 123**45
+              secret: 5tg**ssd
+              sender: +94 775563324
+              type : json
+              properties:
+                - key: body.scope
+                  value: "internal"
+                - key: http.headers
+                  value: "X-Version: 1, Authorization: bearer ,Accept: application/json ,Content-Type: application/json"
+        required: true
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SMSSender'
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        "401":
+          description: Unauthorized
+        "403":
+          description: Forbidden
+        "404":
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        "405":
+          description: Method Not Allowed.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        "500":
+          description: Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+    delete:
+      tags:
+        - SMS Senders
+      summary: Delete a SMS sender by name
+      description: |
+        This API provides the capability to delete a SMS sender by name.
+        The URL encoded SMS sender name is used as sender-name.<br>
+          <b>Permission required:</b> <br>
+            * /permission/admin/manage/identity/configmgt/delete <br>
+          <b>Scope required:</b> <br>
+            * internal_config_mgt_delete
+      operationId: deleteSMSSender
+      parameters:
+        - name: sender-name
+          in: path
+          description: name of the SMS sender
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+      responses:
+        "204":
+          description: No Content
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        "401":
+          description: Unauthorized
+        "403":
+          description: Forbidden
+        "404":
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        "405":
+          description: Method Not Allowed.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        "500":
+          description: Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+  /notification-senders/push:
+    get:
+      tags:
+        - Push Notification Senders
+      summary: Get a list of push notification senders
+      description: |
+        This API provides the capability to retrieve the list of push notification senders. <br>
+          <b>Permission required:</b> <br>
+            * /permission/admin/manage/identity/configmgt/view <br>
+          <b>Scope required:</b> <br>
+            * internal_config_mgt_view
+      operationId: getPushSenders
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PushProviderList'
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        "401":
+          description: Unauthorized
+        "403":
+          description: Forbidden
+        "404":
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        "405":
+          description: Method Not Allowed.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        "500":
+          description: Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+    post:
+      tags:
+        - Push Notification Senders
+      summary: Create a push notification sender
+      description: |
+        This API provides the capability to create a push notification sender.\n\nIf the 'name' is not defined, 'PushPublisher' is taken as the default name. <br>
+          <b>Permission required:</b> <br>
+            * /permission/admin/manage/identity/configmgt/add <br>
+          <b>Scope required:</b> <br>
+            * internal_config_mgt_add
+      operationId: createPushSender
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PushSenderAdd'
+            example:
+              provider: FCM
+              properties:
+                - key: FCM.serviceAccount
+                  value: {"FCMUrl": "UrlValue"}
+      responses:
+        "201":
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PushSender'
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        "401":
+          description: Unauthorized
+        "403":
+          description: Forbidden
+        "404":
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        "405":
+          description: Method Not Allowed.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        "409":
+          description: Conflict
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        "500":
+          description: Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+  /notification-senders/push/{sender-name}:
+    get:
+      tags:
+        - Push Notification Senders
+      summary: Retrieve a push notification sender by name
+      description: |
+        This API provides the capability to retrieve a push notification sender by name.
+        The URL encoded push notification sender name is used as sender-name.<br>
+          <b>Permission required:</b> <br>
+            * /permission/admin/manage/identity/configmgt/view <br>
+          <b>Scope required:</b> <br>
+            * internal_config_mgt_view
+      operationId: getPushSender
+      parameters:
+        - name: sender-name
+          in: path
+          description: name of the push notification sender
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PushSender'
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        "401":
+          description: Unauthorized
+        "403":
+          description: Forbidden
+        "404":
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        "405":
+          description: Method Not Allowed.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        "500":
+          description: Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+    put:
+      tags:
+        - Push Notification Senders
+      summary: Update a push notification sender
+      description: |
+        This API provides the capability to update a push notification sender by name.
+        The URL encoded push notification sender name is used as sender-name.<br>
+          <b>Permission required:</b> <br>
+            * /permission/admin/manage/identity/configmgt/update <br>
+          <b>Scope required:</b> <br>
+            * internal_config_mgt_update
+      operationId: updatePushSender
+      parameters:
+        - name: sender-name
+          in: path
+          description: name of the push notification sender
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PushSenderUpdateRequest'
+            example:
+              provider: FCM
+              properties:
+                - key: FCM.serviceAccount
+                  value: {"FCMUrl": "UrlValue"}
+        required: true
+      responses:
+        "200":
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PushSender'
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        "401":
+          description: Unauthorized
+        "403":
+          description: Forbidden
+        "404":
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        "405":
+          description: Method Not Allowed.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        "500":
+          description: Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+    delete:
+      tags:
+        - Push Notification Senders
+      summary: Delete a push notification sender by name
+      description: |
+        This API provides the capability to delete a push notification sender by name.
+        The URL encoded push notification sender name is used as sender-name.<br>
+          <b>Permission required:</b> <br>
+            * /permission/admin/manage/identity/configmgt/delete <br>
+          <b>Scope required:</b> <br>
+            * internal_config_mgt_delete
+      operationId: deletePushSender
+      parameters:
+        - name: sender-name
+          in: path
+          description: name of the email sender
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+      responses:
+        "204":
+          description: No Content
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        "401":
+          description: Unauthorized
+        "403":
+          description: Forbidden
+        "404":
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        "405":
+          description: Method Not Allowed.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        "500":
+          description: Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+components:
+  schemas:
+    Error:
+      type: object
+      properties:
+        code:
+          type: string
+          example: NSM-00000
+        message:
+          type: string
+          example: Some Error Message
+        description:
+          type: string
+          example: Some Error Description
+        traceId:
+          type: string
+          example: e0fbcfeb-3617-43c4-8dd0-7b7d38e13047
+    EmailSenderAdd:
+      required:
+        - fromAddress
+      type: object
+      properties:
+        name:
+          type: string
+        smtpServerHost:
+          type: string
+        smtpPort:
+          type: integer
+        fromAddress:
+          type: string
+          example: iam@gmail.com
+        authType:
+          type: string
+          example: BASIC
+        properties:
+          type: array
+          example:
+            - key: body.scope
+              value: "true"
+            - key: mail.smtp.starttls.enable
+              value: true
+            - key: userName
+              value: iam
+            - key: password
+              value: iam123
+          items:
+            $ref: '#/components/schemas/Properties'
+    SMSSenderAdd:
+      required:
+        - provider
+        - contentType
+      type: object
+      properties:
+        name:
+          type: string
+          example: SMSPublisher
+        provider:
+          type: string
+          example: NEXMO
+        providerURL:
+          type: string
+          example: https://rest.nexmo.com/sms/json
+        key:
+          type: string
+          example: 123**45
+        secret:
+          type: string
+          example: 5tg**ssd
+        sender:
+          type: string
+          example: +94 775563324
+        contentType:
+          type: string
+          enum:
+            - JSON
+            - FORM
+        properties:
+          type: array
+          example:
+            - key: http.headers
+              value: "X-Version: 1, Authorization: bearer ,Accept: application/json ,Content-Type: application/json"
+          items:
+            $ref: '#/components/schemas/Properties'
+    PushSenderAdd:
+      required:
+        - provider
+        - properties
+      type: object
+      properties:
+        name:
+          type: string
+          example: PushPublisher
+        provider:
+          type: string
+          example: fcm
+        properties:
+          type: array
+          example:
+            - key: fcm.serviceAccount
+              value: jsonString
+            - key: aws.keyId
+              value: sampleKeyId
+          items:
+            $ref: '#/components/schemas/Properties'
+    EmailSender:
+      required:
+        - fromAddress
+        - name
+      type: object
+      properties:
+        name:
+          type: string
+          example: EmailPublisher
+        smtpServerHost:
+          type: string
+          example: smtp.gmail.com
+        smtpPort:
+          type: integer
+          example: 587
+        fromAddress:
+          type: string
+          example: iam@gmail.com
+        authType:
+          type: string
+          example: BASIC
+        properties:
+          type: array
+          example:
+            - key: mail.smtp.starttls.enable
+              value: true
+            - key: userName
+              value: iam
+            - key: password
+              value: iam123
+          items:
+            $ref: '#/components/schemas/Properties'
+    SMSSender:
+      required:
+        - providerURL
+        - name
+        - provider
+        - contentType
+      type: object
+      properties:
+        name:
+          type: string
+          example: SMSPublisher
+        provider:
+          type: string
+          example: NEXMO
+        providerURL:
+          type: string
+          example: https://rest.nexmo.com/sms/json
+        key:
+          type: string
+          example: 123**45
+        secret:
+          type: string
+          example: 5tg**ssd
+        sender:
+          type: string
+          example: +94 775563324
+        contentType:
+          type: string
+          enum:
+            - JSON
+            - FORM
+        properties:
+          type: array
+          example:
+            - key: body.scope
+              value: "internal"
+            - key: http.headers
+              value: "X-Version: 1, Authorization: bearer ,Accept: application/json ,Content-Type: application/json"
+          items:
+            $ref: '#/components/schemas/Properties'
+    PushSender:
+      required:
+        - provider
+        - name
+      properties:
+        name:
+          type: string
+          example: PushPublisher
+        provider:
+          type: string
+          example: fcm
+        properties:
+          type: array
+          example:
+            - key: fcm.serviceAccount
+              value: "jsonString"
+            - key: aws.keyId
+              value: "sampleKeyId"
+          items:
+            $ref: '#/components/schemas/Properties'
+    EmailSenderUpdateRequest:
+      required:
+        - fromAddress
+      type: object
+      properties:
+        smtpServerHost:
+          type: string
+          example: smtp.gmail.com
+        smtpPort:
+          type: integer
+          example: 587
+        fromAddress:
+          type: string
+          example: iam@gmail.com
+        authType:
+          type: string
+          example: BASIC
+        properties:
+          type: array
+          example:
+            - key: body.scope
+              value: "true"
+            - key: mail.smtp.starttls.enable
+              value: true
+            - key: userName
+              value: iam
+            - key: password
+              value: iam123
+          items:
+            $ref: '#/components/schemas/Properties'
+    SMSSenderUpdateRequest:
+      required:
+        - provider
+        - contentType
+      type: object
+      properties:
+        provider:
+          type: string
+          example: NEXMO
+        providerURL:
+          type: string
+          example: https://rest.nexmo.com/sms/json
+        key:
+          type: string
+          example: 123**45
+        secret:
+          type: string
+          example: 5tg**ssd
+        sender:
+          type: string
+          example: +94 775563324
+        contentType:
+          type: string
+          enum:
+            - JSON
+            - FORM
+        properties:
+          type: array
+          example:
+            - key: http.headers
+              value: "X-Version: 1, Authorization: bearer ,Accept: application/json ,Content-Type: application/json"
+          items:
+            $ref: '#/components/schemas/Properties'
+    PushSenderUpdateRequest:
+      required:
+        - provider
+        - properties
+      type: object
+      properties:
+        provider:
+          type: string
+        properties:
+          type: array
+          example:
+            - key: fcm.serviceAccount
+              value: "jsonString"
+            - key: aws.keyId
+              value: "sampleKeyId"
+          items:
+            $ref: '#/components/schemas/Properties'
+    Properties:
+      required:
+        - key
+        - value
+      type: object
+      properties:
+        key:
+          type: string
+        value:
+          type: string
+      example:
+        - key: email
+          value: iam@gmail.com
+    EmailProviderList:
+      type: array
+      items:
+        $ref: '#/components/schemas/EmailSender'
+    SMSProviderList:
+      type: array
+      items:
+        $ref: '#/components/schemas/SMSSender'
+    PushProviderList:
+      type: array
+      items:
+        $ref: '#/components/schemas/PushSender'
+  parameters:
+    typeQueryParam:
+      name: type
+      in: query
+      description: |
+        Type of authenticators. Can be either 'LOCAL' or 'REQUEST_PATH'
+      required: false
+      style: form
+      explode: true
+      schema:
+        type: string
+  securitySchemes:
+    BasicAuth:
+      type: http
+      scheme: basic
+    OAuth2:
+      type: oauth2
+      flows:
+        authorizationCode:
+          authorizationUrl: https://localhost:9443/oauth2/authorize
+          tokenUrl: https://localhost:9443/oauth2/token
+          scopes: {}

--- a/components/org.wso2.carbon.identity.api.server.notification.sender/org.wso2.carbon.identity.api.server.notification.sender.v2/src/main/resources/notification-sender.yaml
+++ b/components/org.wso2.carbon.identity.api.server.notification.sender/org.wso2.carbon.identity.api.server.notification.sender.v2/src/main/resources/notification-sender.yaml
@@ -71,7 +71,7 @@ paths:
         - Email Senders
       summary: Create an email sender
       description: |
-        This API provides the capability to create an email sender.\n\nIf the 'name' is not not defined, 'EmailPublisher' is taken as the default name. <br>
+        This API provides the capability to create an email sender.\n\nIf 'name' is not defined, 'EmailPublisher' is used as the default name. <br>
           <b>Permission required:</b> <br>
             * /permission/admin/manage/identity/configmgt/add <br>
           <b>Scope required:</b> <br>

--- a/components/org.wso2.carbon.identity.api.server.notification.sender/pom.xml
+++ b/components/org.wso2.carbon.identity.api.server.notification.sender/pom.xml
@@ -31,7 +31,7 @@
 
     <modules>
         <module>org.wso2.carbon.identity.api.server.notification.sender.v1</module>
-        <module>org.wso2.carbon.identity.api.server.notification.sender.common</module>
         <module>org.wso2.carbon.identity.api.server.notification.sender.v2</module>
+        <module>org.wso2.carbon.identity.api.server.notification.sender.common</module>
     </modules>
 </project>

--- a/components/org.wso2.carbon.identity.api.server.notification.sender/pom.xml
+++ b/components/org.wso2.carbon.identity.api.server.notification.sender/pom.xml
@@ -32,5 +32,6 @@
     <modules>
         <module>org.wso2.carbon.identity.api.server.notification.sender.v1</module>
         <module>org.wso2.carbon.identity.api.server.notification.sender.common</module>
+        <module>org.wso2.carbon.identity.api.server.notification.sender.v2</module>
     </modules>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -892,7 +892,7 @@
         <maven.findbugsplugin.version>3.0.5</maven.findbugsplugin.version>
         <findsecbugs-plugin.version>1.12.0</findsecbugs-plugin.version>
         <maven.checkstyleplugin.excludes>**/gen/**/*</maven.checkstyleplugin.excludes>
-        <identity.event.handler.version>1.9.34</identity.event.handler.version>
+        <identity.event.handler.version>1.9.48</identity.event.handler.version>
         <identity.inbound.oauth2.version>7.0.224</identity.inbound.oauth2.version>
         <identity.inbound.saml2.version>5.11.51</identity.inbound.saml2.version>
         <identity.x509Certificate.validation.version>1.1.19</identity.x509Certificate.validation.version>


### PR DESCRIPTION
## Purpose
With this PR we will be introducing the new notification sender v2 API. 

**NOTE:** With the notification sender v2 changes are carried out only for Email Provider endpoints. SMS and Push notification endpoints will be kept exactly same as v1.

- The v2 API will introduce a revised payload structure, removing first class attribute support for username and password attributes in Email Provider.
- In v2, credentials will no longer be included in the API response.
- Below are the supported payloads for different authentication mechanisms:

**Basic Authentication (v2 Payload Format)**

```
{
  "name": "EmailPublisher",
  "smtpServerHost": "[smtp.gmail.com](http://smtp.gmail.com/)",
  "smtpPort": 587,
  "fromAddress": "[iam@gmail.com](mailto:iam@gmail.com)",
  "authType": "BASIC",
  "properties": [
    { 
      "key": "mail.smtp.starttls.enable",
      "value": true 
   },
   { 
    "key": "userName", 
    "value": "iam" 
   },
   { 
    "key": "password", 
   "value": "iam123" 
   }
  ]
}
```


Client Credential Authentication (v2 Payload Format)

```
{
  "name": "EmailPublisher",
  "smtpServerHost": "[smtp.gmail.com](http://smtp.gmail.com/)",
  "smtpPort": 587,
  "fromAddress": "[iam@gmail.com](mailto:iam@gmail.com)",
  "authType": "CLIENT_CREDENTIAL",
  "properties": [
    {
      "key": "mail.smtp.starttls.enable",
      "value": true
    },
    {
      "key": "clientId",
      "value": "3e172dd2-901b-43a9-a26a-728466795f01"
    },
    {
      "key": "clientSecret",
      "value": "83cdc120-ccf6-4163-a4a8-c1ba3e872daa"
    },
    {
      "key": "tokenEndpoint",
      "value": "https://login.microsoftonline.com/da76d684-740f-4d94-8717-9d5fb21dd1f9/oauth2/v2.0/token"
    },
    {
      "key": "scopes",
      "value": "https://graph.microsoft.com/.default"
    }
  ]
}
```

### Related Issue

- https://github.com/wso2/product-is/issues/23405