### PR TITLE
Data format support for the attributes

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.claim.management/org.wso2.carbon.identity.api.server.claim.management.common/src/main/java/org/wso2/carbon/identity/api/server/claim/management/common/Constant.java
+++ b/components/org.wso2.carbon.identity.api.server.claim.management/org.wso2.carbon.identity.api.server.claim.management.common/src/main/java/org/wso2/carbon/identity/api/server/claim/management/common/Constant.java
@@ -232,7 +232,16 @@ public class Constant {
                 "form of attribute + '.' + sub attribute"),
         ERROR_CODE_ATTRIBUTES_MARKED_AS_SUB_ATTRIBUTES_NOT_ALLOWED_TO_HAVE_SUB_ATTRIBUTES("CMT-60016",
                 "The attributes marked as sub attribute of another attribute can't have sub attributes.",
-                "This attribute is marked as sub attribute of the attribute %s");
+                "This attribute is marked as sub attribute of the attribute %s"),
+        ERROR_CODE_UNSUPPORTED_INPUT_TYPE("CMT-60017",
+                "The provided input type doesn't match with the configured attribute meta data.",
+                "The provided input type %s doesn't match with the configured attribute meta data."),
+        ERROR_CODE_BOOLEAN_ATTRIBUTE_CANNOT_BE_MULTI_VALUED("CMT-60018",
+                "Boolean attributes cannot be multi-valued.",
+                "The attribute %s is a boolean attribute and cannot be multi-valued."),
+        ERROR_CODE_CANONICAL_VALUES_NOT_SUPPORTED_FOR_NON_STRING_DATA_TYPES("CMT-60019",
+                "Canonical values are not supported for non-string data types.",
+                "The attribute %s is not a string data type and canonical values are not supported.");
 
         private final String code;
         private final String message;
@@ -307,6 +316,7 @@ public class Constant {
     public static final String PROP_DATA_TYPE = "dataType";
     public static final String PROP_SUB_ATTRIBUTES = "subAttributes";
     public static final String PROP_CANONICAL_VALUES = "canonicalValues";
+    public static final String PROP_INPUT_TYPE = "inputFormat";
 
     public static final String PROP_MULTI_VALUED = "multiValued";
     public static final String PROP_UNIQUENESS_SCOPE = "UniquenessScope";

--- a/components/org.wso2.carbon.identity.api.server.claim.management/org.wso2.carbon.identity.api.server.claim.management.common/src/main/java/org/wso2/carbon/identity/api/server/claim/management/common/Constant.java
+++ b/components/org.wso2.carbon.identity.api.server.claim.management/org.wso2.carbon.identity.api.server.claim.management.common/src/main/java/org/wso2/carbon/identity/api/server/claim/management/common/Constant.java
@@ -316,7 +316,7 @@ public class Constant {
     public static final String PROP_DATA_TYPE = "dataType";
     public static final String PROP_SUB_ATTRIBUTES = "subAttributes";
     public static final String PROP_CANONICAL_VALUES = "canonicalValues";
-    public static final String PROP_INPUT_TYPE = "inputFormat";
+    public static final String PROP_INPUT_FORMAT = "inputFormat";
 
     public static final String PROP_MULTI_VALUED = "multiValued";
     public static final String PROP_UNIQUENESS_SCOPE = "UniquenessScope";

--- a/components/org.wso2.carbon.identity.api.server.claim.management/org.wso2.carbon.identity.api.server.claim.management.common/src/main/java/org/wso2/carbon/identity/api/server/claim/management/common/Constant.java
+++ b/components/org.wso2.carbon.identity.api.server.claim.management/org.wso2.carbon.identity.api.server.claim.management.common/src/main/java/org/wso2/carbon/identity/api/server/claim/management/common/Constant.java
@@ -235,13 +235,14 @@ public class Constant {
                 "This attribute is marked as sub attribute of the attribute %s"),
         ERROR_CODE_UNSUPPORTED_INPUT_TYPE("CMT-60017",
                 "The provided input type doesn't match with the configured attribute meta data.",
-                "The provided input type %s doesn't match with the configured attribute meta data."),
+                "The provided input type: %s doesn't match with the configured attribute meta data."),
         ERROR_CODE_BOOLEAN_ATTRIBUTE_CANNOT_BE_MULTI_VALUED("CMT-60018",
                 "Boolean attributes cannot be multi-valued.",
-                "The attribute %s is a boolean attribute and cannot be multi-valued."),
+                "The attribute: %s is a boolean attribute and cannot be multi-valued."),
         ERROR_CODE_CANONICAL_VALUES_NOT_SUPPORTED_FOR_NON_STRING_DATA_TYPES("CMT-60019",
-                "Canonical values are not supported for non-string data types.",
-                "The attribute %s is not a string data type and canonical values are not supported.");
+                "Canonical values are only supported for string data type.",
+                "The attribute: %s is not a string data type and canonical values are only supported for " +
+                        "string data type.");
 
         private final String code;
         private final String message;

--- a/components/org.wso2.carbon.identity.api.server.claim.management/org.wso2.carbon.identity.rest.api.server.claim.management.v1/src/gen/java/org/wso2/carbon/identity/rest/api/server/claim/management/v1/dto/DataType.java
+++ b/components/org.wso2.carbon.identity.api.server.claim.management/org.wso2.carbon.identity.rest.api.server.claim.management.v1/src/gen/java/org/wso2/carbon/identity/rest/api/server/claim/management/v1/dto/DataType.java
@@ -23,7 +23,7 @@ import com.fasterxml.jackson.annotation.JsonValue;
 /**
  * Enum representing the data types for claims.
  */
