### PR TITLE
Add Configs as properties to flows.

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.flow.management/org.wso2.carbon.identity.api.server.flow.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/flow/management/v1/FlowConfig.java
+++ b/components/org.wso2.carbon.identity.api.server.flow.management/org.wso2.carbon.identity.api.server.flow.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/flow/management/v1/FlowConfig.java
@@ -19,86 +19,97 @@
 package org.wso2.carbon.identity.api.server.flow.management.v1;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import javax.validation.constraints.*;
 
+/**
+ * Flow configurations for a flow type
+ **/
+
+import io.swagger.annotations.*;
 import java.util.Objects;
-
 import javax.validation.Valid;
-
+import javax.xml.bind.annotation.*;
 @ApiModel(description = "Flow configurations for a flow type")
-public class FlowConfig {
-
+public class FlowConfig  {
+  
     private String flowType;
     private Boolean isEnabled;
-    private Boolean isAutoLoginEnabled;
+    private Map<String, String> properties = null;
+
 
     /**
-     * Flow type
-     **/
+    * Flow type
+    **/
     public FlowConfig flowType(String flowType) {
 
         this.flowType = flowType;
         return this;
     }
-
+    
     @ApiModelProperty(example = "REGISTRATION", value = "Flow type")
     @JsonProperty("flowType")
     @Valid
     public String getFlowType() {
-
         return flowType;
     }
-
     public void setFlowType(String flowType) {
-
         this.flowType = flowType;
     }
 
     /**
-     * Indicate whether the orchestration is enabled for the flow
-     **/
+    * Indicate whether the orchestration is enabled for the flow
+    **/
     public FlowConfig isEnabled(Boolean isEnabled) {
 
         this.isEnabled = isEnabled;
         return this;
     }
-
+    
     @ApiModelProperty(example = "true", value = "Indicate whether the orchestration is enabled for the flow")
     @JsonProperty("isEnabled")
     @Valid
     public Boolean getIsEnabled() {
-
         return isEnabled;
     }
-
     public void setIsEnabled(Boolean isEnabled) {
-
         this.isEnabled = isEnabled;
     }
 
     /**
-     * Indicate whether the auto login is enabled for the flow
-     **/
-    public FlowConfig isAutoLoginEnabled(Boolean isAutoLoginEnabled) {
+    * Flow properties.
+    **/
+    public FlowConfig properties(Map<String, String> properties) {
 
-        this.isAutoLoginEnabled = isAutoLoginEnabled;
+        this.properties = properties;
+        return this;
+    }
+    
+    @ApiModelProperty(value = "Flow properties.")
+    @JsonProperty("properties")
+    @Valid
+    public Map<String, String> getProperties() {
+        return properties;
+    }
+    public void setProperties(Map<String, String> properties) {
+        this.properties = properties;
+    }
+
+
+    public FlowConfig putPropertiesItem(String key, String propertiesItem) {
+        if (this.properties == null) {
+            this.properties = new HashMap<String, String>();
+        }
+        this.properties.put(key, propertiesItem);
         return this;
     }
 
-    @ApiModelProperty(example = "true", value = "Indicate whether the auto login is enabled for the flow")
-    @JsonProperty("isAutoLoginEnabled")
-    @Valid
-    public Boolean getIsAutoLoginEnabled() {
-
-        return isAutoLoginEnabled;
-    }
-
-    public void setIsAutoLoginEnabled(Boolean isAutoLoginEnabled) {
-
-        this.isAutoLoginEnabled = isAutoLoginEnabled;
-    }
-
+    
 
     @Override
     public boolean equals(java.lang.Object o) {
@@ -111,14 +122,13 @@ public class FlowConfig {
         }
         FlowConfig flowConfig = (FlowConfig) o;
         return Objects.equals(this.flowType, flowConfig.flowType) &&
-                Objects.equals(this.isEnabled, flowConfig.isEnabled) &&
-                Objects.equals(this.isAutoLoginEnabled, flowConfig.isAutoLoginEnabled);
+            Objects.equals(this.isEnabled, flowConfig.isEnabled) &&
+            Objects.equals(this.properties, flowConfig.properties);
     }
 
     @Override
     public int hashCode() {
-
-        return Objects.hash(flowType, isEnabled, isAutoLoginEnabled);
+        return Objects.hash(flowType, isEnabled, properties);
     }
 
     @Override
@@ -126,18 +136,18 @@ public class FlowConfig {
 
         StringBuilder sb = new StringBuilder();
         sb.append("class FlowConfig {\n");
-
+        
         sb.append("    flowType: ").append(toIndentedString(flowType)).append("\n");
         sb.append("    isEnabled: ").append(toIndentedString(isEnabled)).append("\n");
-        sb.append("    isAutoLoginEnabled: ").append(toIndentedString(isAutoLoginEnabled)).append("\n");
+        sb.append("    properties: ").append(toIndentedString(properties)).append("\n");
         sb.append("}");
         return sb.toString();
     }
 
     /**
-     * Convert the given object to string with each line indented by 4 spaces
-     * (except the first line).
-     */
+    * Convert the given object to string with each line indented by 4 spaces
+    * (except the first line).
+    */
     private String toIndentedString(java.lang.Object o) {
 
         if (o == null) {

--- a/components/org.wso2.carbon.identity.api.server.flow.management/org.wso2.carbon.identity.api.server.flow.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/flow/management/v1/FlowConfig.java
+++ b/components/org.wso2.carbon.identity.api.server.flow.management/org.wso2.carbon.identity.api.server.flow.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/flow/management/v1/FlowConfig.java
@@ -40,7 +40,7 @@ public class FlowConfig  {
   
     private String flowType;
     private Boolean isEnabled;
-    private Map<String, String> properties = null;
+    private Map<String, String> flowCompletionConfigs = null;
 
 
     /**
@@ -82,30 +82,30 @@ public class FlowConfig  {
     }
 
     /**
-    * Flow properties.
+    * Flow Completion Configs.
     **/
-    public FlowConfig properties(Map<String, String> properties) {
+    public FlowConfig flowCompletionConfigs(Map<String, String> flowCompletionConfigs) {
 
-        this.properties = properties;
+        this.flowCompletionConfigs = flowCompletionConfigs;
         return this;
     }
     
-    @ApiModelProperty(value = "Flow properties.")
-    @JsonProperty("properties")
+    @ApiModelProperty(value = "Flow Completion Configs.")
+    @JsonProperty("flowCompletionConfigs")
     @Valid
-    public Map<String, String> getProperties() {
-        return properties;
+    public Map<String, String> getFlowCompletionConfigs() {
+        return flowCompletionConfigs;
     }
-    public void setProperties(Map<String, String> properties) {
-        this.properties = properties;
+    public void setFlowCompletionConfigs(Map<String, String> flowCompletionConfigs) {
+        this.flowCompletionConfigs = flowCompletionConfigs;
     }
 
 
-    public FlowConfig putPropertiesItem(String key, String propertiesItem) {
-        if (this.properties == null) {
-            this.properties = new HashMap<String, String>();
+    public FlowConfig putFlowCompletionConfigsItem(String key, String flowCompletionConfigsItem) {
+        if (this.flowCompletionConfigs == null) {
+            this.flowCompletionConfigs = new HashMap<String, String>();
         }
-        this.properties.put(key, propertiesItem);
+        this.flowCompletionConfigs.put(key, flowCompletionConfigsItem);
         return this;
     }
 
@@ -123,12 +123,12 @@ public class FlowConfig  {
         FlowConfig flowConfig = (FlowConfig) o;
         return Objects.equals(this.flowType, flowConfig.flowType) &&
             Objects.equals(this.isEnabled, flowConfig.isEnabled) &&
-            Objects.equals(this.properties, flowConfig.properties);
+            Objects.equals(this.flowCompletionConfigs, flowConfig.flowCompletionConfigs);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(flowType, isEnabled, properties);
+        return Objects.hash(flowType, isEnabled, flowCompletionConfigs);
     }
 
     @Override
@@ -139,7 +139,7 @@ public class FlowConfig  {
         
         sb.append("    flowType: ").append(toIndentedString(flowType)).append("\n");
         sb.append("    isEnabled: ").append(toIndentedString(isEnabled)).append("\n");
-        sb.append("    properties: ").append(toIndentedString(properties)).append("\n");
+        sb.append("    flowCompletionConfigs: ").append(toIndentedString(flowCompletionConfigs)).append("\n");
         sb.append("}");
         return sb.toString();
     }

--- a/components/org.wso2.carbon.identity.api.server.flow.management/org.wso2.carbon.identity.api.server.flow.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/flow/management/v1/FlowConfigPatchModel.java
+++ b/components/org.wso2.carbon.identity.api.server.flow.management/org.wso2.carbon.identity.api.server.flow.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/flow/management/v1/FlowConfigPatchModel.java
@@ -19,89 +19,99 @@
 package org.wso2.carbon.identity.api.server.flow.management.v1;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import javax.validation.constraints.*;
 
+/**
+ * Patch model for configurations of a flow type
+ **/
+
+import io.swagger.annotations.*;
 import java.util.Objects;
-
 import javax.validation.Valid;
-import javax.validation.constraints.NotNull;
-
+import javax.xml.bind.annotation.*;
 @ApiModel(description = "Patch model for configurations of a flow type")
-public class FlowConfigPatchModel {
-
+public class FlowConfigPatchModel  {
+  
     private String flowType;
     private Boolean isEnabled;
-    private Boolean isAutoLoginEnabled;
+    private Map<String, String> properties = null;
+
 
     /**
-     * Flow type
-     **/
+    * Flow type
+    **/
     public FlowConfigPatchModel flowType(String flowType) {
 
         this.flowType = flowType;
         return this;
     }
-
+    
     @ApiModelProperty(example = "REGISTRATION", required = true, value = "Flow type")
     @JsonProperty("flowType")
     @Valid
     @NotNull(message = "Property flowType cannot be null.")
 
     public String getFlowType() {
-
         return flowType;
     }
-
     public void setFlowType(String flowType) {
-
         this.flowType = flowType;
     }
 
     /**
-     * Indicate whether the orchestration is enabled for the flow
-     **/
+    * Indicate whether the orchestration is enabled for the flow
+    **/
     public FlowConfigPatchModel isEnabled(Boolean isEnabled) {
 
         this.isEnabled = isEnabled;
         return this;
     }
-
+    
     @ApiModelProperty(example = "true", value = "Indicate whether the orchestration is enabled for the flow")
     @JsonProperty("isEnabled")
     @Valid
     public Boolean getIsEnabled() {
-
         return isEnabled;
     }
-
     public void setIsEnabled(Boolean isEnabled) {
-
         this.isEnabled = isEnabled;
     }
 
     /**
-     * Indicate whether the auto login is enabled for the flow
-     **/
-    public FlowConfigPatchModel isAutoLoginEnabled(Boolean isAutoLoginEnabled) {
+    * Flow Properties.
+    **/
+    public FlowConfigPatchModel properties(Map<String, String> properties) {
 
-        this.isAutoLoginEnabled = isAutoLoginEnabled;
+        this.properties = properties;
+        return this;
+    }
+    
+    @ApiModelProperty(value = "Flow Properties.")
+    @JsonProperty("properties")
+    @Valid
+    public Map<String, String> getProperties() {
+        return properties;
+    }
+    public void setProperties(Map<String, String> properties) {
+        this.properties = properties;
+    }
+
+
+    public FlowConfigPatchModel putPropertiesItem(String key, String propertiesItem) {
+        if (this.properties == null) {
+            this.properties = new HashMap<String, String>();
+        }
+        this.properties.put(key, propertiesItem);
         return this;
     }
 
-    @ApiModelProperty(example = "true", value = "Indicate whether the auto login is enabled for the flow")
-    @JsonProperty("isAutoLoginEnabled")
-    @Valid
-    public Boolean getIsAutoLoginEnabled() {
-
-        return isAutoLoginEnabled;
-    }
-
-    public void setIsAutoLoginEnabled(Boolean isAutoLoginEnabled) {
-
-        this.isAutoLoginEnabled = isAutoLoginEnabled;
-    }
-
+    
 
     @Override
     public boolean equals(java.lang.Object o) {
@@ -114,14 +124,13 @@ public class FlowConfigPatchModel {
         }
         FlowConfigPatchModel flowConfigPatchModel = (FlowConfigPatchModel) o;
         return Objects.equals(this.flowType, flowConfigPatchModel.flowType) &&
-                Objects.equals(this.isEnabled, flowConfigPatchModel.isEnabled) &&
-                Objects.equals(this.isAutoLoginEnabled, flowConfigPatchModel.isAutoLoginEnabled);
+            Objects.equals(this.isEnabled, flowConfigPatchModel.isEnabled) &&
+            Objects.equals(this.properties, flowConfigPatchModel.properties);
     }
 
     @Override
     public int hashCode() {
-
-        return Objects.hash(flowType, isEnabled, isAutoLoginEnabled);
+        return Objects.hash(flowType, isEnabled, properties);
     }
 
     @Override
@@ -129,18 +138,18 @@ public class FlowConfigPatchModel {
 
         StringBuilder sb = new StringBuilder();
         sb.append("class FlowConfigPatchModel {\n");
-
+        
         sb.append("    flowType: ").append(toIndentedString(flowType)).append("\n");
         sb.append("    isEnabled: ").append(toIndentedString(isEnabled)).append("\n");
-        sb.append("    isAutoLoginEnabled: ").append(toIndentedString(isAutoLoginEnabled)).append("\n");
+        sb.append("    properties: ").append(toIndentedString(properties)).append("\n");
         sb.append("}");
         return sb.toString();
     }
 
     /**
-     * Convert the given object to string with each line indented by 4 spaces
-     * (except the first line).
-     */
+    * Convert the given object to string with each line indented by 4 spaces
+    * (except the first line).
+    */
     private String toIndentedString(java.lang.Object o) {
 
         if (o == null) {

--- a/components/org.wso2.carbon.identity.api.server.flow.management/org.wso2.carbon.identity.api.server.flow.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/flow/management/v1/FlowConfigPatchModel.java
+++ b/components/org.wso2.carbon.identity.api.server.flow.management/org.wso2.carbon.identity.api.server.flow.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/flow/management/v1/FlowConfigPatchModel.java
@@ -40,7 +40,7 @@ public class FlowConfigPatchModel  {
   
     private String flowType;
     private Boolean isEnabled;
-    private Map<String, String> properties = null;
+    private Map<String, String> flowCompletionConfigs = null;
 
 
     /**
@@ -84,30 +84,30 @@ public class FlowConfigPatchModel  {
     }
 
     /**
-    * Flow Properties.
+    * Flow Completion Configs.
     **/
-    public FlowConfigPatchModel properties(Map<String, String> properties) {
+    public FlowConfigPatchModel flowCompletionConfigs(Map<String, String> flowCompletionConfigs) {
 
-        this.properties = properties;
+        this.flowCompletionConfigs = flowCompletionConfigs;
         return this;
     }
     
-    @ApiModelProperty(value = "Flow Properties.")
-    @JsonProperty("properties")
+    @ApiModelProperty(value = "Flow Completion Configs.")
+    @JsonProperty("flowCompletionConfigs")
     @Valid
-    public Map<String, String> getProperties() {
-        return properties;
+    public Map<String, String> getFlowCompletionConfigs() {
+        return flowCompletionConfigs;
     }
-    public void setProperties(Map<String, String> properties) {
-        this.properties = properties;
+    public void setFlowCompletionConfigs(Map<String, String> flowCompletionConfigs) {
+        this.flowCompletionConfigs = flowCompletionConfigs;
     }
 
 
-    public FlowConfigPatchModel putPropertiesItem(String key, String propertiesItem) {
-        if (this.properties == null) {
-            this.properties = new HashMap<String, String>();
+    public FlowConfigPatchModel putFlowCompletionConfigsItem(String key, String flowCompletionConfigsItem) {
+        if (this.flowCompletionConfigs == null) {
+            this.flowCompletionConfigs = new HashMap<String, String>();
         }
-        this.properties.put(key, propertiesItem);
+        this.flowCompletionConfigs.put(key, flowCompletionConfigsItem);
         return this;
     }
 
@@ -125,12 +125,12 @@ public class FlowConfigPatchModel  {
         FlowConfigPatchModel flowConfigPatchModel = (FlowConfigPatchModel) o;
         return Objects.equals(this.flowType, flowConfigPatchModel.flowType) &&
             Objects.equals(this.isEnabled, flowConfigPatchModel.isEnabled) &&
-            Objects.equals(this.properties, flowConfigPatchModel.properties);
+            Objects.equals(this.flowCompletionConfigs, flowConfigPatchModel.flowCompletionConfigs);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(flowType, isEnabled, properties);
+        return Objects.hash(flowType, isEnabled, flowCompletionConfigs);
     }
 
     @Override
@@ -141,7 +141,7 @@ public class FlowConfigPatchModel  {
         
         sb.append("    flowType: ").append(toIndentedString(flowType)).append("\n");
         sb.append("    isEnabled: ").append(toIndentedString(isEnabled)).append("\n");
-        sb.append("    properties: ").append(toIndentedString(properties)).append("\n");
+        sb.append("    flowCompletionConfigs: ").append(toIndentedString(flowCompletionConfigs)).append("\n");
         sb.append("}");
         return sb.toString();
     }

--- a/components/org.wso2.carbon.identity.api.server.flow.management/org.wso2.carbon.identity.api.server.flow.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/flow/management/v1/FlowMetaResponse.java
+++ b/components/org.wso2.carbon.identity.api.server.flow.management/org.wso2.carbon.identity.api.server.flow.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/flow/management/v1/FlowMetaResponse.java
@@ -19,74 +19,75 @@
 package org.wso2.carbon.identity.api.server.flow.management.v1;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
-
 import java.util.ArrayList;
 import java.util.List;
+import org.wso2.carbon.identity.api.server.flow.management.v1.AttributeMetadata;
+import org.wso2.carbon.identity.api.server.flow.management.v1.ExecutorConnections;
+import javax.validation.constraints.*;
+
+/**
+ * General metadata for a flow type
+ **/
+
+import io.swagger.annotations.*;
 import java.util.Objects;
-
 import javax.validation.Valid;
-
+import javax.xml.bind.annotation.*;
 @ApiModel(description = "General metadata for a flow type")
-public class FlowMetaResponse {
-
+public class FlowMetaResponse  {
+  
     private String flowType;
     private List<String> supportedExecutors = null;
 
     private Object connectorConfigs;
     private String attributeProfile;
+    private List<String> supportedProperties = null;
+
     private List<AttributeMetadata> attributeMetadata = null;
 
     private List<ExecutorConnections> executorConnections = null;
 
 
     /**
-     *
-     **/
+    **/
     public FlowMetaResponse flowType(String flowType) {
 
         this.flowType = flowType;
         return this;
     }
-
+    
     @ApiModelProperty(example = "PASSWORD_RECOVERY", value = "")
     @JsonProperty("flowType")
     @Valid
     public String getFlowType() {
-
         return flowType;
     }
-
     public void setFlowType(String flowType) {
-
         this.flowType = flowType;
     }
 
     /**
-     *
-     **/
+    **/
     public FlowMetaResponse supportedExecutors(List<String> supportedExecutors) {
 
         this.supportedExecutors = supportedExecutors;
         return this;
     }
-
+    
     @ApiModelProperty(value = "")
     @JsonProperty("supportedExecutors")
     @Valid
     public List<String> getSupportedExecutors() {
-
         return supportedExecutors;
     }
-
     public void setSupportedExecutors(List<String> supportedExecutors) {
-
         this.supportedExecutors = supportedExecutors;
     }
 
     public FlowMetaResponse addSupportedExecutorsItem(String supportedExecutorsItem) {
-
         if (this.supportedExecutors == null) {
             this.supportedExecutors = new ArrayList<String>();
         }
@@ -94,74 +95,87 @@ public class FlowMetaResponse {
         return this;
     }
 
-    /**
-     *
-     **/
+        /**
+    **/
     public FlowMetaResponse connectorConfigs(Object connectorConfigs) {
 
         this.connectorConfigs = connectorConfigs;
         return this;
     }
-
+    
     @ApiModelProperty(value = "")
     @JsonProperty("connectorConfigs")
     @Valid
     public Object getConnectorConfigs() {
-
         return connectorConfigs;
     }
-
     public void setConnectorConfigs(Object connectorConfigs) {
-
         this.connectorConfigs = connectorConfigs;
     }
 
     /**
-     *
-     **/
+    **/
     public FlowMetaResponse attributeProfile(String attributeProfile) {
 
         this.attributeProfile = attributeProfile;
         return this;
     }
-
+    
     @ApiModelProperty(example = "End-User-Profile", value = "")
     @JsonProperty("attributeProfile")
     @Valid
     public String getAttributeProfile() {
-
         return attributeProfile;
     }
-
     public void setAttributeProfile(String attributeProfile) {
-
         this.attributeProfile = attributeProfile;
     }
 
     /**
-     *
-     **/
+    **/
+    public FlowMetaResponse supportedProperties(List<String> supportedProperties) {
+
+        this.supportedProperties = supportedProperties;
+        return this;
+    }
+    
+    @ApiModelProperty(value = "")
+    @JsonProperty("supportedProperties")
+    @Valid
+    public List<String> getSupportedProperties() {
+        return supportedProperties;
+    }
+    public void setSupportedProperties(List<String> supportedProperties) {
+        this.supportedProperties = supportedProperties;
+    }
+
+    public FlowMetaResponse addSupportedPropertiesItem(String supportedPropertiesItem) {
+        if (this.supportedProperties == null) {
+            this.supportedProperties = new ArrayList<String>();
+        }
+        this.supportedProperties.add(supportedPropertiesItem);
+        return this;
+    }
+
+        /**
+    **/
     public FlowMetaResponse attributeMetadata(List<AttributeMetadata> attributeMetadata) {
 
         this.attributeMetadata = attributeMetadata;
         return this;
     }
-
+    
     @ApiModelProperty(value = "")
     @JsonProperty("attributeMetadata")
     @Valid
     public List<AttributeMetadata> getAttributeMetadata() {
-
         return attributeMetadata;
     }
-
     public void setAttributeMetadata(List<AttributeMetadata> attributeMetadata) {
-
         this.attributeMetadata = attributeMetadata;
     }
 
     public FlowMetaResponse addAttributeMetadataItem(AttributeMetadata attributeMetadataItem) {
-
         if (this.attributeMetadata == null) {
             this.attributeMetadata = new ArrayList<AttributeMetadata>();
         }
@@ -169,30 +183,25 @@ public class FlowMetaResponse {
         return this;
     }
 
-    /**
-     *
-     **/
+        /**
+    **/
     public FlowMetaResponse executorConnections(List<ExecutorConnections> executorConnections) {
 
         this.executorConnections = executorConnections;
         return this;
     }
-
+    
     @ApiModelProperty(value = "")
     @JsonProperty("executorConnections")
     @Valid
     public List<ExecutorConnections> getExecutorConnections() {
-
         return executorConnections;
     }
-
     public void setExecutorConnections(List<ExecutorConnections> executorConnections) {
-
         this.executorConnections = executorConnections;
     }
 
     public FlowMetaResponse addExecutorConnectionsItem(ExecutorConnections executorConnectionsItem) {
-
         if (this.executorConnections == null) {
             this.executorConnections = new ArrayList<ExecutorConnections>();
         }
@@ -200,6 +209,7 @@ public class FlowMetaResponse {
         return this;
     }
 
+    
 
     @Override
     public boolean equals(java.lang.Object o) {
@@ -212,17 +222,17 @@ public class FlowMetaResponse {
         }
         FlowMetaResponse flowMetaResponse = (FlowMetaResponse) o;
         return Objects.equals(this.flowType, flowMetaResponse.flowType) &&
-                Objects.equals(this.supportedExecutors, flowMetaResponse.supportedExecutors) &&
-                Objects.equals(this.connectorConfigs, flowMetaResponse.connectorConfigs) &&
-                Objects.equals(this.attributeProfile, flowMetaResponse.attributeProfile) &&
-                Objects.equals(this.attributeMetadata, flowMetaResponse.attributeMetadata) &&
-                Objects.equals(this.executorConnections, flowMetaResponse.executorConnections);
+            Objects.equals(this.supportedExecutors, flowMetaResponse.supportedExecutors) &&
+            Objects.equals(this.connectorConfigs, flowMetaResponse.connectorConfigs) &&
+            Objects.equals(this.attributeProfile, flowMetaResponse.attributeProfile) &&
+            Objects.equals(this.supportedProperties, flowMetaResponse.supportedProperties) &&
+            Objects.equals(this.attributeMetadata, flowMetaResponse.attributeMetadata) &&
+            Objects.equals(this.executorConnections, flowMetaResponse.executorConnections);
     }
 
     @Override
     public int hashCode() {
-
-        return Objects.hash(flowType, supportedExecutors, connectorConfigs, attributeProfile, attributeMetadata, executorConnections);
+        return Objects.hash(flowType, supportedExecutors, connectorConfigs, attributeProfile, supportedProperties, attributeMetadata, executorConnections);
     }
 
     @Override
@@ -230,11 +240,12 @@ public class FlowMetaResponse {
 
         StringBuilder sb = new StringBuilder();
         sb.append("class FlowMetaResponse {\n");
-
+        
         sb.append("    flowType: ").append(toIndentedString(flowType)).append("\n");
         sb.append("    supportedExecutors: ").append(toIndentedString(supportedExecutors)).append("\n");
         sb.append("    connectorConfigs: ").append(toIndentedString(connectorConfigs)).append("\n");
         sb.append("    attributeProfile: ").append(toIndentedString(attributeProfile)).append("\n");
+        sb.append("    supportedProperties: ").append(toIndentedString(supportedProperties)).append("\n");
         sb.append("    attributeMetadata: ").append(toIndentedString(attributeMetadata)).append("\n");
         sb.append("    executorConnections: ").append(toIndentedString(executorConnections)).append("\n");
         sb.append("}");
@@ -242,9 +253,9 @@ public class FlowMetaResponse {
     }
 
     /**
-     * Convert the given object to string with each line indented by 4 spaces
-     * (except the first line).
-     */
+    * Convert the given object to string with each line indented by 4 spaces
+    * (except the first line).
+    */
     private String toIndentedString(java.lang.Object o) {
 
         if (o == null) {

--- a/components/org.wso2.carbon.identity.api.server.flow.management/org.wso2.carbon.identity.api.server.flow.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/flow/management/v1/FlowMetaResponse.java
+++ b/components/org.wso2.carbon.identity.api.server.flow.management/org.wso2.carbon.identity.api.server.flow.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/flow/management/v1/FlowMetaResponse.java
@@ -44,7 +44,7 @@ public class FlowMetaResponse  {
 
     private Object connectorConfigs;
     private String attributeProfile;
-    private List<String> supportedProperties = null;
+    private List<String> supportedFlowCompletionConfigs = null;
 
     private List<AttributeMetadata> attributeMetadata = null;
 
@@ -133,27 +133,27 @@ public class FlowMetaResponse  {
 
     /**
     **/
-    public FlowMetaResponse supportedProperties(List<String> supportedProperties) {
+    public FlowMetaResponse supportedFlowCompletionConfigs(List<String> supportedFlowCompletionConfigs) {
 
-        this.supportedProperties = supportedProperties;
+        this.supportedFlowCompletionConfigs = supportedFlowCompletionConfigs;
         return this;
     }
     
     @ApiModelProperty(value = "")
-    @JsonProperty("supportedProperties")
+    @JsonProperty("supportedFlowCompletionConfigs")
     @Valid
-    public List<String> getSupportedProperties() {
-        return supportedProperties;
+    public List<String> getSupportedFlowCompletionConfigs() {
+        return supportedFlowCompletionConfigs;
     }
-    public void setSupportedProperties(List<String> supportedProperties) {
-        this.supportedProperties = supportedProperties;
+    public void setSupportedFlowCompletionConfigs(List<String> supportedFlowCompletionConfigs) {
+        this.supportedFlowCompletionConfigs = supportedFlowCompletionConfigs;
     }
 
-    public FlowMetaResponse addSupportedPropertiesItem(String supportedPropertiesItem) {
-        if (this.supportedProperties == null) {
-            this.supportedProperties = new ArrayList<String>();
+    public FlowMetaResponse addSupportedFlowCompletionConfigsItem(String supportedFlowCompletionConfigsItem) {
+        if (this.supportedFlowCompletionConfigs == null) {
+            this.supportedFlowCompletionConfigs = new ArrayList<String>();
         }
-        this.supportedProperties.add(supportedPropertiesItem);
+        this.supportedFlowCompletionConfigs.add(supportedFlowCompletionConfigsItem);
         return this;
     }
 
@@ -225,14 +225,14 @@ public class FlowMetaResponse  {
             Objects.equals(this.supportedExecutors, flowMetaResponse.supportedExecutors) &&
             Objects.equals(this.connectorConfigs, flowMetaResponse.connectorConfigs) &&
             Objects.equals(this.attributeProfile, flowMetaResponse.attributeProfile) &&
-            Objects.equals(this.supportedProperties, flowMetaResponse.supportedProperties) &&
+            Objects.equals(this.supportedFlowCompletionConfigs, flowMetaResponse.supportedFlowCompletionConfigs) &&
             Objects.equals(this.attributeMetadata, flowMetaResponse.attributeMetadata) &&
             Objects.equals(this.executorConnections, flowMetaResponse.executorConnections);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(flowType, supportedExecutors, connectorConfigs, attributeProfile, supportedProperties, attributeMetadata, executorConnections);
+        return Objects.hash(flowType, supportedExecutors, connectorConfigs, attributeProfile, supportedFlowCompletionConfigs, attributeMetadata, executorConnections);
     }
 
     @Override
@@ -245,7 +245,7 @@ public class FlowMetaResponse  {
         sb.append("    supportedExecutors: ").append(toIndentedString(supportedExecutors)).append("\n");
         sb.append("    connectorConfigs: ").append(toIndentedString(connectorConfigs)).append("\n");
         sb.append("    attributeProfile: ").append(toIndentedString(attributeProfile)).append("\n");
-        sb.append("    supportedProperties: ").append(toIndentedString(supportedProperties)).append("\n");
+        sb.append("    supportedFlowCompletionConfigs: ").append(toIndentedString(supportedFlowCompletionConfigs)).append("\n");
         sb.append("    attributeMetadata: ").append(toIndentedString(attributeMetadata)).append("\n");
         sb.append("    executorConnections: ").append(toIndentedString(executorConnections)).append("\n");
         sb.append("}");

--- a/components/org.wso2.carbon.identity.api.server.flow.management/org.wso2.carbon.identity.api.server.flow.management.v1/src/main/java/org/wso2/carbon/identity/api/server/flow/management/v1/constants/FlowEndpointConstants.java
+++ b/components/org.wso2.carbon.identity.api.server.flow.management/org.wso2.carbon.identity.api.server.flow.management.v1/src/main/java/org/wso2/carbon/identity/api/server/flow/management/v1/constants/FlowEndpointConstants.java
@@ -75,7 +75,15 @@ public class FlowEndpointConstants {
 
         ERROR_CODE_GET_SUPPORTED_CLAIMS("10008",
                 "Failed to retrieve supported claims.",
-                "An error occurred while reading supported claim metadata for the given attribute profile.");
+                "An error occurred while reading supported claim metadata for the given attribute profile."),
+
+        ERROR_CODE_INVALID_PROPERTY("10009",
+                "Invalid property value provided.",
+                "The provided value for property %s is not valid."),
+
+        ERROR_CODE_UNSUPPORTED_PROPERTY("10010",
+                "Unsupported property used in the flow.",
+                "The provided property %s is not supported for the flow type %s.");
 
         private final String code;
         private final String message;

--- a/components/org.wso2.carbon.identity.api.server.flow.management/org.wso2.carbon.identity.api.server.flow.management.v1/src/main/java/org/wso2/carbon/identity/api/server/flow/management/v1/core/ServerFlowMgtService.java
+++ b/components/org.wso2.carbon.identity.api.server.flow.management/org.wso2.carbon.identity.api.server.flow.management.v1/src/main/java/org/wso2/carbon/identity/api/server/flow/management/v1/core/ServerFlowMgtService.java
@@ -171,23 +171,25 @@ public class ServerFlowMgtService {
                     flowConfigPatchModel.setIsEnabled(existingFlowConfig.getIsEnabled());
                 }
 
-                Map<String, String> existingProperties = existingFlowConfig.getAllProperties();
-                Map<String, String> patchProperties = flowConfigPatchModel.getProperties();
-                List<String> supportedProperties = Utils.getSupportedProperties(flowConfigPatchModel.getFlowType());
-                // Validate the properties provided in the patch model.
-                if (patchProperties != null) {
-                    for (Map.Entry<String, String> entry : patchProperties.entrySet()) {
+                Map<String, String> existingFlowCompletionConfigs = existingFlowConfig.getAllFlowCompletionConfigs();
+                Map<String, String> patchFlowCompletionConfigs = flowConfigPatchModel.getFlowCompletionConfigs();
+                List<String> supportedFlowCompletionConfigs = Utils.getSupportedFlowCompletionConfig(
+                        flowConfigPatchModel.getFlowType());
+                // Validate the configs provided in the patch model.
+                if (patchFlowCompletionConfigs != null) {
+                    for (Map.Entry<String, String> entry : patchFlowCompletionConfigs.entrySet()) {
                         String key = entry.getKey();
                         String value = entry.getValue();
-                        Utils.validateFlag(key, value, supportedProperties, flowConfigPatchModel.getFlowType());
+                        Utils.validateFlag(key, value,
+                                supportedFlowCompletionConfigs, flowConfigPatchModel.getFlowType());
                     }
                 }
-                // Iterate over existing properties and add those which are not present in the patch model.
-                for (Map.Entry<String, String> entry : existingProperties.entrySet()) {
+                // Iterate over existing configs and add those which are not present in the patch model.
+                for (Map.Entry<String, String> entry : existingFlowCompletionConfigs.entrySet()) {
                     String key = entry.getKey();
                     String value = entry.getValue();
-                    if (patchProperties == null || !patchProperties.containsKey(key)) {
-                        flowConfigPatchModel.putPropertiesItem(key, value);
+                    if (patchFlowCompletionConfigs == null || !patchFlowCompletionConfigs.containsKey(key)) {
+                        flowConfigPatchModel.putFlowCompletionConfigsItem(key, value);
                     }
                 }
             }

--- a/components/org.wso2.carbon.identity.api.server.flow.management/org.wso2.carbon.identity.api.server.flow.management.v1/src/main/java/org/wso2/carbon/identity/api/server/flow/management/v1/response/handlers/AbstractMetaResponseHandler.java
+++ b/components/org.wso2.carbon.identity.api.server.flow.management/org.wso2.carbon.identity.api.server.flow.management.v1/src/main/java/org/wso2/carbon/identity/api/server/flow/management/v1/response/handlers/AbstractMetaResponseHandler.java
@@ -138,13 +138,13 @@ public abstract class AbstractMetaResponseHandler {
         response.setSupportedExecutors(getSupportedExecutors());
         response.setConnectorConfigs(getConnectorConfigs());
         response.setExecutorConnections(getExecutorConnections());
-        response.setSupportedProperties(getSupportedProperties());
+        response.setSupportedFlowCompletionConfigs(getSupportedFlowCompletionConfigs());
         return response;
     }
 
-    private List<String> getSupportedProperties() {
+    private List<String> getSupportedFlowCompletionConfigs() {
 
-        return Utils.getSupportedProperties(getFlowType());
+        return Utils.getSupportedFlowCompletionConfig(getFlowType());
     }
 
     private List<AttributeMetadata> getSupportedClaims(String attributeProfile) {

--- a/components/org.wso2.carbon.identity.api.server.flow.management/org.wso2.carbon.identity.api.server.flow.management.v1/src/main/java/org/wso2/carbon/identity/api/server/flow/management/v1/response/handlers/AbstractMetaResponseHandler.java
+++ b/components/org.wso2.carbon.identity.api.server.flow.management/org.wso2.carbon.identity.api.server.flow.management.v1/src/main/java/org/wso2/carbon/identity/api/server/flow/management/v1/response/handlers/AbstractMetaResponseHandler.java
@@ -138,7 +138,13 @@ public abstract class AbstractMetaResponseHandler {
         response.setSupportedExecutors(getSupportedExecutors());
         response.setConnectorConfigs(getConnectorConfigs());
         response.setExecutorConnections(getExecutorConnections());
+        response.setSupportedProperties(getSupportedProperties());
         return response;
+    }
+
+    private List<String> getSupportedProperties() {
+
+        return Utils.getSupportedProperties(getFlowType());
     }
 
     private List<AttributeMetadata> getSupportedClaims(String attributeProfile) {

--- a/components/org.wso2.carbon.identity.api.server.flow.management/org.wso2.carbon.identity.api.server.flow.management.v1/src/main/java/org/wso2/carbon/identity/api/server/flow/management/v1/utils/Utils.java
+++ b/components/org.wso2.carbon.identity.api.server.flow.management/org.wso2.carbon.identity.api.server.flow.management.v1/src/main/java/org/wso2/carbon/identity/api/server/flow/management/v1/utils/Utils.java
@@ -125,6 +125,7 @@ public class Utils {
      * Handles exceptions and returns an APIError object.
      *
      * @param e FlowMgtFrameworkException object.
+     * @param data Data to be added to the description.
      * @return APIError object.
      */
     public static APIError handleFlowMgtException(FlowMgtFrameworkException e, Object ... data) {

--- a/components/org.wso2.carbon.identity.api.server.flow.management/org.wso2.carbon.identity.api.server.flow.management.v1/src/main/java/org/wso2/carbon/identity/api/server/flow/management/v1/utils/Utils.java
+++ b/components/org.wso2.carbon.identity.api.server.flow.management/org.wso2.carbon.identity.api.server.flow.management.v1/src/main/java/org/wso2/carbon/identity/api/server/flow/management/v1/utils/Utils.java
@@ -480,7 +480,7 @@ public class Utils {
         FlowConfig config = new FlowConfig();
         config.setFlowType(flowConfig.getFlowType());
         config.setIsEnabled(flowConfig.getIsEnabled() != null && flowConfig.getIsEnabled());
-        config.setProperties(flowConfig.getAllProperties());
+        config.setFlowCompletionConfigs(flowConfig.getAllFlowCompletionConfigs());
         return config;
     }
 
@@ -489,7 +489,7 @@ public class Utils {
         FlowConfigDTO config = new FlowConfigDTO();
         config.setFlowType(flowConfig.getFlowType());
         config.setIsEnabled(flowConfig.getIsEnabled() != null && flowConfig.getIsEnabled());
-        config.addAllProperties(flowConfig.getProperties());
+        config.addAllFlowCompletionConfigs(flowConfig.getFlowCompletionConfigs());
         return config;
     }
 
@@ -510,11 +510,11 @@ public class Utils {
      * @param flowType The flow type.
      * @return List of supported properties.
      */
-    public static List<String> getSupportedProperties(String flowType) {
+    public static List<String> getSupportedFlowCompletionConfig(String flowType) {
 
-        Constants.FlowTypes flowTypeRequested  = Constants.FlowTypes.valueOf(flowType);
-        List<Constants.Properties> supportedFlags  = flowTypeRequested.getSupportedProperties();
-        return supportedFlags.stream().map(Constants.Properties::getName).collect(Collectors.toList());
+        Constants.FlowTypes requestedFlowType  = Constants.FlowTypes.valueOf(flowType);
+        List<Constants.FlowCompletionConfig> supportedFlags  = requestedFlowType.getSupportedFlowCompletionConfigs();
+        return supportedFlags.stream().map(Constants.FlowCompletionConfig::getConfig).collect(Collectors.toList());
     }
 
     /**
@@ -529,7 +529,7 @@ public class Utils {
 
         if (StringUtils.isBlank(flag) || StringUtils.isBlank(value)) {
 
-            throw Utils.handleFlowMgtException( new FlowMgtClientException(
+            throw Utils.handleFlowMgtException(new FlowMgtClientException(
                     FlowEndpointConstants.ErrorMessages.ERROR_CODE_INVALID_PROPERTY.getCode(),
                     FlowEndpointConstants.ErrorMessages.ERROR_CODE_INVALID_PROPERTY.getMessage(),
                     FlowEndpointConstants.ErrorMessages.ERROR_CODE_INVALID_PROPERTY.getDescription()),
@@ -537,7 +537,7 @@ public class Utils {
             );
         }
         if (!supportedProperties.contains(flag)) {
-            throw Utils.handleFlowMgtException( new FlowMgtClientException(
+            throw Utils.handleFlowMgtException(new FlowMgtClientException(
                     FlowEndpointConstants.ErrorMessages.ERROR_CODE_UNSUPPORTED_PROPERTY.getCode(),
                     FlowEndpointConstants.ErrorMessages.ERROR_CODE_UNSUPPORTED_PROPERTY.getMessage(),
                     FlowEndpointConstants.ErrorMessages.ERROR_CODE_UNSUPPORTED_PROPERTY.getDescription()),

--- a/components/org.wso2.carbon.identity.api.server.flow.management/org.wso2.carbon.identity.api.server.flow.management.v1/src/main/resources/flow.yaml
+++ b/components/org.wso2.carbon.identity.api.server.flow.management/org.wso2.carbon.identity.api.server.flow.management.v1/src/main/resources/flow.yaml
@@ -513,7 +513,7 @@ components:
         attributeProfile:
           type: string
           example: End-User-Profile
-        supportedProperties:
+        supportedFlowCompletionConfigs:
           type: array
           items:
             type: string
@@ -575,9 +575,9 @@ components:
           type: boolean
           description: Indicate whether the orchestration is enabled for the flow
           example: true
-        properties:
+        flowCompletionConfigs:
           type: object
-          description: Flow properties.
+          description: Flow Completion Configs.
           additionalProperties:
             type: string
             nullable : false
@@ -596,9 +596,9 @@ components:
           type: boolean
           description: Indicate whether the orchestration is enabled for the flow
           example: true
-        properties:
+        flowCompletionConfigs:
           type: object
-          description: Flow Properties.
+          description: Flow Completion Configs.
           additionalProperties:
             type: string
             nullable : false

--- a/components/org.wso2.carbon.identity.api.server.flow.management/org.wso2.carbon.identity.api.server.flow.management.v1/src/main/resources/flow.yaml
+++ b/components/org.wso2.carbon.identity.api.server.flow.management/org.wso2.carbon.identity.api.server.flow.management.v1/src/main/resources/flow.yaml
@@ -513,6 +513,11 @@ components:
         attributeProfile:
           type: string
           example: End-User-Profile
+        supportedProperties:
+          type: array
+          items:
+            type: string
+            example: enableEmailVerification
         attributeMetadata:
           type: array
           items:
@@ -570,10 +575,12 @@ components:
           type: boolean
           description: Indicate whether the orchestration is enabled for the flow
           example: true
-        isAutoLoginEnabled:
-          type: boolean
-          description: Indicate whether the auto login is enabled for the flow
-          example: true
+        properties:
+          type: object
+          description: Flow properties.
+          additionalProperties:
+            type: string
+            nullable : false
 
     FlowConfigPatchModel:
       type: object
@@ -589,10 +596,12 @@ components:
           type: boolean
           description: Indicate whether the orchestration is enabled for the flow
           example: true
-        isAutoLoginEnabled:
-          type: boolean
-          description: Indicate whether the auto login is enabled for the flow
-          example: true
+        properties:
+          type: object
+          description: Flow Properties.
+          additionalProperties:
+            type: string
+            nullable : false
 
     Step:
       type: object

--- a/pom.xml
+++ b/pom.xml
@@ -958,7 +958,7 @@
         <maven.buildnumber.plugin.version>1.4</maven.buildnumber.plugin.version>
         <org.apache.felix.annotations.version>1.2.4</org.apache.felix.annotations.version>
         <identity.governance.version>1.11.103</identity.governance.version>
-        <carbon.identity.framework.version>7.8.476</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.8.493</carbon.identity.framework.version>
         <maven.findbugsplugin.version>3.0.5</maven.findbugsplugin.version>
         <findsecbugs-plugin.version>1.12.0</findsecbugs-plugin.version>
         <maven.checkstyleplugin.excludes>**/gen/**/*</maven.checkstyleplugin.excludes>


### PR DESCRIPTION
This pull request refactors the flow management API models to improve extensibility and clarity around flow configuration properties. The main changes are the removal of the `isAutoLoginEnabled` field and its replacement with a generic `properties` map in both `FlowConfig` and `FlowConfigPatchModel`, as well as the addition of a `supportedProperties` field in `FlowMetaResponse` to better describe supported configuration options for each flow type.
