### PR TITLE
Fix resident IDP import throwing an Internal Server Error

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/main/java/org/wso2/carbon/identity/api/server/idp/v1/core/ServerIdpManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/main/java/org/wso2/carbon/identity/api/server/idp/v1/core/ServerIdpManagementService.java
@@ -497,11 +497,6 @@ public class ServerIdpManagementService {
                     passiveSTSFedAuthn.setName(IdentityApplicationConstants.Authenticator.PassiveSTS.NAME);
                     passiveSTSFedAuthn.setDefinedByType(DefinedByType.SYSTEM);
 
-                    Property stsIdPEntityIdProperty = new Property();
-                    stsIdPEntityIdProperty.setName(IdentityApplicationConstants.Authenticator.PassiveSTS
-                            .IDENTITY_PROVIDER_ENTITY_ID);
-                    stsIdPEntityIdProperty.setValue(newstsIdPEntityIdProperty.getValue());
-
                     fedAuthnConfigs.add(passiveSTSFedAuthn);
                 }
             }


### PR DESCRIPTION
### Purpose
- When we're importing a resident IDP which we have exported before, we have to only update the configurations allowed to be edited which are stored as federated authenticators with properties
- Currently we allow the following properties to be edited
- - SAML2 Web SSO configurations
- - `Identity Provider Entity ID` and `Enable Authentication Requests Signing` for WS-Federation Configurations

### Related Issue
- https://github.com/wso2/product-is/issues/23813