-public enum DataTypeEnum {
+public enum DataType {
     /**
      * String data type.
      */
@@ -51,7 +51,7 @@ public enum DataTypeEnum {
 
     private final String value;
 
-    DataTypeEnum(String value) {
+    DataType(String value) {
         this.value = value;
     }
 

--- a/components/org.wso2.carbon.identity.api.server.claim.management/org.wso2.carbon.identity.rest.api.server.claim.management.v1/src/gen/java/org/wso2/carbon/identity/rest/api/server/claim/management/v1/dto/InputFormatDTO.java
+++ b/components/org.wso2.carbon.identity.api.server.claim.management/org.wso2.carbon.identity.rest.api.server.claim.management.v1/src/gen/java/org/wso2/carbon/identity/rest/api/server/claim/management/v1/dto/InputFormatDTO.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.rest.api.server.claim.management.v1.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+
+import javax.validation.Valid;
+
+@ApiModel(description = "Input format of the attribute.")
+public class InputFormatDTO {
+
+    @Valid 
+    private InputTypeEnum inputType = null;
+
+    /**
+     * Specifies the format of the input type.
+     * @return
+     */
+    @ApiModelProperty(value = "The format of the input type.")
+    @JsonProperty("inputType")
+    public InputTypeEnum getInputType() {
+
+        return inputType;
+    }
+
+    public void setInputType(InputTypeEnum inputType) {
+
+        this.inputType = inputType;
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class InputFormatDTO {\n");
+        sb.append("    inputType: ").append(inputType).append("\n");
+        sb.append("}\n");
+        return sb.toString();
+    }
+}

--- a/components/org.wso2.carbon.identity.api.server.claim.management/org.wso2.carbon.identity.rest.api.server.claim.management.v1/src/gen/java/org/wso2/carbon/identity/rest/api/server/claim/management/v1/dto/InputFormatDTO.java
+++ b/components/org.wso2.carbon.identity.api.server.claim.management/org.wso2.carbon.identity.rest.api.server.claim.management.v1/src/gen/java/org/wso2/carbon/identity/rest/api/server/claim/management/v1/dto/InputFormatDTO.java
@@ -28,7 +28,7 @@ import javax.validation.Valid;
 public class InputFormatDTO {
 
     @Valid 
-    private InputTypeEnum inputType = null;
+    private InputType inputType = null;
 
     /**
      * Specifies the format of the input type.
@@ -36,12 +36,12 @@ public class InputFormatDTO {
      */
     @ApiModelProperty(value = "The format of the input type.")
     @JsonProperty("inputType")
-    public InputTypeEnum getInputType() {
+    public InputType getInputType() {
 
         return inputType;
     }
 
-    public void setInputType(InputTypeEnum inputType) {
+    public void setInputType(InputType inputType) {
 
         this.inputType = inputType;
     }

--- a/components/org.wso2.carbon.identity.api.server.claim.management/org.wso2.carbon.identity.rest.api.server.claim.management.v1/src/gen/java/org/wso2/carbon/identity/rest/api/server/claim/management/v1/dto/InputType.java
+++ b/components/org.wso2.carbon.identity.api.server.claim.management/org.wso2.carbon.identity.rest.api.server.claim.management.v1/src/gen/java/org/wso2/carbon/identity/rest/api/server/claim/management/v1/dto/InputType.java
@@ -23,7 +23,7 @@ import com.fasterxml.jackson.annotation.JsonValue;
 /**
  * Enum representing the input types for user attributes in a UI form.
  */
-public enum InputTypeEnum {
+public enum InputType {
 
     DROPDOWN("dropdown"),
     RADIO_GROUP("radio_group"),
@@ -32,7 +32,6 @@ public enum InputTypeEnum {
     CHECKBOX_GROUP("checkbox_group"),
 
     TEXT_INPUT("text_input"),
-    TEXTAREA("textarea"),
 
     DATE_PICKER("date_picker"),
     NUMBER_INPUT("number_input"),
@@ -42,7 +41,7 @@ public enum InputTypeEnum {
 
     private final String value;
 
-    InputTypeEnum(String value) {
+    InputType(String value) {
 
         this.value = value;
     }

--- a/components/org.wso2.carbon.identity.api.server.claim.management/org.wso2.carbon.identity.rest.api.server.claim.management.v1/src/gen/java/org/wso2/carbon/identity/rest/api/server/claim/management/v1/dto/InputTypeEnum.java
+++ b/components/org.wso2.carbon.identity.api.server.claim.management/org.wso2.carbon.identity.rest.api.server.claim.management.v1/src/gen/java/org/wso2/carbon/identity/rest/api/server/claim/management/v1/dto/InputTypeEnum.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.rest.api.server.claim.management.v1.dto;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+/**
+ * Enum representing the input types for user attributes in a UI form.
+ */
+public enum InputTypeEnum {
+
+    DROPDOWN("dropdown"),
+    RADIO_GROUP("radio_group"),
+
+    MULTI_SELECT_DROPDOWN("multi_select_dropdown"),
+    CHECKBOX_GROUP("checkbox_group"),
+
+    TEXT_INPUT("text_input"),
+    TEXTAREA("textarea"),
+
+    DATE_PICKER("date_picker"),
+    NUMBER_INPUT("number_input"),
+
+    CHECKBOX("checkbox"),
+    TOGGLE("toggle");
+
+    private final String value;
+
+    InputTypeEnum(String value) {
+
+        this.value = value;
+    }
+
+    public String getInputTypeName() {
+
+        return value;
+    }
+
+    @JsonValue
+    public String getValue() {
+
+        return value;
+    }
+}

--- a/components/org.wso2.carbon.identity.api.server.claim.management/org.wso2.carbon.identity.rest.api.server.claim.management.v1/src/gen/java/org/wso2/carbon/identity/rest/api/server/claim/management/v1/dto/LocalClaimReqDTO.java
+++ b/components/org.wso2.carbon.identity.api.server.claim.management/org.wso2.carbon.identity.rest.api.server.claim.management.v1/src/gen/java/org/wso2/carbon/identity/rest/api/server/claim/management/v1/dto/LocalClaimReqDTO.java
@@ -99,6 +99,9 @@ public class LocalClaimReqDTO {
     @Valid 
     private ProfilesDTO profiles = null;
 
+    @Valid
+    private InputFormatDTO inputFormat = null;
+
     /**
     * A unique URI specific to the claim.
     **/
@@ -310,6 +313,15 @@ public class LocalClaimReqDTO {
         this.profiles = profiles;
     }
 
+    @ApiModelProperty(value = "The input format of the attribute.")
+    @JsonProperty("inputFormat")
+    public InputFormatDTO getInputFormat() {
+        return inputFormat;
+    }
+    public void setInputFormat(InputFormatDTO inputFormat) {
+        this.inputFormat = inputFormat;
+    }
+
     @Override
     public String toString() {
 
@@ -333,6 +345,7 @@ public class LocalClaimReqDTO {
         sb.append("    attributeMapping: ").append(attributeMapping).append("\n");
         sb.append("    properties: ").append(properties).append("\n");
         sb.append("    profiles: ").append(profiles).append("\n");
+        sb.append("    inputFormat: ").append(inputFormat).append("\n");
         
         sb.append("}\n");
         return sb.toString();

--- a/components/org.wso2.carbon.identity.api.server.claim.management/org.wso2.carbon.identity.rest.api.server.claim.management.v1/src/gen/java/org/wso2/carbon/identity/rest/api/server/claim/management/v1/dto/LocalClaimReqDTO.java
+++ b/components/org.wso2.carbon.identity.api.server.claim.management/org.wso2.carbon.identity.rest.api.server.claim.management.v1/src/gen/java/org/wso2/carbon/identity/rest/api/server/claim/management/v1/dto/LocalClaimReqDTO.java
@@ -22,17 +22,14 @@ import io.swagger.annotations.ApiModel;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import org.wso2.carbon.identity.rest.api.server.claim.management.v1.dto.AttributeMappingDTO;
-import org.wso2.carbon.identity.rest.api.server.claim.management.v1.dto.ProfilesDTO;
-import org.wso2.carbon.identity.rest.api.server.claim.management.v1.dto.PropertyDTO;
+
 import io.swagger.annotations.*;
 import com.fasterxml.jackson.annotation.*;
 
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
-import javax.validation.constraints.Pattern;
 
-    /**
+/**
     * Local claim request.
     **/
 @ApiModel(description = "Local claim request.")
@@ -65,7 +62,7 @@ public class LocalClaimReqDTO {
     private Boolean supportedByDefault = null;
 
     @Valid
-    private DataTypeEnum dataType = null;
+    private DataType dataType = null;
 
     @Valid
     private String[] subAttributes = null;
@@ -203,11 +200,11 @@ public class LocalClaimReqDTO {
      **/
     @ApiModelProperty(value = "Specifies the type of data stored in the corresponding claim value.")
     @JsonProperty("dataType")
-    public DataTypeEnum getDataType() {
+    public DataType getDataType() {
 
         return dataType;
     }
-    public void setDataType(DataTypeEnum dataType) {
+    public void setDataType(DataType dataType) {
 
         this.dataType = dataType;
     }

--- a/components/org.wso2.carbon.identity.api.server.claim.management/org.wso2.carbon.identity.rest.api.server.claim.management.v1/src/gen/java/org/wso2/carbon/identity/rest/api/server/claim/management/v1/dto/LocalClaimResDTO.java
+++ b/components/org.wso2.carbon.identity.api.server.claim.management/org.wso2.carbon.identity.rest.api.server.claim.management.v1/src/gen/java/org/wso2/carbon/identity/rest/api/server/claim/management/v1/dto/LocalClaimResDTO.java
@@ -22,18 +22,13 @@ import io.swagger.annotations.ApiModel;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import org.wso2.carbon.identity.rest.api.server.claim.management.v1.dto.AttributeMappingDTO;
-import org.wso2.carbon.identity.rest.api.server.claim.management.v1.dto.ClaimResDTO;
-import org.wso2.carbon.identity.rest.api.server.claim.management.v1.dto.ProfilesDTO;
-import org.wso2.carbon.identity.rest.api.server.claim.management.v1.dto.PropertyDTO;
+
 import io.swagger.annotations.*;
 import com.fasterxml.jackson.annotation.*;
 
 import javax.validation.Valid;
-import javax.validation.constraints.NotNull;
-import javax.validation.constraints.Pattern;
 
-    /**
+/**
     * Local claim response.
     **/
 @ApiModel(description = "Local claim response.")
@@ -70,7 +65,7 @@ public class LocalClaimResDTO extends ClaimResDTO {
     private Boolean supportedByDefault = null;
 
     @Valid
-    private DataTypeEnum dataType = null;
+    private DataType dataType = null;
 
     @Valid
     private String[] subAttributes = null;
@@ -230,10 +225,10 @@ public class LocalClaimResDTO extends ClaimResDTO {
      **/
     @ApiModelProperty(value = "Specifies the type of data stored in the corresponding claim value.")
     @JsonProperty("dataType")
-    public DataTypeEnum getDataType() {
+    public DataType getDataType() {
         return dataType;
     }
-    public void setDataType(DataTypeEnum dataType) {
+    public void setDataType(DataType dataType) {
         this.dataType = dataType;
     }
 

--- a/components/org.wso2.carbon.identity.api.server.claim.management/org.wso2.carbon.identity.rest.api.server.claim.management.v1/src/gen/java/org/wso2/carbon/identity/rest/api/server/claim/management/v1/dto/LocalClaimResDTO.java
+++ b/components/org.wso2.carbon.identity.api.server.claim.management/org.wso2.carbon.identity.rest.api.server.claim.management.v1/src/gen/java/org/wso2/carbon/identity/rest/api/server/claim/management/v1/dto/LocalClaimResDTO.java
@@ -102,6 +102,9 @@ public class LocalClaimResDTO extends ClaimResDTO {
     @Valid 
     private ProfilesDTO profiles = null;
 
+    @Valid
+    private InputFormatDTO inputFormat = null;
+
     /**
     * claim ID.
     **/
@@ -338,6 +341,15 @@ public class LocalClaimResDTO extends ClaimResDTO {
         this.profiles = profiles;
     }
 
+    @ApiModelProperty(value = "The input format of the attribute.")
+    @JsonProperty("inputFormat")
+    public InputFormatDTO getInputFormat() {
+        return inputFormat;
+    }
+    public void setInputFormat(InputFormatDTO inputFormat) {
+        this.inputFormat = inputFormat;
+    }
+
     @Override
     public String toString() {
 
@@ -364,6 +376,7 @@ public class LocalClaimResDTO extends ClaimResDTO {
         sb.append("    attributeMapping: ").append(attributeMapping).append("\n");
         sb.append("    properties: ").append(properties).append("\n");
         sb.append("    profiles: ").append(profiles).append("\n");
+        sb.append("    inputFormat: ").append(inputFormat).append("\n");
         
         sb.append("}\n");
         return sb.toString();

--- a/components/org.wso2.carbon.identity.api.server.claim.management/org.wso2.carbon.identity.rest.api.server.claim.management.v1/src/main/java/org/wso2/carbon/identity/rest/api/server/claim/management/v1/core/ServerClaimManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.claim.management/org.wso2.carbon.identity.rest.api.server.claim.management.v1/src/main/java/org/wso2/carbon/identity/rest/api/server/claim/management/v1/core/ServerClaimManagementService.java
@@ -1897,16 +1897,13 @@ public class ServerClaimManagementService {
                             "to be defined.");
                 }
                 boolean isMultiValued = Boolean.TRUE.equals(localClaimReqDTO.getMultiValued());
-                if (inputType == InputType.DROPDOWN || inputType == InputType.RADIO_GROUP) {
-                    if (isMultiValued) {
-                        handleInputFormatClientException("Input format: " + inputTypeName + " requires multi valued " +
-                                "property to be false.");
-                    }
-                } else {
-                    if (!isMultiValued) {
-                        handleInputFormatClientException("Input format: " + inputTypeName + " requires multi valued " +
-                                "property to be enabled.");
-                    }
+                if (isMultiValued && (inputType == InputType.DROPDOWN || inputType == InputType.RADIO_GROUP)) {
+                    handleInputFormatClientException("Input format: " + inputTypeName + " requires multi valued " +
+                            "property to be false.");
+                } else if (!isMultiValued && (inputType == InputType.MULTI_SELECT_DROPDOWN
+                        || inputType == InputType.CHECKBOX_GROUP)) {
+                    handleInputFormatClientException("Input format: " + inputTypeName + " requires multi valued " +
+                            "property to be enabled.");
                 }
                 break;
             }

--- a/components/org.wso2.carbon.identity.api.server.claim.management/org.wso2.carbon.identity.rest.api.server.claim.management.v1/src/main/java/org/wso2/carbon/identity/rest/api/server/claim/management/v1/core/ServerClaimManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.claim.management/org.wso2.carbon.identity.rest.api.server.claim.management.v1/src/main/java/org/wso2/carbon/identity/rest/api/server/claim/management/v1/core/ServerClaimManagementService.java
@@ -56,11 +56,11 @@ import org.wso2.carbon.identity.rest.api.server.claim.management.v1.dto.Attribut
 import org.wso2.carbon.identity.rest.api.server.claim.management.v1.dto.ClaimDialectReqDTO;
 import org.wso2.carbon.identity.rest.api.server.claim.management.v1.dto.ClaimDialectResDTO;
 import org.wso2.carbon.identity.rest.api.server.claim.management.v1.dto.ClaimResDTO;
-import org.wso2.carbon.identity.rest.api.server.claim.management.v1.dto.DataTypeEnum;
+import org.wso2.carbon.identity.rest.api.server.claim.management.v1.dto.DataType;
 import org.wso2.carbon.identity.rest.api.server.claim.management.v1.dto.ExternalClaimReqDTO;
 import org.wso2.carbon.identity.rest.api.server.claim.management.v1.dto.ExternalClaimResDTO;
 import org.wso2.carbon.identity.rest.api.server.claim.management.v1.dto.InputFormatDTO;
-import org.wso2.carbon.identity.rest.api.server.claim.management.v1.dto.InputTypeEnum;
+import org.wso2.carbon.identity.rest.api.server.claim.management.v1.dto.InputType;
 import org.wso2.carbon.identity.rest.api.server.claim.management.v1.dto.LabelValueDTO;
 import org.wso2.carbon.identity.rest.api.server.claim.management.v1.dto.LinkDTO;
 import org.wso2.carbon.identity.rest.api.server.claim.management.v1.dto.LocalClaimReqDTO;
@@ -145,7 +145,7 @@ import static org.wso2.carbon.identity.api.server.claim.management.common.Consta
 import static org.wso2.carbon.identity.api.server.claim.management.common.Constant.PROP_DESCRIPTION;
 import static org.wso2.carbon.identity.api.server.claim.management.common.Constant.PROP_DISPLAY_NAME;
 import static org.wso2.carbon.identity.api.server.claim.management.common.Constant.PROP_DISPLAY_ORDER;
-import static org.wso2.carbon.identity.api.server.claim.management.common.Constant.PROP_INPUT_TYPE;
+import static org.wso2.carbon.identity.api.server.claim.management.common.Constant.PROP_INPUT_FORMAT;
 import static org.wso2.carbon.identity.api.server.claim.management.common.Constant.PROP_MULTI_VALUED;
 import static org.wso2.carbon.identity.api.server.claim.management.common.Constant.PROP_PROFILES_PREFIX;
 import static org.wso2.carbon.identity.api.server.claim.management.common.Constant.PROP_READ_ONLY;
@@ -1085,12 +1085,12 @@ public class ServerClaimManagementService {
         String dataType = handleAdditionalProperties(claimProperties, PROP_DATA_TYPE);
         if (StringUtils.isNotBlank(dataType)) {
             try {
-                localClaimResDTO.setDataType(DataTypeEnum.valueOf(dataType.toUpperCase(Locale.ENGLISH)));
+                localClaimResDTO.setDataType(DataType.valueOf(dataType.toUpperCase(Locale.ENGLISH)));
             } catch (IllegalArgumentException e) {
-                localClaimResDTO.setDataType(DataTypeEnum.STRING);
+                localClaimResDTO.setDataType(DataType.STRING);
             }
         } else {
-            localClaimResDTO.setDataType(DataTypeEnum.STRING);
+            localClaimResDTO.setDataType(DataType.STRING);
         }
 
         String subAttributes = handleAdditionalProperties(claimProperties, PROP_SUB_ATTRIBUTES);
@@ -1098,7 +1098,7 @@ public class ServerClaimManagementService {
             localClaimResDTO.setSubAttributes(subAttributes.split(" "));
         }
 
-        String inputFormat = handleAdditionalProperties(claimProperties, PROP_INPUT_TYPE);
+        String inputFormat = handleAdditionalProperties(claimProperties, PROP_INPUT_FORMAT);
         if (StringUtils.isNotEmpty(inputFormat)) {
             ObjectMapper mapper = new ObjectMapper();
             try {
@@ -1109,14 +1109,14 @@ public class ServerClaimManagementService {
             }
         } else {
             InputFormatDTO inputFormatDTO = new InputFormatDTO();
-            if (localClaimResDTO.getDataType() == DataTypeEnum.BOOLEAN) {
-                inputFormatDTO.setInputType(InputTypeEnum.CHECKBOX);
-            } else if (localClaimResDTO.getDataType() == DataTypeEnum.STRING
+            if (localClaimResDTO.getDataType() == DataType.BOOLEAN) {
+                inputFormatDTO.setInputType(InputType.CHECKBOX);
+            } else if (localClaimResDTO.getDataType() == DataType.STRING
                     && ArrayUtils.isNotEmpty(localClaimResDTO.getCanonicalValues())) {
                 if (Boolean.TRUE.equals(localClaimResDTO.getMultiValued())) {
-                    inputFormatDTO.setInputType(InputTypeEnum.MULTI_SELECT_DROPDOWN);
+                    inputFormatDTO.setInputType(InputType.MULTI_SELECT_DROPDOWN);
                 } else {
-                    inputFormatDTO.setInputType(InputTypeEnum.DROPDOWN);
+                    inputFormatDTO.setInputType(InputType.DROPDOWN);
                 }
             }
             localClaimResDTO.setInputFormat(inputFormatDTO);
@@ -1293,7 +1293,7 @@ public class ServerClaimManagementService {
                     .toLowerCase(Locale.ROOT));
         }
 
-        if (DataTypeEnum.COMPLEX.equals(localClaimReqDTO.getDataType())
+        if (DataType.COMPLEX.equals(localClaimReqDTO.getDataType())
                 && ArrayUtils.isNotEmpty(localClaimReqDTO.getSubAttributes())) {
             claimProperties.put(PROP_SUB_ATTRIBUTES, String.join(" ", localClaimReqDTO.getSubAttributes()));
         }
@@ -1312,7 +1312,7 @@ public class ServerClaimManagementService {
             try {
                 ObjectMapper mapper = new ObjectMapper();
                 String jsonString = mapper.writeValueAsString(localClaimReqDTO.getInputFormat());
-                claimProperties.put(PROP_INPUT_TYPE, jsonString);
+                claimProperties.put(PROP_INPUT_FORMAT, jsonString);
             } catch (JsonProcessingException e) {
                 LOG.error("Error while parsing canonical values.", e);
             }
@@ -1823,9 +1823,9 @@ public class ServerClaimManagementService {
 
 
         // Validate the dataType property is updated.
-        DataTypeEnum requestedDataType = localClaimReqDTO.getDataType();
+        DataType requestedDataType = localClaimReqDTO.getDataType();
         if (requestedDataType == null) {
-            requestedDataType = DataTypeEnum.STRING;
+            requestedDataType = DataType.STRING;
         }
         if (existingClaim.getDataType() != requestedDataType) {
             throw new ClaimMetadataClientException(Constant.ErrorMessage.ERROR_CODE_SYSTEM_ATTRIBUTE_DATA_TYPE_UPDATE
@@ -1835,7 +1835,7 @@ public class ServerClaimManagementService {
 
     private void validateSubAttributeUpdate(LocalClaimReqDTO localClaimReqDTO) throws ClaimMetadataException {
 
-        if (!DataTypeEnum.COMPLEX.equals(localClaimReqDTO.getDataType())) {
+        if (!DataType.COMPLEX.equals(localClaimReqDTO.getDataType())) {
             return;
         }
         if (ArrayUtils.isEmpty(localClaimReqDTO.getSubAttributes())) {
@@ -1854,7 +1854,7 @@ public class ServerClaimManagementService {
         if (localClaimReqDTO.getDataType() == null) {
             return;
         }
-        if (DataTypeEnum.BOOLEAN.equals(localClaimReqDTO.getDataType())
+        if (DataType.BOOLEAN.equals(localClaimReqDTO.getDataType())
                 && Boolean.TRUE.equals(localClaimReqDTO.getMultiValued())) {
             String errorDescription = String.format(Constant.ErrorMessage
                     .ERROR_CODE_BOOLEAN_ATTRIBUTE_CANNOT_BE_MULTI_VALUED.getDescription(),
@@ -1863,7 +1863,7 @@ public class ServerClaimManagementService {
                     .ERROR_CODE_BOOLEAN_ATTRIBUTE_CANNOT_BE_MULTI_VALUED.getCode(), errorDescription);
         }
         if (ArrayUtils.isNotEmpty(localClaimReqDTO.getCanonicalValues()) &&
-                !DataTypeEnum.STRING.equals(localClaimReqDTO.getDataType())) {
+                !DataType.STRING.equals(localClaimReqDTO.getDataType())) {
             String errorDescription = String.format(Constant.ErrorMessage
                     .ERROR_CODE_CANONICAL_VALUES_NOT_SUPPORTED_FOR_NON_STRING_DATA_TYPES.getDescription(),
                     localClaimReqDTO.getClaimURI(), localClaimReqDTO.getDataType());
@@ -1877,19 +1877,18 @@ public class ServerClaimManagementService {
         if (localClaimReqDTO.getInputFormat() == null || localClaimReqDTO.getInputFormat().getInputType() == null) {
             return; // No input format specified, no validation needed.
         }
-        InputTypeEnum inputTypeEnum = localClaimReqDTO.getInputFormat().getInputType();
-        DataTypeEnum dataType = localClaimReqDTO.getDataType();
+        InputType inputType = localClaimReqDTO.getInputFormat().getInputType();
+        DataType dataType = localClaimReqDTO.getDataType();
 
-        switch (inputTypeEnum) {
+        switch (inputType) {
             case TEXT_INPUT:
-            case TEXTAREA:
                 break;
             case DROPDOWN:
             case RADIO_GROUP:
             case MULTI_SELECT_DROPDOWN:
             case CHECKBOX_GROUP: {
-                String inputTypeName = inputTypeEnum.getInputTypeName();
-                if (!DataTypeEnum.STRING.equals(dataType)) {
+                String inputTypeName = inputType.getInputTypeName();
+                if (!DataType.STRING.equals(dataType)) {
                     handleInputFormatClientException("Input format: " + inputTypeName + " not aligned with string " +
                             "data type.");
                 }
@@ -1898,7 +1897,7 @@ public class ServerClaimManagementService {
                             "to be defined.");
                 }
                 boolean isMultiValued = Boolean.TRUE.equals(localClaimReqDTO.getMultiValued());
-                if (inputTypeEnum == InputTypeEnum.DROPDOWN || inputTypeEnum == InputTypeEnum.RADIO_GROUP) {
+                if (inputType == InputType.DROPDOWN || inputType == InputType.RADIO_GROUP) {
                     if (isMultiValued) {
                         handleInputFormatClientException("Input format: " + inputTypeName + " requires multi valued " +
                                 "property to be false.");
@@ -1912,19 +1911,19 @@ public class ServerClaimManagementService {
                 break;
             }
             case DATE_PICKER:
-                if (!DataTypeEnum.DATE_TIME.equals(dataType)) {
+                if (!DataType.DATE_TIME.equals(dataType)) {
                     handleInputFormatClientException("Input format: date_picker can be used with date data type.");
                 }
                 break;
             case NUMBER_INPUT:
-                if (!DataTypeEnum.INTEGER.equals(dataType)) {
+                if (!DataType.INTEGER.equals(dataType)) {
                     handleInputFormatClientException("Input format: number_input can be used with integer data type.");
                 }
                 break;
             case CHECKBOX:
             case TOGGLE:
-                if (!DataTypeEnum.BOOLEAN.equals(dataType)) {
-                    handleInputFormatClientException("Input format: " + inputTypeEnum.getInputTypeName() +
+                if (!DataType.BOOLEAN.equals(dataType)) {
+                    handleInputFormatClientException("Input format: " + inputType.getInputTypeName() +
                             "should be boolean data type.");
                 }
                 break;
@@ -2080,7 +2079,7 @@ public class ServerClaimManagementService {
         localClaim.getClaimProperties().putIfAbsent(PROP_REQUIRED, FALSE);
         localClaim.getClaimProperties().putIfAbsent(PROP_SUPPORTED_BY_DEFAULT, FALSE);
         localClaim.getClaimProperties().putIfAbsent(PROP_MULTI_VALUED, FALSE);
-        localClaim.getClaimProperties().putIfAbsent(PROP_DATA_TYPE, DataTypeEnum.STRING.toString()
+        localClaim.getClaimProperties().putIfAbsent(PROP_DATA_TYPE, DataType.STRING.toString()
                 .toLowerCase(Locale.ROOT));
     }
 

--- a/components/org.wso2.carbon.identity.api.server.claim.management/org.wso2.carbon.identity.rest.api.server.claim.management.v1/src/main/java/org/wso2/carbon/identity/rest/api/server/claim/management/v1/core/ServerClaimManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.claim.management/org.wso2.carbon.identity.rest.api.server.claim.management.v1/src/main/java/org/wso2/carbon/identity/rest/api/server/claim/management/v1/core/ServerClaimManagementService.java
@@ -1107,19 +1107,10 @@ public class ServerClaimManagementService {
             } catch (IOException e) {
                 LOG.error("Error while parsing inputFormat.");
             }
-        } else {
-            InputFormatDTO inputFormatDTO = new InputFormatDTO();
-            if (localClaimResDTO.getDataType() == DataType.BOOLEAN) {
+        } else if (localClaimResDTO.getDataType() == DataType.BOOLEAN) {
+                InputFormatDTO inputFormatDTO = new InputFormatDTO();
                 inputFormatDTO.setInputType(InputType.CHECKBOX);
-            } else if (localClaimResDTO.getDataType() == DataType.STRING
-                    && ArrayUtils.isNotEmpty(localClaimResDTO.getCanonicalValues())) {
-                if (Boolean.TRUE.equals(localClaimResDTO.getMultiValued())) {
-                    inputFormatDTO.setInputType(InputType.MULTI_SELECT_DROPDOWN);
-                } else {
-                    inputFormatDTO.setInputType(InputType.DROPDOWN);
-                }
-            }
-            localClaimResDTO.setInputFormat(inputFormatDTO);
+                localClaimResDTO.setInputFormat(inputFormatDTO);
         }
 
         String canonicalValues = handleAdditionalProperties(claimProperties, PROP_CANONICAL_VALUES);

--- a/components/org.wso2.carbon.identity.api.server.claim.management/org.wso2.carbon.identity.rest.api.server.claim.management.v1/src/main/java/org/wso2/carbon/identity/rest/api/server/claim/management/v1/core/ServerClaimManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.claim.management/org.wso2.carbon.identity.rest.api.server.claim.management.v1/src/main/java/org/wso2/carbon/identity/rest/api/server/claim/management/v1/core/ServerClaimManagementService.java
@@ -59,6 +59,8 @@ import org.wso2.carbon.identity.rest.api.server.claim.management.v1.dto.ClaimRes
 import org.wso2.carbon.identity.rest.api.server.claim.management.v1.dto.DataTypeEnum;
 import org.wso2.carbon.identity.rest.api.server.claim.management.v1.dto.ExternalClaimReqDTO;
 import org.wso2.carbon.identity.rest.api.server.claim.management.v1.dto.ExternalClaimResDTO;
+import org.wso2.carbon.identity.rest.api.server.claim.management.v1.dto.InputFormatDTO;
+import org.wso2.carbon.identity.rest.api.server.claim.management.v1.dto.InputTypeEnum;
 import org.wso2.carbon.identity.rest.api.server.claim.management.v1.dto.LabelValueDTO;
 import org.wso2.carbon.identity.rest.api.server.claim.management.v1.dto.LinkDTO;
 import org.wso2.carbon.identity.rest.api.server.claim.management.v1.dto.LocalClaimReqDTO;
@@ -143,6 +145,7 @@ import static org.wso2.carbon.identity.api.server.claim.management.common.Consta
 import static org.wso2.carbon.identity.api.server.claim.management.common.Constant.PROP_DESCRIPTION;
 import static org.wso2.carbon.identity.api.server.claim.management.common.Constant.PROP_DISPLAY_NAME;
 import static org.wso2.carbon.identity.api.server.claim.management.common.Constant.PROP_DISPLAY_ORDER;
+import static org.wso2.carbon.identity.api.server.claim.management.common.Constant.PROP_INPUT_TYPE;
 import static org.wso2.carbon.identity.api.server.claim.management.common.Constant.PROP_MULTI_VALUED;
 import static org.wso2.carbon.identity.api.server.claim.management.common.Constant.PROP_PROFILES_PREFIX;
 import static org.wso2.carbon.identity.api.server.claim.management.common.Constant.PROP_READ_ONLY;
@@ -527,6 +530,8 @@ public class ServerClaimManagementService {
             validateAttributeMappings(localClaimReqDTO.getAttributeMapping());
             validateSubAttributeUpdate(localClaimReqDTO);
             validateSystemClaimUpdate(localClaimReqDTO, claimId);
+            validateDataTypeUpdates(localClaimReqDTO);
+            validateAttributeInputFormat(localClaimReqDTO);
 
             claimMetadataManagementService.updateLocalClaim(createLocalClaim(localClaimReqDTO),
                     ContextLoader.getTenantDomainFromContext());
@@ -1093,6 +1098,30 @@ public class ServerClaimManagementService {
             localClaimResDTO.setSubAttributes(subAttributes.split(" "));
         }
 
+        String inputFormat = handleAdditionalProperties(claimProperties, PROP_INPUT_TYPE);
+        if (StringUtils.isNotEmpty(inputFormat)) {
+            ObjectMapper mapper = new ObjectMapper();
+            try {
+                InputFormatDTO inputFormatDTO = mapper.readValue(inputFormat, InputFormatDTO.class);
+                localClaimResDTO.setInputFormat(inputFormatDTO);
+            } catch (IOException e) {
+                LOG.error("Error while parsing inputFormat.");
+            }
+        } else {
+            InputFormatDTO inputFormatDTO = new InputFormatDTO();
+            if (localClaimResDTO.getDataType() == DataTypeEnum.BOOLEAN) {
+                inputFormatDTO.setInputType(InputTypeEnum.CHECKBOX);
+            } else if (localClaimResDTO.getDataType() == DataTypeEnum.STRING
+                    && ArrayUtils.isNotEmpty(localClaimResDTO.getCanonicalValues())) {
+                if (Boolean.TRUE.equals(localClaimResDTO.getMultiValued())) {
+                    inputFormatDTO.setInputType(InputTypeEnum.MULTI_SELECT_DROPDOWN);
+                } else {
+                    inputFormatDTO.setInputType(InputTypeEnum.DROPDOWN);
+                }
+            }
+            localClaimResDTO.setInputFormat(inputFormatDTO);
+        }
+
         String canonicalValues = handleAdditionalProperties(claimProperties, PROP_CANONICAL_VALUES);
         if (StringUtils.isNotEmpty(canonicalValues)) {
             ObjectMapper mapper = new ObjectMapper();
@@ -1274,6 +1303,16 @@ public class ServerClaimManagementService {
                 ObjectMapper mapper = new ObjectMapper();
                 String jsonString = mapper.writeValueAsString(localClaimReqDTO.getCanonicalValues());
                 claimProperties.put(PROP_CANONICAL_VALUES, jsonString);
+            } catch (JsonProcessingException e) {
+                LOG.error("Error while parsing canonical values.", e);
+            }
+        }
+
+        if (localClaimReqDTO.getInputFormat() != null) {
+            try {
+                ObjectMapper mapper = new ObjectMapper();
+                String jsonString = mapper.writeValueAsString(localClaimReqDTO.getInputFormat());
+                claimProperties.put(PROP_INPUT_TYPE, jsonString);
             } catch (JsonProcessingException e) {
                 LOG.error("Error while parsing canonical values.", e);
             }
@@ -1808,6 +1847,94 @@ public class ServerClaimManagementService {
         validateAttributeIsSubAttributeOfAnotherAttribute(localClaimReqDTO.getClaimURI(), tenantDomain);
         validateSubAttributeSCIMMappingPattern(localClaimReqDTO.getClaimURI(), tenantDomain,
                 localClaimReqDTO.getSubAttributes());
+    }
+
+    private void validateDataTypeUpdates(LocalClaimReqDTO localClaimReqDTO) throws ClaimMetadataClientException {
+
+        if (localClaimReqDTO.getDataType() == null) {
+            return;
+        }
+        if (DataTypeEnum.BOOLEAN.equals(localClaimReqDTO.getDataType())
+                && Boolean.TRUE.equals(localClaimReqDTO.getMultiValued())) {
+            String errorDescription = String.format(Constant.ErrorMessage
+                    .ERROR_CODE_BOOLEAN_ATTRIBUTE_CANNOT_BE_MULTI_VALUED.getDescription(),
+                    localClaimReqDTO.getClaimURI());
+            throw new ClaimMetadataClientException(Constant.ErrorMessage
+                    .ERROR_CODE_BOOLEAN_ATTRIBUTE_CANNOT_BE_MULTI_VALUED.getCode(), errorDescription);
+        }
+        if (ArrayUtils.isNotEmpty(localClaimReqDTO.getCanonicalValues()) &&
+                !DataTypeEnum.STRING.equals(localClaimReqDTO.getDataType())) {
+            String errorDescription = String.format(Constant.ErrorMessage
+                    .ERROR_CODE_CANONICAL_VALUES_NOT_SUPPORTED_FOR_NON_STRING_DATA_TYPES.getDescription(),
+                    localClaimReqDTO.getClaimURI(), localClaimReqDTO.getDataType());
+            throw new ClaimMetadataClientException(Constant.ErrorMessage
+                    .ERROR_CODE_CANONICAL_VALUES_NOT_SUPPORTED_FOR_NON_STRING_DATA_TYPES.getCode(), errorDescription);
+        }
+    }
+
+    private void validateAttributeInputFormat(LocalClaimReqDTO localClaimReqDTO) throws ClaimMetadataClientException {
+
+        if (localClaimReqDTO.getInputFormat() == null || localClaimReqDTO.getInputFormat().getInputType() == null) {
+            return; // No input format specified, no validation needed.
+        }
+        InputTypeEnum inputTypeEnum = localClaimReqDTO.getInputFormat().getInputType();
+        DataTypeEnum dataType = localClaimReqDTO.getDataType();
+
+        switch (inputTypeEnum) {
+            case TEXT_INPUT:
+            case TEXTAREA:
+                break;
+            case DROPDOWN:
+            case RADIO_GROUP:
+            case MULTI_SELECT_DROPDOWN:
+            case CHECKBOX_GROUP: {
+                String inputTypeName = inputTypeEnum.getInputTypeName();
+                if (!DataTypeEnum.STRING.equals(dataType)) {
+                    handleInputFormatClientException("Input format: " + inputTypeName + " not aligned with string " +
+                            "data type.");
+                }
+                if (ArrayUtils.isEmpty(localClaimReqDTO.getCanonicalValues())) {
+                    handleInputFormatClientException("Input format: " + inputTypeName + " requires multiple options " +
+                            "to be defined.");
+                }
+                boolean isMultiValued = Boolean.TRUE.equals(localClaimReqDTO.getMultiValued());
+                if (inputTypeEnum == InputTypeEnum.DROPDOWN || inputTypeEnum == InputTypeEnum.RADIO_GROUP) {
+                    if (isMultiValued) {
+                        handleInputFormatClientException("Input format: " + inputTypeName + " requires multi valued " +
+                                "property to be false.");
+                    }
+                } else {
+                    if (!isMultiValued) {
+                        handleInputFormatClientException("Input format: " + inputTypeName + " requires multi valued " +
+                                "property to be enabled.");
+                    }
+                }
+                break;
+            }
+            case DATE_PICKER:
+                if (!DataTypeEnum.DATE_TIME.equals(dataType)) {
+                    handleInputFormatClientException("Input format: date_picker can be used with date data type.");
+                }
+                break;
+            case NUMBER_INPUT:
+                if (!DataTypeEnum.INTEGER.equals(dataType)) {
+                    handleInputFormatClientException("Input format: number_input can be used with integer data type.");
+                }
+                break;
+            case CHECKBOX:
+            case TOGGLE:
+                if (!DataTypeEnum.BOOLEAN.equals(dataType)) {
+                    handleInputFormatClientException("Input format: " + inputTypeEnum.getInputTypeName() +
+                            "should be boolean data type.");
+                }
+                break;
+        }
+    }
+
+    private void handleInputFormatClientException(String errorDescription) throws ClaimMetadataClientException {
+
+        throw new ClaimMetadataClientException(Constant.ErrorMessage.ERROR_CODE_UNSUPPORTED_INPUT_TYPE.getCode(),
+                errorDescription);
     }
 
     private String getMappedSCIMClaim(String claimURI, String tenantDomain) throws ClaimMetadataException {

--- a/components/org.wso2.carbon.identity.api.server.claim.management/org.wso2.carbon.identity.rest.api.server.claim.management.v1/src/main/resources/claim-management.yaml
+++ b/components/org.wso2.carbon.identity.api.server.claim.management/org.wso2.carbon.identity.rest.api.server.claim.management.v1/src/main/resources/claim-management.yaml
@@ -782,6 +782,8 @@ definitions:
         type: boolean
         description: Specifies if the claim can hold multiple values or not.
         example: true
+      inputFormat:
+        $ref: '#/definitions/InputFormat'
       uniquenessScope:
         type: string
         description: Specifies the scope of uniqueness validation for the claim value.
@@ -878,6 +880,8 @@ definitions:
             type: boolean
             description: Specifies if the claim can hold multiple values.
             example: true
+          inputFormat:
+            $ref: '#/definitions/InputFormat'
           uniquenessScope:
             type: string
             description: Specifies the scope of uniqueness validation for the claim value.
@@ -1091,8 +1095,29 @@ definitions:
     properties:
       label:
         type: string
+        description: The display name shown to the user.
+        example: Work Account
       value:
         type: string
+        description: The internal value used in processing.
+        example: WorkAccount
+    example:
+      label: Work Account
+      value: WorkAccount
+
+  #-----------------------------------------------------
+  # InputFormat Object
+  #-----------------------------------------------------
+  InputFormat:
+    type: object
+    description: The input formatting of the attribute.
+    properties:
+      inputType:
+        type: string
+        description: Type of the input format (e.g., dropdown, checkbox, etc.)
+        example: dropdown
+    example:
+      inputType: dropdown
 
   #-----------------------------------------------------
   # The Error  object


### PR DESCRIPTION
## Purpose
The default input type of the attributes will be `text_input`. This PR gives the capability to define a input format for a given claim. The allowed input formats as per now are described below.

- dropdown
- radio_group
- checkbox_group
- multi_select_dropdown
- checkbox
- text_input
- textarea
- date_picker
- number_input
- toggle

### Related Issues
- https://github.com/wso2/product-is/issues/24392

The following property is introduced for the claim API.
```
"inputFormat": {
        "inputType": "dropdown"
}
```

Sample response.

```
{
    "id": "aHR0cDovL3dzbzIub3JnL2NsYWltcy9jdXN0b20x",
    "claimURI": "http://wso2.org/claims/custom1",
    "dialectURI": "http://wso2.org/claims",
    "description": "",
    "displayOrder": 20,
    "displayName": "custom1",
    "readOnly": false,
    "regEx": "",
    "required": false,
    "supportedByDefault": false,
    "dataType": "string",
    "subAttributes": [],
    "canonicalValues": [
        {
            "label": "ABC",
            "value": "abc"
        }
    ],
    "multiValued": false,
    "sharedProfileValueResolvingMethod": "FromOrigin",
    "attributeMapping": [
        {
            "mappedAttribute": "custom1",
            "userstore": "PRIMARY"
        }
    ],
    "properties": [
        {
            "key": "USER_CUSTOM_ATTRIBUTE",
            "value": "TRUE"
        }
    ],
    "profiles": {},
    "inputFormat": {
        "inputType": "dropdown"
    }
}
```

The API contract update.

<img width="617" alt="Screenshot 2025-06-24 at 10 21 37" src="https://github.com/user-attachments/assets/d8c2f6ee-a754-4e70-84bd-e7c8d3556fa1" />

