### PR TITLE
Add backend validations to password reset

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.flow.management/org.wso2.carbon.identity.api.server.flow.management.v1/src/main/java/org/wso2/carbon/identity/api/server/flow/management/v1/constants/FlowEndpointConstants.java
+++ b/components/org.wso2.carbon.identity.api.server.flow.management/org.wso2.carbon.identity.api.server.flow.management.v1/src/main/java/org/wso2/carbon/identity/api/server/flow/management/v1/constants/FlowEndpointConstants.java
@@ -91,7 +91,11 @@ public class FlowEndpointConstants {
 
         ERROR_CODE_EMPTY_STEPS("10012",
                 "Empty steps in the flow.",
-                "The steps in the flow cannot be empty.");
+                "The steps in the flow cannot be empty."),
+
+        ERROR_CODE_REQUIRED_EXECUTOR_MISSING("10013",
+                "Required executor is missing in the flow.",
+                "The flow must contain the required executors.");
 
         private final String code;
         private final String message;


### PR DESCRIPTION
### Issue

https://github.com/wso2/product-is/issues/25587

This pull request introduces additional validation for required executors in password recovery flows and improves error handling for missing executors. The main changes include extending the executor collection logic, updating error messages, and enforcing the presence of specific executors for password recovery flows.

**Validation and error handling improvements:**

* Added a new error message `ERROR_CODE_REQUIRED_EXECUTOR_MISSING` to the `ErrorMessages` enum for cases where required executors are missing in a flow.
* In the `validateExecutors` method in `Utils.java`, added logic to check for the presence of `EMAIL_OTP_EXECUTOR`, `SMS_OTP_EXECUTOR`, or `MAGIC_LINK_EXECUTOR` in password recovery flows, and throw the new error if none are present.

**Executor collection enhancements:**

* Updated the `collectFlowData` method to also collect executor names from steps whose action type is `EXECUTOR`, ensuring all relevant executors are captured during flow validation.
* Imported `PasswordRecoveryFlowMetaHandler` in `Utils.java` to support the new password recovery flow validation logic.