### PR TITLE
Utilize subscription management service in the webhooks api

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.webhook.management/org.wso2.carbon.identity.api.server.webhook.management.v1/pom.xml
+++ b/components/org.wso2.carbon.identity.api.server.webhook.management/org.wso2.carbon.identity.api.server.webhook.management.v1/pom.xml
@@ -44,6 +44,11 @@
             </exclusions>
         </dependency>
         <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.subscription.management</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>com.fasterxml.jackson.jaxrs</groupId>
             <artifactId>jackson-jaxrs-json-provider</artifactId>
             <scope>provided</scope>

--- a/components/org.wso2.carbon.identity.api.server.webhook.management/org.wso2.carbon.identity.api.server.webhook.management.v1/src/main/java/org/wso2/carbon/identity/api/server/webhook/management/v1/core/ServerWebhookManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.webhook.management/org.wso2.carbon.identity.api.server.webhook.management.v1/src/main/java/org/wso2/carbon/identity/api/server/webhook/management/v1/core/ServerWebhookManagementService.java
@@ -27,9 +27,9 @@ import org.wso2.carbon.identity.api.server.webhook.management.v1.model.WebhookRe
 import org.wso2.carbon.identity.api.server.webhook.management.v1.model.WebhookSubscription;
 import org.wso2.carbon.identity.api.server.webhook.management.v1.model.WebhookSummary;
 import org.wso2.carbon.identity.api.server.webhook.management.v1.util.WebhookManagementAPIErrorBuilder;
+import org.wso2.carbon.identity.subscription.management.api.model.Subscription;
+import org.wso2.carbon.identity.subscription.management.api.model.SubscriptionStatus;
 import org.wso2.carbon.identity.webhook.management.api.exception.WebhookMgtException;
-import org.wso2.carbon.identity.webhook.management.api.model.Subscription;
-import org.wso2.carbon.identity.webhook.management.api.model.SubscriptionStatus;
 import org.wso2.carbon.identity.webhook.management.api.model.Webhook;
 import org.wso2.carbon.identity.webhook.management.api.model.WebhookStatus;
 import org.wso2.carbon.identity.webhook.management.api.service.WebhookManagementService;

--- a/pom.xml
+++ b/pom.xml
@@ -249,6 +249,12 @@
             </dependency>
             <dependency>
                 <groupId>org.wso2.carbon.identity.framework</groupId>
+                <artifactId>org.wso2.carbon.identity.subscription.management</artifactId>
+                <version>${carbon.identity.framework.version}</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.wso2.carbon.identity.framework</groupId>
                 <artifactId>org.wso2.carbon.identity.webhook.metadata</artifactId>
                 <version>${carbon.identity.framework.version}</version>
                 <scope>provided</scope>
@@ -947,7 +953,7 @@
         <maven.buildnumber.plugin.version>1.4</maven.buildnumber.plugin.version>
         <org.apache.felix.annotations.version>1.2.4</org.apache.felix.annotations.version>
         <identity.governance.version>1.11.27</identity.governance.version>
-        <carbon.identity.framework.version>7.8.255</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.8.269</carbon.identity.framework.version>
         <maven.findbugsplugin.version>3.0.5</maven.findbugsplugin.version>
         <findsecbugs-plugin.version>1.12.0</findsecbugs-plugin.version>
         <maven.checkstyleplugin.excludes>**/gen/**/*</maven.checkstyleplugin.excludes>


### PR DESCRIPTION
## Purpose

This pull request introduces dependency updates and version changes across multiple files to integrate the `org.wso2.carbon.identity.subscription.management` module and upgrade the `carbon.identity.framework` version. These changes ensure compatibility and extend functionality for subscription management within the webhook management service.

### Dependency Integration:

* Added the `org.wso2.carbon.identity.subscription.management` dependency with `provided` scope to the `pom.xml` files in both the project root and the `webhook.management.v1` module. This integration supports subscription management features. [[1]](diffhunk://#diff-84e84ab908499ae605b26461def45457542e2ffe69bd12bd45a806fd9e6e9e1aR46-R50) [[2]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8R250-R255)

### Version Upgrade:

* Upgraded the `carbon.identity.framework.version` from `7.8.255` to `7.8.269` in the root `pom.xml` file to ensure compatibility with the newly added subscription management module.

### Import Adjustments:

* Adjusted imports in `ServerWebhookManagementService.java` to reference classes from the `org.wso2.carbon.identity.subscription.management.api.model` package, replacing similar imports from the `org.wso2.carbon.identity.webhook.management.api.model` package. This reflects the shift to the new subscription management module.