### PR TITLE
Remove b2b metadata

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.webhook.metadata/org.wso2.carbon.identity.api.server.webhook.metadata.v1/src/main/java/org/wso2/carbon/identity/api/server/webhook/metadata/v1/core/ServerWebhookMetadataService.java
+++ b/components/org.wso2.carbon.identity.api.server.webhook.metadata/org.wso2.carbon.identity.api.server.webhook.metadata.v1/src/main/java/org/wso2/carbon/identity/api/server/webhook/metadata/v1/core/ServerWebhookMetadataService.java
@@ -27,7 +27,6 @@ import org.wso2.carbon.identity.api.server.webhook.metadata.v1.model.EventProfil
 import org.wso2.carbon.identity.api.server.webhook.metadata.v1.model.EventProfileMetadata;
 import org.wso2.carbon.identity.api.server.webhook.metadata.v1.model.WebhookMetadata;
 import org.wso2.carbon.identity.api.server.webhook.metadata.v1.model.WebhookMetadataAdapter;
-import org.wso2.carbon.identity.api.server.webhook.metadata.v1.model.WebhookMetadataOrganizationPolicy;
 import org.wso2.carbon.identity.api.server.webhook.metadata.v1.model.WebhookMetadataProperties;
 import org.wso2.carbon.identity.api.server.webhook.metadata.v1.util.WebhookMetadataAPIErrorBuilder;
 import org.wso2.carbon.identity.organization.resource.sharing.policy.management.constant.PolicyEnum;
@@ -85,10 +84,6 @@ public class ServerWebhookMetadataService {
                     .map(this::mapEventProfileMetadata)
                     .collect(Collectors.toList());
 
-            org.wso2.carbon.identity.webhook.metadata.api.model.WebhookMetadataProperties webhookMetadataProperties =
-                    WebhookMetadataServiceHolder.getWebhookMetadataService().getWebhookMetadataProperties(
-                            CarbonContext.getThreadLocalCarbonContext().getTenantDomain());
-
             Adapter adapter =
                     WebhookMetadataServiceHolder.getEventAdapterMetadataService().getCurrentActiveAdapter();
             WebhookMetadataAdapter webhookMetadataAdapter = mapWebhookMetadataAdapter(adapter);
@@ -96,7 +91,6 @@ public class ServerWebhookMetadataService {
             WebhookMetadata webhookMetadata = new WebhookMetadata();
             webhookMetadata.setProfiles(eventProfileMetadataList);
             webhookMetadata.setAdapter(webhookMetadataAdapter);
-            webhookMetadata.setOrganizationPolicy(mapOrganizationPolicy(webhookMetadataProperties));
             return webhookMetadata;
         } catch (WebhookMetadataException e) {
             throw WebhookMetadataAPIErrorBuilder.buildAPIError(e);
@@ -174,18 +168,6 @@ public class ServerWebhookMetadataService {
         webhookMetadataAdapter.setName(adapter.getName());
         webhookMetadataAdapter.setType(adapter.getType().toString());
         return webhookMetadataAdapter;
-    }
-
-    private WebhookMetadataOrganizationPolicy mapOrganizationPolicy(
-            org.wso2.carbon.identity.webhook.metadata.api.model.WebhookMetadataProperties properties) {
-
-        WebhookMetadataOrganizationPolicy organizationPolicy = new WebhookMetadataOrganizationPolicy();
-        organizationPolicy.setPolicyName(
-                WebhookMetadataOrganizationPolicy.PolicyNameEnum.fromValue(
-                        properties.getOrganizationPolicy().getPolicyValue()
-                )
-        );
-        return organizationPolicy;
     }
 
     private org.wso2.carbon.identity.webhook.metadata.api.model.WebhookMetadataProperties mapWebhookMetadataProperties(


### PR DESCRIPTION
## Purpose

This pull request simplifies the `ServerWebhookMetadataService` class by removing all logic and references related to mapping and including organization policy in the webhook metadata API response. The changes focus on reducing unnecessary complexity in the metadata service.

Removed organization policy handling:

* Removed import and usage of `WebhookMetadataOrganizationPolicy` from `ServerWebhookMetadataService`, as well as the associated mapping logic. [[1]](diffhunk://#diff-d682502396fa953793530cbbddcc08aece8e669ac9f6f2eaa06fdb3c102cbad0L30) [[2]](diffhunk://#diff-d682502396fa953793530cbbddcc08aece8e669ac9f6f2eaa06fdb3c102cbad0L179-L190)
* Eliminated fetching and setting of organization policy in the `getWebhookMetadata` method, so the API response no longer includes organization policy information.