### PR TITLE
Add API support to local account lookup during JIT provisioning using attribute matching

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/gen/java/org/wso2/carbon/identity/api/server/idp/v1/model/AccountLookupAttributeMapping.java
+++ b/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/gen/java/org/wso2/carbon/identity/api/server/idp/v1/model/AccountLookupAttributeMapping.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.idp.v1.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import javax.validation.constraints.*;
+
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+import javax.validation.Valid;
+import javax.xml.bind.annotation.*;
+
+public class AccountLookupAttributeMapping  {
+  
+    private String localAttribute;
+    private String federatedAttribute;
+
+    /**
+    **/
+    public AccountLookupAttributeMapping localAttribute(String localAttribute) {
+
+        this.localAttribute = localAttribute;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "http://wso2.org/claims/emailaddress", value = "")
+    @JsonProperty("localAttribute")
+    @Valid
+    public String getLocalAttribute() {
+        return localAttribute;
+    }
+    public void setLocalAttribute(String localAttribute) {
+        this.localAttribute = localAttribute;
+    }
+
+    /**
+    **/
+    public AccountLookupAttributeMapping federatedAttribute(String federatedAttribute) {
+
+        this.federatedAttribute = federatedAttribute;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "email", value = "")
+    @JsonProperty("federatedAttribute")
+    @Valid
+    public String getFederatedAttribute() {
+        return federatedAttribute;
+    }
+    public void setFederatedAttribute(String federatedAttribute) {
+        this.federatedAttribute = federatedAttribute;
+    }
+
+
+
+    @Override
+    public boolean equals(java.lang.Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        AccountLookupAttributeMapping accountLookupAttributeMapping = (AccountLookupAttributeMapping) o;
+        return Objects.equals(this.localAttribute, accountLookupAttributeMapping.localAttribute) &&
+            Objects.equals(this.federatedAttribute, accountLookupAttributeMapping.federatedAttribute);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(localAttribute, federatedAttribute);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class AccountLookupAttributeMapping {\n");
+        
+        sb.append("    localAttribute: ").append(toIndentedString(localAttribute)).append("\n");
+        sb.append("    federatedAttribute: ").append(toIndentedString(federatedAttribute)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+    * Convert the given object to string with each line indented by 4 spaces
+    * (except the first line).
+    */
+    private String toIndentedString(java.lang.Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}

--- a/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/gen/java/org/wso2/carbon/identity/api/server/idp/v1/model/JustInTimeProvisioning.java
+++ b/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/gen/java/org/wso2/carbon/identity/api/server/idp/v1/model/JustInTimeProvisioning.java
@@ -1,18 +1,20 @@
 /*
-* Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-* http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
+ * Copyright (c) 2019-2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 
 package org.wso2.carbon.identity.api.server.idp.v1.model;
 
@@ -20,6 +22,9 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import java.util.ArrayList;
+import java.util.List;
+import org.wso2.carbon.identity.api.server.idp.v1.model.AccountLookupAttributeMapping;
 import javax.validation.constraints.*;
 
 
@@ -67,6 +72,8 @@ public enum SchemeEnum {
     private SchemeEnum scheme = SchemeEnum.PROVISION_SILENTLY;
     private String userstore = "PRIMARY";
     private Boolean associateLocalUser = false;
+    private List<AccountLookupAttributeMapping> accountLookupAttributeMappings = null;
+
 
 @XmlType(name="AttributeSyncMethodEnum")
 @XmlEnum(String.class)
@@ -177,6 +184,33 @@ public enum AttributeSyncMethodEnum {
     }
 
     /**
+    * List of local and federated attributes to be used for account lookup. 
+    **/
+    public JustInTimeProvisioning accountLookupAttributeMappings(List<AccountLookupAttributeMapping> accountLookupAttributeMappings) {
+
+        this.accountLookupAttributeMappings = accountLookupAttributeMappings;
+        return this;
+    }
+    
+    @ApiModelProperty(value = "List of local and federated attributes to be used for account lookup. ")
+    @JsonProperty("AccountLookupAttributeMappings")
+    @Valid
+    public List<AccountLookupAttributeMapping> getAccountLookupAttributeMappings() {
+        return accountLookupAttributeMappings;
+    }
+    public void setAccountLookupAttributeMappings(List<AccountLookupAttributeMapping> accountLookupAttributeMappings) {
+        this.accountLookupAttributeMappings = accountLookupAttributeMappings;
+    }
+
+    public JustInTimeProvisioning addAccountLookupAttributeMappingsItem(AccountLookupAttributeMapping accountLookupAttributeMappingsItem) {
+        if (this.accountLookupAttributeMappings == null) {
+            this.accountLookupAttributeMappings = new ArrayList<>();
+        }
+        this.accountLookupAttributeMappings.add(accountLookupAttributeMappingsItem);
+        return this;
+    }
+
+        /**
     **/
     public JustInTimeProvisioning attributeSyncMethod(AttributeSyncMethodEnum attributeSyncMethod) {
 
@@ -210,12 +244,13 @@ public enum AttributeSyncMethodEnum {
             Objects.equals(this.scheme, justInTimeProvisioning.scheme) &&
             Objects.equals(this.userstore, justInTimeProvisioning.userstore) &&
             Objects.equals(this.associateLocalUser, justInTimeProvisioning.associateLocalUser) &&
+            Objects.equals(this.accountLookupAttributeMappings, justInTimeProvisioning.accountLookupAttributeMappings) &&
             Objects.equals(this.attributeSyncMethod, justInTimeProvisioning.attributeSyncMethod);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(isEnabled, scheme, userstore, associateLocalUser, attributeSyncMethod);
+        return Objects.hash(isEnabled, scheme, userstore, associateLocalUser, accountLookupAttributeMappings, attributeSyncMethod);
     }
 
     @Override
@@ -228,6 +263,7 @@ public enum AttributeSyncMethodEnum {
         sb.append("    scheme: ").append(toIndentedString(scheme)).append("\n");
         sb.append("    userstore: ").append(toIndentedString(userstore)).append("\n");
         sb.append("    associateLocalUser: ").append(toIndentedString(associateLocalUser)).append("\n");
+        sb.append("    accountLookupAttributeMappings: ").append(toIndentedString(accountLookupAttributeMappings)).append("\n");
         sb.append("    attributeSyncMethod: ").append(toIndentedString(attributeSyncMethod)).append("\n");
         sb.append("}");
         return sb.toString();

--- a/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/main/java/org/wso2/carbon/identity/api/server/idp/v1/core/ServerIdpManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/main/java/org/wso2/carbon/identity/api/server/idp/v1/core/ServerIdpManagementService.java
@@ -41,6 +41,7 @@ import org.wso2.carbon.identity.api.server.common.error.APIError;
 import org.wso2.carbon.identity.api.server.common.error.ErrorResponse;
 import org.wso2.carbon.identity.api.server.idp.common.Constants;
 import org.wso2.carbon.identity.api.server.idp.v1.impl.FederatedAuthenticatorConfigBuilderFactory;
+import org.wso2.carbon.identity.api.server.idp.v1.model.AccountLookupAttributeMapping;
 import org.wso2.carbon.identity.api.server.idp.v1.model.AssociationRequest;
 import org.wso2.carbon.identity.api.server.idp.v1.model.AssociationResponse;
 import org.wso2.carbon.identity.api.server.idp.v1.model.Certificate;
@@ -79,6 +80,7 @@ import org.wso2.carbon.identity.api.server.idp.v1.model.ProvisioningResponse;
 import org.wso2.carbon.identity.api.server.idp.v1.model.Roles;
 import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants;
 import org.wso2.carbon.identity.application.common.ApplicationAuthenticatorService;
+import org.wso2.carbon.identity.application.common.model.AccountLookupAttributeMappingConfig;
 import org.wso2.carbon.identity.application.common.model.CertificateInfo;
 import org.wso2.carbon.identity.application.common.model.ClaimConfig;
 import org.wso2.carbon.identity.application.common.model.ClaimMapping;
@@ -1821,6 +1823,8 @@ public class ServerIdpManagementService {
                     break;
             }
             jitConfig.setAssociateLocalUserEnabled(jit.getAssociateLocalUser());
+            jitConfig.setAccountLookupAttributeMappings(createAccountLookupAttributeMappingsConfig(
+                    jit.getAccountLookupAttributeMappings()));
             jitConfig.setAttributeSyncMethod(jit.getAttributeSyncMethod().toString());
             identityProvider.setJustInTimeProvisioningConfig(jitConfig);
         }
@@ -2434,12 +2438,43 @@ public class ServerIdpManagementService {
                     jitProvisionConfig.getProvisioningUserStore() : IdentityUtil.getPrimaryDomainName();
             jitConfig.setUserstore(provisioningUserStore);
             jitConfig.setAssociateLocalUser(jitProvisionConfig.isAssociateLocalUserEnabled());
+            jitConfig.setAccountLookupAttributeMappings(createAccountLookupAttributeMapping(jitProvisionConfig));
             String attributeSyncMethod = StringUtils.isNotBlank(jitProvisionConfig.getAttributeSyncMethod()) ?
                     jitProvisionConfig.getAttributeSyncMethod() : FrameworkConstants.OVERRIDE_ALL;
             jitConfig.setAttributeSyncMethod(JustInTimeProvisioning.AttributeSyncMethodEnum
                     .valueOf(attributeSyncMethod));
         }
         return jitConfig;
+    }
+
+    private List<AccountLookupAttributeMapping> createAccountLookupAttributeMapping(
+            JustInTimeProvisioningConfig justInTimeProvisioningConfig) {
+
+        List<AccountLookupAttributeMapping> accLookupAttributeMappings = new ArrayList<>();
+        AccountLookupAttributeMappingConfig[] accountLookupAttributeMappings =
+                justInTimeProvisioningConfig.getAccountLookupAttributeMappings();
+        if (accountLookupAttributeMappings != null) {
+            for (AccountLookupAttributeMappingConfig accountLookupAttributeMapping : accountLookupAttributeMappings) {
+                AccountLookupAttributeMapping mapping = new AccountLookupAttributeMapping();
+                mapping.setLocalAttribute(accountLookupAttributeMapping.getLocalAttribute());
+                mapping.setFederatedAttribute(accountLookupAttributeMapping.getFederatedAttribute());
+                accLookupAttributeMappings.add(mapping);
+            }
+        }
+        return accLookupAttributeMappings;
+    }
+
+    private AccountLookupAttributeMappingConfig[] createAccountLookupAttributeMappingsConfig(
+            List<AccountLookupAttributeMapping> accountLookupAttributeMappings) {
+
+        if (accountLookupAttributeMappings == null || accountLookupAttributeMappings.isEmpty()) {
+            return new AccountLookupAttributeMappingConfig[0];
+        }
+        return accountLookupAttributeMappings.stream()
+                .map(mapping -> new AccountLookupAttributeMappingConfig(
+                        mapping.getLocalAttribute(),
+                        mapping.getFederatedAttribute()))
+                .toArray(AccountLookupAttributeMappingConfig[]::new);
     }
 
     private JustInTimeProvisioning.SchemeEnum getProvisioningType(JustInTimeProvisioningConfig jitProvisionConfig) {

--- a/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/main/resources/idp.yaml
+++ b/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/main/resources/idp.yaml
@@ -3258,6 +3258,12 @@ components:
           type: boolean
           default: false
           example: true
+        AccountLookupAttributeMappings:
+          type: array
+          items:
+            $ref: '#/components/schemas/AccountLookupAttributeMapping'
+          description: >
+            List of local and federated attributes to be used for account lookup.
         attributeSyncMethod:
           type: string
           enum:
@@ -3265,6 +3271,15 @@ components:
             - NONE
             - PRESERVE_LOCAL
           default: OVERRIDE_ALL
+    AccountLookupAttributeMapping:
+      type: object
+      properties:
+        localAttribute:
+          type: string
+          example: http://wso2.org/claims/emailaddress
+        federatedAttribute:
+          type: string
+          example: email
     ConnectedApps:
       type: object
       properties:


### PR DESCRIPTION
### Proposed changes in this pull request

- Add API support for `AccountLookupAttributeMappingConfig` as part of JIT provisioning configurations to support local account lookup using attribute matching during JIT provisioning.

### Related Issue
- https://github.com/wso2/product-is/issues/24707

### Depends on
- https://github.com/wso2/carbon-identity-framework/pull/7000
