### PR TITLE
Add attributes field support for preUpdatePassword action type in Action Management APIs

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.action.management/org.wso2.carbon.identity.api.server.action.management.v1/src/extend/java/org/wso2/carbon/identity/api/server/action/management/v1/PreUpdatePasswordActionModel.java
+++ b/components/org.wso2.carbon.identity.api.server.action.management/org.wso2.carbon.identity.api.server.action.management.v1/src/extend/java/org/wso2/carbon/identity/api/server/action/management/v1/PreUpdatePasswordActionModel.java
@@ -21,6 +21,7 @@ package org.wso2.carbon.identity.api.server.action.management.v1;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.annotations.ApiModelProperty;
 
+import java.util.List;
 import java.util.Objects;
 
 import javax.validation.Valid;
@@ -32,6 +33,7 @@ import javax.validation.constraints.NotNull;
 public class PreUpdatePasswordActionModel extends ActionModel {
 
     private PasswordSharing passwordSharing;
+    private List<String> attributes;
 
     public PreUpdatePasswordActionModel() {
         // Default constructor required for Jackson
@@ -65,6 +67,25 @@ public class PreUpdatePasswordActionModel extends ActionModel {
         this.passwordSharing = passwordSharing;
     }
 
+    public PreUpdatePasswordActionModel attributes(List<String> attributes) {
+
+        this.attributes = attributes;
+        return this;
+    }
+
+    @ApiModelProperty()
+    @JsonProperty("attributes")
+    @Valid
+    public List<String> getAttributes() {
+
+        return attributes;
+    }
+
+    public void setAttributes(List<String> attributes) {
+
+        this.attributes = attributes;
+    }
+
     @Override
     public boolean equals(java.lang.Object o) {
 
@@ -79,12 +100,13 @@ public class PreUpdatePasswordActionModel extends ActionModel {
                 Objects.equals(this.getDescription(), actionModel.getDescription()) &&
                 Objects.equals(this.getEndpoint(), actionModel.getEndpoint()) &&
                 Objects.equals(this.passwordSharing, actionModel.passwordSharing) &&
+                Objects.equals(this.attributes, actionModel.attributes) &&
                 Objects.equals(this.getRule(), actionModel.getRule());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(getName(), getDescription(), getEndpoint(), passwordSharing, getRule());
+        return Objects.hash(getName(), getDescription(), getEndpoint(), passwordSharing, attributes, getRule());
     }
 
     @Override
@@ -96,6 +118,7 @@ public class PreUpdatePasswordActionModel extends ActionModel {
         sb.append("    description: ").append(toIndentedString(getDescription())).append("\n");
         sb.append("    endpoint: ").append(toIndentedString(getEndpoint())).append("\n");
         sb.append("    passwordSharing: ").append(toIndentedString(passwordSharing)).append("\n");
+        sb.append("    attributes: ").append(toIndentedString(attributes)).append("\n");
         sb.append("    rule: ").append(toIndentedString(getRule())).append("\n");
         sb.append("}");
         return sb.toString();

--- a/components/org.wso2.carbon.identity.api.server.action.management/org.wso2.carbon.identity.api.server.action.management.v1/src/extend/java/org/wso2/carbon/identity/api/server/action/management/v1/PreUpdatePasswordActionResponse.java
+++ b/components/org.wso2.carbon.identity.api.server.action.management/org.wso2.carbon.identity.api.server.action.management.v1/src/extend/java/org/wso2/carbon/identity/api/server/action/management/v1/PreUpdatePasswordActionResponse.java
@@ -21,6 +21,7 @@ package org.wso2.carbon.identity.api.server.action.management.v1;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.annotations.ApiModelProperty;
 
+import java.util.List;
 import java.util.Objects;
 
 import javax.validation.Valid;
@@ -31,6 +32,7 @@ import javax.validation.Valid;
 public class PreUpdatePasswordActionResponse extends ActionResponse {
 
     private PasswordSharing passwordSharing;
+    private List<String> attributes;
 
     public PreUpdatePasswordActionResponse(ActionResponse actionResponse) {
 
@@ -62,6 +64,25 @@ public class PreUpdatePasswordActionResponse extends ActionResponse {
         this.passwordSharing = passwordSharing;
     }
 
+    public PreUpdatePasswordActionResponse attributes(List<String> attributes) {
+
+        this.attributes = attributes;
+        return this;
+    }
+
+    @ApiModelProperty()
+    @JsonProperty("attributes")
+    @Valid
+    public List<String> getAttributes() {
+
+        return attributes;
+    }
+
+    public void setAttributes(List<String> attributes) {
+
+        this.attributes = attributes;
+    }
+
     @Override
     public boolean equals(java.lang.Object o) {
 
@@ -79,12 +100,14 @@ public class PreUpdatePasswordActionResponse extends ActionResponse {
                 Objects.equals(this.getStatus(), actionResponse.getStatus()) &&
                 Objects.equals(this.getEndpoint(), actionResponse.getEndpoint()) &&
                 Objects.equals(this.passwordSharing, actionResponse.passwordSharing) &&
+                Objects.equals(this.attributes, actionResponse.attributes) &&
                 Objects.equals(this.getRule(), actionResponse.getRule());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(getId(), getType(), getName(), getDescription(), getStatus(), getEndpoint(), getRule());
+        return Objects.hash(getId(), getType(), getName(), getDescription(), getStatus(), getEndpoint(),
+                passwordSharing, attributes, getRule());
     }
 
     @Override
@@ -99,6 +122,7 @@ public class PreUpdatePasswordActionResponse extends ActionResponse {
         sb.append("    status: ").append(toIndentedString(getStatus())).append("\n");
         sb.append("    endpoint: ").append(toIndentedString(getEndpoint())).append("\n");
         sb.append("    passwordSharing: ").append(toIndentedString(passwordSharing)).append("\n");
+        sb.append("    attributes: ").append(toIndentedString(attributes)).append("\n");
         sb.append("    rule: ").append(toIndentedString(getRule())).append("\n");
         sb.append("}");
         return sb.toString();

--- a/components/org.wso2.carbon.identity.api.server.action.management/org.wso2.carbon.identity.api.server.action.management.v1/src/extend/java/org/wso2/carbon/identity/api/server/action/management/v1/PreUpdatePasswordActionUpdateModel.java
+++ b/components/org.wso2.carbon.identity.api.server.action.management/org.wso2.carbon.identity.api.server.action.management.v1/src/extend/java/org/wso2/carbon/identity/api/server/action/management/v1/PreUpdatePasswordActionUpdateModel.java
@@ -21,6 +21,7 @@ package org.wso2.carbon.identity.api.server.action.management.v1;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.annotations.ApiModelProperty;
 
+import java.util.List;
 import java.util.Objects;
 
 import javax.validation.Valid;
@@ -31,6 +32,7 @@ import javax.validation.Valid;
 public class PreUpdatePasswordActionUpdateModel extends ActionUpdateModel {
 
     private PasswordSharingUpdateModel passwordSharing;
+    private List<String> attributes;
 
     public PreUpdatePasswordActionUpdateModel() {
         // Default constructor required for Jackson
@@ -63,6 +65,25 @@ public class PreUpdatePasswordActionUpdateModel extends ActionUpdateModel {
         this.passwordSharing = passwordSharing;
     }
 
+    public PreUpdatePasswordActionUpdateModel attributes(List<String> attributes) {
+
+        this.attributes = attributes;
+        return this;
+    }
+
+    @ApiModelProperty()
+    @JsonProperty("attributes")
+    @Valid
+    public List<String> getAttributes() {
+
+        return attributes;
+    }
+
+    public void setAttributes(List<String> attributes) {
+
+        this.attributes = attributes;
+    }
+
     @Override
     public boolean equals(java.lang.Object o) {
 
@@ -77,12 +98,13 @@ public class PreUpdatePasswordActionUpdateModel extends ActionUpdateModel {
                 Objects.equals(this.getDescription(), actionUpdateModel.getDescription()) &&
                 Objects.equals(this.getEndpoint(), actionUpdateModel.getEndpoint()) &&
                 Objects.equals(this.passwordSharing, actionUpdateModel.passwordSharing) &&
+                Objects.equals(this.attributes, actionUpdateModel.attributes) &&
                 Objects.equals(this.getRule(), actionUpdateModel.getRule());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(getName(), getDescription(), getEndpoint(), passwordSharing, getRule());
+        return Objects.hash(getName(), getDescription(), getEndpoint(), passwordSharing, attributes, getRule());
     }
 
     @Override
@@ -94,6 +116,7 @@ public class PreUpdatePasswordActionUpdateModel extends ActionUpdateModel {
         sb.append("    description: ").append(toIndentedString(getDescription())).append("\n");
         sb.append("    endpoint: ").append(toIndentedString(getEndpoint())).append("\n");
         sb.append("    passwordSharing: ").append(toIndentedString(passwordSharing)).append("\n");
+        sb.append("    attributes: ").append(toIndentedString(attributes)).append("\n");
         sb.append("    rule: ").append(toIndentedString(getRule())).append("\n");
         sb.append("}");
         return sb.toString();

--- a/components/org.wso2.carbon.identity.api.server.action.management/org.wso2.carbon.identity.api.server.action.management.v1/src/main/java/org/wso2/carbon/identity/api/server/action/management/v1/core/ServerActionManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.action.management/org.wso2.carbon.identity.api.server.action.management.v1/src/main/java/org/wso2/carbon/identity/api/server/action/management/v1/core/ServerActionManagementService.java
@@ -106,8 +106,7 @@ public class ServerActionManagementService {
                 throw ActionMgtEndpointUtil.handleException(Response.Status.NOT_FOUND,
                         ERROR_NO_ACTION_FOUND_ON_GIVEN_ACTION_TYPE_AND_ID);
             }
-            return buildActionResponse(actionManagementService.getActionByActionId(actionType, actionId,
-                    CarbonContext.getThreadLocalCarbonContext().getTenantDomain()));
+            return buildActionResponse(action);
         } catch (ActionMgtException e) {
             throw ActionMgtEndpointUtil.handleActionMgtException(e);
         }

--- a/components/org.wso2.carbon.identity.api.server.action.management/org.wso2.carbon.identity.api.server.action.management.v1/src/main/java/org/wso2/carbon/identity/api/server/action/management/v1/mapper/PreUpdatePasswordActionMapper.java
+++ b/components/org.wso2.carbon.identity.api.server.action.management/org.wso2.carbon.identity.api.server.action.management.v1/src/main/java/org/wso2/carbon/identity/api/server/action/management/v1/mapper/PreUpdatePasswordActionMapper.java
@@ -53,6 +53,7 @@ public class PreUpdatePasswordActionMapper implements ActionMapper {
         Action basicAction = ActionMapperUtil.buildActionRequest(getSupportedActionType(), actionModel);
         return new PreUpdatePasswordAction.RequestBuilder(basicAction)
                 .passwordSharing(buildPasswordSharingRequest((PreUpdatePasswordActionModel) actionModel))
+                .attributes(((PreUpdatePasswordActionModel) actionModel).getAttributes())
                 .build();
     }
 
@@ -69,6 +70,7 @@ public class PreUpdatePasswordActionMapper implements ActionMapper {
         return new PreUpdatePasswordAction.RequestBuilder(basicUpdatingAction)
                 .passwordSharing(
                         buildPasswordSharingUpdateRequest((PreUpdatePasswordActionUpdateModel) actionUpdateModel))
+                .attributes(((PreUpdatePasswordActionUpdateModel) actionUpdateModel).getAttributes())
                 .build();
     }
 
@@ -82,7 +84,9 @@ public class PreUpdatePasswordActionMapper implements ActionMapper {
 
         ActionResponse actionResponse = ActionMapperUtil.buildActionResponse(action);
         return new PreUpdatePasswordActionResponse(actionResponse)
-                .passwordSharing(buildPasswordSharingResponse((PreUpdatePasswordAction) action));
+                .passwordSharing(buildPasswordSharingResponse((PreUpdatePasswordAction) action))
+                .attributes(((PreUpdatePasswordAction) action).getAttributes());
+
     }
 
     private PasswordSharing buildPasswordSharingRequest(PreUpdatePasswordActionModel actionModel) {

--- a/components/org.wso2.carbon.identity.api.server.action.management/org.wso2.carbon.identity.api.server.action.management.v1/src/main/resources/Actions.yaml
+++ b/components/org.wso2.carbon.identity.api.server.action.management/org.wso2.carbon.identity.api.server.action.management.v1/src/main/resources/Actions.yaml
@@ -46,6 +46,11 @@ paths:
                   description: This action invokes before updating a user password.
                   count: 1
                   self: "/api/server/v1/actions/preUpdatePassword"
+                - type: PRE_UPDATE_PROFILE
+                  displayName: Pre Update Profile
+                  description: This action invokes before updating a user profile.
+                  count: 1
+                  self: "/api/server/v1/actions/preUpdateProfile"
         '401':
           description: Unauthorized
         '403':
@@ -130,6 +135,9 @@ paths:
                   passwordSharing:
                     format: SHA256_HASHED
                     certificate: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURxRENDQXBDZ0F3SUJBZ0lFWlhCR0NUQU5CZ2txaGtpRzl3MEJBUXNGQURCaU1Rc3dDUVlEVlFRR0V3SlYNClV6RUxNQWtHQTFVRUNBd0NRMEV4RkRBU0JnTlZCQWNNQzFOaGJuUmhJRU5zWVhKaE1RMHdDd1lEVlFRS0RBUlgNClUwOHlNUTB3Q3dZRFZRUUxEQVJYVTA4eU1SSXdFQVlEVlFRRERBbHNiMk5oYkdodmMzUXdIaGNOTWpNeE1qQTINCk1EazFPVE0zV2hjTk1qVXdNVEEzTURrMU9UTTNXakJpTVFzd0NRWURWUVFHRXdKVlV6RUxNQWtHQTFVRUNBd0MNClEwRXhGREFTQmdOVkJBY01DMU5oYm5SaElFTnNZWEpoTVEwd0N3WURWUVFLREFSWFUwOHlNUTB3Q3dZRFZRUUwNCkRBUlhVMDh5TVJJd0VBWURWUVFEREFsc2IyTmhiR2h2YzNRd2dnRWlNQTBHQ1NxR1NJYjNEUUVCQVFVQUE0SUINCkR3QXdnZ0VLQW9JQkFRQ2E0amx3OEtyWHMzOTZTdktmVFEwMkllUm9hWnF1ZWtvSlNpdzBsOWU5QkkyRWF2blQNCkc4SnlvcDh6MnJPcjZDNmpqZGdVeXR6NWpCaG9wYmdmeHJQMmkwTkd1akpGTE5uU1U4cmNoRDJUSjlRbzh0V3YNCmZqQUtDL1VsUnhTb0VyT1RkejdYUzFDY1BmNm9RZk56TVo2QnkyOXpmSVN1QytyV25qTHFUM002ejBGMGIzK20NCm9paVpmUTA1RjAwaHd6U0U5V0JsTCtHUnh3cHlRUVl3c2JHZlordmlJM0VHdjdzUnYreHFwTFBoVzVTTHpoR3oNCnNaaTlDME0wRzFqYnZWMWQrUFkwTVRoRTYwcmthdmpNKytSUkJlc29pNUprblprc0F0OWhPcXhZM0ExSU1kREENCk5wZEtxaGRGMWFBeURYK3ZUWkZySGZMc3VFQmVjNVBwM3RJWEFnTUJBQUdqWmpCa01BNEdBMVVkRHdFQi93UUUNCkF3SUU4REFVQmdOVkhSRUVEVEFMZ2dsc2IyTmhiR2h2YzNRd0hRWURWUjBPQkJZRUZIWFhWMm5sb2ZoaThXd2oNCncwRW9hRlNZbldiU01CMEdBMVVkSlFRV01CUUdDQ3NHQVFVRkJ3TUJCZ2dyQmdFRkJRY0RBakFOQmdrcWhraUcNCjl3MEJBUXNGQUFPQ0FRRUFSZThESThuNzJlVWxReTlHU3BpeXh2OFFVSEZkaVFhMW5CVzluVlRaZHlKb1NYMHENCmg2TjN4Vk5KWFIzL3pMdkw4TUJWTXZqa3QwT1FxdkVpeWp3bkVXTzZEYnhUUnIzdmRmK3J2NVZ3ZGtZbjRNY00NCkt4NHhGOFphZzh4aHlhWXFVUXpRWG5nNTFyVjErYzR1elh1Z0VoRTVTemRESFlFWHpYNmpvWklnMXlOK2hFUGMNCjc3UlpKSkhtd0lRclRkM2JuWnB5dEI2UmRCam5qU3loMEJlSGxKUUdtUHhvbXhZQVMxaFZzelJkZld0cnhEQUINCmZsSUppbUppSGgzZHlrY3lObHJ3QnU5MDNwTWRVR1FHcXNVeUVqaEZkN3M0QXp1cVlISnI1cll5OTUwZGY5SWINCllTaHUyWWZsVkVzV1pxSlI2MkNpYldCY0pLeUhQWW10QzBjU1JRPT0NCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K
+                  attributes:
+                    - http://wso2.org/claims/givenname
+                    - http://wso2.org/claims/dob
                   rule:
                     condition: OR
                     rules:
@@ -146,6 +154,37 @@ paths:
                           - field: flow
                             operator: equals
                             value: userInitiatedPasswordReset
+              preUpdateProfile:
+                summary: Sample payload for pre update profile action
+                value:
+                  name: Profile Update Action
+                  description: This action invokes before updating a user profile.
+                  endpoint:
+                    uri: https://myextension.com/pre-update-profile
+                    authentication:
+                      properties:
+                        header: x-api-key
+                        value: e12595c1-1435-4bf2-94e8-445135ab505a
+                      type: API_KEY
+                  attributes:
+                    - http://wso2.org/claims/givenname
+                    - http://wso2.org/claims/dob
+                  rule:
+                    condition: OR
+                    rules:
+                      - condition: AND
+                        expressions:
+                          - field: flow
+                            operator: equals
+                            value: adminInitiatedProfileUpdate
+                          - field: claim
+                            operator: notEquals
+                            value: http://wso2.org/claims/country
+                      - condition: AND
+                        expressions:
+                          - field: flow
+                            operator: equals
+                            value: userInitiatedProfileUpdate
         description: This represents the information of the action to be created.
         required: true
       responses:
@@ -162,7 +201,7 @@ paths:
                     id: 24f64d17-9824-4e28-8413-de45728d8e84
                     name: Access Token Pre Issue
                     description: This action invokes before issuing an access token.
-                    status: ACTIVE
+                    status: INACTIVE
                     endpoint:
                       uri: https://myextension.com/token
                       authentication:
@@ -189,7 +228,7 @@ paths:
                     id: 24f64d17-9824-4e28-8413-de45728d8e84
                     name: Password Update Action
                     description: This action invokes before updating a user password.
-                    status: ACTIVE
+                    status: INACTIVE
                     endpoint:
                       uri: https://myextension.com/pre-update-password
                       authentication:
@@ -197,6 +236,9 @@ paths:
                     passwordSharing:
                       format: SHA256_HASHED
                       certificate: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURxRENDQXBDZ0F3SUJBZ0lFWlhCR0NUQU5CZ2txaGtpRzl3MEJBUXNGQURCaU1Rc3dDUVlEVlFRR0V3SlYNClV6RUxNQWtHQTFVRUNBd0NRMEV4RkRBU0JnTlZCQWNNQzFOaGJuUmhJRU5zWVhKaE1RMHdDd1lEVlFRS0RBUlgNClUwOHlNUTB3Q3dZRFZRUUxEQVJYVTA4eU1SSXdFQVlEVlFRRERBbHNiMk5oYkdodmMzUXdIaGNOTWpNeE1qQTINCk1EazFPVE0zV2hjTk1qVXdNVEEzTURrMU9UTTNXakJpTVFzd0NRWURWUVFHRXdKVlV6RUxNQWtHQTFVRUNBd0MNClEwRXhGREFTQmdOVkJBY01DMU5oYm5SaElFTnNZWEpoTVEwd0N3WURWUVFLREFSWFUwOHlNUTB3Q3dZRFZRUUwNCkRBUlhVMDh5TVJJd0VBWURWUVFEREFsc2IyTmhiR2h2YzNRd2dnRWlNQTBHQ1NxR1NJYjNEUUVCQVFVQUE0SUINCkR3QXdnZ0VLQW9JQkFRQ2E0amx3OEtyWHMzOTZTdktmVFEwMkllUm9hWnF1ZWtvSlNpdzBsOWU5QkkyRWF2blQNCkc4SnlvcDh6MnJPcjZDNmpqZGdVeXR6NWpCaG9wYmdmeHJQMmkwTkd1akpGTE5uU1U4cmNoRDJUSjlRbzh0V3YNCmZqQUtDL1VsUnhTb0VyT1RkejdYUzFDY1BmNm9RZk56TVo2QnkyOXpmSVN1QytyV25qTHFUM002ejBGMGIzK20NCm9paVpmUTA1RjAwaHd6U0U5V0JsTCtHUnh3cHlRUVl3c2JHZlordmlJM0VHdjdzUnYreHFwTFBoVzVTTHpoR3oNCnNaaTlDME0wRzFqYnZWMWQrUFkwTVRoRTYwcmthdmpNKytSUkJlc29pNUprblprc0F0OWhPcXhZM0ExSU1kREENCk5wZEtxaGRGMWFBeURYK3ZUWkZySGZMc3VFQmVjNVBwM3RJWEFnTUJBQUdqWmpCa01BNEdBMVVkRHdFQi93UUUNCkF3SUU4REFVQmdOVkhSRUVEVEFMZ2dsc2IyTmhiR2h2YzNRd0hRWURWUjBPQkJZRUZIWFhWMm5sb2ZoaThXd2oNCncwRW9hRlNZbldiU01CMEdBMVVkSlFRV01CUUdDQ3NHQVFVRkJ3TUJCZ2dyQmdFRkJRY0RBakFOQmdrcWhraUcNCjl3MEJBUXNGQUFPQ0FRRUFSZThESThuNzJlVWxReTlHU3BpeXh2OFFVSEZkaVFhMW5CVzluVlRaZHlKb1NYMHENCmg2TjN4Vk5KWFIzL3pMdkw4TUJWTXZqa3QwT1FxdkVpeWp3bkVXTzZEYnhUUnIzdmRmK3J2NVZ3ZGtZbjRNY00NCkt4NHhGOFphZzh4aHlhWXFVUXpRWG5nNTFyVjErYzR1elh1Z0VoRTVTemRESFlFWHpYNmpvWklnMXlOK2hFUGMNCjc3UlpKSkhtd0lRclRkM2JuWnB5dEI2UmRCam5qU3loMEJlSGxKUUdtUHhvbXhZQVMxaFZzelJkZld0cnhEQUINCmZsSUppbUppSGgzZHlrY3lObHJ3QnU5MDNwTWRVR1FHcXNVeUVqaEZkN3M0QXp1cVlISnI1cll5OTUwZGY5SWINCllTaHUyWWZsVkVzV1pxSlI2MkNpYldCY0pLeUhQWW10QzBjU1JRPT0NCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K
+                    attributes:
+                      - http://wso2.org/claims/givenname
+                      - http://wso2.org/claims/dob
                     rule:
                       condition: OR
                       rules:
@@ -213,6 +255,36 @@ paths:
                             - field: flow
                               operator: equals
                               value: userInitiatedPasswordReset
+                preUpdateProfile:
+                  summary: Sample response for pre update profile action
+                  value:
+                    id: 24f64d17-9824-4e28-8413-de45728d8e84
+                    name: Profile Update Action
+                    description: This action invokes before updating a user profile.
+                    status: INACTIVE
+                    endpoint:
+                      uri: https://myextension.com/pre-update-profile
+                      authentication:
+                        type: API_KEY
+                    attributes:
+                      - http://wso2.org/claims/givenname
+                      - http://wso2.org/claims/dob
+                    rule:
+                      condition: OR
+                      rules:
+                        - condition: AND
+                          expressions:
+                            - field: flow
+                              operator: equals
+                              value: adminInitiatedProfileUpdate
+                            - field: claim
+                              operator: notEquals
+                              value: http://wso2.org/claims/country
+                        - condition: AND
+                          expressions:
+                            - field: flow
+                              operator: equals
+                              value: userInitiatedProfileUpdate
         '400':
           description: Bad Request
           content:
@@ -275,7 +347,28 @@ paths:
                 },
                 "passwordSharing": {
                     "format": "SHA256_HASHED"
-                }
+                },
+                "attributes": ["http://wso2.org/claims/givenname", "http://wso2.org/claims/dob"]
+            }'
+        - lang: Curl - preUpdateProfile
+          source: |
+            curl --location 'https://localhost:9443/api/server/v1/actions/preUpdateProfile' \
+            -H 'Authorization: Basic YWRtaW46YWRtaW4=' \
+            -H 'Content-Type: application/json' \
+            -d '{
+                "name": "Profile Update Action",
+                "description": "This action invokes before updating a user profile.",
+                "endpoint": {
+                    "uri": "https://myextension.com/pre-update-profile",
+                    "authentication": {
+                        "properties": {
+                            "header": "x-api-key",
+                            "value": "e12595c1-1435-4bf2-94e8-445135ab505a"
+                        },
+                        "type": "API_KEY"
+                    }
+                },
+                "attributes": ["http://wso2.org/claims/givenname", "http://wso2.org/claims/dob"]
             }'
       x-codegen-request-body-name: body
 
@@ -327,6 +420,18 @@ paths:
                       status: ACTIVE
                       links:
                         - href: "/api/server/v1/actions/preUpdatePassword/24f64d17-9824-4e28-8413-de45728d8e84"
+                          method: GET
+                          rel: self
+                preUpdateProfile:
+                  summary: Sample response for pre update profile action
+                  value:
+                    - id: 24f64d17-9824-4e28-8413-de45728d8e84
+                      type: PRE_UPDATE_PROFILE
+                      name: Profile Update Action
+                      description: This action invokes before updating a user profile.
+                      status: ACTIVE
+                      links:
+                        - href: "/api/server/v1/actions/preUpdateProfile/24f64d17-9824-4e28-8413-de45728d8e84"
                           method: GET
                           rel: self
         '400':
@@ -439,6 +544,9 @@ paths:
                     passwordSharing:
                       format: SHA256_HASHED
                       certificate: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURxRENDQXBDZ0F3SUJBZ0lFWlhCR0NUQU5CZ2txaGtpRzl3MEJBUXNGQURCaU1Rc3dDUVlEVlFRR0V3SlYNClV6RUxNQWtHQTFVRUNBd0NRMEV4RkRBU0JnTlZCQWNNQzFOaGJuUmhJRU5zWVhKaE1RMHdDd1lEVlFRS0RBUlgNClUwOHlNUTB3Q3dZRFZRUUxEQVJYVTA4eU1SSXdFQVlEVlFRRERBbHNiMk5oYkdodmMzUXdIaGNOTWpNeE1qQTINCk1EazFPVE0zV2hjTk1qVXdNVEEzTURrMU9UTTNXakJpTVFzd0NRWURWUVFHRXdKVlV6RUxNQWtHQTFVRUNBd0MNClEwRXhGREFTQmdOVkJBY01DMU5oYm5SaElFTnNZWEpoTVEwd0N3WURWUVFLREFSWFUwOHlNUTB3Q3dZRFZRUUwNCkRBUlhVMDh5TVJJd0VBWURWUVFEREFsc2IyTmhiR2h2YzNRd2dnRWlNQTBHQ1NxR1NJYjNEUUVCQVFVQUE0SUINCkR3QXdnZ0VLQW9JQkFRQ2E0amx3OEtyWHMzOTZTdktmVFEwMkllUm9hWnF1ZWtvSlNpdzBsOWU5QkkyRWF2blQNCkc4SnlvcDh6MnJPcjZDNmpqZGdVeXR6NWpCaG9wYmdmeHJQMmkwTkd1akpGTE5uU1U4cmNoRDJUSjlRbzh0V3YNCmZqQUtDL1VsUnhTb0VyT1RkejdYUzFDY1BmNm9RZk56TVo2QnkyOXpmSVN1QytyV25qTHFUM002ejBGMGIzK20NCm9paVpmUTA1RjAwaHd6U0U5V0JsTCtHUnh3cHlRUVl3c2JHZlordmlJM0VHdjdzUnYreHFwTFBoVzVTTHpoR3oNCnNaaTlDME0wRzFqYnZWMWQrUFkwTVRoRTYwcmthdmpNKytSUkJlc29pNUprblprc0F0OWhPcXhZM0ExSU1kREENCk5wZEtxaGRGMWFBeURYK3ZUWkZySGZMc3VFQmVjNVBwM3RJWEFnTUJBQUdqWmpCa01BNEdBMVVkRHdFQi93UUUNCkF3SUU4REFVQmdOVkhSRUVEVEFMZ2dsc2IyTmhiR2h2YzNRd0hRWURWUjBPQkJZRUZIWFhWMm5sb2ZoaThXd2oNCncwRW9hRlNZbldiU01CMEdBMVVkSlFRV01CUUdDQ3NHQVFVRkJ3TUJCZ2dyQmdFRkJRY0RBakFOQmdrcWhraUcNCjl3MEJBUXNGQUFPQ0FRRUFSZThESThuNzJlVWxReTlHU3BpeXh2OFFVSEZkaVFhMW5CVzluVlRaZHlKb1NYMHENCmg2TjN4Vk5KWFIzL3pMdkw4TUJWTXZqa3QwT1FxdkVpeWp3bkVXTzZEYnhUUnIzdmRmK3J2NVZ3ZGtZbjRNY00NCkt4NHhGOFphZzh4aHlhWXFVUXpRWG5nNTFyVjErYzR1elh1Z0VoRTVTemRESFlFWHpYNmpvWklnMXlOK2hFUGMNCjc3UlpKSkhtd0lRclRkM2JuWnB5dEI2UmRCam5qU3loMEJlSGxKUUdtUHhvbXhZQVMxaFZzelJkZld0cnhEQUINCmZsSUppbUppSGgzZHlrY3lObHJ3QnU5MDNwTWRVR1FHcXNVeUVqaEZkN3M0QXp1cVlISnI1cll5OTUwZGY5SWINCllTaHUyWWZsVkVzV1pxSlI2MkNpYldCY0pLeUhQWW10QzBjU1JRPT0NCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K
+                    attributes:
+                      - http://wso2.org/claims/givenname
+                      - http://wso2.org/claims/dob
                     rule:
                       condition: OR
                       rules:
@@ -455,6 +563,37 @@ paths:
                             - field: flow
                               operator: equals
                               value: userInitiatedPasswordReset
+                preUpdateProfile:
+                  summary: Sample response for pre update profile action
+                  value:
+                    id: 24f64d17-9824-4e28-8413-de45728d8e84
+                    type: PRE_UPDATE_PROFILE
+                    name: Profile Update Action
+                    description: This action invokes before updating a user profile.
+                    status: ACTIVE
+                    endpoint:
+                      uri: https://myextension.com/pre-update-profile
+                      authentication:
+                        type: API_KEY
+                    attributes:
+                      - http://wso2.org/claims/givenname
+                      - http://wso2.org/claims/dob
+                    rule:
+                      condition: OR
+                      rules:
+                        - condition: AND
+                          expressions:
+                            - field: flow
+                              operator: equals
+                              value: adminInitiatedProfileUpdate
+                            - field: claim
+                              operator: notEquals
+                              value: http://wso2.org/claims/country
+                        - condition: AND
+                          expressions:
+                            - field: flow
+                              operator: equals
+                              value: userInitiatedProfileUpdate
         '400':
           description: Bad Request
           content:
@@ -553,6 +692,8 @@ paths:
                   passwordSharing:
                     format: PLAIN_TEXT
                     certificate: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURxRENDQXBDZ0F3SUJBZ0lFWlhCR0NUQU5CZ2txaGtpRzl3MEJBUXNGQURCaU1Rc3dDUVlEVlFRR0V3SlYNClV6RUxNQWtHQTFVRUNBd0NRMEV4RkRBU0JnTlZCQWNNQzFOaGJuUmhJRU5zWVhKaE1RMHdDd1lEVlFRS0RBUlgNClUwOHlNUTB3Q3dZRFZRUUxEQVJYVTA4eU1SSXdFQVlEVlFRRERBbHNiMk5oYkdodmMzUXdIaGNOTWpNeE1qQTINCk1EazFPVE0zV2hjTk1qVXdNVEEzTURrMU9UTTNXakJpTVFzd0NRWURWUVFHRXdKVlV6RUxNQWtHQTFVRUNBd0MNClEwRXhGREFTQmdOVkJBY01DMU5oYm5SaElFTnNZWEpoTVEwd0N3WURWUVFLREFSWFUwOHlNUTB3Q3dZRFZRUUwNCkRBUlhVMDh5TVJJd0VBWURWUVFEREFsc2IyTmhiR2h2YzNRd2dnRWlNQTBHQ1NxR1NJYjNEUUVCQVFVQUE0SUINCkR3QXdnZ0VLQW9JQkFRQ2E0amx3OEtyWHMzOTZTdktmVFEwMkllUm9hWnF1ZWtvSlNpdzBsOWU5QkkyRWF2blQNCkc4SnlvcDh6MnJPcjZDNmpqZGdVeXR6NWpCaG9wYmdmeHJQMmkwTkd1akpGTE5uU1U4cmNoRDJUSjlRbzh0V3YNCmZqQUtDL1VsUnhTb0VyT1RkejdYUzFDY1BmNm9RZk56TVo2QnkyOXpmSVN1QytyV25qTHFUM002ejBGMGIzK20NCm9paVpmUTA1RjAwaHd6U0U5V0JsTCtHUnh3cHlRUVl3c2JHZlordmlJM0VHdjdzUnYreHFwTFBoVzVTTHpoR3oNCnNaaTlDME0wRzFqYnZWMWQrUFkwTVRoRTYwcmthdmpNKytSUkJlc29pNUprblprc0F0OWhPcXhZM0ExSU1kREENCk5wZEtxaGRGMWFBeURYK3ZUWkZySGZMc3VFQmVjNVBwM3RJWEFnTUJBQUdqWmpCa01BNEdBMVVkRHdFQi93UUUNCkF3SUU4REFVQmdOVkhSRUVEVEFMZ2dsc2IyTmhiR2h2YzNRd0hRWURWUjBPQkJZRUZIWFhWMm5sb2ZoaThXd2oNCncwRW9hRlNZbldiU01CMEdBMVVkSlFRV01CUUdDQ3NHQVFVRkJ3TUJCZ2dyQmdFRkJRY0RBakFOQmdrcWhraUcNCjl3MEJBUXNGQUFPQ0FRRUFSZThESThuNzJlVWxReTlHU3BpeXh2OFFVSEZkaVFhMW5CVzluVlRaZHlKb1NYMHENCmg2TjN4Vk5KWFIzL3pMdkw4TUJWTXZqa3QwT1FxdkVpeWp3bkVXTzZEYnhUUnIzdmRmK3J2NVZ3ZGtZbjRNY00NCkt4NHhGOFphZzh4aHlhWXFVUXpRWG5nNTFyVjErYzR1elh1Z0VoRTVTemRESFlFWHpYNmpvWklnMXlOK2hFUGMNCjc3UlpKSkhtd0lRclRkM2JuWnB5dEI2UmRCam5qU3loMEJlSGxKUUdtUHhvbXhZQVMxaFZzelJkZld0cnhEQUINCmZsSUppbUppSGgzZHlrY3lObHJ3QnU5MDNwTWRVR1FHcXNVeUVqaEZkN3M0QXp1cVlISnI1cll5OTUwZGY5SWINCllTaHUyWWZsVkVzV1pxSlI2MkNpYldCY0pLeUhQWW10QzBjU1JRPT0NCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K
+                  attributes:
+                    - http://wso2.org/claims/dob
                   rule:
                     condition: OR
                     rules:
@@ -564,6 +705,29 @@ paths:
                           - field: flow
                             operator: notEquals
                             value: adminInitiatedPasswordUpdate
+              preUpdateProfile:
+                summary: Sample payload for pre update profile action update
+                value:
+                  name: Updated Profile Update Action
+                  description: This action invokes before updating a user profile.
+                  endpoint:
+                    uri: https://myextension.com/external/pre-update-profile
+                    authentication:
+                      properties: {}
+                      type: NONE
+                  attributes:
+                    - http://wso2.org/claims/dob
+                  rule:
+                    condition: OR
+                    rules:
+                      - condition: AND
+                        expressions:
+                          - field: flow
+                            operator: equals
+                            value: userInitiatedProfileUpdate
+                          - field: claim
+                            operator: notEquals
+                            value: http://wso2.org/claims/postalcode
         description: This represents the action to be updated.
         required: true
       responses:
@@ -610,6 +774,8 @@ paths:
                     passwordSharing:
                       format: PLAIN_TEXT
                       certificate: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURxRENDQXBDZ0F3SUJBZ0lFWlhCR0NUQU5CZ2txaGtpRzl3MEJBUXNGQURCaU1Rc3dDUVlEVlFRR0V3SlYNClV6RUxNQWtHQTFVRUNBd0NRMEV4RkRBU0JnTlZCQWNNQzFOaGJuUmhJRU5zWVhKaE1RMHdDd1lEVlFRS0RBUlgNClUwOHlNUTB3Q3dZRFZRUUxEQVJYVTA4eU1SSXdFQVlEVlFRRERBbHNiMk5oYkdodmMzUXdIaGNOTWpNeE1qQTINCk1EazFPVE0zV2hjTk1qVXdNVEEzTURrMU9UTTNXakJpTVFzd0NRWURWUVFHRXdKVlV6RUxNQWtHQTFVRUNBd0MNClEwRXhGREFTQmdOVkJBY01DMU5oYm5SaElFTnNZWEpoTVEwd0N3WURWUVFLREFSWFUwOHlNUTB3Q3dZRFZRUUwNCkRBUlhVMDh5TVJJd0VBWURWUVFEREFsc2IyTmhiR2h2YzNRd2dnRWlNQTBHQ1NxR1NJYjNEUUVCQVFVQUE0SUINCkR3QXdnZ0VLQW9JQkFRQ2E0amx3OEtyWHMzOTZTdktmVFEwMkllUm9hWnF1ZWtvSlNpdzBsOWU5QkkyRWF2blQNCkc4SnlvcDh6MnJPcjZDNmpqZGdVeXR6NWpCaG9wYmdmeHJQMmkwTkd1akpGTE5uU1U4cmNoRDJUSjlRbzh0V3YNCmZqQUtDL1VsUnhTb0VyT1RkejdYUzFDY1BmNm9RZk56TVo2QnkyOXpmSVN1QytyV25qTHFUM002ejBGMGIzK20NCm9paVpmUTA1RjAwaHd6U0U5V0JsTCtHUnh3cHlRUVl3c2JHZlordmlJM0VHdjdzUnYreHFwTFBoVzVTTHpoR3oNCnNaaTlDME0wRzFqYnZWMWQrUFkwTVRoRTYwcmthdmpNKytSUkJlc29pNUprblprc0F0OWhPcXhZM0ExSU1kREENCk5wZEtxaGRGMWFBeURYK3ZUWkZySGZMc3VFQmVjNVBwM3RJWEFnTUJBQUdqWmpCa01BNEdBMVVkRHdFQi93UUUNCkF3SUU4REFVQmdOVkhSRUVEVEFMZ2dsc2IyTmhiR2h2YzNRd0hRWURWUjBPQkJZRUZIWFhWMm5sb2ZoaThXd2oNCncwRW9hRlNZbldiU01CMEdBMVVkSlFRV01CUUdDQ3NHQVFVRkJ3TUJCZ2dyQmdFRkJRY0RBakFOQmdrcWhraUcNCjl3MEJBUXNGQUFPQ0FRRUFSZThESThuNzJlVWxReTlHU3BpeXh2OFFVSEZkaVFhMW5CVzluVlRaZHlKb1NYMHENCmg2TjN4Vk5KWFIzL3pMdkw4TUJWTXZqa3QwT1FxdkVpeWp3bkVXTzZEYnhUUnIzdmRmK3J2NVZ3ZGtZbjRNY00NCkt4NHhGOFphZzh4aHlhWXFVUXpRWG5nNTFyVjErYzR1elh1Z0VoRTVTemRESFlFWHpYNmpvWklnMXlOK2hFUGMNCjc3UlpKSkhtd0lRclRkM2JuWnB5dEI2UmRCam5qU3loMEJlSGxKUUdtUHhvbXhZQVMxaFZzelJkZld0cnhEQUINCmZsSUppbUppSGgzZHlrY3lObHJ3QnU5MDNwTWRVR1FHcXNVeUVqaEZkN3M0QXp1cVlISnI1cll5OTUwZGY5SWINCllTaHUyWWZsVkVzV1pxSlI2MkNpYldCY0pLeUhQWW10QzBjU1JRPT0NCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K
+                    attributes:
+                      - http://wso2.org/claims/dob
                     rule:
                       condition: OR
                       rules:
@@ -621,6 +787,30 @@ paths:
                             - field: flow
                               operator: notEquals
                               value: adminInitiatedPasswordUpdate
+                preUpdateProfile:
+                  summary: Sample response for pre update profile action update
+                  value:
+                    id: 24f64d17-9824-4e28-8413-de45728d8e84
+                    name: Updated Profile Update Action
+                    description: This action invokes before updating a user profile.
+                    status: ACTIVE
+                    endpoint:
+                      uri: https://myextension.com/external/pre-update-profile
+                      authentication:
+                        type: NONE
+                    attributes:
+                      - http://wso2.org/claims/dob
+                    rule:
+                      condition: OR
+                      rules:
+                        - condition: AND
+                          expressions:
+                            - field: flow
+                              operator: equals
+                              value: userInitiatedProfileUpdate
+                            - field: claim
+                              operator: notEquals
+                              value: http://wso2.org/claims/postalcode
         '400':
           description: Bad Request
           content:
@@ -688,7 +878,26 @@ paths:
                 },
                 "passwordSharing": {
                     "format": "PLAIN_TEXT"
-                }
+                },
+                "attributes": ["http://wso2.org/claims/dob"]
+            }'
+        - lang: Curl - preUpdateProfile
+          source: |
+            curl --location --request PATCH 'https://localhost:9443/api/server/v1/actions/preUpdateProfile/{actionId}' \
+            -H 'Content-Type: application/json' \
+            -H 'Accept: application/json' \
+            -H 'Authorization: Basic YWRtaW46YWRtaW4=' \
+            -d '{
+                "name": "Updated Profile Update Action",
+                "description": "This is the configuration of pre-action for updating profile",
+                "endpoint": {
+                    "uri": "http://myextensions.com/external/pre-update-profile",
+                    "authentication": {
+                        "type": "NONE",
+                        "properties": {}
+                    }
+                },
+                "attributes": ["http://wso2.org/claims/dob"]
             }'
       x-codegen-request-body-name: body
 
@@ -804,6 +1013,18 @@ paths:
                         - href: "/api/server/v1/actions/preUpdatePassword/24f64d17-9824-4e28-8413-de45728d8e84"
                           method: GET
                           rel: self
+                preUpdateProfile:
+                  summary: Sample response for pre update profile action
+                  value:
+                    - id: 24f64d17-9824-4e28-8413-de45728d8e84
+                      type: PRE_UPDATE_PROFILE
+                      name: Profile Update Action
+                      description: This action invokes before updating a user profile.
+                      status: ACTIVE
+                      links:
+                        - href: "/api/server/v1/actions/preUpdateProfile/24f64d17-9824-4e28-8413-de45728d8e84"
+                          method: GET
+                          rel: self
         '400':
           description: Bad Request
           content:
@@ -893,6 +1114,18 @@ paths:
                       status: INACTIVE
                       links:
                         - href: "/api/server/v1/actions/preUpdatePassword/24f64d17-9824-4e28-8413-de45728d8e84"
+                          method: GET
+                          rel: self
+                preUpdateProfile:
+                  summary: Sample response for pre update profile action
+                  value:
+                    - id: 24f64d17-9824-4e28-8413-de45728d8e84
+                      type: PRE_UPDATE_PROFILE
+                      name: Profile Update Action
+                      description: This action invokes before updating a user profile.
+                      status: INACTIVE
+                      links:
+                        - href: "/api/server/v1/actions/preUpdateProfile/24f64d17-9824-4e28-8413-de45728d8e84"
                           method: GET
                           rel: self
         '400':

--- a/pom.xml
+++ b/pom.xml
@@ -953,7 +953,7 @@
         <maven.buildnumber.plugin.version>1.4</maven.buildnumber.plugin.version>
         <org.apache.felix.annotations.version>1.2.4</org.apache.felix.annotations.version>
         <identity.governance.version>1.11.27</identity.governance.version>
-        <carbon.identity.framework.version>7.8.269</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.8.273</carbon.identity.framework.version>
         <maven.findbugsplugin.version>3.0.5</maven.findbugsplugin.version>
         <findsecbugs-plugin.version>1.12.0</findsecbugs-plugin.version>
         <maven.checkstyleplugin.excludes>**/gen/**/*</maven.checkstyleplugin.excludes>


### PR DESCRIPTION
## Purpose
> Provide support for the new `attributes` field in preUpdatePassword action type in Action Management APIs.

## Depends on
- https://github.com/wso2/carbon-identity-framework/pull/6924

### Related Issue
- https://github.com/wso2/product-is/issues/24555