### PR TITLE
Include hasChildren and ancestorPath details to organization get responses as required

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/management/v1/model/BasicOrganizationResponse.java
+++ b/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/management/v1/model/BasicOrganizationResponse.java
@@ -185,12 +185,10 @@ public enum StatusEnum {
         this.hasChildren = hasChildren;
         return this;
     }
-
-    @ApiModelProperty(example = "true", required = true, value = "")
+    
+    @ApiModelProperty(example = "true", value = "")
     @JsonProperty("hasChildren")
     @Valid
-    @NotNull(message = "Property hasChildren cannot be null.")
-
     public Boolean getHasChildren() {
         return hasChildren;
     }

--- a/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/management/v1/model/BasicOrganizationResponse.java
+++ b/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/management/v1/model/BasicOrganizationResponse.java
@@ -73,6 +73,7 @@ public enum StatusEnum {
 
     private StatusEnum status;
     private String version;
+    private Boolean hasChildren;
     private String ref;
     private List<Attribute> attributes = null;
 
@@ -179,13 +180,33 @@ public enum StatusEnum {
 
     /**
     **/
+    public BasicOrganizationResponse hasChildren(Boolean hasChildren) {
+
+        this.hasChildren = hasChildren;
+        return this;
+    }
+
+    @ApiModelProperty(example = "true", required = true, value = "")
+    @JsonProperty("hasChildren")
+    @Valid
+    @NotNull(message = "Property hasChildren cannot be null.")
+
+    public Boolean getHasChildren() {
+        return hasChildren;
+    }
+    public void setHasChildren(Boolean hasChildren) {
+        this.hasChildren = hasChildren;
+    }
+
+    /**
+    **/
     public BasicOrganizationResponse ref(String ref) {
 
         this.ref = ref;
         return this;
     }
     
-    @ApiModelProperty(example = "o/10084a8d-113f-4211-a0d5-efe36b082211/api/server/v1/organizations/b4526d91-a8bf-43d2-8b14-c548cf73065b", required = true, value = "")
+    @ApiModelProperty(example = "/api/server/v1/organizations/b4526d91-a8bf-43d2-8b14-c548cf73065b", required = true, value = "")
     @JsonProperty("ref")
     @Valid
     @NotNull(message = "Property ref cannot be null.")
@@ -240,13 +261,14 @@ public enum StatusEnum {
             Objects.equals(this.orgHandle, basicOrganizationResponse.orgHandle) &&
             Objects.equals(this.status, basicOrganizationResponse.status) &&
             Objects.equals(this.version, basicOrganizationResponse.version) &&
+            Objects.equals(this.hasChildren, basicOrganizationResponse.hasChildren) &&
             Objects.equals(this.ref, basicOrganizationResponse.ref) &&
             Objects.equals(this.attributes, basicOrganizationResponse.attributes);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, name, orgHandle, status, version, ref, attributes);
+        return Objects.hash(id, name, orgHandle, status, version, hasChildren, ref, attributes);
     }
 
     @Override
@@ -260,6 +282,7 @@ public enum StatusEnum {
         sb.append("    orgHandle: ").append(toIndentedString(orgHandle)).append("\n");
         sb.append("    status: ").append(toIndentedString(status)).append("\n");
         sb.append("    version: ").append(toIndentedString(version)).append("\n");
+        sb.append("    hasChildren: ").append(toIndentedString(hasChildren)).append("\n");
         sb.append("    ref: ").append(toIndentedString(ref)).append("\n");
         sb.append("    attributes: ").append(toIndentedString(attributes)).append("\n");
         sb.append("}");

--- a/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/management/v1/model/GetOrganizationResponse.java
+++ b/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/management/v1/model/GetOrganizationResponse.java
@@ -25,6 +25,7 @@ import io.swagger.annotations.ApiModelProperty;
 import java.util.ArrayList;
 import java.util.List;
 import org.wso2.carbon.identity.api.server.organization.management.v1.model.Attribute;
+import org.wso2.carbon.identity.api.server.organization.management.v1.model.GetOrganizationResponseAncestorPath;
 import org.wso2.carbon.identity.api.server.organization.management.v1.model.ParentOrganization;
 import javax.validation.constraints.*;
 
@@ -111,10 +112,13 @@ public enum TypeEnum {
 }
 
     private TypeEnum type;
+    private Boolean hasChildren;
     private ParentOrganization parent;
     private List<Attribute> attributes = null;
 
     private List<String> permissions = null;
+
+    private List<GetOrganizationResponseAncestorPath> ancestorPath = null;
 
 
     /**
@@ -297,6 +301,26 @@ public enum TypeEnum {
 
     /**
     **/
+    public GetOrganizationResponse hasChildren(Boolean hasChildren) {
+
+        this.hasChildren = hasChildren;
+        return this;
+    }
+
+    @ApiModelProperty(example = "true", required = true, value = "")
+    @JsonProperty("hasChildren")
+    @Valid
+    @NotNull(message = "Property hasChildren cannot be null.")
+
+    public Boolean getHasChildren() {
+        return hasChildren;
+    }
+    public void setHasChildren(Boolean hasChildren) {
+        this.hasChildren = hasChildren;
+    }
+
+    /**
+    **/
     public GetOrganizationResponse parent(ParentOrganization parent) {
 
         this.parent = parent;
@@ -365,7 +389,33 @@ public enum TypeEnum {
         return this;
     }
 
-    
+        /**
+    **/
+    public GetOrganizationResponse ancestorPath(List<GetOrganizationResponseAncestorPath> ancestorPath) {
+
+        this.ancestorPath = ancestorPath;
+        return this;
+    }
+
+    @ApiModelProperty(example = "[{\"id\":\"10084a8d-113f-4211-a0d5-efe36b082211\",\"name\":\"Global Holding Corp\",\"depth\":0},{\"id\":\"b4526d91-a8bf-43d2-8b14-c548cf73065b\",\"name\":\"South Asia Division\",\"depth\":1}]", value = "")
+    @JsonProperty("ancestorPath")
+    @Valid
+    public List<GetOrganizationResponseAncestorPath> getAncestorPath() {
+        return ancestorPath;
+    }
+    public void setAncestorPath(List<GetOrganizationResponseAncestorPath> ancestorPath) {
+        this.ancestorPath = ancestorPath;
+    }
+
+    public GetOrganizationResponse addAncestorPathItem(GetOrganizationResponseAncestorPath ancestorPathItem) {
+        if (this.ancestorPath == null) {
+            this.ancestorPath = new ArrayList<>();
+        }
+        this.ancestorPath.add(ancestorPathItem);
+        return this;
+    }
+
+
 
     @Override
     public boolean equals(java.lang.Object o) {
@@ -386,14 +436,16 @@ public enum TypeEnum {
             Objects.equals(this.created, getOrganizationResponse.created) &&
             Objects.equals(this.lastModified, getOrganizationResponse.lastModified) &&
             Objects.equals(this.type, getOrganizationResponse.type) &&
+            Objects.equals(this.hasChildren, getOrganizationResponse.hasChildren) &&
             Objects.equals(this.parent, getOrganizationResponse.parent) &&
             Objects.equals(this.attributes, getOrganizationResponse.attributes) &&
-            Objects.equals(this.permissions, getOrganizationResponse.permissions);
+            Objects.equals(this.permissions, getOrganizationResponse.permissions) &&
+            Objects.equals(this.ancestorPath, getOrganizationResponse.ancestorPath);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, name, orgHandle, description, status, version, created, lastModified, type, parent, attributes, permissions);
+        return Objects.hash(id, name, orgHandle, description, status, version, created, lastModified, type, hasChildren, parent, attributes, permissions);
     }
 
     @Override
@@ -411,9 +463,11 @@ public enum TypeEnum {
         sb.append("    created: ").append(toIndentedString(created)).append("\n");
         sb.append("    lastModified: ").append(toIndentedString(lastModified)).append("\n");
         sb.append("    type: ").append(toIndentedString(type)).append("\n");
+        sb.append("    hasChildren: ").append(toIndentedString(hasChildren)).append("\n");
         sb.append("    parent: ").append(toIndentedString(parent)).append("\n");
         sb.append("    attributes: ").append(toIndentedString(attributes)).append("\n");
         sb.append("    permissions: ").append(toIndentedString(permissions)).append("\n");
+        sb.append("    ancestorPath: ").append(toIndentedString(ancestorPath)).append("\n");
         sb.append("}");
         return sb.toString();
     }

--- a/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/management/v1/model/GetOrganizationResponse.java
+++ b/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/management/v1/model/GetOrganizationResponse.java
@@ -307,11 +307,9 @@ public enum TypeEnum {
         return this;
     }
 
-    @ApiModelProperty(example = "true", required = true, value = "")
+    @ApiModelProperty(example = "true", value = "")
     @JsonProperty("hasChildren")
     @Valid
-    @NotNull(message = "Property hasChildren cannot be null.")
-
     public Boolean getHasChildren() {
         return hasChildren;
     }
@@ -390,14 +388,15 @@ public enum TypeEnum {
     }
 
         /**
+    * Ancestors up to the request initiated organization
     **/
     public GetOrganizationResponse ancestorPath(List<GetOrganizationResponseAncestorPath> ancestorPath) {
 
         this.ancestorPath = ancestorPath;
         return this;
     }
-
-    @ApiModelProperty(example = "[{\"id\":\"10084a8d-113f-4211-a0d5-efe36b082211\",\"name\":\"Global Holding Corp\",\"depth\":0},{\"id\":\"b4526d91-a8bf-43d2-8b14-c548cf73065b\",\"name\":\"South Asia Division\",\"depth\":1}]", value = "")
+    
+    @ApiModelProperty(example = "[{\"id\":\"10084a8d-113f-4211-a0d5-efe36b082211\",\"name\":\"Global Holding Corp\",\"depth\":0},{\"id\":\"b4526d91-a8bf-43d2-8b14-c548cf73065b\",\"name\":\"South Asia Division\",\"depth\":1}]", value = "Ancestors up to the request initiated organization")
     @JsonProperty("ancestorPath")
     @Valid
     public List<GetOrganizationResponseAncestorPath> getAncestorPath() {
@@ -445,7 +444,7 @@ public enum TypeEnum {
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, name, orgHandle, description, status, version, created, lastModified, type, hasChildren, parent, attributes, permissions);
+        return Objects.hash(id, name, orgHandle, description, status, version, created, lastModified, type, hasChildren, parent, attributes, permissions, ancestorPath);
     }
 
     @Override

--- a/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/management/v1/model/GetOrganizationResponseAncestorPath.java
+++ b/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/management/v1/model/GetOrganizationResponseAncestorPath.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -30,24 +30,23 @@ import java.util.Objects;
 import javax.validation.Valid;
 import javax.xml.bind.annotation.*;
 
-public class ParentOrganization  {
+public class GetOrganizationResponseAncestorPath  {
   
     private String id;
-    private String ref;
+    private String name;
+    private Integer depth;
 
     /**
     **/
-    public ParentOrganization id(String id) {
+    public GetOrganizationResponseAncestorPath id(String id) {
 
         this.id = id;
         return this;
     }
     
-    @ApiModelProperty(example = "b4526d91-a8bf-43d2-8b14-c548cf73065b", required = true, value = "")
+    @ApiModelProperty(value = "")
     @JsonProperty("id")
     @Valid
-    @NotNull(message = "Property id cannot be null.")
-
     public String getId() {
         return id;
     }
@@ -57,22 +56,38 @@ public class ParentOrganization  {
 
     /**
     **/
-    public ParentOrganization ref(String ref) {
+    public GetOrganizationResponseAncestorPath name(String name) {
 
-        this.ref = ref;
+        this.name = name;
         return this;
     }
     
-    @ApiModelProperty(example = "/api/server/v1/organizations/b4526d91-a8bf-43d2-8b14-c548cf73065b", required = true, value = "")
-    @JsonProperty("ref")
+    @ApiModelProperty(value = "")
+    @JsonProperty("name")
     @Valid
-    @NotNull(message = "Property ref cannot be null.")
-
-    public String getRef() {
-        return ref;
+    public String getName() {
+        return name;
     }
-    public void setRef(String ref) {
-        this.ref = ref;
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    /**
+    **/
+    public GetOrganizationResponseAncestorPath depth(Integer depth) {
+
+        this.depth = depth;
+        return this;
+    }
+    
+    @ApiModelProperty(value = "")
+    @JsonProperty("depth")
+    @Valid
+    public Integer getDepth() {
+        return depth;
+    }
+    public void setDepth(Integer depth) {
+        this.depth = depth;
     }
 
 
@@ -86,24 +101,26 @@ public class ParentOrganization  {
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        ParentOrganization parentOrganization = (ParentOrganization) o;
-        return Objects.equals(this.id, parentOrganization.id) &&
-            Objects.equals(this.ref, parentOrganization.ref);
+        GetOrganizationResponseAncestorPath getOrganizationResponseAncestorPath = (GetOrganizationResponseAncestorPath) o;
+        return Objects.equals(this.id, getOrganizationResponseAncestorPath.id) &&
+            Objects.equals(this.name, getOrganizationResponseAncestorPath.name) &&
+            Objects.equals(this.depth, getOrganizationResponseAncestorPath.depth);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, ref);
+        return Objects.hash(id, name, depth);
     }
 
     @Override
     public String toString() {
 
         StringBuilder sb = new StringBuilder();
-        sb.append("class ParentOrganization {\n");
+        sb.append("class GetOrganizationResponseAncestorPath {\n");
         
         sb.append("    id: ").append(toIndentedString(id)).append("\n");
-        sb.append("    ref: ").append(toIndentedString(ref)).append("\n");
+        sb.append("    name: ").append(toIndentedString(name)).append("\n");
+        sb.append("    depth: ").append(toIndentedString(depth)).append("\n");
         sb.append("}");
         return sb.toString();
     }

--- a/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/management/v1/model/MetaAttributesResponse.java
+++ b/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/management/v1/model/MetaAttributesResponse.java
@@ -48,7 +48,7 @@ public class MetaAttributesResponse  {
         return this;
     }
     
-    @ApiModelProperty(example = "[{\"href\":\"/o/api/server/v1/organizations/meta-attributes?limit=10&recursive=false&filter=attributes+co+C&after=MjAyMS0xMi0yMSAwNToxODozMS4wMDQzNDg=\",\"rel\":\"next\"},{\"href\":\"/o/api/server/v1/organizations/meta-attributes?limit=10&recursive=false&filter=attributes+co+C&before=MjAyMS0xMi0yMSAwNToxODozMS4wMDQzNDg=\",\"rel\":\"previous\"}]", value = "")
+    @ApiModelProperty(example = "[{\"href\":\"/api/server/v1/organizations/meta-attributes?limit=10&recursive=false&filter=attributes+co+C&after=MjAyMS0xMi0yMSAwNToxODozMS4wMDQzNDg=\",\"rel\":\"next\"},{\"href\":\"/api/server/v1/organizations/meta-attributes?limit=10&recursive=false&filter=attributes+co+C&before=MjAyMS0xMi0yMSAwNToxODozMS4wMDQzNDg=\",\"rel\":\"previous\"}]", value = "")
     @JsonProperty("links")
     @Valid
     public List<Link> getLinks() {

--- a/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/management/v1/model/OrganizationResponse.java
+++ b/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/management/v1/model/OrganizationResponse.java
@@ -319,12 +319,10 @@ public enum TypeEnum {
         this.hasChildren = hasChildren;
         return this;
     }
-
-    @ApiModelProperty(example = "true", required = true, value = "")
+    
+    @ApiModelProperty(example = "true", value = "")
     @JsonProperty("hasChildren")
     @Valid
-    @NotNull(message = "Property hasChildren cannot be null.")
-
     public Boolean getHasChildren() {
         return hasChildren;
     }

--- a/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/management/v1/model/OrganizationResponse.java
+++ b/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/management/v1/model/OrganizationResponse.java
@@ -112,6 +112,7 @@ public enum TypeEnum {
 
     private TypeEnum type;
     private ParentOrganization parent;
+    private Boolean hasChildren;
     private List<Attribute> attributes = null;
 
 
@@ -313,6 +314,26 @@ public enum TypeEnum {
 
     /**
     **/
+    public OrganizationResponse hasChildren(Boolean hasChildren) {
+
+        this.hasChildren = hasChildren;
+        return this;
+    }
+
+    @ApiModelProperty(example = "true", required = true, value = "")
+    @JsonProperty("hasChildren")
+    @Valid
+    @NotNull(message = "Property hasChildren cannot be null.")
+
+    public Boolean getHasChildren() {
+        return hasChildren;
+    }
+    public void setHasChildren(Boolean hasChildren) {
+        this.hasChildren = hasChildren;
+    }
+
+    /**
+    **/
     public OrganizationResponse attributes(List<Attribute> attributes) {
 
         this.attributes = attributes;
@@ -359,12 +380,13 @@ public enum TypeEnum {
             Objects.equals(this.lastModified, organizationResponse.lastModified) &&
             Objects.equals(this.type, organizationResponse.type) &&
             Objects.equals(this.parent, organizationResponse.parent) &&
+            Objects.equals(this.hasChildren, organizationResponse.hasChildren) &&
             Objects.equals(this.attributes, organizationResponse.attributes);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, name, orgHandle, description, status, version, created, lastModified, type, parent, attributes);
+        return Objects.hash(id, name, orgHandle, description, status, version, created, lastModified, type, parent, hasChildren, attributes);
     }
 
     @Override
@@ -383,6 +405,7 @@ public enum TypeEnum {
         sb.append("    lastModified: ").append(toIndentedString(lastModified)).append("\n");
         sb.append("    type: ").append(toIndentedString(type)).append("\n");
         sb.append("    parent: ").append(toIndentedString(parent)).append("\n");
+        sb.append("    hasChildren: ").append(toIndentedString(hasChildren)).append("\n");
         sb.append("    attributes: ").append(toIndentedString(attributes)).append("\n");
         sb.append("}");
         return sb.toString();

--- a/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/management/v1/model/OrganizationsDiscoveryResponse.java
+++ b/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/management/v1/model/OrganizationsDiscoveryResponse.java
@@ -106,7 +106,7 @@ public class OrganizationsDiscoveryResponse  {
         return this;
     }
     
-    @ApiModelProperty(example = "[{\"href\":\"/o/10084a8d-113f-4211-a0d5-efe36b082211/api/server/v1/organizations/discovery?filter=attributes.type+eq+emailDomain&limit=10&offset=50\",\"rel\":\"next\"},{\"href\":\"/o/10084a8d-113f-4211-a0d5-efe36b082211/api/server/v1/organizations/discovery?filter=attributes.type+eq+emailDomain&limit=10&offset=30\",\"rel\":\"previous\"}]", value = "")
+    @ApiModelProperty(example = "[{\"href\":\"/api/server/v1/organizations/discovery?filter=attributes.type+eq+emailDomain&limit=10&offset=50\",\"rel\":\"next\"},{\"href\":\"/api/server/v1/organizations/discovery?filter=attributes.type+eq+emailDomain&limit=10&offset=30\",\"rel\":\"previous\"}]", value = "")
     @JsonProperty("links")
     @Valid
     public List<Link> getLinks() {

--- a/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/management/v1/model/OrganizationsResponse.java
+++ b/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/management/v1/model/OrganizationsResponse.java
@@ -49,7 +49,7 @@ public class OrganizationsResponse  {
         return this;
     }
     
-    @ApiModelProperty(example = "[{\"href\":\"/o/10084a8d-113f-4211-a0d5-efe36b082211/api/server/v1/organizations?limit=10&filter=name+co+der&next=MjAyMS0xMi0yMSAwNToxODozMS4wMDQzNDg=\",\"rel\":\"next\"},{\"href\":\"/o/10084a8d-113f-4211-a0d5-efe36b082211/api/server/v1/organizations?limit=10&filter=name+co+der&before=MjAyMS0xMi0yMSAwNToxODozMS4wMDQzNDg=\",\"rel\":\"previous\"}]", value = "")
+    @ApiModelProperty(example = "[{\"href\":\"/api/server/v1/organizations?limit=10&filter=name+co+der&next=MjAyMS0xMi0yMSAwNToxODozMS4wMDQzNDg=\",\"rel\":\"next\"},{\"href\":\"/api/server/v1/organizations?limit=10&filter=name+co+der&before=MjAyMS0xMi0yMSAwNToxODozMS4wMDQzNDg=\",\"rel\":\"previous\"}]", value = "")
     @JsonProperty("links")
     @Valid
     public List<Link> getLinks() {

--- a/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.v1/src/main/resources/org.wso2.carbon.identity.organization.management.yaml
+++ b/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.v1/src/main/resources/org.wso2.carbon.identity.organization.management.yaml
@@ -1086,10 +1086,10 @@ components:
           example:
             [
               {
-                "href": "/o/10084a8d-113f-4211-a0d5-efe36b082211/api/server/v1/organizations?limit=10&filter=name+co+der&next=MjAyMS0xMi0yMSAwNToxODozMS4wMDQzNDg=",
+                "href": "/api/server/v1/organizations?limit=10&filter=name+co+der&next=MjAyMS0xMi0yMSAwNToxODozMS4wMDQzNDg=",
                 "rel": "next",
               },  {
-              "href": "/o/10084a8d-113f-4211-a0d5-efe36b082211/api/server/v1/organizations?limit=10&filter=name+co+der&before=MjAyMS0xMi0yMSAwNToxODozMS4wMDQzNDg=",
+              "href": "/api/server/v1/organizations?limit=10&filter=name+co+der&before=MjAyMS0xMi0yMSAwNToxODozMS4wMDQzNDg=",
               "rel": "previous",
             }
             ]
@@ -1134,9 +1134,12 @@ components:
         version:
           type: string
           example: 'V1.0.0'
+        hasChildren:
+          type: boolean
+          example: true
         ref:
           type: string
-          example: 'o/10084a8d-113f-4211-a0d5-efe36b082211/api/server/v1/organizations/b4526d91-a8bf-43d2-8b14-c548cf73065b'
+          example: '/api/server/v1/organizations/b4526d91-a8bf-43d2-8b14-c548cf73065b'
         attributes:
           type: array
           items:
@@ -1186,6 +1189,9 @@ components:
             - STRUCTURAL
         parent:
           $ref: '#/components/schemas/ParentOrganization'
+        hasChildren:
+          type: boolean
+          example: true
         attributes:
           type: array
           items:
@@ -1233,6 +1239,9 @@ components:
           enum:
             - TENANT
             - STRUCTURAL
+        hasChildren:
+          type: boolean
+          example: true
         parent:
           $ref: '#/components/schemas/ParentOrganization'
         attributes:
@@ -1243,6 +1252,31 @@ components:
           type: array
           items:
             type: string
+        ancestorPath:
+          type: array
+          description: 'Ancestors up to the request initiated organization'
+          items:
+            type: object
+            properties:
+              id:
+                type: string
+              name:
+                type: string
+              depth:
+                type: integer
+          example:
+            [
+              {
+                "id": "10084a8d-113f-4211-a0d5-efe36b082211",
+                "name": "Global Holding Corp",
+                "depth": 0
+              },
+              {
+                "id": "b4526d91-a8bf-43d2-8b14-c548cf73065b",
+                "name": "South Asia Division",
+                "depth": 1
+              }
+            ]
     MetaAttributesResponse:
       type: object
       properties:
@@ -1253,10 +1287,10 @@ components:
           example:
             [
               {
-                "href": "/o/api/server/v1/organizations/meta-attributes?limit=10&recursive=false&filter=attributes+co+C&after=MjAyMS0xMi0yMSAwNToxODozMS4wMDQzNDg=",
+                "href": "/api/server/v1/organizations/meta-attributes?limit=10&recursive=false&filter=attributes+co+C&after=MjAyMS0xMi0yMSAwNToxODozMS4wMDQzNDg=",
                 "rel": "next",
               },  {
-              "href": "/o/api/server/v1/organizations/meta-attributes?limit=10&recursive=false&filter=attributes+co+C&before=MjAyMS0xMi0yMSAwNToxODozMS4wMDQzNDg=",
+              "href": "/api/server/v1/organizations/meta-attributes?limit=10&recursive=false&filter=attributes+co+C&before=MjAyMS0xMi0yMSAwNToxODozMS4wMDQzNDg=",
               "rel": "previous",
             }
             ]
@@ -1281,7 +1315,7 @@ components:
           example: 'b4526d91-a8bf-43d2-8b14-c548cf73065b'
         ref:
           type: string
-          example: 'o/10084a8d-113f-4211-a0d5-efe36b082211/api/server/v1/organizations/b4526d91-a8bf-43d2-8b14-c548cf73065b'
+          example: '/api/server/v1/organizations/b4526d91-a8bf-43d2-8b14-c548cf73065b'
 
     #-----------------------------------------------------
     # Organization Patch Operation Object
@@ -1400,10 +1434,10 @@ components:
           example:
             [
               {
-                "href": "/o/10084a8d-113f-4211-a0d5-efe36b082211/api/server/v1/organizations/discovery?filter=attributes.type+eq+emailDomain&limit=10&offset=50",
+                "href": "/api/server/v1/organizations/discovery?filter=attributes.type+eq+emailDomain&limit=10&offset=50",
                 "rel": "next",
               },  {
-              "href": "/o/10084a8d-113f-4211-a0d5-efe36b082211/api/server/v1/organizations/discovery?filter=attributes.type+eq+emailDomain&limit=10&offset=30",
+              "href": "/api/server/v1/organizations/discovery?filter=attributes.type+eq+emailDomain&limit=10&offset=30",
               "rel": "previous",
             }
             ]

--- a/pom.xml
+++ b/pom.xml
@@ -979,7 +979,7 @@
         <identity.verification.version>1.0.15</identity.verification.version>
 
         <!-- Organization management core Version -->
-        <org.wso2.carbon.identity.organization.management.core.version>1.1.38
+        <org.wso2.carbon.identity.organization.management.core.version>1.1.39
         </org.wso2.carbon.identity.organization.management.core.version>
         <org.wso2.carbon.identity.organization.management.core.version.range>[1.0.0, 2.0.0)
         </org.wso2.carbon.identity.organization.management.core.version.range>


### PR DESCRIPTION
This pull request introduces new features and enhancements to the organization management API models, including the addition of the `hasChildren` property, the `ancestorPath` feature, and updates to example references in API documentation. These changes improve the API's functionality and usability.
Part of https://github.com/wso2/product-is/issues/24612

### New Features and Enhancements:

#### 1. Addition of `hasChildren` Property:
* Added a `hasChildren` field to the `BasicOrganizationResponse`, `GetOrganizationResponse`, and `OrganizationResponse` models, along with associated getter, setter, and `equals`/`hashCode`/`toString` methods. This property indicates whether an organization has child organizations. [[1]](diffhunk://#diff-241c5c7306150becd2a6aa0166fd8187fc997ab4b6dc804bf107b756bd59b4f1R76) [[2]](diffhunk://#diff-241c5c7306150becd2a6aa0166fd8187fc997ab4b6dc804bf107b756bd59b4f1R181-R198) [[3]](diffhunk://#diff-f46baf1ffd8eeaa39e3861f8e0e0d483195d9c55ad6cb072d8a34cbe7588e018R115-R122) [[4]](diffhunk://#diff-f46baf1ffd8eeaa39e3861f8e0e0d483195d9c55ad6cb072d8a34cbe7588e018R302-R319) [[5]](diffhunk://#diff-ce064575d3e3de007d0aca0ba7c41ab1c18426fa2e6653a6bf5d84258cc1549fR115) [[6]](diffhunk://#diff-ce064575d3e3de007d0aca0ba7c41ab1c18426fa2e6653a6bf5d84258cc1549fR315-R332)

#### 2. Introduction of `ancestorPath` Feature:
* Added a new `ancestorPath` property to `GetOrganizationResponse` to provide a list of ancestor organizations up to the requested organization. This includes a new model, `GetOrganizationResponseAncestorPath`, to represent individual ancestor details. [[1]](diffhunk://#diff-f46baf1ffd8eeaa39e3861f8e0e0d483195d9c55ad6cb072d8a34cbe7588e018R115-R122) [[2]](diffhunk://#diff-f46baf1ffd8eeaa39e3861f8e0e0d483195d9c55ad6cb072d8a34cbe7588e018R390-R416) [[3]](diffhunk://#diff-ef73548de1661731b11d7b84c41f326a4598b89dac0ea18f72934e36a33c6cfcR1-R140)

### Documentation and Example Updates:

* Updated example references in the `ref` field of `BasicOrganizationResponse`, `links` field of `MetaAttributesResponse`, and `OrganizationsDiscoveryResponse` to remove the `/o/` prefix for consistency. [[1]](diffhunk://#diff-241c5c7306150becd2a6aa0166fd8187fc997ab4b6dc804bf107b756bd59b4f1L188-R207) [[2]](diffhunk://#diff-2f1f8c8122affd47d77e19a6d5a96dd4ef2830fda8fc933c8640972da527a9d1L51-R51) [[3]](diffhunk://#diff-245f11cdb35bbe29cffbcea6d7367aaa8f84b5668aaa041b99100d0994928d2cL109-R109)## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.


### Depends on

- https://github.com/wso2/identity-organization-management-core/pull/190