### PR TITLE
refactor the methods

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.webhook.management/org.wso2.carbon.identity.api.server.webhook.management.v1/src/main/java/org/wso2/carbon/identity/api/server/webhook/management/v1/core/ServerWebhookManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.webhook.management/org.wso2.carbon.identity.api.server.webhook.management.v1/src/main/java/org/wso2/carbon/identity/api/server/webhook/management/v1/core/ServerWebhookManagementService.java
@@ -181,9 +181,9 @@ public class ServerWebhookManagementService {
                 .endpoint(webhookRequest.getEndpoint())
                 .name(webhookRequest.getName())
                 .secret(webhookRequest.getSecret())
-                .eventSchemaName(
+                .eventProfileName(
                         webhookRequest.getEventProfile() != null ? webhookRequest.getEventProfile().getName() : null)
-                .eventSchemaUri(
+                .eventProfileUri(
                         webhookRequest.getEventProfile() != null ? webhookRequest.getEventProfile().getUri() : null)
                 .eventsSubscribed(webhookRequest.getChannelsSubscribed())
                 .build();
@@ -226,8 +226,8 @@ public class ServerWebhookManagementService {
         webhookResponse.setEndpoint(webhook.getEndpoint());
         webhookResponse.setName(webhook.getName());
         WebhookRequestEventProfile eventProfile = new WebhookRequestEventProfile();
-        eventProfile.setName(webhook.getEventSchemaName());
-        eventProfile.setUri(webhook.getEventSchemaUri());
+        eventProfile.setName(webhook.getEventProfileName());
+        eventProfile.setUri(webhook.getEventProfileUri());
         webhookResponse.setEventProfile(eventProfile);
         webhookResponse.setStatus(WebhookResponse.StatusEnum.fromValue(webhook.getStatus().name()));
         try {

--- a/pom.xml
+++ b/pom.xml
@@ -958,7 +958,7 @@
         <maven.buildnumber.plugin.version>1.4</maven.buildnumber.plugin.version>
         <org.apache.felix.annotations.version>1.2.4</org.apache.felix.annotations.version>
         <identity.governance.version>1.11.27</identity.governance.version>
-        <carbon.identity.framework.version>7.8.215</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.8.224</carbon.identity.framework.version>
         <maven.findbugsplugin.version>3.0.5</maven.findbugsplugin.version>
         <findsecbugs-plugin.version>1.12.0</findsecbugs-plugin.version>
         <maven.checkstyleplugin.excludes>**/gen/**/*</maven.checkstyleplugin.excludes>


### PR DESCRIPTION
## Purpose

This pull request includes changes to improve the naming consistency of webhook-related attributes and updates a dependency version in the project. The most important changes involve renaming attributes in the `ServerWebhookManagementService` class and updating the `carbon.identity.framework.version` in the `pom.xml` file.

### Naming consistency improvements:

* [`ServerWebhookManagementService.java`](diffhunk://#diff-5a2204fc9a36cd25c075512ba3bfc32826dbfb9d4dac4abb47e49448326a8ee5L184-R186): Renamed `eventSchemaName` and `eventSchemaUri` to `eventProfileName` and `eventProfileUri` in the `buildWebhook` and `getWebhookResponse` methods to align with the naming convention used in the `WebhookRequestEventProfile` class. [[1]](diffhunk://#diff-5a2204fc9a36cd25c075512ba3bfc32826dbfb9d4dac4abb47e49448326a8ee5L184-R186) [[2]](diffhunk://#diff-5a2204fc9a36cd25c075512ba3bfc32826dbfb9d4dac4abb47e49448326a8ee5L229-R230)

### Dependency updates:

* [`pom.xml`](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L961-R961): Updated the `carbon.identity.framework.version` from `7.8.215` to `7.8.224` to include the latest framework improvements and fixes.