### PR TITLE
Update webhook metadata api to response complete metadata

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.webhook.metadata/org.wso2.carbon.identity.api.server.webhook.metadata.v1/src/gen/java/org/wso2/carbon/identity/api/server/webhook/metadata/v1/WebhooksApi.java
+++ b/components/org.wso2.carbon.identity.api.server.webhook.metadata/org.wso2.carbon.identity.api.server.webhook.metadata.v1/src/gen/java/org/wso2/carbon/identity/api/server/webhook/metadata/v1/WebhooksApi.java
@@ -99,14 +99,14 @@ public class WebhooksApi  {
     @Path("/metadata")
     @Consumes({ "application/json" })
     @Produces({ "application/json" })
-    @ApiOperation(value = "Update webhook metadata properties", notes = "This API updates an webhook metadata property and return the updated webhook metadata properties.    <b>Scope (Permission) required:</b> ``internal_webhook_meta_update``  ", response = WebhookMetadataProperties.class, authorizations = {
+    @ApiOperation(value = "Update webhook metadata properties", notes = "This API updates an webhook metadata property and return the updated webhook metadata properties.    <b>Scope (Permission) required:</b> ``internal_webhook_meta_update``  ", response = WebhookMetadata.class, authorizations = {
         @Authorization(value = "BasicAuth"),
         @Authorization(value = "OAuth2", scopes = {
             
         })
     }, tags={ "Webhook Metadata", })
     @ApiResponses(value = { 
-        @ApiResponse(code = 200, message = "Successful Response", response = WebhookMetadataProperties.class),
+        @ApiResponse(code = 200, message = "Successful Response", response = WebhookMetadata.class),
         @ApiResponse(code = 400, message = "Bad Request", response = Error.class),
         @ApiResponse(code = 401, message = "Unauthorized", response = Void.class),
         @ApiResponse(code = 403, message = "Forbidden", response = Void.class),

--- a/components/org.wso2.carbon.identity.api.server.webhook.metadata/org.wso2.carbon.identity.api.server.webhook.metadata.v1/src/main/java/org/wso2/carbon/identity/api/server/webhook/metadata/v1/core/ServerWebhookMetadataService.java
+++ b/components/org.wso2.carbon.identity.api.server.webhook.metadata/org.wso2.carbon.identity.api.server.webhook.metadata.v1/src/main/java/org/wso2/carbon/identity/api/server/webhook/metadata/v1/core/ServerWebhookMetadataService.java
@@ -103,19 +103,15 @@ public class ServerWebhookMetadataService {
         }
     }
 
-    public WebhookMetadataProperties updateWebhookMetadataProperties(
+    public WebhookMetadata updateWebhookMetadataProperties(
             WebhookMetadataProperties webhookMetadataProperties) {
 
         try {
-            WebhookMetadataProperties webhookMetadataPropertiesResponse = new WebhookMetadataProperties();
-            WebhookMetadataOrganizationPolicy organizationPolicy = new WebhookMetadataOrganizationPolicy();
-            organizationPolicy.setPolicyName(WebhookMetadataOrganizationPolicy.PolicyNameEnum.fromValue(
-                    (WebhookMetadataServiceHolder.getWebhookMetadataService()
-                            .updateWebhookMetadataProperties(mapWebhookMetadataProperties(webhookMetadataProperties),
-                                    CarbonContext.getThreadLocalCarbonContext()
-                                            .getTenantDomain())).getOrganizationPolicy().getPolicyValue()));
-            webhookMetadataPropertiesResponse.setOrganizationPolicy(organizationPolicy);
-            return webhookMetadataPropertiesResponse;
+            WebhookMetadataServiceHolder.getWebhookMetadataService()
+                    .updateWebhookMetadataProperties(mapWebhookMetadataProperties(webhookMetadataProperties),
+                            CarbonContext.getThreadLocalCarbonContext()
+                                    .getTenantDomain());
+            return getWebhookMetadata();
         } catch (WebhookMetadataException e) {
             throw WebhookMetadataAPIErrorBuilder.buildAPIError(e);
         }

--- a/components/org.wso2.carbon.identity.api.server.webhook.metadata/org.wso2.carbon.identity.api.server.webhook.metadata.v1/src/main/resources/webhook-metadata.yaml
+++ b/components/org.wso2.carbon.identity.api.server.webhook.metadata/org.wso2.carbon.identity.api.server.webhook.metadata.v1/src/main/resources/webhook-metadata.yaml
@@ -67,7 +67,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/WebhookMetadataProperties'
+                $ref: '#/components/schemas/WebhookMetadata'
         "400":
           description: Bad Request
           content:


### PR DESCRIPTION
## Purpose

This pull request updates the webhook metadata API to use the `WebhookMetadata` class instead of `WebhookMetadataProperties` for improved consistency and clarity. The changes affect the API's annotations, service logic, and OpenAPI specification.

### Updates to API Annotations and Responses:
* Modified the `@ApiOperation` and `@ApiResponse` annotations in `WebhooksApi.java` to replace `WebhookMetadataProperties` with `WebhookMetadata` for the response type.

### Updates to Service Logic:
* Updated the `updateWebhookMetadataProperties` method in `ServerWebhookMetadataService.java` to return a `WebhookMetadata` object instead of `WebhookMetadataProperties`. Simplified the method logic by removing intermediate mapping and directly calling `getWebhookMetadata()`.

### Updates to OpenAPI Specification:
* Changed the reference in `webhook-metadata.yaml` to use `WebhookMetadata` instead of `WebhookMetadataProperties` in the schema definition for the API response.