### PR TITLE
Support allowed headers and params management in custom authenticators in REST APIs

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.authenticators/org.wso2.carbon.identity.api.server.authenticators.v1/src/gen/java/org/wso2/carbon/identity/api/server/authenticators/v1/model/Endpoint.java
+++ b/components/org.wso2.carbon.identity.api.server.authenticators/org.wso2.carbon.identity.api.server.authenticators.v1/src/gen/java/org/wso2/carbon/identity/api/server/authenticators/v1/model/Endpoint.java
@@ -22,6 +22,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import java.util.ArrayList;
+import java.util.List;
 import org.wso2.carbon.identity.api.server.authenticators.v1.model.AuthenticationType;
 import javax.validation.constraints.*;
 
@@ -35,6 +37,10 @@ public class Endpoint  {
   
     private String uri;
     private AuthenticationType authentication;
+    private List<String> allowedHeaders = null;
+
+    private List<String> allowedParameters = null;
+
 
     /**
     **/
@@ -72,7 +78,61 @@ public class Endpoint  {
         this.authentication = authentication;
     }
 
+    /**
+    * List of HTTP headers to forward to the extension.
+    **/
+    public Endpoint allowedHeaders(List<String> allowedHeaders) {
 
+        this.allowedHeaders = allowedHeaders;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "[\"x-geo-location\",\"host\"]", value = "List of HTTP headers to forward to the extension.")
+    @JsonProperty("allowedHeaders")
+    @Valid
+    public List<String> getAllowedHeaders() {
+        return allowedHeaders;
+    }
+    public void setAllowedHeaders(List<String> allowedHeaders) {
+        this.allowedHeaders = allowedHeaders;
+    }
+
+    public Endpoint addAllowedHeadersItem(String allowedHeadersItem) {
+        if (this.allowedHeaders == null) {
+            this.allowedHeaders = new ArrayList<>();
+        }
+        this.allowedHeaders.add(allowedHeadersItem);
+        return this;
+    }
+
+        /**
+    * List of parameters to forward to the extension.
+    **/
+    public Endpoint allowedParameters(List<String> allowedParameters) {
+
+        this.allowedParameters = allowedParameters;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "[\"device-id\"]", value = "List of parameters to forward to the extension.")
+    @JsonProperty("allowedParameters")
+    @Valid
+    public List<String> getAllowedParameters() {
+        return allowedParameters;
+    }
+    public void setAllowedParameters(List<String> allowedParameters) {
+        this.allowedParameters = allowedParameters;
+    }
+
+    public Endpoint addAllowedParametersItem(String allowedParametersItem) {
+        if (this.allowedParameters == null) {
+            this.allowedParameters = new ArrayList<>();
+        }
+        this.allowedParameters.add(allowedParametersItem);
+        return this;
+    }
+
+    
 
     @Override
     public boolean equals(java.lang.Object o) {
@@ -85,12 +145,14 @@ public class Endpoint  {
         }
         Endpoint endpoint = (Endpoint) o;
         return Objects.equals(this.uri, endpoint.uri) &&
-            Objects.equals(this.authentication, endpoint.authentication);
+            Objects.equals(this.authentication, endpoint.authentication) &&
+            Objects.equals(this.allowedHeaders, endpoint.allowedHeaders) &&
+            Objects.equals(this.allowedParameters, endpoint.allowedParameters);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(uri, authentication);
+        return Objects.hash(uri, authentication, allowedHeaders, allowedParameters);
     }
 
     @Override
@@ -101,6 +163,8 @@ public class Endpoint  {
         
         sb.append("    uri: ").append(toIndentedString(uri)).append("\n");
         sb.append("    authentication: ").append(toIndentedString(authentication)).append("\n");
+        sb.append("    allowedHeaders: ").append(toIndentedString(allowedHeaders)).append("\n");
+        sb.append("    allowedParameters: ").append(toIndentedString(allowedParameters)).append("\n");
         sb.append("}");
         return sb.toString();
     }

--- a/components/org.wso2.carbon.identity.api.server.authenticators/org.wso2.carbon.identity.api.server.authenticators.v1/src/main/java/org/wso2/carbon/identity/api/server/authenticators/v1/impl/LocalAuthenticatorConfigBuilderFactory.java
+++ b/components/org.wso2.carbon.identity.api.server.authenticators/org.wso2.carbon.identity.api.server.authenticators.v1/src/main/java/org/wso2/carbon/identity/api/server/authenticators/v1/impl/LocalAuthenticatorConfigBuilderFactory.java
@@ -133,6 +133,8 @@ public class LocalAuthenticatorConfigBuilderFactory {
             endpointConfigBuilder.authenticationProperties(endpointConfig.getAuthentication().getProperties()
                     .entrySet().stream().collect(Collectors.toMap(
                             Map.Entry::getKey, entry -> entry.getValue().toString())));
+            endpointConfigBuilder.allowedHeaders(endpointConfig.getAllowedHeaders());
+            endpointConfigBuilder.allowedParameters(endpointConfig.getAllowedParameters());
             return endpointConfigBuilder.build();
         } catch (NoSuchElementException | IllegalArgumentException e) {
             AuthenticatorMgtError error = AuthenticatorMgtError.ERROR_CODE_INVALID_ENDPOINT_CONFIG;

--- a/components/org.wso2.carbon.identity.api.server.authenticators/org.wso2.carbon.identity.api.server.authenticators.v1/src/main/resources/authenticators.yaml
+++ b/components/org.wso2.carbon.identity.api.server.authenticators/org.wso2.carbon.identity.api.server.authenticators.v1/src/main/resources/authenticators.yaml
@@ -426,6 +426,18 @@ components:
           pattern: '^https?://.+'
         authentication:
           $ref: '#/components/schemas/AuthenticationType'
+        allowedHeaders:
+          type: array
+          description: List of HTTP headers to forward to the extension.
+          items:
+            type: string
+          example: [ "x-geo-location", "host"]
+        allowedParameters:
+          type: array
+          description: List of parameters to forward to the extension.
+          items:
+            type: string
+          example: [ "device-id"]
     AuthenticationType:
       type: object
       required:
@@ -467,7 +479,8 @@ components:
               {
                 "href": "authenticator/123e4567-e89b-12d3-a456-556642440000/connected-apps?offset=50&limit=10",
                 "rel": "next"
-              },  {
+              },
+              {
                 "href": "authenticator/provider/123e4567-e89b-12d3-a456-556642440000/connected-apps?offset=30&limit=10",
                 "rel": "previous"
               }

--- a/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/gen/java/org/wso2/carbon/identity/api/server/configs/v1/model/Endpoint.java
+++ b/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/gen/java/org/wso2/carbon/identity/api/server/configs/v1/model/Endpoint.java
@@ -22,6 +22,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import java.util.ArrayList;
+import java.util.List;
 import org.wso2.carbon.identity.api.server.configs.v1.model.AuthenticationType;
 import javax.validation.constraints.*;
 
@@ -35,6 +37,10 @@ public class Endpoint  {
   
     private String uri;
     private AuthenticationType authentication;
+    private List<String> allowedHeaders = null;
+
+    private List<String> allowedParameters = null;
+
 
     /**
     **/
@@ -72,7 +78,61 @@ public class Endpoint  {
         this.authentication = authentication;
     }
 
+    /**
+    * List of HTTP headers to forward to the extension.
+    **/
+    public Endpoint allowedHeaders(List<String> allowedHeaders) {
 
+        this.allowedHeaders = allowedHeaders;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "[\"x-geo-location\",\"host\"]", value = "List of HTTP headers to forward to the extension.")
+    @JsonProperty("allowedHeaders")
+    @Valid
+    public List<String> getAllowedHeaders() {
+        return allowedHeaders;
+    }
+    public void setAllowedHeaders(List<String> allowedHeaders) {
+        this.allowedHeaders = allowedHeaders;
+    }
+
+    public Endpoint addAllowedHeadersItem(String allowedHeadersItem) {
+        if (this.allowedHeaders == null) {
+            this.allowedHeaders = new ArrayList<>();
+        }
+        this.allowedHeaders.add(allowedHeadersItem);
+        return this;
+    }
+
+        /**
+    * List of parameters to forward to the extension.
+    **/
+    public Endpoint allowedParameters(List<String> allowedParameters) {
+
+        this.allowedParameters = allowedParameters;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "[\"device-id\"]", value = "List of parameters to forward to the extension.")
+    @JsonProperty("allowedParameters")
+    @Valid
+    public List<String> getAllowedParameters() {
+        return allowedParameters;
+    }
+    public void setAllowedParameters(List<String> allowedParameters) {
+        this.allowedParameters = allowedParameters;
+    }
+
+    public Endpoint addAllowedParametersItem(String allowedParametersItem) {
+        if (this.allowedParameters == null) {
+            this.allowedParameters = new ArrayList<>();
+        }
+        this.allowedParameters.add(allowedParametersItem);
+        return this;
+    }
+
+    
 
     @Override
     public boolean equals(java.lang.Object o) {
@@ -85,12 +145,14 @@ public class Endpoint  {
         }
         Endpoint endpoint = (Endpoint) o;
         return Objects.equals(this.uri, endpoint.uri) &&
-            Objects.equals(this.authentication, endpoint.authentication);
+            Objects.equals(this.authentication, endpoint.authentication) &&
+            Objects.equals(this.allowedHeaders, endpoint.allowedHeaders) &&
+            Objects.equals(this.allowedParameters, endpoint.allowedParameters);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(uri, authentication);
+        return Objects.hash(uri, authentication, allowedHeaders, allowedParameters);
     }
 
     @Override
@@ -101,6 +163,8 @@ public class Endpoint  {
         
         sb.append("    uri: ").append(toIndentedString(uri)).append("\n");
         sb.append("    authentication: ").append(toIndentedString(authentication)).append("\n");
+        sb.append("    allowedHeaders: ").append(toIndentedString(allowedHeaders)).append("\n");
+        sb.append("    allowedParameters: ").append(toIndentedString(allowedParameters)).append("\n");
         sb.append("}");
         return sb.toString();
     }

--- a/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/main/java/org/wso2/carbon/identity/api/server/configs/v1/core/ServerConfigManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/main/java/org/wso2/carbon/identity/api/server/configs/v1/core/ServerConfigManagementService.java
@@ -913,8 +913,8 @@ public class ServerConfigManagementService {
         Endpoint endpoint = new Endpoint();
         endpoint.setUri(endpointConfig.getAuthenticatorEndpointUri());
         endpoint.setAuthentication(authenticationType);
-        endpoint.allowedHeaders(endpointConfig.getEndpointConfig().getAllowedHeaders());
-        endpoint.allowedParameters(endpointConfig.getEndpointConfig().getAllowedParameters());
+        endpoint.allowedHeaders(endpointConfig.getAuthenticatorEndpointAllowedHeaders());
+        endpoint.allowedParameters(endpointConfig.getAuthenticatorEndpointAllowedParameters());
         authenticator.endpoint(endpoint);
     }
 

--- a/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/main/java/org/wso2/carbon/identity/api/server/configs/v1/core/ServerConfigManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/main/java/org/wso2/carbon/identity/api/server/configs/v1/core/ServerConfigManagementService.java
@@ -913,6 +913,8 @@ public class ServerConfigManagementService {
         Endpoint endpoint = new Endpoint();
         endpoint.setUri(endpointConfig.getAuthenticatorEndpointUri());
         endpoint.setAuthentication(authenticationType);
+        endpoint.allowedHeaders(endpointConfig.getEndpointConfig().getAllowedHeaders());
+        endpoint.allowedParameters(endpointConfig.getEndpointConfig().getAllowedParameters());
         authenticator.endpoint(endpoint);
     }
 

--- a/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/main/resources/configs.yaml
+++ b/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/main/resources/configs.yaml
@@ -1312,6 +1312,18 @@ components:
           pattern: '^https?://.+'
         authentication:
           $ref: '#/components/schemas/AuthenticationType'
+        allowedHeaders:
+          type: array
+          description: List of HTTP headers to forward to the extension.
+          items:
+            type: string
+          example: [ "x-geo-location", "host"]
+        allowedParameters:
+          type: array
+          description: List of parameters to forward to the extension.
+          items:
+            type: string
+          example: [ "device-id"]
     AuthenticationType:
       type: object
       required:

--- a/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/gen/java/org/wso2/carbon/identity/api/server/idp/v1/model/Endpoint.java
+++ b/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/gen/java/org/wso2/carbon/identity/api/server/idp/v1/model/Endpoint.java
@@ -22,6 +22,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import java.util.ArrayList;
+import java.util.List;
 import org.wso2.carbon.identity.api.server.idp.v1.model.AuthenticationType;
 import javax.validation.constraints.*;
 
@@ -35,6 +37,10 @@ public class Endpoint  {
   
     private String uri;
     private AuthenticationType authentication;
+    private List<String> allowedHeaders = null;
+
+    private List<String> allowedParameters = null;
+
 
     /**
     **/
@@ -76,7 +82,61 @@ public class Endpoint  {
         this.authentication = authentication;
     }
 
+    /**
+    * List of HTTP headers to forward to the extension.
+    **/
+    public Endpoint allowedHeaders(List<String> allowedHeaders) {
 
+        this.allowedHeaders = allowedHeaders;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "[\"x-geo-location\",\"host\"]", value = "List of HTTP headers to forward to the extension.")
+    @JsonProperty("allowedHeaders")
+    @Valid
+    public List<String> getAllowedHeaders() {
+        return allowedHeaders;
+    }
+    public void setAllowedHeaders(List<String> allowedHeaders) {
+        this.allowedHeaders = allowedHeaders;
+    }
+
+    public Endpoint addAllowedHeadersItem(String allowedHeadersItem) {
+        if (this.allowedHeaders == null) {
+            this.allowedHeaders = new ArrayList<>();
+        }
+        this.allowedHeaders.add(allowedHeadersItem);
+        return this;
+    }
+
+        /**
+    * List of parameters to forward to the extension.
+    **/
+    public Endpoint allowedParameters(List<String> allowedParameters) {
+
+        this.allowedParameters = allowedParameters;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "[\"device-id\"]", value = "List of parameters to forward to the extension.")
+    @JsonProperty("allowedParameters")
+    @Valid
+    public List<String> getAllowedParameters() {
+        return allowedParameters;
+    }
+    public void setAllowedParameters(List<String> allowedParameters) {
+        this.allowedParameters = allowedParameters;
+    }
+
+    public Endpoint addAllowedParametersItem(String allowedParametersItem) {
+        if (this.allowedParameters == null) {
+            this.allowedParameters = new ArrayList<>();
+        }
+        this.allowedParameters.add(allowedParametersItem);
+        return this;
+    }
+
+    
 
     @Override
     public boolean equals(java.lang.Object o) {
@@ -89,12 +149,14 @@ public class Endpoint  {
         }
         Endpoint endpoint = (Endpoint) o;
         return Objects.equals(this.uri, endpoint.uri) &&
-            Objects.equals(this.authentication, endpoint.authentication);
+            Objects.equals(this.authentication, endpoint.authentication) &&
+            Objects.equals(this.allowedHeaders, endpoint.allowedHeaders) &&
+            Objects.equals(this.allowedParameters, endpoint.allowedParameters);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(uri, authentication);
+        return Objects.hash(uri, authentication, allowedHeaders, allowedParameters);
     }
 
     @Override
@@ -105,6 +167,8 @@ public class Endpoint  {
         
         sb.append("    uri: ").append(toIndentedString(uri)).append("\n");
         sb.append("    authentication: ").append(toIndentedString(authentication)).append("\n");
+        sb.append("    allowedHeaders: ").append(toIndentedString(allowedHeaders)).append("\n");
+        sb.append("    allowedParameters: ").append(toIndentedString(allowedParameters)).append("\n");
         sb.append("}");
         return sb.toString();
     }

--- a/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/main/java/org/wso2/carbon/identity/api/server/idp/v1/impl/FederatedAuthenticatorConfigBuilderFactory.java
+++ b/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/main/java/org/wso2/carbon/identity/api/server/idp/v1/impl/FederatedAuthenticatorConfigBuilderFactory.java
@@ -273,6 +273,8 @@ public class FederatedAuthenticatorConfigBuilderFactory {
                         .entrySet().stream().collect(Collectors.toMap(
                                 Map.Entry::getKey, entry -> entry.getValue().toString())));
             }
+            endpointConfigBuilder.allowedHeaders(federatedAuthenticatorConfigDTO.endpoint.getAllowedHeaders());
+            endpointConfigBuilder.allowedParameters(federatedAuthenticatorConfigDTO.endpoint.getAllowedParameters());
             authConfig.setEndpointConfig(endpointConfigBuilder.build());
 
             return authConfig;
@@ -465,6 +467,8 @@ public class FederatedAuthenticatorConfigBuilderFactory {
             Endpoint endpoint = new Endpoint();
             endpoint.setUri(endpointConfig.getEndpointConfig().getUri());
             endpoint.setAuthentication(authenticationType);
+            endpoint.setAllowedHeaders(endpointConfig.getEndpointConfig().getAllowedHeaders());
+            endpoint.setAllowedParameters(endpointConfig.getEndpointConfig().getAllowedParameters());
             authenticator.setEndpoint(endpoint);
         } catch (ClassCastException e) {
             throw new IdentityProviderManagementServerException(String.format("Error occurred while resolving" +

--- a/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/main/resources/idp.yaml
+++ b/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/main/resources/idp.yaml
@@ -2891,6 +2891,18 @@ components:
           pattern: '^https?://.+'
         authentication:
           $ref: '#/components/schemas/AuthenticationType'
+        allowedHeaders:
+          type: array
+          description: List of HTTP headers to forward to the extension.
+          items:
+            type: string
+          example: [ "x-geo-location", "host"]
+        allowedParameters:
+          type: array
+          description: List of parameters to forward to the extension.
+          items:
+            type: string
+          example: [ "device-id"]
     AuthenticationType:
       type: object
       required:

--- a/pom.xml
+++ b/pom.xml
@@ -953,7 +953,7 @@
         <maven.buildnumber.plugin.version>1.4</maven.buildnumber.plugin.version>
         <org.apache.felix.annotations.version>1.2.4</org.apache.felix.annotations.version>
         <identity.governance.version>1.11.103</identity.governance.version>
-        <carbon.identity.framework.version>7.8.368</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.8.389</carbon.identity.framework.version>
         <maven.findbugsplugin.version>3.0.5</maven.findbugsplugin.version>
         <findsecbugs-plugin.version>1.12.0</findsecbugs-plugin.version>
         <maven.checkstyleplugin.excludes>**/gen/**/*</maven.checkstyleplugin.excludes>


### PR DESCRIPTION
## Purpose
Update custom authenticator related REST APIs to have allowed headers and parameters in the Endpoint object
1. Custom External Authenticator - IDP REST API
2. Custom Internal & 2FA Authenticator - Authenticators REST API/ CONFIGS REST API

## Depends on
- https://github.com/wso2/carbon-identity-framework/pull/7090

## Related Issue
- 