### PR TITLE
Add workflowEnabled property to flow/meta endpoint

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.flow.management/org.wso2.carbon.identity.api.server.flow.management.common/pom.xml
+++ b/components/org.wso2.carbon.identity.api.server.flow.management/org.wso2.carbon.identity.api.server.flow.management.common/pom.xml
@@ -44,6 +44,10 @@
             <artifactId>org.wso2.carbon.identity.flow.mgt</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.workflow.mgt</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.wso2.carbon.identity.governance</groupId>
             <artifactId>org.wso2.carbon.identity.governance</artifactId>
         </dependency>

--- a/components/org.wso2.carbon.identity.api.server.flow.management/org.wso2.carbon.identity.api.server.flow.management.common/src/main/java/org/wso2/carbon/identity/api/server/flow/management/common/FlowMgtServiceHolder.java
+++ b/components/org.wso2.carbon.identity.api.server.flow.management/org.wso2.carbon.identity.api.server.flow.management.common/src/main/java/org/wso2/carbon/identity/api/server/flow/management/common/FlowMgtServiceHolder.java
@@ -22,6 +22,7 @@ import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.identity.flow.mgt.FlowAIService;
 import org.wso2.carbon.identity.flow.mgt.FlowMgtService;
 import org.wso2.carbon.identity.governance.IdentityGovernanceService;
+import org.wso2.carbon.identity.workflow.mgt.WorkflowManagementService;
 import org.wso2.carbon.idp.mgt.IdpManager;
 
 /**
@@ -57,6 +58,13 @@ public class FlowMgtServiceHolder {
 
         private static final FlowAIService SERVICE = (FlowAIService) PrivilegedCarbonContext
                 .getThreadLocalCarbonContext().getOSGiService(FlowAIService.class, null);
+    }
+
+    private static class WorkflowServiceHolder {
+
+        private static final WorkflowManagementService SERVICE =
+                (WorkflowManagementService) PrivilegedCarbonContext.getThreadLocalCarbonContext()
+                        .getOSGiService(WorkflowManagementService.class, null);
     }
 
     /**
@@ -97,5 +105,15 @@ public class FlowMgtServiceHolder {
     public static FlowAIService getFlowAIService() {
 
         return FlowAIServiceHolder.SERVICE;
+    }
+
+    /**
+     * Get WorkflowManagementService OSGi service.
+     *
+     * @return WorkflowManagementService
+     */
+    public static WorkflowManagementService getWorkflowManagementService() {
+
+        return WorkflowServiceHolder.SERVICE;
     }
 }

--- a/components/org.wso2.carbon.identity.api.server.flow.management/org.wso2.carbon.identity.api.server.flow.management.v1/pom.xml
+++ b/components/org.wso2.carbon.identity.api.server.flow.management/org.wso2.carbon.identity.api.server.flow.management.v1/pom.xml
@@ -126,6 +126,10 @@
             <artifactId>org.wso2.carbon.identity.application.authentication.framework</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.workflow.mgt</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.wso2.carbon.identity.server.api</groupId>
             <artifactId>org.wso2.carbon.identity.api.server.claim.management.common</artifactId>
         </dependency>

