### PR TITLE
Fix the server error thrown when updating OIDC protocol parameters without providing the "allowedOrigins" attribute in the request body

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/application/management/v1/OpenIDConnectConfiguration.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/application/management/v1/OpenIDConnectConfiguration.java
@@ -217,8 +217,12 @@ public enum StateEnum {
     @JsonProperty("allowedOrigins")
     @Valid
     public List<String> getAllowedOrigins() {
+        if (this.allowedOrigins == null) {
+            this.allowedOrigins = new ArrayList<>();
+        }
         return allowedOrigins;
     }
+
     public void setAllowedOrigins(List<String> allowedOrigins) {
         this.allowedOrigins = allowedOrigins;
     }


### PR DESCRIPTION
## Purpose
> Fixes the server error thrown when updating OIDC protocol parameters without providing the "allowedOrigins" attribute in the request body.
Resolves issue [product-is#23159](https://github.com/wso2/product-is/issues/23159).

## Goals
> Ensure the backend gracefully handles requests that omit the allowedOrigins field by defaulting it to an empty list, preventing server errors.

## Approach
> Added a null-check in the getter of the request model for OpenIDConnectConfiguration
```java
public List<String> getAllowedOrigins() {
    if (this.allowedOrigins == null) {
        this.allowedOrigins = new ArrayList<>();
    }
    return allowedOrigins;
}
```
This ensures allowedOrigins is never null during request processing.

## User stories
> N/A

## Developer Checklist (Mandatory)

- [x] Complete the **Developer Checklist** in the related `product-is` issue to track any behavioral change or migration impact.

## Release note
> Fixes a server error occurring when the allowedOrigins field is missing in OIDC inbound protocol update requests by safely handling null values.

## Documentation
> N/A — no change in API contract or documentation required; the allowedOrigins field remains optional.

## Training
> N/A

## Certification
> N/A — This change is an internal bug fix related to null handling in the backend and does not impact certification exam content or questions.

## Marketing
> N/A

## Automation tests
 - Unit tests cover null-safe handling of inbound protocol fields.
 - Integration tests validated that requests without allowedOrigins no longer cause server errors.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> N/A

## Related PRs
> N/A

## Migrations (if applicable)
> N/A

## Test environment
- JDK 11

- macOS

- WSO2 Identity Server local build

- Postman 11.51
 
## Learning
> N/A.