### PR TITLE
Restrict session config update in sub-orgs

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.common/src/main/java/org/wso2/carbon/identity/api/server/configs/common/Constants.java
+++ b/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.common/src/main/java/org/wso2/carbon/identity/api/server/configs/common/Constants.java
@@ -102,6 +102,9 @@ public class Constants {
         ERROR_CODE_SCHEMA_NOT_FOUND("60004",
                 "Resource not found.",
                 "Unable to find a resource matching the provided schema identifier %s."),
+        ERROR_CODE_CONFIG_UPDATE_NOT_ALLOWED("60005",
+                "Configuration update not allowed.",
+                "The requested update is not allowed for the organization."),
 
         /**
          * CORS errors.

--- a/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/main/java/org/wso2/carbon/identity/api/server/configs/v1/core/ServerConfigManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/main/java/org/wso2/carbon/identity/api/server/configs/v1/core/ServerConfigManagementService.java
@@ -287,6 +287,11 @@ public class ServerConfigManagementService {
     public void patchConfigs(List<Patch> patchRequest) {
 
         try {
+            if (OrganizationManagementUtil.isOrganization(ContextLoader.getTenantDomainFromContext())) {
+                throw handleException(Response.Status.FORBIDDEN, Constants.ErrorMessage
+                        .ERROR_CODE_CONFIG_UPDATE_NOT_ALLOWED, null);
+            }
+
             IdentityProvider residentIdP = idpManager.getResidentIdP(ContextLoader.getTenantDomainFromContext());
             // Resident Identity Provider can be null only due to an internal server error.
             if (residentIdP == null) {
@@ -305,6 +310,9 @@ public class ServerConfigManagementService {
             }
         } catch (IdentityProviderManagementException e) {
             throw handleIdPException(e, Constants.ErrorMessage.ERROR_CODE_ERROR_UPDATING_CONFIGS, null);
+        } catch (OrganizationManagementException e) {
+            throw handleException(Response.Status.INTERNAL_SERVER_ERROR, Constants.ErrorMessage
+                    .ERROR_CODE_ERROR_UPDATING_CONFIGS, e.getMessage());
         }
     }
 


### PR DESCRIPTION
### Purpose
This PR will restrict updating session configs (idle session timeout and remember me period) in sub-organizations.

### Related feature
- https://github.com/wso2/product-is/issues/24318