### PR TITLE
Fix issue when boolean attribute update in suborganization

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.claim.management/org.wso2.carbon.identity.api.server.claim.management.common/src/main/java/org/wso2/carbon/identity/api/server/claim/management/common/Constant.java
+++ b/components/org.wso2.carbon.identity.api.server.claim.management/org.wso2.carbon.identity.api.server.claim.management.common/src/main/java/org/wso2/carbon/identity/api/server/claim/management/common/Constant.java
@@ -193,6 +193,9 @@ public class Constant {
         ERROR_CODE_UPDATING_LOCAL_CLAIMS("50051",
                 "Some local claims were not updated.",
                 "%s out of %s local claims could not be updated."),
+        ERROR_CODE_ERROR_SERIALIZING_INPUT_FORMAT("50052",
+                "Unable to serialize input format.",
+                "A server error occurred while serializing the input format property."),
         ERROR_CODE_INVALID_IDENTIFIER("CMT-60001", "Invalid identifier",
                 "Invalid Identifier: %s"),
         ERROR_CODE_CLAIM_URI_NOT_SPECIFIED("CMT-60002", "Empty claim URI", "Claim URI is " +

--- a/components/org.wso2.carbon.identity.api.server.claim.management/org.wso2.carbon.identity.rest.api.server.claim.management.v1/src/main/java/org/wso2/carbon/identity/rest/api/server/claim/management/v1/core/ServerClaimManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.claim.management/org.wso2.carbon.identity.rest.api.server.claim.management.v1/src/main/java/org/wso2/carbon/identity/rest/api/server/claim/management/v1/core/ServerClaimManagementService.java
@@ -2080,8 +2080,7 @@ public class ServerClaimManagementService {
         localClaim.getClaimProperties().putIfAbsent(PROP_REQUIRED, FALSE);
         localClaim.getClaimProperties().putIfAbsent(PROP_SUPPORTED_BY_DEFAULT, FALSE);
         localClaim.getClaimProperties().putIfAbsent(PROP_MULTI_VALUED, FALSE);
-        localClaim.getClaimProperties().putIfAbsent(PROP_DATA_TYPE, DataType.STRING.toString()
-                .toLowerCase(Locale.ROOT));
+        localClaim.getClaimProperties().putIfAbsent(PROP_DATA_TYPE, DataType.STRING.getValue());
         // The input type of the boolean data type is defined as checkbox by default.
         if (DataType.BOOLEAN.getValue().equals(incomingLocalClaim.getClaimProperties().get(PROP_DATA_TYPE))) {
             InputFormatDTO inputFormat = new InputFormatDTO();

--- a/components/org.wso2.carbon.identity.api.server.claim.management/org.wso2.carbon.identity.rest.api.server.claim.management.v1/src/main/java/org/wso2/carbon/identity/rest/api/server/claim/management/v1/core/ServerClaimManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.claim.management/org.wso2.carbon.identity.rest.api.server.claim.management.v1/src/main/java/org/wso2/carbon/identity/rest/api/server/claim/management/v1/core/ServerClaimManagementService.java
@@ -205,6 +205,8 @@ public class ServerClaimManagementService {
     private final ClaimMetadataManagementService claimMetadataManagementService;
     private final OrganizationManager organizationManager;
 
+    private static final ObjectMapper mapper = new ObjectMapper();
+
     public ServerClaimManagementService(ClaimMetadataManagementService claimMetadataManagementService,
                                         OrganizationManager organizationManager) {
 
@@ -1108,7 +1110,6 @@ public class ServerClaimManagementService {
 
         String inputFormat = handleAdditionalProperties(claimProperties, PROP_INPUT_FORMAT);
         if (StringUtils.isNotEmpty(inputFormat)) {
-            ObjectMapper mapper = new ObjectMapper();
             try {
                 InputFormatDTO inputFormatDTO = mapper.readValue(inputFormat, InputFormatDTO.class);
                 localClaimResDTO.setInputFormat(inputFormatDTO);
@@ -1123,7 +1124,6 @@ public class ServerClaimManagementService {
 
         String canonicalValues = handleAdditionalProperties(claimProperties, PROP_CANONICAL_VALUES);
         if (StringUtils.isNotEmpty(canonicalValues)) {
-            ObjectMapper mapper = new ObjectMapper();
             try {
                 List<LabelValueDTO> list = mapper.readValue(canonicalValues, mapper.getTypeFactory()
                                 .constructCollectionType(List.class, LabelValueDTO.class));
@@ -1299,7 +1299,6 @@ public class ServerClaimManagementService {
 
         if (ArrayUtils.isNotEmpty(localClaimReqDTO.getCanonicalValues())) {
             try {
-                ObjectMapper mapper = new ObjectMapper();
                 String jsonString = mapper.writeValueAsString(localClaimReqDTO.getCanonicalValues());
                 claimProperties.put(PROP_CANONICAL_VALUES, jsonString);
             } catch (JsonProcessingException e) {
@@ -1309,7 +1308,6 @@ public class ServerClaimManagementService {
 
         if (localClaimReqDTO.getInputFormat() != null) {
             try {
-                ObjectMapper mapper = new ObjectMapper();
                 String jsonString = mapper.writeValueAsString(localClaimReqDTO.getInputFormat());
                 claimProperties.put(PROP_INPUT_FORMAT, jsonString);
             } catch (JsonProcessingException e) {
@@ -1470,7 +1468,7 @@ public class ServerClaimManagementService {
     private ClaimDialectConfiguration parseClaimDialectFromJson(FileContent fileContent) throws ClaimMetadataException {
 
         try {
-            return new ObjectMapper().readValue(fileContent.getContent(), ClaimDialectConfiguration.class);
+            return mapper.readValue(fileContent.getContent(), ClaimDialectConfiguration.class);
         } catch (JsonProcessingException e) {
             throw new ClaimMetadataException(String.format(
                       Constant.ErrorMessage.ERROR_CODE_ERROR_READING_FILE_CONTENT.toString(), MEDIA_TYPE_JSON), e);
@@ -2088,7 +2086,6 @@ public class ServerClaimManagementService {
         if (DataType.BOOLEAN.getValue().equals(incomingLocalClaim.getClaimProperties().get(PROP_DATA_TYPE))) {
             InputFormatDTO inputFormat = new InputFormatDTO();
             inputFormat.setInputType(INPUT_TYPE_CHECKBOX);
-            ObjectMapper mapper = new ObjectMapper();
             try {
                 String inputFormatPayload = mapper.writeValueAsString(inputFormat);
                 localClaim.getClaimProperties().putIfAbsent(PROP_INPUT_FORMAT, inputFormatPayload);


### PR DESCRIPTION
## Purpose
The attribute update at the sub-organization level is restricted and only mapped attribute update is allowed. When trying to update boolean attributes, it fails the validation as it incorrectly identifying as changing the input formatting as the current validation logic is not improved to handle that case.
This didn't affect for other data types (except boolean) as we had to preserve the previous input formatting of checkbox for the boolean attributes. 
 
### Related Issues
- https://github.com/wso2/product-is/issues/24718