### PR TITLE
Add exclude-hidden-claims query param to claim mgt endpoint

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.claim.management/org.wso2.carbon.identity.rest.api.server.claim.management.v1/src/gen/java/org/wso2/carbon/identity/rest/api/server/claim/management/v1/ClaimManagementApi.java
+++ b/components/org.wso2.carbon.identity.api.server.claim.management/org.wso2.carbon.identity.rest.api.server.claim.management.v1/src/gen/java/org/wso2/carbon/identity/rest/api/server/claim/management/v1/ClaimManagementApi.java
@@ -370,9 +370,10 @@ public class ClaimManagementApi  {
     @ApiParam(value = "Number of records to skip for pagination.") @QueryParam("offset")  Integer offset,
     @ApiParam(value = "Condition to filter the retrieval of records.") @QueryParam("filter")  String filter,
     @ApiParam(value = "Define the order by which the retrieved records should be sorted.") @QueryParam("sort")  String sort,
-    @ApiParam(value = "Exclude identity claims when listing local claims.") @QueryParam("exclude-identity-claims")  Boolean excludeIdentityClaims) {
+    @ApiParam(value = "Exclude identity claims when listing local claims.") @QueryParam("exclude-identity-claims")  Boolean excludeIdentityClaims,
+    @ApiParam(value = "Exclude hidden claims when listing local claims.") @QueryParam("exclude-hidden-claims") Boolean excludeHiddenClaims) {
 
-        return delegate.getLocalClaims(attributes,limit,offset,filter,sort,excludeIdentityClaims);
+        return delegate.getLocalClaims(attributes,limit,offset,filter,sort,excludeIdentityClaims,excludeHiddenClaims);
     }
 
     @Valid

