### PR TITLE
Remove default description population to avoid claim update mismatches from sub-orgs

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.claim.management/org.wso2.carbon.identity.rest.api.server.claim.management.v1/src/main/java/org/wso2/carbon/identity/rest/api/server/claim/management/v1/core/ServerClaimManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.claim.management/org.wso2.carbon.identity.rest.api.server.claim.management.v1/src/main/java/org/wso2/carbon/identity/rest/api/server/claim/management/v1/core/ServerClaimManagementService.java
@@ -1947,7 +1947,6 @@ public class ServerClaimManagementService {
 
     private void populateDefaultProperties(LocalClaim localClaim) {
 
-        localClaim.getClaimProperties().putIfAbsent(PROP_DESCRIPTION, StringUtils.EMPTY);
         localClaim.getClaimProperties().putIfAbsent(PROP_DISPLAY_ORDER, "0");
         localClaim.getClaimProperties().putIfAbsent(PROP_READ_ONLY, FALSE);
         localClaim.getClaimProperties().putIfAbsent(PROP_REQUIRED, FALSE);


### PR DESCRIPTION
## Purpose
This PR removes the default population of the description field in populateDefaultProperties(LocalClaim) to resolve claim update mismatches when modifying shared claims from sub-organizations.

When a custom claim is created without a description and shared, attempting to update only the attributeMapping from a sub-org fails due to a mismatch in claim properties. This happens because:

During the update operation, we compare the incoming claim properties against the existing ones.

The existing claim properties were being auto-filled with an empty string for the description field (via putIfAbsent), even if it wasn’t originally set.

Meanwhile, the incoming claim (when description is not set) does not include the field at all.

This causes a false mismatch in the comparison logic, leading to rejected updates.

### Related Issues
- https://github.com/wso2/product-is/issues/24402