### PR TITLE
Validate password policy pattern at configuration time

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.identity.governance/org.wso2.carbon.identity.api.server.identity.governance.common/src/main/java/org/wso2/carbon/identity/api/server/identity/governance/common/GovernanceConstants.java
+++ b/components/org.wso2.carbon.identity.api.server.identity.governance/org.wso2.carbon.identity.api.server.identity.governance.common/src/main/java/org/wso2/carbon/identity/api/server/identity/governance/common/GovernanceConstants.java
@@ -71,7 +71,9 @@ public class GovernanceConstants {
         ERROR_CODE_INVALID_CONNECTOR_CONFIGURATION("50013", "Connector update failed.",
                 "Unable to update the identity governance connector %s."),
         ERROR_CODE_INVALID_PASSWORD_EXPIRY_RULE("50014", "Connector update failed.",
-                "Password expiry rule: %s is invalid.");
+                "Password expiry rule: %s is invalid."),
+        ERROR_CODE_INVALID_PASSWORD_PATTERN_REGEX("50015", "Connector update failed.",
+                "Password pattern regex is invalid.");
 
         private final String code;
         private final String message;

--- a/components/org.wso2.carbon.identity.api.server.identity.governance/org.wso2.carbon.identity.api.server.identity.governance.v1/src/main/java/org/wso2/carbon/identity/api/server/identity/governance/v1/core/ServerIdentityGovernanceService.java
+++ b/components/org.wso2.carbon.identity.api.server.identity.governance/org.wso2.carbon.identity.api.server.identity.governance.v1/src/main/java/org/wso2/carbon/identity/api/server/identity/governance/v1/core/ServerIdentityGovernanceService.java
@@ -52,6 +52,7 @@ import java.util.Base64;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.regex.Pattern;
 import javax.ws.rs.core.Response;
 
 import static org.wso2.carbon.identity.api.server.common.Constants.V1_API_PATH_COMPONENT;
@@ -60,6 +61,7 @@ import static org.wso2.carbon.identity.api.server.identity.governance.common.Gov
 import static org.wso2.carbon.identity.api.server.identity.governance.common.GovernanceConstants.ErrorMessage.ERROR_CODE_PAGINATION_NOT_IMPLEMENTED;
 import static org.wso2.carbon.identity.api.server.identity.governance.common.GovernanceConstants.ErrorMessage.ERROR_CODE_SORTING_NOT_IMPLEMENTED;
 import static org.wso2.carbon.identity.api.server.identity.governance.common.GovernanceConstants.IDENTITY_GOVERNANCE_PATH_COMPONENT;
+import static org.wso2.carbon.identity.input.validation.mgt.utils.Constants.PW_POLICY_PATTERN;
 import static org.wso2.carbon.identity.password.expiry.constants.PasswordPolicyConstants.PASSWORD_EXPIRY_RULES_PREFIX;
 
 /**
@@ -306,6 +308,12 @@ public class ServerIdentityGovernanceService {
                             GovernanceConstants.ErrorMessage.ERROR_CODE_INVALID_PASSWORD_EXPIRY_RULE,
                             propertyReqDTO.getValue());
                 }
+                if (StringUtils.equals(propertyReqDTO.getName(), PW_POLICY_PATTERN) &&
+                        StringUtils.isNotBlank(propertyReqDTO.getValue()) &&
+                        !isValidPasswordPatternRegex(propertyReqDTO.getValue())) {
+                    throw handleBadRequestError(
+                            GovernanceConstants.ErrorMessage.ERROR_CODE_INVALID_PASSWORD_PATTERN_REGEX);
+                }
             }
             identityGovernanceService.updateConfiguration(tenantDomain, configurationDetails);
         } catch (IdentityGovernanceClientException e) {
@@ -359,6 +367,12 @@ public class ServerIdentityGovernanceService {
                         throw handleBadRequestError(
                                 GovernanceConstants.ErrorMessage.ERROR_CODE_INVALID_PASSWORD_EXPIRY_RULE,
                                 propertyReqDTO.getValue());
+                    }
+                    if (StringUtils.equals(propertyReqDTO.getName(), PW_POLICY_PATTERN) &&
+                            StringUtils.isNotBlank(propertyReqDTO.getValue()) &&
+                            !isValidPasswordPatternRegex(propertyReqDTO.getValue())) {
+                        throw handleBadRequestError(
+                                GovernanceConstants.ErrorMessage.ERROR_CODE_INVALID_PASSWORD_PATTERN_REGEX);
                     }
                     configurationDetails.put(propertyReqDTO.getName(), propertyReqDTO.getValue());
                 }
@@ -540,6 +554,22 @@ public class ServerIdentityGovernanceService {
             new PasswordExpiryRule(rule);
             return true;
         } catch (IllegalArgumentException e) {
+            return false;
+        }
+    }
+
+    /**
+     * Validate the password pattern regex.
+     *
+     * @param passwordPatternRegex Password pattern regex.
+     * @return true if the regex is valid, false otherwise.
+     */
+    private boolean isValidPasswordPatternRegex(String passwordPatternRegex) {
+
+        try {
+            Pattern.compile(passwordPatternRegex);
+            return true;
+        } catch (Exception e) {
             return false;
         }
     }


### PR DESCRIPTION
### Purpose

This PR adds server-side validation for the password-policy pattern regex whenever the old password-policy connector is updated. Invalid Java regexes can no longer be saved, eliminating downstream failures during user creation and ensuring administrators receive immediate, actionable feedback.

### Related Issues
- https://github.com/wso2/product-is/issues/23943