### PR TITLE
Add flow initiator claim property 

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.claim.management/org.wso2.carbon.identity.rest.api.server.claim.management.v1/src/gen/java/org/wso2/carbon/identity/rest/api/server/claim/management/v1/dto/LocalClaimReqDTO.java
+++ b/components/org.wso2.carbon.identity.api.server.claim.management/org.wso2.carbon.identity.rest.api.server.claim.management.v1/src/gen/java/org/wso2/carbon/identity/rest/api/server/claim/management/v1/dto/LocalClaimReqDTO.java
@@ -69,6 +69,9 @@ public class LocalClaimReqDTO {
     @Valid 
     private UniquenessScopeEnum uniquenessScope = null;
 
+    @Valid
+    private boolean flowInitiator = false;
+
     public enum SharedProfileValueResolvingMethodEnum {
         FromOrigin, FromSharedProfile, FromFirstFoundInHierarchy,
     };
@@ -195,6 +198,19 @@ public class LocalClaimReqDTO {
     }
 
     /**
+     * Specifies claim property for FlowInitiator.
+     **/
+    @ApiModelProperty(value = "Specifies claim property for FlowInitiator.")
+    @JsonProperty("flowInitiator")
+    public boolean getFlowInitiator() {
+        return flowInitiator;
+    }
+
+    public void setFlowInitiator(boolean flowInitiator) {
+        this.flowInitiator = flowInitiator;
+    }
+
+    /**
      * Specifies claim value resolving method for shared user profile.
      **/
     @ApiModelProperty(value = "Specifies claim value resolving method for shared user profile.")
@@ -258,6 +274,7 @@ public class LocalClaimReqDTO {
         sb.append("    required: ").append(required).append("\n");
         sb.append("    supportedByDefault: ").append(supportedByDefault).append("\n");
         sb.append("    uniquenessScope: ").append(uniquenessScope).append("\n");
+        sb.append("    flowInitiator: ").append(flowInitiator).append("\n");
         sb.append("    sharedProfileValueResolvingMethod: ").append(sharedProfileValueResolvingMethod).append("\n");
         sb.append("    attributeMapping: ").append(attributeMapping).append("\n");
         sb.append("    properties: ").append(properties).append("\n");

--- a/components/org.wso2.carbon.identity.api.server.claim.management/org.wso2.carbon.identity.rest.api.server.claim.management.v1/src/gen/java/org/wso2/carbon/identity/rest/api/server/claim/management/v1/dto/LocalClaimResDTO.java
+++ b/components/org.wso2.carbon.identity.api.server.claim.management/org.wso2.carbon.identity.rest.api.server.claim.management.v1/src/gen/java/org/wso2/carbon/identity/rest/api/server/claim/management/v1/dto/LocalClaimResDTO.java
@@ -74,6 +74,9 @@ public class LocalClaimResDTO extends ClaimResDTO {
     @Valid 
     private UniquenessScopeEnum uniquenessScope = null;
 
+    @Valid
+    private boolean flowInitiator = false;
+
     public enum SharedProfileValueResolvingMethodEnum {
         FromOrigin, FromSharedProfile, FromFirstFoundInHierarchy,
     };
@@ -222,6 +225,19 @@ public class LocalClaimResDTO extends ClaimResDTO {
     }
 
     /**
+     * Specifies claim property for FlowInitiator.
+     **/
+    @ApiModelProperty(value = "Specifies claim property for FlowInitiator.")
+    @JsonProperty("flowInitiator")
+    public boolean getFlowInitiator() {
+        return flowInitiator;
+    }
+
+    public void setFlowInitiator(boolean flowInitiator) {
+        this.flowInitiator = flowInitiator;
+    }
+
+    /**
      * Specifies claim value resolving method for shared user profile.
      **/
     @ApiModelProperty(value = "Specifies claim value resolving method for shared user profile.")
@@ -289,6 +305,7 @@ public class LocalClaimResDTO extends ClaimResDTO {
         sb.append("    required: ").append(required).append("\n");
         sb.append("    supportedByDefault: ").append(supportedByDefault).append("\n");
         sb.append("    uniquenessScope: ").append(uniquenessScope).append("\n");
+        sb.append("    flowInitiator: ").append(flowInitiator).append("\n");
         sb.append("    sharedProfileValueResolvingMethod: ").append(sharedProfileValueResolvingMethod).append("\n");
         sb.append("    attributeMapping: ").append(attributeMapping).append("\n");
         sb.append("    properties: ").append(properties).append("\n");

--- a/components/org.wso2.carbon.identity.api.server.claim.management/org.wso2.carbon.identity.rest.api.server.claim.management.v1/src/main/java/org/wso2/carbon/identity/rest/api/server/claim/management/v1/core/ServerClaimManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.claim.management/org.wso2.carbon.identity.rest.api.server.claim.management.v1/src/main/java/org/wso2/carbon/identity/rest/api/server/claim/management/v1/core/ServerClaimManagementService.java
@@ -1041,6 +1041,11 @@ public class ServerClaimManagementService {
 
         addAttributeProfilesToLocalClaimResponse(claimProperties, localClaimResDTO);
 
+        String flowInitiatorClaim = claimProperties.remove(ClaimConstants.FLOW_INITIATOR);
+        if (StringUtils.isNotBlank(flowInitiatorClaim)) {
+            localClaimResDTO.setFlowInitiator(Boolean.parseBoolean(flowInitiatorClaim));
+        }
+
         String sharedProfileValueResolvingMethod =
                 claimProperties.remove(ClaimConstants.SHARED_PROFILE_VALUE_RESOLVING_METHOD);
         if (StringUtils.isNotBlank(sharedProfileValueResolvingMethod)) {

--- a/components/org.wso2.carbon.identity.api.server.claim.management/org.wso2.carbon.identity.rest.api.server.claim.management.v1/src/main/resources/claim-management.yaml
+++ b/components/org.wso2.carbon.identity.api.server.claim.management/org.wso2.carbon.identity.rest.api.server.claim.management.v1/src/main/resources/claim-management.yaml
@@ -752,6 +752,10 @@ definitions:
           - FromSharedProfile
           - FromFirstFoundInHierarchy
         example: "FromOrigin"
+      flowInitiator:
+        type: boolean
+        description: Specifies the flow initiator property of the claim.
+        example: true
       attributeMapping:
         type: array
         description: Userstore attribute mappings.
@@ -830,6 +834,10 @@ definitions:
               - FromSharedProfile
               - FromFirstFoundInHierarchy
             example: "FromOrigin"
+          flowInitiator:
+            type: boolean
+            description: Specifies the flow initiator property of the claim.
+            example: true
           attributeMapping:
             type: array
             description: Userstore attribute mappings.

--- a/pom.xml
+++ b/pom.xml
@@ -888,7 +888,7 @@
         <maven.buildnumber.plugin.version>1.4</maven.buildnumber.plugin.version>
         <org.apache.felix.annotations.version>1.2.4</org.apache.felix.annotations.version>
         <identity.governance.version>1.11.27</identity.governance.version>
-        <carbon.identity.framework.version>7.8.66</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.8.111</carbon.identity.framework.version>
         <maven.findbugsplugin.version>3.0.5</maven.findbugsplugin.version>
         <findsecbugs-plugin.version>1.12.0</findsecbugs-plugin.version>
         <maven.checkstyleplugin.excludes>**/gen/**/*</maven.checkstyleplugin.excludes>


### PR DESCRIPTION
### Description

This PR introduces the flow initiator claim property for system claims.

Below system claims are identified as flow initiator claims where all the other system claims are not treated as flow initiator claims.
- claims/identity/verifyEmail
- claims/identity/verifyMobile
- claims/identity/askPassword
- claims/identity/adminForcedPasswordReset

#### Proposed change

- The flow initiator claim property added to the local claim by the claim metadata service is treated as a first class property of the claim. Therefore the property is removed from the claim property map

#### Related Issues
- https://github.com/wso2/product-is/issues/23798

#### Merging
Merge after
-  https://github.com/wso2/carbon-identity-framework/pull/6680
