### PR TITLE
Return the previous attribute properties if enabled

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.claim.management/org.wso2.carbon.identity.api.server.claim.management.common/src/main/java/org/wso2/carbon/identity/api/server/claim/management/common/Constant.java
+++ b/components/org.wso2.carbon.identity.api.server.claim.management/org.wso2.carbon.identity.api.server.claim.management.common/src/main/java/org/wso2/carbon/identity/api/server/claim/management/common/Constant.java
@@ -312,6 +312,7 @@ public class Constant {
     public static final String PROP_UNIQUENESS_SCOPE = "UniquenessScope";
     public static final String PROP_PROFILES_PREFIX = "Profiles.";
     public static final String PROP_EXCLUDED_USER_STORES = "ExcludedUserStores";
+    public static final String RETURN_PREVIOUS_ADDITIONAL_PROPERTIES = "Attribute.ReturnPreviousAdditionalProperties";
 
     public static final Set<String> ALLOWED_PROPERTY_KEYS_FOR_SUB_ORG_UPDATE = Collections.unmodifiableSet(
             new HashSet<>(Collections.singletonList(PROP_EXCLUDED_USER_STORES)));

--- a/components/org.wso2.carbon.identity.api.server.claim.management/org.wso2.carbon.identity.rest.api.server.claim.management.v1/src/main/java/org/wso2/carbon/identity/rest/api/server/claim/management/v1/core/ServerClaimManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.claim.management/org.wso2.carbon.identity.rest.api.server.claim.management.v1/src/main/java/org/wso2/carbon/identity/rest/api/server/claim/management/v1/core/ServerClaimManagementService.java
@@ -1947,7 +1947,8 @@ public class ServerClaimManagementService {
         localClaim.getClaimProperties().putIfAbsent(PROP_REQUIRED, FALSE);
         localClaim.getClaimProperties().putIfAbsent(PROP_SUPPORTED_BY_DEFAULT, FALSE);
         localClaim.getClaimProperties().putIfAbsent(PROP_MULTI_VALUED, FALSE);
-        localClaim.getClaimProperties().putIfAbsent(PROP_DATA_TYPE, DataTypeEnum.STRING.toString());
+        localClaim.getClaimProperties().putIfAbsent(PROP_DATA_TYPE, DataTypeEnum.STRING.toString()
+                .toLowerCase(Locale.ROOT));
     }
 
     private String handleAdditionalProperties(Map<String, String> claimProperties, String propertyName) {

--- a/components/org.wso2.carbon.identity.api.server.claim.management/org.wso2.carbon.identity.rest.api.server.claim.management.v1/src/main/java/org/wso2/carbon/identity/rest/api/server/claim/management/v1/core/ServerClaimManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.claim.management/org.wso2.carbon.identity.rest.api.server.claim.management.v1/src/main/java/org/wso2/carbon/identity/rest/api/server/claim/management/v1/core/ServerClaimManagementService.java
@@ -1111,7 +1111,7 @@ public class ServerClaimManagementService {
         String multiValued = handleAdditionalProperties(claimProperties, PROP_MULTI_VALUED);
         localClaimResDTO.setMultiValued(Boolean.valueOf(multiValued));
 
-        String uniquenessScope = handleAdditionalProperties(claimProperties, PROP_UNIQUENESS_SCOPE);
+        String uniquenessScope = claimProperties.remove(PROP_UNIQUENESS_SCOPE);
         if (StringUtils.isNotBlank(uniquenessScope)) {
             try {
                 localClaimResDTO.setUniquenessScope(LocalClaimResDTO.UniquenessScopeEnum.valueOf(uniquenessScope));

--- a/components/org.wso2.carbon.identity.api.server.claim.management/org.wso2.carbon.identity.rest.api.server.claim.management.v1/src/main/resources/claim-management.yaml
+++ b/components/org.wso2.carbon.identity.api.server.claim.management/org.wso2.carbon.identity.rest.api.server.claim.management.v1/src/main/resources/claim-management.yaml
@@ -747,6 +747,13 @@ definitions:
         type: string
         description: The data type of the attribute.
         example: complex
+        enum:
+          - string
+          - boolean
+          - data_time
+          - integer
+          - complex
+          - decimal
       subAttributes:
         type: array
         description: The sub attributes of the complex attribute.

--- a/pom.xml
+++ b/pom.xml
@@ -958,7 +958,7 @@
         <maven.buildnumber.plugin.version>1.4</maven.buildnumber.plugin.version>
         <org.apache.felix.annotations.version>1.2.4</org.apache.felix.annotations.version>
         <identity.governance.version>1.11.27</identity.governance.version>
-        <carbon.identity.framework.version>7.8.182</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.8.192</carbon.identity.framework.version>
         <maven.findbugsplugin.version>3.0.5</maven.findbugsplugin.version>
         <findsecbugs-plugin.version>1.12.0</findsecbugs-plugin.version>
         <maven.checkstyleplugin.excludes>**/gen/**/*</maven.checkstyleplugin.excludes>


### PR DESCRIPTION
## Purpose
> $subject

The following property should be configured in order to keep the previous behaviour of returning additional attributes
```toml
[attribute.return_previous_additional_properties]
enable=true
```

### Depends on
- https://github.com/wso2/carbon-identity-framework/pull/6811

### Related Issues
- https://github.com/wso2/product-is/issues/24049