### PR TITLE
[ bug-fix ] Fix /api/server/v1/configs/schemas/ API not returning custom SCIM schemas

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.common/pom.xml
+++ b/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.common/pom.xml
@@ -77,6 +77,11 @@
             <artifactId>org.wso2.carbon.identity.organization.management.service</artifactId>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.inbound.provisioning.scim2</groupId>
+            <artifactId>org.wso2.carbon.identity.scim2.common</artifactId>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
     
 </project>

--- a/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.common/src/main/java/org/wso2/carbon/identity/api/server/configs/common/ConfigsServiceHolder.java
+++ b/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.common/src/main/java/org/wso2/carbon/identity/api/server/configs/common/ConfigsServiceHolder.java
@@ -21,6 +21,7 @@ package org.wso2.carbon.identity.api.server.configs.common;
 import org.wso2.carbon.base.api.ServerConfigurationService;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.identity.application.mgt.ApplicationManagementService;
+import org.wso2.carbon.identity.claim.metadata.mgt.ClaimMetadataManagementService;
 import org.wso2.carbon.identity.cors.mgt.core.CORSManagementService;
 import org.wso2.carbon.identity.oauth.dcr.DCRConfigurationMgtService;
 import org.wso2.carbon.identity.oauth2.impersonation.services.ImpersonationConfigMgtService;
@@ -84,6 +85,13 @@ public class ConfigsServiceHolder {
         static final ServerConfigurationService SERVICE =
                 (ServerConfigurationService) PrivilegedCarbonContext.getThreadLocalCarbonContext()
                         .getOSGiService(ServerConfigurationService.class, null);
+    }
+
+    private static class ClaimMetaDataManagementServiceHolder {
+
+        static final ClaimMetadataManagementService SERVICE =
+                (ClaimMetadataManagementService) PrivilegedCarbonContext.getThreadLocalCarbonContext()
+                        .getOSGiService(ClaimMetadataManagementService.class, null);
     }
 
     /**
@@ -164,5 +172,15 @@ public class ConfigsServiceHolder {
     public static ServerConfigurationService getServerConfigurationService() {
 
         return ServerConfigurationServiceHolder.SERVICE;
+    }
+
+    /**
+     * Get ClaimMetadataManagementService osgi service.
+     *
+     * @return ClaimMetadataManagementService
+     */
+    public static ClaimMetadataManagementService getClaimMetadataManagementService() {
+
+        return ClaimMetaDataManagementServiceHolder.SERVICE;
     }
 }

--- a/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.common/src/main/java/org/wso2/carbon/identity/api/server/configs/common/Utils.java
+++ b/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.common/src/main/java/org/wso2/carbon/identity/api/server/configs/common/Utils.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.configs.common;
+
+import org.wso2.carbon.identity.claim.metadata.mgt.exception.ClaimMetadataException;
+import org.wso2.carbon.identity.claim.metadata.mgt.model.ExternalClaim;
+
+import java.util.List;
+
+/**
+ * Utility class for Configs Service.
+ */
+public class Utils {
+
+    private Utils() {}
+
+    /**
+     * Get external claims for a given external claim dialect.
+     *
+     * @param externalClaimDialect External claim dialect.
+     * @return List of external claims.
+     * @throws ClaimMetadataException If an error occurs while retrieving external claims.
+     */
+    public static List<ExternalClaim> getExternalClaims(String externalClaimDialect, String tenantDomain)
+            throws ClaimMetadataException {
+
+        try {
+            return ConfigsServiceHolder.getClaimMetadataManagementService().
+                    getExternalClaims(externalClaimDialect, tenantDomain);
+        } catch (ClaimMetadataException e) {
+            throw new ClaimMetadataException("Error while retrieving external claims.", e);
+        }
+    }
+}


### PR DESCRIPTION
## Purpose
>  Fix the issue of  `GET /api/server/v1/configs/schemas/` API endpoint not returning `custom` and `system` SCIM schemas. This change also fixes `GET /api/server/v1/configs/schemas/{schema-id}` endpoint. 

## Approach
> Instead of loading schema information from `schemas.xml` (as done currently), retrieve it from the claim management service. Four schemas; core, user, enterprise, and system are fixed, while the custom schema is dynamic and updated whenever a new attribute mapping is added.
The schema map is monitored for changes to the custom schema, and updates are applied accordingly when one of the endpoints are called.

## Related
- https://github.com/wso2/product-is/issues/24620

## Endpoint results after fix

`GET /api/server/v1/configs/schemas` 

<img width="882" height="678" alt="image" src="https://github.com/user-attachments/assets/661b738e-c39c-49c9-84df-ddb9cbd651b0" />

`GET /api/server/v1/configs/schemas/{schema_id}`

<img width="882" height="720" alt="image" src="https://github.com/user-attachments/assets/78cbdb5a-bf2c-4b6f-b382-b0715178f380" />

