### PR TITLE
Add missing createdAt and updatedAt attributes in PreUpdatePassword and PreUpdateProfile Response objects

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.action.management/org.wso2.carbon.identity.api.server.action.management.v1/src/extend/java/org/wso2/carbon/identity/api/server/action/management/v1/PreUpdatePasswordActionResponse.java
+++ b/components/org.wso2.carbon.identity.api.server.action.management/org.wso2.carbon.identity.api.server.action.management.v1/src/extend/java/org/wso2/carbon/identity/api/server/action/management/v1/PreUpdatePasswordActionResponse.java
@@ -41,6 +41,8 @@ public class PreUpdatePasswordActionResponse extends ActionResponse {
         setName(actionResponse.getName());
         setDescription(actionResponse.getDescription());
         setStatus(actionResponse.getStatus());
+        setCreatedAt(actionResponse.getCreatedAt());
+        setUpdatedAt(actionResponse.getUpdatedAt());
         setEndpoint(actionResponse.getEndpoint());
         setRule(actionResponse.getRule());
     }
@@ -99,6 +101,8 @@ public class PreUpdatePasswordActionResponse extends ActionResponse {
                 Objects.equals(this.getDescription(), actionResponse.getDescription()) &&
                 Objects.equals(this.getStatus(), actionResponse.getStatus()) &&
                 Objects.equals(this.getEndpoint(), actionResponse.getEndpoint()) &&
+                Objects.equals(this.getCreatedAt(), actionResponse.getCreatedAt()) &&
+                Objects.equals(this.getUpdatedAt(), actionResponse.getUpdatedAt()) &&
                 Objects.equals(this.passwordSharing, actionResponse.passwordSharing) &&
                 Objects.equals(this.attributes, actionResponse.attributes) &&
                 Objects.equals(this.getRule(), actionResponse.getRule());
@@ -106,8 +110,8 @@ public class PreUpdatePasswordActionResponse extends ActionResponse {
 
     @Override
     public int hashCode() {
-        return Objects.hash(getId(), getType(), getName(), getDescription(), getStatus(), getEndpoint(),
-                passwordSharing, attributes, getRule());
+        return Objects.hash(getId(), getType(), getName(), getDescription(), getStatus(), getCreatedAt(),
+                getUpdatedAt(), getEndpoint(), passwordSharing, attributes, getRule());
     }
 
     @Override
@@ -120,6 +124,8 @@ public class PreUpdatePasswordActionResponse extends ActionResponse {
         sb.append("    name: ").append(toIndentedString(getName())).append("\n");
         sb.append("    description: ").append(toIndentedString(getDescription())).append("\n");
         sb.append("    status: ").append(toIndentedString(getStatus())).append("\n");
+        sb.append("    createdAt: ").append(toIndentedString(getCreatedAt())).append("\n");
+        sb.append("    updatedAt: ").append(toIndentedString(getUpdatedAt())).append("\n");
         sb.append("    endpoint: ").append(toIndentedString(getEndpoint())).append("\n");
         sb.append("    passwordSharing: ").append(toIndentedString(passwordSharing)).append("\n");
         sb.append("    attributes: ").append(toIndentedString(attributes)).append("\n");

--- a/components/org.wso2.carbon.identity.api.server.action.management/org.wso2.carbon.identity.api.server.action.management.v1/src/extend/java/org/wso2/carbon/identity/api/server/action/management/v1/PreUpdatePasswordActionResponse.java
+++ b/components/org.wso2.carbon.identity.api.server.action.management/org.wso2.carbon.identity.api.server.action.management.v1/src/extend/java/org/wso2/carbon/identity/api/server/action/management/v1/PreUpdatePasswordActionResponse.java
@@ -100,9 +100,9 @@ public class PreUpdatePasswordActionResponse extends ActionResponse {
                 Objects.equals(this.getName(), actionResponse.getName()) &&
                 Objects.equals(this.getDescription(), actionResponse.getDescription()) &&
                 Objects.equals(this.getStatus(), actionResponse.getStatus()) &&
-                Objects.equals(this.getEndpoint(), actionResponse.getEndpoint()) &&
                 Objects.equals(this.getCreatedAt(), actionResponse.getCreatedAt()) &&
                 Objects.equals(this.getUpdatedAt(), actionResponse.getUpdatedAt()) &&
+                Objects.equals(this.getEndpoint(), actionResponse.getEndpoint()) &&
                 Objects.equals(this.passwordSharing, actionResponse.passwordSharing) &&
                 Objects.equals(this.attributes, actionResponse.attributes) &&
                 Objects.equals(this.getRule(), actionResponse.getRule());

--- a/components/org.wso2.carbon.identity.api.server.action.management/org.wso2.carbon.identity.api.server.action.management.v1/src/extend/java/org/wso2/carbon/identity/api/server/action/management/v1/PreUpdateProfileActionResponse.java
+++ b/components/org.wso2.carbon.identity.api.server.action.management/org.wso2.carbon.identity.api.server.action.management.v1/src/extend/java/org/wso2/carbon/identity/api/server/action/management/v1/PreUpdateProfileActionResponse.java
@@ -40,6 +40,8 @@ public class PreUpdateProfileActionResponse extends ActionResponse {
         setName(actionResponse.getName());
         setDescription(actionResponse.getDescription());
         setStatus(actionResponse.getStatus());
+        setCreatedAt(actionResponse.getCreatedAt());
+        setUpdatedAt(actionResponse.getUpdatedAt());
         setEndpoint(actionResponse.getEndpoint());
         setRule(actionResponse.getRule());
     }
@@ -78,6 +80,8 @@ public class PreUpdateProfileActionResponse extends ActionResponse {
                 Objects.equals(this.getName(), actionResponse.getName()) &&
                 Objects.equals(this.getDescription(), actionResponse.getDescription()) &&
                 Objects.equals(this.getStatus(), actionResponse.getStatus()) &&
+                Objects.equals(this.getCreatedAt(), actionResponse.getCreatedAt()) &&
+                Objects.equals(this.getUpdatedAt(), actionResponse.getUpdatedAt()) &&
                 Objects.equals(this.getEndpoint(), actionResponse.getEndpoint()) &&
                 Objects.equals(this.attributes, actionResponse.attributes) &&
                 Objects.equals(this.getRule(), actionResponse.getRule());
@@ -85,7 +89,8 @@ public class PreUpdateProfileActionResponse extends ActionResponse {
 
     @Override
     public int hashCode() {
-        return Objects.hash(getId(), getType(), getName(), getDescription(), getStatus(), getEndpoint(), getRule());
+        return Objects.hash(getId(), getType(), getName(), getDescription(), getStatus(), getCreatedAt(),
+                getUpdatedAt(), getEndpoint(), getRule());
     }
 
     @Override
@@ -98,6 +103,8 @@ public class PreUpdateProfileActionResponse extends ActionResponse {
         sb.append("    name: ").append(toIndentedString(getName())).append("\n");
         sb.append("    description: ").append(toIndentedString(getDescription())).append("\n");
         sb.append("    status: ").append(toIndentedString(getStatus())).append("\n");
+        sb.append("    createdAt: ").append(toIndentedString(getCreatedAt())).append("\n");
+        sb.append("    updatedAt: ").append(toIndentedString(getUpdatedAt())).append("\n");
         sb.append("    endpoint: ").append(toIndentedString(getEndpoint())).append("\n");
         sb.append("    attributes: ").append(toIndentedString(attributes)).append("\n");
         sb.append("    rule: ").append(toIndentedString(getRule())).append("\n");


### PR DESCRIPTION
## Purpose
> $subject
Above is missed to update through https://github.com/wso2/identity-api-server/pull/958. Hence adding back with this PR.

### Related PR
- https://github.com/wso2/identity-api-server/pull/958

### Related Issue
- 