### PR TITLE
Improved webhook metadata api to return the adapter

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.webhook.management/org.wso2.carbon.identity.api.server.webhook.management.v1/src/main/java/org/wso2/carbon/identity/api/server/webhook/management/v1/constants/WebhookMgtEndpointConstants.java
+++ b/components/org.wso2.carbon.identity.api.server.webhook.management/org.wso2.carbon.identity.api.server.webhook.management.v1/src/main/java/org/wso2/carbon/identity/api/server/webhook/management/v1/constants/WebhookMgtEndpointConstants.java
@@ -35,7 +35,7 @@ public class WebhookMgtEndpointConstants {
     public enum ErrorMessage {
 
         // Client errors.
-        ERROR_NO_WEBHOOK_FOUND_ON_GIVEN_ID("60010",
+        ERROR_NO_WEBHOOK_FOUND_ON_GIVEN_ID("WEBHOOKMGT-60010",
                 "Webhook is not found.",
                 "No webhook is found for given webhook id: %s");
 

--- a/components/org.wso2.carbon.identity.api.server.webhook.management/org.wso2.carbon.identity.api.server.webhook.management.v1/src/main/java/org/wso2/carbon/identity/api/server/webhook/management/v1/core/ServerWebhookManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.webhook.management/org.wso2.carbon.identity.api.server.webhook.management.v1/src/main/java/org/wso2/carbon/identity/api/server/webhook/management/v1/core/ServerWebhookManagementService.java
@@ -28,7 +28,6 @@ import org.wso2.carbon.identity.api.server.webhook.management.v1.model.WebhookSu
 import org.wso2.carbon.identity.api.server.webhook.management.v1.model.WebhookSummary;
 import org.wso2.carbon.identity.api.server.webhook.management.v1.util.WebhookManagementAPIErrorBuilder;
 import org.wso2.carbon.identity.subscription.management.api.model.Subscription;
-import org.wso2.carbon.identity.subscription.management.api.model.SubscriptionStatus;
 import org.wso2.carbon.identity.webhook.management.api.exception.WebhookMgtException;
 import org.wso2.carbon.identity.webhook.management.api.model.Webhook;
 import org.wso2.carbon.identity.webhook.management.api.model.WebhookStatus;
@@ -199,7 +198,6 @@ public class ServerWebhookManagementService {
             subscriptions = webhookRequest.getChannelsSubscribed().stream()
                     .map(channelUri -> Subscription.builder()
                             .channelUri(channelUri)
-                            .status(SubscriptionStatus.SUBSCRIPTION_PENDING)
                             .build())
                     .collect(Collectors.toList());
         }
@@ -265,8 +263,10 @@ public class ServerWebhookManagementService {
                         webhook.getEventsSubscribed().stream()
                                 .map(subscription -> new WebhookSubscription()
                                         .channelUri(subscription.getChannelUri())
-                                        .status(WebhookSubscription.StatusEnum.fromValue(
-                                                subscription.getStatus().name())))
+                                        .status(subscription.getStatus() != null
+                                                ? WebhookSubscription.StatusEnum.fromValue(
+                                                subscription.getStatus().name())
+                                                : null))
                                 .collect(Collectors.toList())
                 );
             } else {

--- a/components/org.wso2.carbon.identity.api.server.webhook.metadata/org.wso2.carbon.identity.api.server.webhook.metadata.common/src/main/java/org/wso2/carbon/identity/api/server/webhook/metadata/common/WebhookMetadataServiceHolder.java
+++ b/components/org.wso2.carbon.identity.api.server.webhook.metadata/org.wso2.carbon.identity.api.server.webhook.metadata.common/src/main/java/org/wso2/carbon/identity/api/server/webhook/metadata/common/WebhookMetadataServiceHolder.java
@@ -19,6 +19,7 @@
 package org.wso2.carbon.identity.api.server.webhook.metadata.common;
 
 import org.wso2.carbon.context.PrivilegedCarbonContext;
+import org.wso2.carbon.identity.webhook.metadata.api.service.EventAdapterMetadataService;
 import org.wso2.carbon.identity.webhook.metadata.api.service.WebhookMetadataService;
 
 /**
@@ -32,8 +33,12 @@ public class WebhookMetadataServiceHolder {
 
     private static class WebhookMetadataServiceHolderInstance {
 
-        static final WebhookMetadataService SERVICE = (WebhookMetadataService) PrivilegedCarbonContext.
+        static final WebhookMetadataService WEBHOOK_METADATA_SERVICE = (WebhookMetadataService) PrivilegedCarbonContext.
                 getThreadLocalCarbonContext().getOSGiService(WebhookMetadataService.class, null);
+
+        static final EventAdapterMetadataService EVENT_ADAPTER_METADATA_SERVICE =
+                (EventAdapterMetadataService) PrivilegedCarbonContext.getThreadLocalCarbonContext()
+                        .getOSGiService(EventAdapterMetadataService.class, null);
     }
 
     /**
@@ -43,6 +48,16 @@ public class WebhookMetadataServiceHolder {
      */
     public static WebhookMetadataService getWebhookMetadataService() {
 
-        return WebhookMetadataServiceHolderInstance.SERVICE;
+        return WebhookMetadataServiceHolderInstance.WEBHOOK_METADATA_SERVICE;
+    }
+
+    /**
+     * Get Event Adapter Metadata Service osgi service.
+     *
+     * @return EventAdapterMetadataService.
+     */
+    public static EventAdapterMetadataService getEventAdapterMetadataService() {
+
+        return WebhookMetadataServiceHolderInstance.EVENT_ADAPTER_METADATA_SERVICE;
     }
 }

--- a/components/org.wso2.carbon.identity.api.server.webhook.metadata/org.wso2.carbon.identity.api.server.webhook.metadata.v1/src/gen/java/org/wso2/carbon/identity/api/server/webhook/metadata/v1/WebhooksApi.java
+++ b/components/org.wso2.carbon.identity.api.server.webhook.metadata/org.wso2.carbon.identity.api.server.webhook.metadata.v1/src/gen/java/org/wso2/carbon/identity/api/server/webhook/metadata/v1/WebhooksApi.java
@@ -25,7 +25,7 @@ import java.util.List;
 
 import org.wso2.carbon.identity.api.server.webhook.metadata.v1.model.Error;
 import org.wso2.carbon.identity.api.server.webhook.metadata.v1.model.EventProfile;
-import org.wso2.carbon.identity.api.server.webhook.metadata.v1.model.EventProfileList;
+import org.wso2.carbon.identity.api.server.webhook.metadata.v1.model.WebhookMetadata;
 import org.wso2.carbon.identity.api.server.webhook.metadata.v1.WebhooksApiService;
 import org.wso2.carbon.identity.api.server.webhook.metadata.v1.factories.WebhooksApiServiceFactory;
 
@@ -73,17 +73,17 @@ public class WebhooksApi  {
 
     @Valid
     @GET
-    @Path("/metadata/event-profiles")
+    @Path("/metadata")
     
     @Produces({ "application/json" })
-    @ApiOperation(value = "List Event Profiles", notes = "This API returns the list of event profiles supported by WSO2 Identity Server.   <b>Scope(Permission) required:</b> `internal_webhook_metadata_view`   ", response = EventProfileList.class, authorizations = {
+    @ApiOperation(value = "List Event Profiles", notes = "This API returns the list of event profiles supported by WSO2 Identity Server.   <b>Scope(Permission) required:</b> `internal_webhook_metadata_view`   ", response = WebhookMetadata.class, authorizations = {
         @Authorization(value = "BasicAuth"),
         @Authorization(value = "OAuth2", scopes = {
             
         })
     }, tags={ "Webhook Metadata" })
     @ApiResponses(value = { 
-        @ApiResponse(code = 200, message = "OK", response = EventProfileList.class),
+        @ApiResponse(code = 200, message = "OK", response = WebhookMetadata.class),
         @ApiResponse(code = 401, message = "Unauthorized", response = Void.class),
         @ApiResponse(code = 403, message = "Forbidden", response = Void.class),
         @ApiResponse(code = 500, message = "Internal server error", response = Error.class)

--- a/components/org.wso2.carbon.identity.api.server.webhook.metadata/org.wso2.carbon.identity.api.server.webhook.metadata.v1/src/gen/java/org/wso2/carbon/identity/api/server/webhook/metadata/v1/WebhooksApiService.java
+++ b/components/org.wso2.carbon.identity.api.server.webhook.metadata/org.wso2.carbon.identity.api.server.webhook.metadata.v1/src/gen/java/org/wso2/carbon/identity/api/server/webhook/metadata/v1/WebhooksApiService.java
@@ -26,7 +26,7 @@ import java.io.InputStream;
 import java.util.List;
 import org.wso2.carbon.identity.api.server.webhook.metadata.v1.model.Error;
 import org.wso2.carbon.identity.api.server.webhook.metadata.v1.model.EventProfile;
-import org.wso2.carbon.identity.api.server.webhook.metadata.v1.model.EventProfileList;
+import org.wso2.carbon.identity.api.server.webhook.metadata.v1.model.WebhookMetadata;
 import javax.ws.rs.core.Response;
 
 

--- a/components/org.wso2.carbon.identity.api.server.webhook.metadata/org.wso2.carbon.identity.api.server.webhook.metadata.v1/src/gen/java/org/wso2/carbon/identity/api/server/webhook/metadata/v1/model/WebhookMetadata.java
+++ b/components/org.wso2.carbon.identity.api.server.webhook.metadata/org.wso2.carbon.identity.api.server.webhook.metadata.v1/src/gen/java/org/wso2/carbon/identity/api/server/webhook/metadata/v1/model/WebhookMetadata.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.webhook.metadata.v1.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import java.util.ArrayList;
+import java.util.List;
+import org.wso2.carbon.identity.api.server.webhook.metadata.v1.model.EventProfileMetadata;
+import org.wso2.carbon.identity.api.server.webhook.metadata.v1.model.WebhookMetadataAdapter;
+import javax.validation.constraints.*;
+
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+import javax.validation.Valid;
+import javax.xml.bind.annotation.*;
+
+public class WebhookMetadata  {
+  
+    private List<EventProfileMetadata> profiles = null;
+
+    private WebhookMetadataAdapter adapter;
+
+    /**
+    **/
+    public WebhookMetadata profiles(List<EventProfileMetadata> profiles) {
+
+        this.profiles = profiles;
+        return this;
+    }
+    
+    @ApiModelProperty(value = "")
+    @JsonProperty("profiles")
+    @Valid
+    public List<EventProfileMetadata> getProfiles() {
+        return profiles;
+    }
+    public void setProfiles(List<EventProfileMetadata> profiles) {
+        this.profiles = profiles;
+    }
+
+    public WebhookMetadata addProfilesItem(EventProfileMetadata profilesItem) {
+        if (this.profiles == null) {
+            this.profiles = new ArrayList<EventProfileMetadata>();
+        }
+        this.profiles.add(profilesItem);
+        return this;
+    }
+
+        /**
+    **/
+    public WebhookMetadata adapter(WebhookMetadataAdapter adapter) {
+
+        this.adapter = adapter;
+        return this;
+    }
+    
+    @ApiModelProperty(value = "")
+    @JsonProperty("adapter")
+    @Valid
+    public WebhookMetadataAdapter getAdapter() {
+        return adapter;
+    }
+    public void setAdapter(WebhookMetadataAdapter adapter) {
+        this.adapter = adapter;
+    }
+
+
+
+    @Override
+    public boolean equals(java.lang.Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        WebhookMetadata webhookMetadata = (WebhookMetadata) o;
+        return Objects.equals(this.profiles, webhookMetadata.profiles) &&
+            Objects.equals(this.adapter, webhookMetadata.adapter);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(profiles, adapter);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class WebhookMetadata {\n");
+        
+        sb.append("    profiles: ").append(toIndentedString(profiles)).append("\n");
+        sb.append("    adapter: ").append(toIndentedString(adapter)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+    * Convert the given object to string with each line indented by 4 spaces
+    * (except the first line).
+    */
+    private String toIndentedString(java.lang.Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}
+

--- a/components/org.wso2.carbon.identity.api.server.webhook.metadata/org.wso2.carbon.identity.api.server.webhook.metadata.v1/src/gen/java/org/wso2/carbon/identity/api/server/webhook/metadata/v1/model/WebhookMetadataAdapter.java
+++ b/components/org.wso2.carbon.identity.api.server.webhook.metadata/org.wso2.carbon.identity.api.server.webhook.metadata.v1/src/gen/java/org/wso2/carbon/identity/api/server/webhook/metadata/v1/model/WebhookMetadataAdapter.java
@@ -22,9 +22,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
-import java.util.ArrayList;
-import java.util.List;
-import org.wso2.carbon.identity.api.server.webhook.metadata.v1.model.EventProfileMetadata;
 import javax.validation.constraints.*;
 
 
@@ -33,38 +30,48 @@ import java.util.Objects;
 import javax.validation.Valid;
 import javax.xml.bind.annotation.*;
 
-public class EventProfileList  {
+public class WebhookMetadataAdapter  {
   
-    private List<EventProfileMetadata> profiles = null;
-
+    private String name;
+    private String type;
 
     /**
     **/
-    public EventProfileList profiles(List<EventProfileMetadata> profiles) {
+    public WebhookMetadataAdapter name(String name) {
 
-        this.profiles = profiles;
+        this.name = name;
         return this;
     }
     
-    @ApiModelProperty(value = "")
-    @JsonProperty("profiles")
+    @ApiModelProperty(example = "httppublisher", value = "")
+    @JsonProperty("name")
     @Valid
-    public List<EventProfileMetadata> getProfiles() {
-        return profiles;
+    public String getName() {
+        return name;
     }
-    public void setProfiles(List<EventProfileMetadata> profiles) {
-        this.profiles = profiles;
+    public void setName(String name) {
+        this.name = name;
     }
 
-    public EventProfileList addProfilesItem(EventProfileMetadata profilesItem) {
-        if (this.profiles == null) {
-            this.profiles = new ArrayList<EventProfileMetadata>();
-        }
-        this.profiles.add(profilesItem);
+    /**
+    **/
+    public WebhookMetadataAdapter type(String type) {
+
+        this.type = type;
         return this;
     }
-
     
+    @ApiModelProperty(example = "Publisher", value = "")
+    @JsonProperty("type")
+    @Valid
+    public String getType() {
+        return type;
+    }
+    public void setType(String type) {
+        this.type = type;
+    }
+
+
 
     @Override
     public boolean equals(java.lang.Object o) {
@@ -75,22 +82,24 @@ public class EventProfileList  {
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        EventProfileList eventProfileList = (EventProfileList) o;
-        return Objects.equals(this.profiles, eventProfileList.profiles);
+        WebhookMetadataAdapter webhookMetadataAdapter = (WebhookMetadataAdapter) o;
+        return Objects.equals(this.name, webhookMetadataAdapter.name) &&
+            Objects.equals(this.type, webhookMetadataAdapter.type);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(profiles);
+        return Objects.hash(name, type);
     }
 
     @Override
     public String toString() {
 
         StringBuilder sb = new StringBuilder();
-        sb.append("class EventProfileList {\n");
+        sb.append("class WebhookMetadataAdapter {\n");
         
-        sb.append("    profiles: ").append(toIndentedString(profiles)).append("\n");
+        sb.append("    name: ").append(toIndentedString(name)).append("\n");
+        sb.append("    type: ").append(toIndentedString(type)).append("\n");
         sb.append("}");
         return sb.toString();
     }

--- a/components/org.wso2.carbon.identity.api.server.webhook.metadata/org.wso2.carbon.identity.api.server.webhook.metadata.v1/src/main/java/org/wso2/carbon/identity/api/server/webhook/metadata/v1/impl/WebhooksApiServiceImpl.java
+++ b/components/org.wso2.carbon.identity.api.server.webhook.metadata/org.wso2.carbon.identity.api.server.webhook.metadata.v1/src/main/java/org/wso2/carbon/identity/api/server/webhook/metadata/v1/impl/WebhooksApiServiceImpl.java
@@ -22,9 +22,7 @@ import org.wso2.carbon.identity.api.server.webhook.metadata.v1.WebhooksApiServic
 import org.wso2.carbon.identity.api.server.webhook.metadata.v1.core.ServerWebhookMetadataService;
 import org.wso2.carbon.identity.api.server.webhook.metadata.v1.factories.ServerWebhookMetadataServiceFactory;
 import org.wso2.carbon.identity.api.server.webhook.metadata.v1.model.EventProfile;
-import org.wso2.carbon.identity.api.server.webhook.metadata.v1.model.EventProfileMetadata;
-
-import java.util.List;
+import org.wso2.carbon.identity.api.server.webhook.metadata.v1.model.WebhookMetadata;
 
 import javax.ws.rs.core.Response;
 
@@ -47,7 +45,7 @@ public class WebhooksApiServiceImpl implements WebhooksApiService {
 
         ServerWebhookMetadataService webhookMetadataService =
                 ServerWebhookMetadataServiceFactory.getServerWebhookMetadataService();
-        List<EventProfileMetadata> eventProfiles = webhookMetadataService.getEventProfileNames();
-        return Response.ok().entity(eventProfiles).build();
+        WebhookMetadata webhookMetadata = webhookMetadataService.getWebhookMetadata();
+        return Response.ok().entity(webhookMetadata).build();
     }
 }

--- a/components/org.wso2.carbon.identity.api.server.webhook.metadata/org.wso2.carbon.identity.api.server.webhook.metadata.v1/src/main/resources/webhook-metadata.yaml
+++ b/components/org.wso2.carbon.identity.api.server.webhook.metadata/org.wso2.carbon.identity.api.server.webhook.metadata.v1/src/main/resources/webhook-metadata.yaml
@@ -20,7 +20,7 @@ security:
   - OAuth2: []
 
 paths:
-  /webhooks/metadata/event-profiles:
+  /webhooks/metadata:
     get:
       summary: List Event Profiles
       description: "This API returns the list of event profiles supported by WSO2 Identity Server.\n\n <b>Scope(Permission) required:</b> `internal_webhook_metadata_view` \n\n"
@@ -33,7 +33,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/EventProfileList'
+                $ref: '#/components/schemas/WebhookMetadata'
         '401':
           description: Unauthorized
         '403':
@@ -148,13 +148,22 @@ components:
           items:
             $ref: '#/components/schemas/Channel'
 
-    EventProfileList:
+    WebhookMetadata:
       type: object
       properties:
         profiles:
           type: array
           items:
             $ref: '#/components/schemas/EventProfileMetadata'
+        adapter:
+          type: object
+          properties:
+            name:
+              type: string
+              example: "httppublisher"
+            type:
+              type: string
+              example: "Publisher"
 
     EventProfileMetadata:
       type: object

--- a/pom.xml
+++ b/pom.xml
@@ -953,7 +953,7 @@
         <maven.buildnumber.plugin.version>1.4</maven.buildnumber.plugin.version>
         <org.apache.felix.annotations.version>1.2.4</org.apache.felix.annotations.version>
         <identity.governance.version>1.11.27</identity.governance.version>
-        <carbon.identity.framework.version>7.8.303-SNAPSHOT</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.8.305</carbon.identity.framework.version>
         <maven.findbugsplugin.version>3.0.5</maven.findbugsplugin.version>
         <findsecbugs-plugin.version>1.12.0</findsecbugs-plugin.version>
         <maven.checkstyleplugin.excludes>**/gen/**/*</maven.checkstyleplugin.excludes>

--- a/pom.xml
+++ b/pom.xml
@@ -953,7 +953,7 @@
         <maven.buildnumber.plugin.version>1.4</maven.buildnumber.plugin.version>
         <org.apache.felix.annotations.version>1.2.4</org.apache.felix.annotations.version>
         <identity.governance.version>1.11.27</identity.governance.version>
-        <carbon.identity.framework.version>7.8.282</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.8.303-SNAPSHOT</carbon.identity.framework.version>
         <maven.findbugsplugin.version>3.0.5</maven.findbugsplugin.version>
         <findsecbugs-plugin.version>1.12.0</findsecbugs-plugin.version>
         <maven.checkstyleplugin.excludes>**/gen/**/*</maven.checkstyleplugin.excludes>


### PR DESCRIPTION
## Purpose

```
{
    "profiles": [
        {
            "name": "WSO2",
            "uri": "https://schemas.identity.wso2.org/events",
            "self": "/api/server/v1/webhooks/metadata/event-profiles/WSO2"
        }
    ],
    "adapter": {
        "name": "websubhub",
        "type": "PublisherSubscriber"
    }
}
```

This pull request introduces several updates to the Webhook Management and Metadata APIs, focusing on enhancing functionality, improving error handling, and extending metadata capabilities. The most significant changes include updates to error codes, the removal of unused fields, the addition of adapter metadata, and the renaming and modification of classes to better reflect their purpose.

### Webhook Management API Changes:
* Updated the error code for `ERROR_NO_WEBHOOK_FOUND_ON_GIVEN_ID` to include a prefix (`WEBHOOKMGT-60010`) for better categorization. (`WebhookMgtEndpointConstants.java`, [components/org.wso2.carbon.identity.api.server.webhook.management/org.wso2.carbon.identity.api.server.webhook.management.v1/src/main/java/org/wso2/carbon/identity/api/server/webhook/management/v1/constants/WebhookMgtEndpointConstants.javaL38-R38](diffhunk://#diff-ea0aa8e685bd292c44d803ef66ef39abbb28c5cd4f198da85c7f055fc44a856bL38-R38))
* Removed the `SubscriptionStatus.SUBSCRIPTION_PENDING` field from the `Subscription` object during webhook creation, as it is no longer required. (`ServerWebhookManagementService.java`, [components/org.wso2.carbon.identity.api.server.webhook.management/org.wso2.carbon.identity.api.server.webhook.management.v1/src/main/java/org/wso2/carbon/identity/api/server/webhook/management/v1/core/ServerWebhookManagementService.javaL202](diffhunk://#diff-5a2204fc9a36cd25c075512ba3bfc32826dbfb9d4dac4abb47e49448326a8ee5L202))
* Modified the `getWebhookResponse` method to handle cases where the subscription status is null, preventing potential null pointer exceptions. (`ServerWebhookManagementService.java`, [components/org.wso2.carbon.identity.api.server.webhook.management/org.wso2.carbon.identity.api.server.webhook.management.v1/src/main/java/org/wso2/carbon/identity/api/server/webhook/management/v1/core/ServerWebhookManagementService.javaL268-R269](diffhunk://#diff-5a2204fc9a36cd25c075512ba3bfc32826dbfb9d4dac4abb47e49448326a8ee5L268-R269))

### Webhook Metadata API Changes:
* Added a new `WebhookMetadataAdapter` class to represent adapter metadata, including properties like `name` and `type`. (`WebhookMetadataAdapter.java`, [components/org.wso2.carbon.identity.api.server.webhook.metadata/org.wso2.carbon.identity.api.server.webhook.metadata.v1/src/gen/java/org/wso2/carbon/identity/api/server/webhook/metadata/v1/model/WebhookMetadataAdapter.javaR1-R119](diffhunk://#diff-f81ea422cdfb0517d1effe1358d9cd998ffcae2e79881354672dca425295f755R1-R119))
* Renamed `EventProfileList` to `WebhookMetadata` and added an `adapter` field to include adapter details in the metadata response. (`WebhookMetadata.java`, [[1]](diffhunk://#diff-2136c69bcffc824fdb964a59f5df872b0587f5f58dbe04461b8e8186e6a6c9d2L36-R45) [[2]](diffhunk://#diff-2136c69bcffc824fdb964a59f5df872b0587f5f58dbe04461b8e8186e6a6c9d2L59-R86) [[3]](diffhunk://#diff-2136c69bcffc824fdb964a59f5df872b0587f5f58dbe04461b8e8186e6a6c9d2L78-R115)
* Updated the API path and response type for listing metadata to include both event profiles and adapter details. (`WebhooksApi.java`, [components/org.wso2.carbon.identity.api.server.webhook.metadata/org.wso2.carbon.identity.api.server.webhook.metadata.v1/src/gen/java/org/wso2/carbon/identity/api/server/webhook/metadata/v1/WebhooksApi.javaL76-R86](diffhunk://#diff-dd50b06a649105515684836d0b0092521fb41acf1fd9fe2f244cb2b7d111979aL76-R86))
* Added a new method `getWebhookMetadata` to fetch both event profiles and the active adapter, replacing the previous method that only returned event profiles. (`ServerWebhookMetadataService.java`, [components/org.wso2.carbon.identity.api.server.webhook.metadata/org.wso2.carbon.identity.api.server.webhook.metadata.v1/src/main/java/org/wso2/carbon/identity/api/server/webhook/metadata/v1/core/ServerWebhookMetadataService.javaL67-R90](diffhunk://#diff-d682502396fa953793530cbbddcc08aece8e669ac9f6f2eaa06fdb3c102cbad0L67-R90))
* Introduced a helper method to map adapter details to the new `WebhookMetadataAdapter` model. (`ServerWebhookMetadataService.java`, [components/org.wso2.carbon.identity.api.server.webhook.metadata/org.wso2.carbon.identity.api.server.webhook.metadata.v1/src/main/java/org/wso2/carbon/identity/api/server/webhook/metadata/v1/core/ServerWebhookMetadataService.javaR146-R153](diffhunk://#diff-d682502396fa953793530cbbddcc08aece8e669ac9f6f2eaa06fdb3c102cbad0R146-R153))

### Internal Refactoring:
* Updated the `WebhookMetadataServiceHolder` to include a new static reference for `EventAdapterMetadataService` and provided a getter method for it. (`WebhookMetadataServiceHolder.java`, [[1]](diffhunk://#diff-cfe01f5ea843315e5aff23e515cb3f8bef06f718fa48c8f8a7c67421fdd27013L35-R41) [[2]](diffhunk://#diff-cfe01f5ea843315e5aff23e515cb3f8bef06f718fa48c8f8a7c67421fdd27013L46-R61)