### PR TITLE
Add ai-log-agent github actions

### DIFF
--- a/.github/workflows/log-pr-comment-analyzer.yml
+++ b/.github/workflows/log-pr-comment-analyzer.yml
@@ -1,0 +1,49 @@
+name: Notify Merged PR to AI Log Agent
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  find-pr-details:
+    runs-on: ubuntu-latest
+    outputs:
+      url: ${{ steps.pr.outputs.url }}
+    steps:
+      - name: Get merged PR info
+        id: pr
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const commitSha = context.sha;
+
+            const prs = await github.rest.pulls.list({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'closed',
+              sort: 'updated',
+              direction: 'desc',
+              per_page: 10
+            });
+
+            const mergedPr = prs.data.find(pr =>
+              pr.merge_commit_sha === commitSha
+            );
+
+            if (!mergedPr) {
+              core.setFailed("No merged PR found for this commit.");
+              return;
+            }
+
+            core.info(`Found merged PR: ${mergedPr.html_url} (#${mergedPr.number})`);
+            core.setOutput("url", mergedPr.html_url);
+  invoke-ai-log-agent:
+    name: Invoke AI Log Agent
+    needs: find-pr-details
+    uses: wso2/wso2-organization-templates/.github/workflows/log-pr-comment-analyzer.yml@main
+    with:
+      prUrl: ${{ needs.find-pr-details.outputs.url }}
+    secrets:
+      clientId: ${{ secrets.AI_LOG_AGENT_CLIENT_ID }}
+      clientSecret: ${{ secrets.AI_LOG_AGENT_CLIENT_SECRET }}

--- a/.github/workflows/pr-reviewer-for-logs.yml
+++ b/.github/workflows/pr-reviewer-for-logs.yml
@@ -1,0 +1,14 @@
+name: PR Reviewer for Logs
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  call-template:
+    uses: wso2/wso2-organization-templates/.github/workflows/pr-reviewer.yml@main
+    with:
+      prUrl: ${{ github.event.pull_request.html_url }}
+    secrets:
+      clientId: ${{ secrets.AI_LOG_AGENT_CLIENT_ID }}
+      clientSecret: ${{ secrets.AI_LOG_AGENT_CLIENT_SECRET }}


### PR DESCRIPTION
### Proposed changes in this pull request
Add log pr reviewer and ai-comment-analyzer github actions

Issue: https://github.com/wso2-enterprise/digiops-engineering/issues/196

====================

This pull request introduces two new GitHub Actions workflows to enhance automation around pull requests and logging. The first workflow notifies an AI Log Agent when a pull request is merged, and the second assigns a PR reviewer for logs when a pull request is opened.

### New GitHub Actions Workflows:

* **Notify Merged PR to AI Log Agent**:
  - Added `.github/workflows/log-pr-comment-analyzer.yml` to detect merged pull requests on the `main` branch and notify an AI Log Agent with the pull request details. This includes fetching the merged PR's URL and invoking a pre-defined template workflow with authentication secrets.

* **PR Reviewer for Logs**:
  - Added `.github/workflows/pr-reviewer-for-logs.yml` to trigger on pull request creation (`pull_request_target` event). It assigns a reviewer for logs by calling a shared template workflow with the pull request URL and authentication secrets.