--- a/components/org.wso2.carbon.identity.api.server.claim.management/org.wso2.carbon.identity.rest.api.server.claim.management.v1/src/gen/java/org/wso2/carbon/identity/rest/api/server/claim/management/v1/ClaimManagementApiService.java
+++ b/components/org.wso2.carbon.identity.api.server.claim.management/org.wso2.carbon.identity.rest.api.server.claim.management.v1/src/gen/java/org/wso2/carbon/identity/rest/api/server/claim/management/v1/ClaimManagementApiService.java
@@ -60,7 +60,7 @@ public abstract class ClaimManagementApiService {
 
     public abstract Response getLocalClaim(String claimId);
 
-    public abstract Response getLocalClaims(String attributes, Integer limit, Integer offset, String filter, String sort, Boolean excludeIdentityClaims);
+    public abstract Response getLocalClaims(String attributes, Integer limit, Integer offset, String filter, String sort, Boolean excludeIdentityClaims, Boolean excludeHiddenClaims);
 
     public abstract Response importClaimDialectFromFile(InputStream fileInputStream,Attachment fileDetail);
 

--- a/components/org.wso2.carbon.identity.api.server.claim.management/org.wso2.carbon.identity.rest.api.server.claim.management.v1/src/main/java/org/wso2/carbon/identity/rest/api/server/claim/management/v1/core/ServerClaimManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.claim.management/org.wso2.carbon.identity.rest.api.server.claim.management.v1/src/main/java/org/wso2/carbon/identity/rest/api/server/claim/management/v1/core/ServerClaimManagementService.java
@@ -166,6 +166,7 @@ public class ServerClaimManagementService {
     private static final Log LOG = LogFactory.getLog(ServerClaimManagementService.class);
     private static final String REL_CLAIMS = "claims";
     private static final String IDENTITY_CLAIM_URI = "http://wso2.org/claims/identity/";
+    private static final String HIDDEN_CLAIMS_IDENTITY_CONFIG = "HiddenClaims.HiddenClaim";
     private static final List<String> conflictErrorScenarios = Arrays.asList(
             ClaimConstants.ErrorMessage.ERROR_CODE_EXISTING_CLAIM_DIALECT.getCode(),
             ClaimConstants.ErrorMessage.ERROR_CODE_EXISTING_EXTERNAL_CLAIM_URI.getCode(),
@@ -436,6 +437,25 @@ public class ServerClaimManagementService {
     public List<LocalClaimResDTO> getLocalClaims(Boolean excludeIdentityClaims, String attributes, Integer limit,
                                                  Integer offset, String filter, String sort) {
 
+        return getLocalClaims(excludeIdentityClaims, attributes, limit, offset, filter, sort, false);
+    }
+
+    /**
+     * Retrieve all claims belonging to the local dialect.
+     *
+     * @param excludeIdentityClaims     Exclude identity claims in the local dialect if this is set to true.
+     * @param attributes                attributes filter (optional).
+     * @param limit                     limit (optional).
+     * @param offset                    offset (optional).
+     * @param filter                    filter (optional).
+     * @param sort                      sort (optional).
+     * @param excludeHiddenClaims   Exclude hidden claims in the local dialect if this is set to true.
+     * @return List of local claims.
+     */
+    public List<LocalClaimResDTO> getLocalClaims(Boolean excludeIdentityClaims, String attributes, Integer limit,
+                                                 Integer offset, String filter, String sort,
+                                                 Boolean excludeHiddenClaims) {
+
         handleNotImplementedCapabilities(attributes, limit, offset, filter, sort);
 
         try {
@@ -445,6 +465,13 @@ public class ServerClaimManagementService {
             if (excludeIdentityClaims != null && excludeIdentityClaims) {
                 localClaimList = localClaimList.stream()
                         .filter(claim -> !claim.getClaimURI().startsWith(IDENTITY_CLAIM_URI))
+                        .collect(Collectors.toList());
+            }
+
+            if (excludeHiddenClaims != null && excludeHiddenClaims) {
+                List<String> hiddenClaims = IdentityUtil.getPropertyAsList(HIDDEN_CLAIMS_IDENTITY_CONFIG);
+                localClaimList = localClaimList.stream()
+                        .filter(claim -> !hiddenClaims.contains(claim.getClaimURI()))
                         .collect(Collectors.toList());
             }
 

--- a/components/org.wso2.carbon.identity.api.server.claim.management/org.wso2.carbon.identity.rest.api.server.claim.management.v1/src/main/java/org/wso2/carbon/identity/rest/api/server/claim/management/v1/impl/ClaimManagementApiServiceImpl.java
+++ b/components/org.wso2.carbon.identity.api.server.claim.management/org.wso2.carbon.identity.rest.api.server.claim.management.v1/src/main/java/org/wso2/carbon/identity/rest/api/server/claim/management/v1/impl/ClaimManagementApiServiceImpl.java
@@ -150,10 +150,10 @@ public class ClaimManagementApiServiceImpl extends ClaimManagementApiService {
 
     @Override
     public Response getLocalClaims(String attributes, Integer limit, Integer offset, String filter,
-                                   String sort, Boolean excludeIdentityClaims) {
+                                   String sort, Boolean excludeIdentityClaims, Boolean excludeHiddenClaims) {
 
         return Response.ok().entity(claimManagementService.getLocalClaims(
-                excludeIdentityClaims, attributes, limit, offset, filter, sort)).build();
+                excludeIdentityClaims, attributes, limit, offset, filter, sort, excludeHiddenClaims)).build();
     }
 
     @Override

--- a/components/org.wso2.carbon.identity.api.server.claim.management/org.wso2.carbon.identity.rest.api.server.claim.management.v1/src/main/resources/claim-management.yaml
+++ b/components/org.wso2.carbon.identity.api.server.claim.management/org.wso2.carbon.identity.rest.api.server.claim.management.v1/src/main/resources/claim-management.yaml
@@ -79,6 +79,7 @@ paths:
       - $ref : '#/parameters/filterQueryParam'
       - $ref : '#/parameters/sortQueryParam'
       - $ref : '#/parameters/excludeIdentityClaimsQueryParam'
+      - $ref : '#/parameters/excludeHiddenClaimsQueryParam'
       x-wso2-curl: |
       responses:
         200:
@@ -647,6 +648,12 @@ parameters:
     required: false
     type: boolean
     description: Exclude identity claims when listing local claims.
+  excludeHiddenClaimsQueryParam:
+    in: query
+    name: exclude-hidden-claims
+    required: false
+    type: boolean
+    description: Exclude hidden claims when listing local claims.
   dialectIdPathParam:
     in: path
     name: dialect-id


### PR DESCRIPTION
### Purpose

This PR introduces a new query parameter `exclude-hidden-claims` to the `GET /claim-dialects/local/claims` REST API endpoint, enabling clients to optionally filter out hidden claims from the response.

Hidden claims are those configured in the backend (via deployment.toml) that are not intended to be exposed or selectable for use in service provider (SP) and identity provider (IdP) claim mappings or in any other local claim listings. This change allows frontend applications to exclude backend-configured hidden claims when rendering claim selection UIs.

```
GET /t/{tenant-domain}/api/server/v1/claim-dialects/local/claims?exclude-hidden-claims=true
```

### Related Issue
- https://github.com/wso2/product-is/issues/23902