### PR TITLE
Refactored the webhook metadata api implementation

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.webhook.metadata/org.wso2.carbon.identity.api.server.webhook.metadata.v1/src/main/java/org/wso2/carbon/identity/api/server/webhook/metadata/v1/constants/WebhookMetadataEndpointConstants.java
+++ b/components/org.wso2.carbon.identity.api.server.webhook.metadata/org.wso2.carbon.identity.api.server.webhook.metadata.v1/src/main/java/org/wso2/carbon/identity/api/server/webhook/metadata/v1/constants/WebhookMetadataEndpointConstants.java
@@ -29,4 +29,46 @@ public class WebhookMetadataEndpointConstants {
     private WebhookMetadataEndpointConstants() {
 
     }
+
+    /**
+     * Enum for error messages.
+     */
+    public enum ErrorMessage {
+
+        // Client errors.
+        ERROR_CODE_PROFILE_NOT_FOUND("WEBHOOKMETA-61001", "Profile not found",
+                "The requested event profile %s could not be found.");
+
+        private final String code;
+        private final String message;
+        private final String description;
+
+        ErrorMessage(String code, String message, String description) {
+
+            this.code = code;
+            this.message = message;
+            this.description = description;
+        }
+
+        public String getCode() {
+
+            return code;
+        }
+
+        public String getMessage() {
+
+            return message;
+        }
+
+        public String getDescription() {
+
+            return description;
+        }
+
+        @Override
+        public String toString() {
+
+            return code + " | " + message;
+        }
+    }
 }

--- a/components/org.wso2.carbon.identity.api.server.webhook.metadata/org.wso2.carbon.identity.api.server.webhook.metadata.v1/src/main/java/org/wso2/carbon/identity/api/server/webhook/metadata/v1/core/ServerWebhookMetadataService.java
+++ b/components/org.wso2.carbon.identity.api.server.webhook.metadata/org.wso2.carbon.identity.api.server.webhook.metadata.v1/src/main/java/org/wso2/carbon/identity/api/server/webhook/metadata/v1/core/ServerWebhookMetadataService.java
@@ -30,8 +30,11 @@ import org.wso2.carbon.identity.webhook.metadata.api.exception.WebhookMetadataEx
 import java.util.List;
 import java.util.stream.Collectors;
 
+import javax.ws.rs.core.Response;
+
 import static org.wso2.carbon.identity.api.server.common.Constants.V1_API_PATH_COMPONENT;
 import static org.wso2.carbon.identity.api.server.webhook.metadata.v1.constants.WebhookMetadataEndpointConstants.EVENT_PROFILE_PATH_COMPONENT;
+import static org.wso2.carbon.identity.api.server.webhook.metadata.v1.constants.WebhookMetadataEndpointConstants.ErrorMessage.ERROR_CODE_PROFILE_NOT_FOUND;
 import static org.wso2.carbon.identity.api.server.webhook.metadata.v1.constants.WebhookMetadataEndpointConstants.WEBHOOK_METADATA_PATH_COMPONENT;
 
 /**
@@ -50,6 +53,10 @@ public class ServerWebhookMetadataService {
         try {
             org.wso2.carbon.identity.webhook.metadata.api.model.EventProfile eventProfile =
                     WebhookMetadataServiceHolder.getWebhookMetadataService().getEventProfile(profileName);
+            if (eventProfile == null) {
+                throw WebhookMetadataAPIErrorBuilder.buildAPIError(Response.Status.NOT_FOUND,
+                        ERROR_CODE_PROFILE_NOT_FOUND, profileName);
+            }
             return mapEventProfile(eventProfile);
         } catch (WebhookMetadataException e) {
             throw WebhookMetadataAPIErrorBuilder.buildAPIError(e);

--- a/components/org.wso2.carbon.identity.api.server.webhook.metadata/org.wso2.carbon.identity.api.server.webhook.metadata.v1/src/main/java/org/wso2/carbon/identity/api/server/webhook/metadata/v1/util/WebhookMetadataAPIErrorBuilder.java
+++ b/components/org.wso2.carbon.identity.api.server.webhook.metadata/org.wso2.carbon.identity.api.server.webhook.metadata.v1/src/main/java/org/wso2/carbon/identity/api/server/webhook/metadata/v1/util/WebhookMetadataAPIErrorBuilder.java
@@ -18,20 +18,16 @@
 
 package org.wso2.carbon.identity.api.server.webhook.metadata.v1.util;
 
+import org.apache.commons.lang.ArrayUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.identity.api.server.common.error.APIError;
 import org.wso2.carbon.identity.api.server.common.error.ErrorDTO;
+import org.wso2.carbon.identity.api.server.webhook.metadata.v1.constants.WebhookMetadataEndpointConstants;
 import org.wso2.carbon.identity.webhook.metadata.api.exception.WebhookMetadataClientException;
 import org.wso2.carbon.identity.webhook.metadata.api.exception.WebhookMetadataException;
 
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.Set;
-
 import javax.ws.rs.core.Response;
-
-import static org.wso2.carbon.identity.webhook.metadata.api.constant.ErrorMessage.ERROR_CODE_PROFILE_NOT_FOUND;
 
 /**
  * Class that handles exceptions and builds API error object.
@@ -39,31 +35,29 @@ import static org.wso2.carbon.identity.webhook.metadata.api.constant.ErrorMessag
 public class WebhookMetadataAPIErrorBuilder {
 
     private static final Log LOG = LogFactory.getLog(WebhookMetadataAPIErrorBuilder.class);
-    private static final Set<String> NOT_FOUND_ERRORS = Collections.unmodifiableSet(new HashSet<>(
-            Collections.singletonList(
-                    ERROR_CODE_PROFILE_NOT_FOUND.getCode()
-            )));
-
-    private WebhookMetadataAPIErrorBuilder() {
-
-    }
 
     public static APIError buildAPIError(WebhookMetadataException exception) {
 
         Response.Status status = Response.Status.INTERNAL_SERVER_ERROR;
         if (exception instanceof WebhookMetadataClientException) {
             LOG.debug(exception.getMessage(), exception);
-            if (NOT_FOUND_ERRORS.contains(exception.getErrorCode())) {
-                status = Response.Status.NOT_FOUND;
-            } else {
-                status = Response.Status.BAD_REQUEST;
-            }
+            status = Response.Status.BAD_REQUEST;
         } else {
             LOG.error(exception.getMessage(), exception);
         }
 
         String errorCode = exception.getErrorCode();
         return buildAPIError(status, errorCode, exception.getMessage(), exception.getDescription());
+    }
+
+    public static APIError buildAPIError(Response.Status status, WebhookMetadataEndpointConstants.ErrorMessage error,
+                                         String... data) {
+
+        String description = error.getDescription();
+        if (ArrayUtils.isNotEmpty(data)) {
+            description = String.format(description, (Object[]) data);
+        }
+        return buildAPIError(status, error.getCode(), error.getMessage(), description);
     }
 
     private static APIError buildAPIError(Response.Status status, String errorCode,

--- a/pom.xml
+++ b/pom.xml
@@ -953,7 +953,7 @@
         <maven.buildnumber.plugin.version>1.4</maven.buildnumber.plugin.version>
         <org.apache.felix.annotations.version>1.2.4</org.apache.felix.annotations.version>
         <identity.governance.version>1.11.27</identity.governance.version>
-        <carbon.identity.framework.version>7.8.273</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.8.278-SNAPSHOT</carbon.identity.framework.version>
         <maven.findbugsplugin.version>3.0.5</maven.findbugsplugin.version>
         <findsecbugs-plugin.version>1.12.0</findsecbugs-plugin.version>
         <maven.checkstyleplugin.excludes>**/gen/**/*</maven.checkstyleplugin.excludes>


