### PR TITLE
Update applications/meta/inbound-protocols/oidc GET response to include the publicClientAllowed property of each grant type

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/application/management/v1/GrantType.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/application/management/v1/GrantType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2023-2025, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -31,9 +31,10 @@ import javax.validation.Valid;
 import javax.xml.bind.annotation.*;
 
 public class GrantType  {
-  
+
     private String name;
     private String displayName;
+    private Boolean publicClientAllowed;
 
     /**
     **/
@@ -42,7 +43,7 @@ public class GrantType  {
         this.name = name;
         return this;
     }
-    
+
     @ApiModelProperty(example = "authorization_code", value = "")
     @JsonProperty("name")
     @Valid
@@ -60,7 +61,7 @@ public class GrantType  {
         this.displayName = displayName;
         return this;
     }
-    
+
     @ApiModelProperty(example = "Code", value = "")
     @JsonProperty("displayName")
     @Valid
@@ -69,6 +70,24 @@ public class GrantType  {
     }
     public void setDisplayName(String displayName) {
         this.displayName = displayName;
+    }
+
+    /**
+     **/
+    public GrantType publicClientAllowed(Boolean publicClientAllowed) {
+
+        this.publicClientAllowed = publicClientAllowed;
+        return this;
+    }
+
+    @ApiModelProperty(example = "false", value = "")
+    @JsonProperty("publicClientAllowed")
+    @Valid
+    public Boolean getPublicClientAllowed() {
+        return publicClientAllowed;
+    }
+    public void setPublicClientAllowed(Boolean publicClientAllowed) {
+        this.publicClientAllowed = publicClientAllowed;
     }
 
 
@@ -84,12 +103,13 @@ public class GrantType  {
         }
         GrantType grantType = (GrantType) o;
         return Objects.equals(this.name, grantType.name) &&
-            Objects.equals(this.displayName, grantType.displayName);
+            Objects.equals(this.displayName, grantType.displayName) &&
+            Objects.equals(this.publicClientAllowed, grantType.publicClientAllowed);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(name, displayName);
+        return Objects.hash(name, displayName, publicClientAllowed);
     }
 
     @Override
@@ -97,9 +117,10 @@ public class GrantType  {
 
         StringBuilder sb = new StringBuilder();
         sb.append("class GrantType {\n");
-        
+
         sb.append("    name: ").append(toIndentedString(name)).append("\n");
         sb.append("    displayName: ").append(toIndentedString(displayName)).append("\n");
+        sb.append("    publicClientAllowed: ").append(toIndentedString(publicClientAllowed)).append("\n");
         sb.append("}");
         return sb.toString();
     }

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/ServerApplicationMetadataService.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/ServerApplicationMetadataService.java
@@ -242,6 +242,8 @@ public class ServerApplicationMetadataService {
                 .options(supportedFapiClientAuthenticationMethods));
         oidcMetaData.setFapiMetadata(fapiMetadata);
         List<String> supportedGrantTypes = new LinkedList<>(Arrays.asList(oAuthAdminService.getAllowedGrantTypes()));
+        List<String> publicClientSupportedGrantTypes = Arrays.asList(
+                oAuthAdminService.getPublicClientSupportedGrantTypes());
         List<GrantType> supportedGrantTypeNames = new ArrayList<>();
         // Iterate through the standard grant type names and add matching elements.
         for (String supportedGrantTypeName : supportedGrantTypes) {
@@ -253,6 +255,8 @@ public class ServerApplicationMetadataService {
                 grantType.setName(supportedGrantTypeName);
                 grantType.setDisplayName(supportedGrantTypeName);
             }
+            // If the grant type is public client supported, set it as such.
+            grantType.setPublicClientAllowed(publicClientSupportedGrantTypes.contains(supportedGrantTypeName));
             supportedGrantTypeNames.add(grantType);
         }
         // Set extracted grant types.

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/resources/applications.yaml
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/resources/applications.yaml
@@ -4048,6 +4048,9 @@ components:
         displayName:
           type: string
           example: Code
+        publicClientAllowed:
+          type: boolean
+          example: false
     SAMLMetaData:
       type: object
       properties:

--- a/pom.xml
+++ b/pom.xml
@@ -963,7 +963,7 @@
         <findsecbugs-plugin.version>1.12.0</findsecbugs-plugin.version>
         <maven.checkstyleplugin.excludes>**/gen/**/*</maven.checkstyleplugin.excludes>
         <identity.event.handler.version>1.9.48</identity.event.handler.version>
-        <identity.inbound.oauth2.version>7.0.224</identity.inbound.oauth2.version>
+        <identity.inbound.oauth2.version>7.0.302</identity.inbound.oauth2.version>
         <identity.inbound.saml2.version>5.11.51</identity.inbound.saml2.version>
         <identity.x509Certificate.validation.version>1.1.19</identity.x509Certificate.validation.version>
         <commons.beanutils.version>1.9.4</commons.beanutils.version>


### PR DESCRIPTION
## Purpose
The GET response of the `applications/meta/inbound-protocols/oidc` contains the following list of allowed grant types.
```
"allowedGrantTypes": {
        "options": [
            {
                "name": "urn:ietf:params:oauth:grant-type:saml2-bearer",
                "displayName": "SAML2"
            },
            {
                "name": "implicit",
                "displayName": "Implicit"
            },
...
}
```

This will be updated as follows to include the publicClientAllowed value of each grant type

```
"allowedGrantTypes": {
        "options": [
            {
                "name": "urn:ietf:params:oauth:grant-type:saml2-bearer",
                "displayName": "SAML2",
                "publicClientAllowed": true
            },
            {
                "name": "implicit",
                "displayName": "Implicit",
                "publicClientAllowed": false
            },
...
}
```

### Dependent on
- https://github.com/wso2-extensions/identity-inbound-auth-oauth/pull/2806

### Related issue
- https://github.com/wso2/product-is/issues/23972
