### PR TITLE
[next] Validate duplicate canonical values

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.claim.management/org.wso2.carbon.identity.rest.api.server.claim.management.v1/src/main/java/org/wso2/carbon/identity/rest/api/server/claim/management/v1/core/ServerClaimManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.claim.management/org.wso2.carbon.identity.rest.api.server.claim.management.v1/src/main/java/org/wso2/carbon/identity/rest/api/server/claim/management/v1/core/ServerClaimManagementService.java
@@ -90,6 +90,7 @@ import java.util.Base64;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -1303,7 +1304,7 @@ public class ServerClaimManagementService {
             try {
                 Collection<LabelValueDTO> canonicalValuesSet = Arrays.stream(localClaimReqDTO.getCanonicalValues())
                                 .collect(Collectors.toMap(LabelValueDTO::getLabel, Function.identity(),
-                                        (v1, v2) -> v1)).values();
+                                        (v1, v2) -> v1, LinkedHashMap::new)).values();
                 if (LOG.isDebugEnabled()) {
                     LOG.debug("Processing " + canonicalValuesSet.size() + " unique canonical values for claim: " +
                             localClaimReqDTO.getClaimURI());

--- a/components/org.wso2.carbon.identity.api.server.claim.management/org.wso2.carbon.identity.rest.api.server.claim.management.v1/src/main/java/org/wso2/carbon/identity/rest/api/server/claim/management/v1/core/ServerClaimManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.claim.management/org.wso2.carbon.identity.rest.api.server.claim.management.v1/src/main/java/org/wso2/carbon/identity/rest/api/server/claim/management/v1/core/ServerClaimManagementService.java
@@ -88,14 +88,13 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Base64;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import javax.ws.rs.core.Response;
@@ -1302,10 +1301,13 @@ public class ServerClaimManagementService {
 
         if (ArrayUtils.isNotEmpty(localClaimReqDTO.getCanonicalValues())) {
             try {
-                Collection<LabelValueDTO> canonicalValuesSet =
-                        new HashSet<>(Arrays.asList(localClaimReqDTO.getCanonicalValues())).stream()
-                        .collect(Collectors.toMap(LabelValueDTO::getLabel, v -> v,
-                                (v1, v2) -> v1)).values();
+                Collection<LabelValueDTO> canonicalValuesSet = Arrays.stream(localClaimReqDTO.getCanonicalValues())
+                                .collect(Collectors.toMap(LabelValueDTO::getLabel, Function.identity(),
+                                        (v1, v2) -> v1)).values();
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("Processing " + canonicalValuesSet.size() + " unique canonical values for claim: " +
+                            localClaimReqDTO.getClaimURI());
+                }
                 String jsonString = mapper.writeValueAsString(canonicalValuesSet);
                 claimProperties.put(PROP_CANONICAL_VALUES, jsonString);
             } catch (JsonProcessingException e) {

--- a/components/org.wso2.carbon.identity.api.server.claim.management/org.wso2.carbon.identity.rest.api.server.claim.management.v1/src/main/java/org/wso2/carbon/identity/rest/api/server/claim/management/v1/core/ServerClaimManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.claim.management/org.wso2.carbon.identity.rest.api.server.claim.management.v1/src/main/java/org/wso2/carbon/identity/rest/api/server/claim/management/v1/core/ServerClaimManagementService.java
@@ -87,7 +87,10 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Base64;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
@@ -1299,7 +1302,11 @@ public class ServerClaimManagementService {
 
         if (ArrayUtils.isNotEmpty(localClaimReqDTO.getCanonicalValues())) {
             try {
-                String jsonString = mapper.writeValueAsString(localClaimReqDTO.getCanonicalValues());
+                Collection<LabelValueDTO> canonicalValuesSet =
+                        new HashSet<>(Arrays.asList(localClaimReqDTO.getCanonicalValues())).stream()
+                        .collect(Collectors.toMap(LabelValueDTO::getLabel, v -> v,
+                                (v1, v2) -> v1)).values();
+                String jsonString = mapper.writeValueAsString(canonicalValuesSet);
                 claimProperties.put(PROP_CANONICAL_VALUES, jsonString);
             } catch (JsonProcessingException e) {
                 LOG.error("Error while parsing canonical values.", e);


### PR DESCRIPTION
## Purpose
The duplicated canonical values send to the processing will be filtered.

## Related Issues
- https://github.com/wso2/product-is/issues/25335

### Related PRs
- https://github.com/wso2/identity-api-server/pull/971