### PR DESCRIPTION
## Purpose

This pull request introduces enhancements to error handling in the webhook metadata API and updates a dependency version in the project. Key changes include the addition of an `ErrorMessage` enum for standardized error codes and descriptions, improvements to the API error builder utility, and a dependency upgrade in the `pom.xml` file.

### Enhancements to Error Handling:

* **Addition of `ErrorMessage` Enum**: Introduced a new `ErrorMessage` enum in `WebhookMetadataEndpointConstants` to centralize error codes, messages, and descriptions for client errors, such as "Profile not found." This improves consistency and maintainability. (`WebhookMetadataEndpointConstants.java`, [components/org.wso2.carbon.identity.api.server.webhook.metadata/org.wso2.carbon.identity.api.server.webhook.metadata.v1/src/main/java/org/wso2/carbon/identity/api/server/webhook/metadata/v1/constants/WebhookMetadataEndpointConstants.javaR32-R73](diffhunk://#diff-5dafb676f3c0f39bb4c2d47a6bee0a286b2b5c08748f3c269925031c23567420R32-R73))
* **Improved Error Handling in `ServerWebhookMetadataService`**: Added logic to throw a structured API error when an event profile is not found, leveraging the new `ErrorMessage` enum for error details. (`ServerWebhookMetadataService.java`, [components/org.wso2.carbon.identity.api.server.webhook.metadata/org.wso2.carbon.identity.api.server.webhook.metadata.v1/src/main/java/org/wso2/carbon/identity/api/server/webhook/metadata/v1/core/ServerWebhookMetadataService.javaR56-R59](diffhunk://#diff-d682502396fa953793530cbbddcc08aece8e669ac9f6f2eaa06fdb3c102cbad0R56-R59))
* **Refactoring of `WebhookMetadataAPIErrorBuilder`**: Simplified the error builder utility by removing hardcoded error sets and introducing a method to build API errors dynamically using the `ErrorMessage` enum. (`WebhookMetadataAPIErrorBuilder.java`, [components/org.wso2.carbon.identity.api.server.webhook.metadata/org.wso2.carbon.identity.api.server.webhook.metadata.v1/src/main/java/org/wso2/carbon/identity/api/server/webhook/metadata/v1/util/WebhookMetadataAPIErrorBuilder.javaR53-R62](diffhunk://#diff-f8bd4539db95c7b81046570d919484c9133be7b5d4ee4bc08cdc75c4499fb036R53-R62))

### Dependency Update:

* **Upgrade of `carbon.identity.framework` Version**: Updated the framework dependency version in `pom.xml` from `7.8.273` to `7.8.278-SNAPSHOT` to incorporate the latest fixes and features. (`pom.xml`, [pom.xmlL956-R956](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L956-R956))