### PR TITLE
Return realm configs based on mgt permission

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/main/java/org/wso2/carbon/identity/api/server/configs/v1/core/ServerConfigManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/main/java/org/wso2/carbon/identity/api/server/configs/v1/core/ServerConfigManagementService.java
@@ -244,17 +244,17 @@ public class ServerConfigManagementService {
         RealmConfig realmConfig = null;
 
         try {
-            boolean isUerAuthorizedToInternalConfigView;
+            boolean isUerAuthorizedToViewInternalConfig;
             boolean isSubOrganization = OrganizationManagementUtil.isOrganization(tenantDomain);
             if (isSubOrganization) {
-                isUerAuthorizedToInternalConfigView =
+                isUerAuthorizedToViewInternalConfig =
                         AuthzUtil.isUserAuthorized(user, Collections.singletonList("internal_org_config_view"));
             } else {
-                isUerAuthorizedToInternalConfigView =
+                isUerAuthorizedToViewInternalConfig =
                         AuthzUtil.isUserAuthorized(user, Collections.singletonList("internal_config_view"));
             }
 
-            if (isUerAuthorizedToInternalConfigView) {
+            if (isUerAuthorizedToViewInternalConfig) {
                 try {
                     if (userRealm != null && userRealm.getRealmConfiguration() != null) {
                         realmConfig = new RealmConfig();


### PR DESCRIPTION
## Purpose
This pull request enhances the authorization logic in the `ServerConfigManagementService#getConfigs` method to ensure that only users with the appropriate permissions can view internal configuration details. The changes introduce user-specific authorization checks and handle sub-organization scenarios, improving security and compliance with organizational boundaries.

**Authorization and Security Improvements:**

* Added logic to determine if the current tenant is a sub-organization and to check user authorization for viewing internal configuration, using `AuthzUtil.isUserAuthorized` with the relevant permission (`internal_org_config_view` for sub-organizations, `internal_config_view` otherwise).
* Constructed an `AuthenticatedUser` object from the current context to use in permission checks, ensuring authorization is performed for the correct user.

**Error Handling Enhancements:**

* Updated error handling to catch `IdentityOAuth2Exception` and `OrganizationManagementException` during authorization checks, returning an internal server error if an exception occurs.

**Dependency Additions:**

* Imported `AuthenticatedUser`, `IdentityOAuth2Exception`, and `AuthzUtil` to support the new authorization logic. [[1]](diffhunk://#diff-795c8a71a78557b8ee61df48cd95fc7ce1b63a5272acaddef7385eccce84f14dR67) [[2]](diffhunk://#diff-795c8a71a78557b8ee61df48cd95fc7ce1b63a5272acaddef7385eccce84f14dR95-R102)