--- a/components/org.wso2.carbon.identity.api.server.flow.management/org.wso2.carbon.identity.api.server.flow.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/flow/management/v1/FlowMetaResponse.java
+++ b/components/org.wso2.carbon.identity.api.server.flow.management/org.wso2.carbon.identity.api.server.flow.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/flow/management/v1/FlowMetaResponse.java
@@ -50,6 +50,7 @@ public class FlowMetaResponse  {
 
     private List<ExecutorConnections> executorConnections = null;
 
+    private Boolean workflowEnabled;
 
     /**
     **/
@@ -209,7 +210,25 @@ public class FlowMetaResponse  {
         return this;
     }
 
+        /**
+    **/
+    public FlowMetaResponse workflowEnabled(Boolean workflowEnabled) {
+
+        this.workflowEnabled = workflowEnabled;
+        return this;
+    }
     
+    @ApiModelProperty(example = "false", value = "")
+    @JsonProperty("workflowEnabled")
+    @Valid
+    public Boolean getWorkflowEnabled() {
+        return workflowEnabled;
+    }
+    public void setWorkflowEnabled(Boolean workflowEnabled) {
+        this.workflowEnabled = workflowEnabled;
+    }
+
+
 
     @Override
     public boolean equals(java.lang.Object o) {
@@ -227,12 +246,13 @@ public class FlowMetaResponse  {
             Objects.equals(this.attributeProfile, flowMetaResponse.attributeProfile) &&
             Objects.equals(this.supportedFlowCompletionConfigs, flowMetaResponse.supportedFlowCompletionConfigs) &&
             Objects.equals(this.attributeMetadata, flowMetaResponse.attributeMetadata) &&
-            Objects.equals(this.executorConnections, flowMetaResponse.executorConnections);
+            Objects.equals(this.executorConnections, flowMetaResponse.executorConnections) &&
+            Objects.equals(this.workflowEnabled, flowMetaResponse.workflowEnabled);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(flowType, supportedExecutors, connectorConfigs, attributeProfile, supportedFlowCompletionConfigs, attributeMetadata, executorConnections);
+        return Objects.hash(flowType, supportedExecutors, connectorConfigs, attributeProfile, supportedFlowCompletionConfigs, attributeMetadata, executorConnections, workflowEnabled);
     }
 
     @Override
@@ -248,6 +268,7 @@ public class FlowMetaResponse  {
         sb.append("    supportedFlowCompletionConfigs: ").append(toIndentedString(supportedFlowCompletionConfigs)).append("\n");
         sb.append("    attributeMetadata: ").append(toIndentedString(attributeMetadata)).append("\n");
         sb.append("    executorConnections: ").append(toIndentedString(executorConnections)).append("\n");
+        sb.append("    workflowEnabled: ").append(toIndentedString(workflowEnabled)).append("\n");
         sb.append("}");
         return sb.toString();
     }

--- a/components/org.wso2.carbon.identity.api.server.flow.management/org.wso2.carbon.identity.api.server.flow.management.v1/src/main/java/org/wso2/carbon/identity/api/server/flow/management/v1/response/handlers/AbstractMetaResponseHandler.java
+++ b/components/org.wso2.carbon.identity.api.server.flow.management/org.wso2.carbon.identity.api.server.flow.management.v1/src/main/java/org/wso2/carbon/identity/api/server/flow/management/v1/response/handlers/AbstractMetaResponseHandler.java
@@ -88,6 +88,16 @@ public abstract class AbstractMetaResponseHandler {
     public abstract String getAttributeProfile();
 
     /**
+     * Check if the workflow is enabled for the flow.
+     *
+     * @return True if workflow is enabled, false otherwise.
+     */
+    public boolean getWorkflowEnabled() {
+
+        return false;
+    }
+
+    /**
      * Get the supported executors for the flow.
      *
      * @return List of supported executors.
@@ -134,6 +144,7 @@ public abstract class AbstractMetaResponseHandler {
         FlowMetaResponse response = new FlowMetaResponse();
         response.setFlowType(getFlowType());
         response.setAttributeProfile(getAttributeProfile());
+        response.setWorkflowEnabled(getWorkflowEnabled());
         response.setAttributeMetadata(getSupportedClaims(getAttributeProfile()));
         response.setSupportedExecutors(getSupportedExecutors());
         response.setConnectorConfigs(getConnectorConfigs());

--- a/components/org.wso2.carbon.identity.api.server.flow.management/org.wso2.carbon.identity.api.server.flow.management.v1/src/main/resources/flow.yaml
+++ b/components/org.wso2.carbon.identity.api.server.flow.management/org.wso2.carbon.identity.api.server.flow.management.v1/src/main/resources/flow.yaml
@@ -526,6 +526,9 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/ExecutorConnections'
+        workflowEnabled:
+          type: boolean
+          example: false
 
     ExecutorConnections:
       type: object


### PR DESCRIPTION
## Purpose
This pull request introduces support for indicating whether workflow is enabled for the registration flow in the flow management API. The changes add a new `workflowEnabled` field to the `FlowMetaResponse`, update the OpenAPI spec, and implement logic to detect workflow associations for self-registration. Supporting code is also updated to provide access to the workflow management service.

Key changes include:

**API Model and OpenAPI Spec Updates**
- Added a new boolean field `workflowEnabled` to the `FlowMetaResponse` model, including getter/setter, equality/hashCode, and toString updates. [[1]](diffhunk://#diff-7f34cd6c2559f915e4be246a29e263658a15b3a71e9a5998edddfed4557f6ae9R53) [[2]](diffhunk://#diff-7f34cd6c2559f915e4be246a29e263658a15b3a71e9a5998edddfed4557f6ae9R213-R230) [[3]](diffhunk://#diff-7f34cd6c2559f915e4be246a29e263658a15b3a71e9a5998edddfed4557f6ae9L230-R255) [[4]](diffhunk://#diff-7f34cd6c2559f915e4be246a29e263658a15b3a71e9a5998edddfed4557f6ae9R271)
- Updated the OpenAPI specification (`flow.yaml`) to document the new `workflowEnabled` property in the response schema.

**Service Access and Dependency Management**
- Added the `org.wso2.carbon.identity.workflow.mgt` dependency to relevant Maven modules to enable access to workflow management functionality. [[1]](diffhunk://#diff-e612d8cea2604823fd080edc4f29fb83cf67cf7e2c982bfead59071b8d39655aR46-R49) [[2]](diffhunk://#diff-fc8ff8e91cc3cf7e1918d6e5349a5ef23db32fefbb8da2b0df6fd780a8f56ae5R128-R131)
- Updated `FlowMgtServiceHolder` to provide a static accessor for the `WorkflowManagementService` OSGi service. [[1]](diffhunk://#diff-0a18bfad2c315eeaa685ad31d4b3896613da592a2e43405eed5072e90986ea30R25) [[2]](diffhunk://#diff-0a18bfad2c315eeaa685ad31d4b3896613da592a2e43405eed5072e90986ea30R63-R69) [[3]](diffhunk://#diff-0a18bfad2c315eeaa685ad31d4b3896613da592a2e43405eed5072e90986ea30R109-R118)

**Response Handling Logic**
- Extended the abstract response handler to include a `getWorkflowEnabled()` method, defaulting to `false`, and set this value in the `FlowMetaResponse`. [[1]](diffhunk://#diff-e3271f71f78b5744eae16bd62e474d2c569143516caf75fcbb6e0c1c61d9c506R90-R99) [[2]](diffhunk://#diff-e3271f71f78b5744eae16bd62e474d2c569143516caf75fcbb6e0c1c61d9c506R147)
- Overrode `getWorkflowEnabled()` in `RegistrationFlowMetaHandler` to check for workflow associations for the self-registration operation, using the new service accessor and handling exceptions appropriately. [[1]](diffhunk://#diff-354fc5ac841d436f3ca9e41e00d464255910e92e1923364aac565738b80056e3R21-R30) [[2]](diffhunk://#diff-354fc5ac841d436f3ca9e41e00d464255910e92e1923364aac565738b80056e3R51-R53) [[3]](diffhunk://#diff-354fc5ac841d436f3ca9e41e00d464255910e92e1923364aac565738b80056e3R66-R88)

## Related Issues
- https://github.com/wso2/product-is/issues/25895

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.