### PR TITLE
Add store location property to claims

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.claim.management/org.wso2.carbon.identity.api.server.claim.management.common/src/main/java/org/wso2/carbon/identity/api/server/claim/management/common/Constant.java
+++ b/components/org.wso2.carbon.identity.api.server.claim.management/org.wso2.carbon.identity.api.server.claim.management.common/src/main/java/org/wso2/carbon/identity/api/server/claim/management/common/Constant.java
@@ -242,10 +242,7 @@ public class Constant {
         ERROR_CODE_CANONICAL_VALUES_NOT_SUPPORTED_FOR_NON_STRING_DATA_TYPES("CMT-60019",
                 "Canonical values are only supported for string data type.",
                 "The attribute: %s is not a string data type and canonical values are only supported for " +
-                        "string data type."),
-        ERROR_CODE_SKIP_USER_STORE_UPDATE_FAILURE("CMT-60020",
-                "Unable to update storage location.",
-                "Server encountered an error while updating the storage location for the claim.");
+                        "string data type.");
 
 
 
@@ -323,7 +320,7 @@ public class Constant {
     public static final String PROP_SUB_ATTRIBUTES = "subAttributes";
     public static final String PROP_CANONICAL_VALUES = "canonicalValues";
     public static final String PROP_INPUT_FORMAT = "inputFormat";
-    public static final String PROP_SKIP_USER_STORE = "skipUserStore";
+    public static final String PROP_IS_CUSTOM_PERSISTENCE_ENABLED = "isCustomPersistenceEnabled";
 
     public static final String PROP_MULTI_VALUED = "multiValued";
     public static final String PROP_UNIQUENESS_SCOPE = "UniquenessScope";

--- a/components/org.wso2.carbon.identity.api.server.claim.management/org.wso2.carbon.identity.api.server.claim.management.common/src/main/java/org/wso2/carbon/identity/api/server/claim/management/common/Constant.java
+++ b/components/org.wso2.carbon.identity.api.server.claim.management/org.wso2.carbon.identity.api.server.claim.management.common/src/main/java/org/wso2/carbon/identity/api/server/claim/management/common/Constant.java
@@ -242,7 +242,12 @@ public class Constant {
         ERROR_CODE_CANONICAL_VALUES_NOT_SUPPORTED_FOR_NON_STRING_DATA_TYPES("CMT-60019",
                 "Canonical values are only supported for string data type.",
                 "The attribute: %s is not a string data type and canonical values are only supported for " +
-                        "string data type.");
+                        "string data type."),
+        ERROR_CODE_SKIP_USER_STORE_UPDATE_FAILURE("CMT-60020",
+                "Unable to update storage location.",
+                "Server encountered an error while updating the storage location for the claim.");
+
+
 
         private final String code;
         private final String message;
@@ -318,6 +323,7 @@ public class Constant {
     public static final String PROP_SUB_ATTRIBUTES = "subAttributes";
     public static final String PROP_CANONICAL_VALUES = "canonicalValues";
     public static final String PROP_INPUT_FORMAT = "inputFormat";
+    public static final String PROP_SKIP_USER_STORE = "skipUserStore";
 
     public static final String PROP_MULTI_VALUED = "multiValued";
     public static final String PROP_UNIQUENESS_SCOPE = "UniquenessScope";

--- a/components/org.wso2.carbon.identity.api.server.claim.management/org.wso2.carbon.identity.rest.api.server.claim.management.v1/src/gen/java/org/wso2/carbon/identity/rest/api/server/claim/management/v1/dto/LocalClaimReqDTO.java
+++ b/components/org.wso2.carbon.identity.api.server.claim.management/org.wso2.carbon.identity.rest.api.server.claim.management.v1/src/gen/java/org/wso2/carbon/identity/rest/api/server/claim/management/v1/dto/LocalClaimReqDTO.java
@@ -99,6 +99,8 @@ public class LocalClaimReqDTO {
     @Valid
     private InputFormatDTO inputFormat = null;
 
+    @Valid
+    private Boolean skipUserStore = null;
     /**
     * A unique URI specific to the claim.
     **/
@@ -319,6 +321,19 @@ public class LocalClaimReqDTO {
         this.inputFormat = inputFormat;
     }
 
+    /**
+     * Specifies if the claim value stored in the user store should be skipped.
+     * And retrieve the claim value stored in the identity db.
+     **/
+    @ApiModelProperty(value = "Specifies if the claim value stored in the user store should be skipped.")
+    @JsonProperty("skipUserStore")
+    public Boolean getSkipUserStore() {
+        return skipUserStore;
+    }
+    public void setSkipUserStore(Boolean skipUserStore) {
+        this.skipUserStore = skipUserStore;
+    }
+
     @Override
     public String toString() {
 
@@ -343,7 +358,8 @@ public class LocalClaimReqDTO {
         sb.append("    properties: ").append(properties).append("\n");
         sb.append("    profiles: ").append(profiles).append("\n");
         sb.append("    inputFormat: ").append(inputFormat).append("\n");
-        
+        sb.append("    skipUserStore: ").append(skipUserStore).append("\n");
+
         sb.append("}\n");
         return sb.toString();
     }

--- a/components/org.wso2.carbon.identity.api.server.claim.management/org.wso2.carbon.identity.rest.api.server.claim.management.v1/src/gen/java/org/wso2/carbon/identity/rest/api/server/claim/management/v1/dto/LocalClaimReqDTO.java
+++ b/components/org.wso2.carbon.identity.api.server.claim.management/org.wso2.carbon.identity.rest.api.server.claim.management.v1/src/gen/java/org/wso2/carbon/identity/rest/api/server/claim/management/v1/dto/LocalClaimReqDTO.java
@@ -100,7 +100,7 @@ public class LocalClaimReqDTO {
     private InputFormatDTO inputFormat = null;
 
     @Valid
-    private Boolean skipUserStore = null;
+    private Boolean isCustomPersistenceEnabled = null;
     /**
     * A unique URI specific to the claim.
     **/
@@ -325,13 +325,13 @@ public class LocalClaimReqDTO {
      * Specifies if the claim value stored in the user store should be skipped.
      * And retrieve the claim value stored in the identity db.
      **/
-    @ApiModelProperty(value = "Specifies if the claim value stored in the user store should be skipped.")
-    @JsonProperty("skipUserStore")
-    public Boolean getSkipUserStore() {
-        return skipUserStore;
+    @ApiModelProperty(value = "Specifies whether the default claim persistence should be override.")
+    @JsonProperty("isCustomPersistenceEnabled")
+    public Boolean getIsCustomPersistenceEnabled() {
+        return isCustomPersistenceEnabled;
     }
-    public void setSkipUserStore(Boolean skipUserStore) {
-        this.skipUserStore = skipUserStore;
+    public void setIsCustomPersistenceEnabled(Boolean skipUserStore) {
+        this.isCustomPersistenceEnabled = skipUserStore;
     }
 
     @Override
@@ -358,7 +358,7 @@ public class LocalClaimReqDTO {
         sb.append("    properties: ").append(properties).append("\n");
         sb.append("    profiles: ").append(profiles).append("\n");
         sb.append("    inputFormat: ").append(inputFormat).append("\n");
-        sb.append("    skipUserStore: ").append(skipUserStore).append("\n");
+        sb.append("    isCustomPersistenceEnabled: ").append(isCustomPersistenceEnabled).append("\n");
 
         sb.append("}\n");
         return sb.toString();

--- a/components/org.wso2.carbon.identity.api.server.claim.management/org.wso2.carbon.identity.rest.api.server.claim.management.v1/src/gen/java/org/wso2/carbon/identity/rest/api/server/claim/management/v1/dto/LocalClaimResDTO.java
+++ b/components/org.wso2.carbon.identity.api.server.claim.management/org.wso2.carbon.identity.rest.api.server.claim.management.v1/src/gen/java/org/wso2/carbon/identity/rest/api/server/claim/management/v1/dto/LocalClaimResDTO.java
@@ -101,7 +101,7 @@ public class LocalClaimResDTO extends ClaimResDTO {
     private InputFormatDTO inputFormat = null;
 
     @Valid
-    private Boolean skipUserStore = null;
+    private Boolean isCustomPersistenceEnabled = null;
 
     /**
     * claim ID.
@@ -352,13 +352,13 @@ public class LocalClaimResDTO extends ClaimResDTO {
      * Specifies if the claim value stored in the user store should be skipped.
      * And retrieve the claim value stored in the identity db.
      **/
-    @ApiModelProperty(value = "Specifies if the claim value stored in the user store should be skipped.")
-    @JsonProperty("skipUserStore")
-    public Boolean getSkipUserStore() {
-        return skipUserStore;
+    @ApiModelProperty(value = "Specifies whether the default claim persistence should be override.")
+    @JsonProperty("isCustomPersistenceEnabled")
+    public Boolean getIsCustomPersistenceEnabled() {
+        return isCustomPersistenceEnabled;
     }
-    public void setSkipUserStore(Boolean skipUserStore) {
-        this.skipUserStore = skipUserStore;
+    public void setIsCustomPersistenceEnabled(Boolean skipUserStore) {
+        this.isCustomPersistenceEnabled = skipUserStore;
     }
 
     @Override
@@ -366,8 +366,8 @@ public class LocalClaimResDTO extends ClaimResDTO {
 
         StringBuilder sb = new StringBuilder();
         sb.append("class LocalClaimResDTO {\n");
+
         sb.append("  " + super.toString()).append("\n");
-        
         sb.append("    id: ").append(id).append("\n");
         sb.append("    claimURI: ").append(claimURI).append("\n");
         sb.append("    dialectURI: ").append(dialectURI).append("\n");
@@ -388,7 +388,7 @@ public class LocalClaimResDTO extends ClaimResDTO {
         sb.append("    properties: ").append(properties).append("\n");
         sb.append("    profiles: ").append(profiles).append("\n");
         sb.append("    inputFormat: ").append(inputFormat).append("\n");
-        sb.append("    skipUserStore: ").append(skipUserStore).append("\n");
+        sb.append("    isCustomPersistenceEnabled: ").append(isCustomPersistenceEnabled).append("\n");
         
         sb.append("}\n");
         return sb.toString();

--- a/components/org.wso2.carbon.identity.api.server.claim.management/org.wso2.carbon.identity.rest.api.server.claim.management.v1/src/gen/java/org/wso2/carbon/identity/rest/api/server/claim/management/v1/dto/LocalClaimResDTO.java
+++ b/components/org.wso2.carbon.identity.api.server.claim.management/org.wso2.carbon.identity.rest.api.server.claim.management.v1/src/gen/java/org/wso2/carbon/identity/rest/api/server/claim/management/v1/dto/LocalClaimResDTO.java
@@ -100,6 +100,9 @@ public class LocalClaimResDTO extends ClaimResDTO {
     @Valid
     private InputFormatDTO inputFormat = null;
 
+    @Valid
+    private Boolean skipUserStore = null;
+
     /**
     * claim ID.
     **/
@@ -345,6 +348,19 @@ public class LocalClaimResDTO extends ClaimResDTO {
         this.inputFormat = inputFormat;
     }
 
+    /**
+     * Specifies if the claim value stored in the user store should be skipped.
+     * And retrieve the claim value stored in the identity db.
+     **/
+    @ApiModelProperty(value = "Specifies if the claim value stored in the user store should be skipped.")
+    @JsonProperty("skipUserStore")
+    public Boolean getSkipUserStore() {
+        return skipUserStore;
+    }
+    public void setSkipUserStore(Boolean skipUserStore) {
+        this.skipUserStore = skipUserStore;
+    }
+
     @Override
     public String toString() {
 
@@ -372,6 +388,7 @@ public class LocalClaimResDTO extends ClaimResDTO {
         sb.append("    properties: ").append(properties).append("\n");
         sb.append("    profiles: ").append(profiles).append("\n");
         sb.append("    inputFormat: ").append(inputFormat).append("\n");
+        sb.append("    skipUserStore: ").append(skipUserStore).append("\n");
         
         sb.append("}\n");
         return sb.toString();

--- a/components/org.wso2.carbon.identity.api.server.claim.management/org.wso2.carbon.identity.rest.api.server.claim.management.v1/src/main/java/org/wso2/carbon/identity/rest/api/server/claim/management/v1/core/ServerClaimManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.claim.management/org.wso2.carbon.identity.rest.api.server.claim.management.v1/src/main/java/org/wso2/carbon/identity/rest/api/server/claim/management/v1/core/ServerClaimManagementService.java
@@ -137,7 +137,6 @@ import static org.wso2.carbon.identity.api.server.claim.management.common.Consta
 import static org.wso2.carbon.identity.api.server.claim.management.common.Constant.ErrorMessage.ERROR_CODE_UNAUTHORIZED_ORG_FOR_CLAIM_PROPERTY_UPDATE;
 import static org.wso2.carbon.identity.api.server.claim.management.common.Constant.ErrorMessage.ERROR_CODE_UNAUTHORIZED_ORG_FOR_EXCLUDED_USER_STORES_PROPERTY_UPDATE;
 import static org.wso2.carbon.identity.api.server.claim.management.common.Constant.ErrorMessage.ERROR_CODE_USERSTORE_NOT_SPECIFIED_IN_MAPPINGS;
-import static org.wso2.carbon.identity.api.server.claim.management.common.Constant.ErrorMessage.ERROR_CODE_SKIP_USER_STORE_UPDATE_FAILURE;
 import static org.wso2.carbon.identity.api.server.claim.management.common.Constant.INPUT_TYPE_CHECKBOX;
 import static org.wso2.carbon.identity.api.server.claim.management.common.Constant.INPUT_TYPE_CHECKBOX_GROUP;
 import static org.wso2.carbon.identity.api.server.claim.management.common.Constant.INPUT_TYPE_DATE_PICKER;
@@ -155,7 +154,7 @@ import static org.wso2.carbon.identity.api.server.claim.management.common.Consta
 import static org.wso2.carbon.identity.api.server.claim.management.common.Constant.PROP_DISPLAY_NAME;
 import static org.wso2.carbon.identity.api.server.claim.management.common.Constant.PROP_DISPLAY_ORDER;
 import static org.wso2.carbon.identity.api.server.claim.management.common.Constant.PROP_INPUT_FORMAT;
-import static org.wso2.carbon.identity.api.server.claim.management.common.Constant.PROP_SKIP_USER_STORE;
+import static org.wso2.carbon.identity.api.server.claim.management.common.Constant.PROP_IS_CUSTOM_PERSISTENCE_ENABLED;
 import static org.wso2.carbon.identity.api.server.claim.management.common.Constant.PROP_MULTI_VALUED;
 import static org.wso2.carbon.identity.api.server.claim.management.common.Constant.PROP_PROFILES_PREFIX;
 import static org.wso2.carbon.identity.api.server.claim.management.common.Constant.PROP_READ_ONLY;
@@ -1084,7 +1083,7 @@ public class ServerClaimManagementService {
 
         localClaimResDTO.setDisplayName(claimProperties.remove(PROP_DISPLAY_NAME));
         localClaimResDTO.setReadOnly(Boolean.valueOf(claimProperties.remove(PROP_READ_ONLY)));
-        localClaimResDTO.setSkipUserStore(Boolean.valueOf(claimProperties.remove(PROP_SKIP_USER_STORE)));
+        localClaimResDTO.setIsCustomPersistenceEnabled(Boolean.valueOf(claimProperties.remove(PROP_IS_CUSTOM_PERSISTENCE_ENABLED)));
         String regEx = claimProperties.remove(PROP_REG_EX);
         localClaimResDTO.setRegEx(regEx);
         if (regEx == null) {
@@ -1288,7 +1287,7 @@ public class ServerClaimManagementService {
         addAttributeProfilesToClaimProperties(localClaimReqDTO.getProfiles(), claimProperties);
 
         claimProperties.put(PROP_READ_ONLY, String.valueOf(localClaimReqDTO.getReadOnly()));
-        claimProperties.put(PROP_SKIP_USER_STORE, String.valueOf(localClaimReqDTO.getSkipUserStore()));
+        claimProperties.put(PROP_IS_CUSTOM_PERSISTENCE_ENABLED, String.valueOf(localClaimReqDTO.getIsCustomPersistenceEnabled()));
         claimProperties.put(PROP_REQUIRED, String.valueOf(localClaimReqDTO.getRequired()));
         claimProperties.put(PROP_SUPPORTED_BY_DEFAULT, String.valueOf(localClaimReqDTO.getSupportedByDefault()));
         if (localClaimReqDTO.getDataType() != null) {

--- a/components/org.wso2.carbon.identity.api.server.claim.management/org.wso2.carbon.identity.rest.api.server.claim.management.v1/src/main/java/org/wso2/carbon/identity/rest/api/server/claim/management/v1/core/ServerClaimManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.claim.management/org.wso2.carbon.identity.rest.api.server.claim.management.v1/src/main/java/org/wso2/carbon/identity/rest/api/server/claim/management/v1/core/ServerClaimManagementService.java
@@ -137,6 +137,7 @@ import static org.wso2.carbon.identity.api.server.claim.management.common.Consta
 import static org.wso2.carbon.identity.api.server.claim.management.common.Constant.ErrorMessage.ERROR_CODE_UNAUTHORIZED_ORG_FOR_CLAIM_PROPERTY_UPDATE;
 import static org.wso2.carbon.identity.api.server.claim.management.common.Constant.ErrorMessage.ERROR_CODE_UNAUTHORIZED_ORG_FOR_EXCLUDED_USER_STORES_PROPERTY_UPDATE;
 import static org.wso2.carbon.identity.api.server.claim.management.common.Constant.ErrorMessage.ERROR_CODE_USERSTORE_NOT_SPECIFIED_IN_MAPPINGS;
+import static org.wso2.carbon.identity.api.server.claim.management.common.Constant.ErrorMessage.ERROR_CODE_SKIP_USER_STORE_UPDATE_FAILURE;
 import static org.wso2.carbon.identity.api.server.claim.management.common.Constant.INPUT_TYPE_CHECKBOX;
 import static org.wso2.carbon.identity.api.server.claim.management.common.Constant.INPUT_TYPE_CHECKBOX_GROUP;
 import static org.wso2.carbon.identity.api.server.claim.management.common.Constant.INPUT_TYPE_DATE_PICKER;
@@ -154,6 +155,7 @@ import static org.wso2.carbon.identity.api.server.claim.management.common.Consta
 import static org.wso2.carbon.identity.api.server.claim.management.common.Constant.PROP_DISPLAY_NAME;
 import static org.wso2.carbon.identity.api.server.claim.management.common.Constant.PROP_DISPLAY_ORDER;
 import static org.wso2.carbon.identity.api.server.claim.management.common.Constant.PROP_INPUT_FORMAT;
+import static org.wso2.carbon.identity.api.server.claim.management.common.Constant.PROP_SKIP_USER_STORE;
 import static org.wso2.carbon.identity.api.server.claim.management.common.Constant.PROP_MULTI_VALUED;
 import static org.wso2.carbon.identity.api.server.claim.management.common.Constant.PROP_PROFILES_PREFIX;
 import static org.wso2.carbon.identity.api.server.claim.management.common.Constant.PROP_READ_ONLY;
@@ -1082,6 +1084,7 @@ public class ServerClaimManagementService {
 
         localClaimResDTO.setDisplayName(claimProperties.remove(PROP_DISPLAY_NAME));
         localClaimResDTO.setReadOnly(Boolean.valueOf(claimProperties.remove(PROP_READ_ONLY)));
+        localClaimResDTO.setSkipUserStore(Boolean.valueOf(claimProperties.remove(PROP_SKIP_USER_STORE)));
         String regEx = claimProperties.remove(PROP_REG_EX);
         localClaimResDTO.setRegEx(regEx);
         if (regEx == null) {
@@ -1285,6 +1288,7 @@ public class ServerClaimManagementService {
         addAttributeProfilesToClaimProperties(localClaimReqDTO.getProfiles(), claimProperties);
 
         claimProperties.put(PROP_READ_ONLY, String.valueOf(localClaimReqDTO.getReadOnly()));
+        claimProperties.put(PROP_SKIP_USER_STORE, String.valueOf(localClaimReqDTO.getSkipUserStore()));
         claimProperties.put(PROP_REQUIRED, String.valueOf(localClaimReqDTO.getRequired()));
         claimProperties.put(PROP_SUPPORTED_BY_DEFAULT, String.valueOf(localClaimReqDTO.getSupportedByDefault()));
         if (localClaimReqDTO.getDataType() != null) {
@@ -1829,6 +1833,14 @@ public class ServerClaimManagementService {
         if (existingClaim.getDataType() != requestedDataType) {
             throw new ClaimMetadataClientException(Constant.ErrorMessage.ERROR_CODE_SYSTEM_ATTRIBUTE_DATA_TYPE_UPDATE
                     .getCode(), Constant.ErrorMessage.ERROR_CODE_SYSTEM_ATTRIBUTE_DATA_TYPE_UPDATE.getDescription());
+        }
+
+        //Validate the skipUserStore property is updated.
+        if (Boolean.TRUE.equals(existingClaim.getSkipUserStore()) !=
+                Boolean.TRUE.equals(localClaimReqDTO.getSkipUserStore())) {
+            throw new ClaimMetadataClientException(Constant.ErrorMessage
+                    .ERROR_CODE_SKIP_USER_STORE_UPDATE_FAILURE.getCode(),
+                    Constant.ErrorMessage.ERROR_CODE_SKIP_USER_STORE_UPDATE_FAILURE.getDescription());
         }
     }
 

--- a/components/org.wso2.carbon.identity.api.server.claim.management/org.wso2.carbon.identity.rest.api.server.claim.management.v1/src/main/java/org/wso2/carbon/identity/rest/api/server/claim/management/v1/core/ServerClaimManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.claim.management/org.wso2.carbon.identity.rest.api.server.claim.management.v1/src/main/java/org/wso2/carbon/identity/rest/api/server/claim/management/v1/core/ServerClaimManagementService.java
@@ -1835,13 +1835,6 @@ public class ServerClaimManagementService {
                     .getCode(), Constant.ErrorMessage.ERROR_CODE_SYSTEM_ATTRIBUTE_DATA_TYPE_UPDATE.getDescription());
         }
 
-        //Validate the skipUserStore property is updated.
-        if (Boolean.TRUE.equals(existingClaim.getSkipUserStore()) !=
-                Boolean.TRUE.equals(localClaimReqDTO.getSkipUserStore())) {
-            throw new ClaimMetadataClientException(Constant.ErrorMessage
-                    .ERROR_CODE_SKIP_USER_STORE_UPDATE_FAILURE.getCode(),
-                    Constant.ErrorMessage.ERROR_CODE_SKIP_USER_STORE_UPDATE_FAILURE.getDescription());
-        }
     }
 
     private void validateSubAttributeUpdate(LocalClaimReqDTO localClaimReqDTO) throws ClaimMetadataException {

--- a/components/org.wso2.carbon.identity.api.server.claim.management/org.wso2.carbon.identity.rest.api.server.claim.management.v1/src/main/resources/claim-management.yaml
+++ b/components/org.wso2.carbon.identity.api.server.claim.management/org.wso2.carbon.identity.rest.api.server.claim.management.v1/src/main/resources/claim-management.yaml
@@ -812,6 +812,10 @@ definitions:
           $ref: '#/definitions/Property'
       profiles:
         $ref: '#/definitions/Profiles'
+      skipUserStore:
+        type: boolean
+        description: Specifies if the claim value stored in the user store should be skipped.
+        example: true
 
   #-----------------------------------------------------
   # The Local Claim Response object
@@ -910,6 +914,10 @@ definitions:
               $ref: '#/definitions/Property'
           profiles:
             $ref: '#/definitions/Profiles'
+          skipUserStore:
+            type: boolean
+            description: Specifies if the claim value stored in the user store should be skipped.
+            example: true
 
   #-----------------------------------------------------
   # The Additional Attribute Mapping object

--- a/components/org.wso2.carbon.identity.api.server.claim.management/org.wso2.carbon.identity.rest.api.server.claim.management.v1/src/main/resources/claim-management.yaml
+++ b/components/org.wso2.carbon.identity.api.server.claim.management/org.wso2.carbon.identity.rest.api.server.claim.management.v1/src/main/resources/claim-management.yaml
@@ -812,9 +812,9 @@ definitions:
           $ref: '#/definitions/Property'
       profiles:
         $ref: '#/definitions/Profiles'
-      skipUserStore:
+      isCustomPersistenceEnabled:
         type: boolean
-        description: Specifies if the claim value stored in the user store should be skipped.
+        description: Specifies whether the default claim persistence should be override.
         example: true
 
   #-----------------------------------------------------
@@ -914,9 +914,9 @@ definitions:
               $ref: '#/definitions/Property'
           profiles:
             $ref: '#/definitions/Profiles'
-          skipUserStore:
+          isCustomPersistenceEnabled:
             type: boolean
-            description: Specifies if the claim value stored in the user store should be skipped.
+            description: Specifies whether the default claim persistence should be override.
             example: true
 
   #-----------------------------------------------------


### PR DESCRIPTION
## Purpose
> Adding a new claim constant to be used for the new claim property 'skipUserStore'. This property is introduced to define the storing location of the values of the respective claim; whether the claim values should be stored in the USER_STORE or in the IDENTITY_DB.

Related
- https://github.com/wso2-extensions/identity-governance/pull/999
- https://github.com/wso2/carbon-identity-framework/pull/7014

## Goals
> A `boolean`  property `skipUserStore`  is introduced as a new claim property. The default value is `null`. Only the selected claims that has been configured will have the property value.