### PR TITLE
Block workflow associations for the same operation by multiple workflows

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.workflow/org.wso2.carbon.identity.rest.api.server.workflow.v1/src/main/java/org/wso2/carbon/identity/rest/api/server/workflow/v1/core/WorkflowService.java
+++ b/components/org.wso2.carbon.identity.api.server.workflow/org.wso2.carbon.identity.rest.api.server.workflow.v1/src/main/java/org/wso2/carbon/identity/rest/api/server/workflow/v1/core/WorkflowService.java
@@ -230,11 +230,6 @@ public class WorkflowService {
             Workflow currentWorkflow = workflowManagementService.getWorkflow(workflowAssociation.getWorkflowId());
             WorkflowEvent event = workflowManagementService.getEvent(workflowAssociation.getOperation().toString());
 
-            if (!workflowManagementService.listPaginatedAssociations(tenantId, 1, 0,
-                    "operation eq " + event.getEventId()).isEmpty()) {
-                throw new WorkflowClientException("A workflow association already exist for the event: " +
-                        event.getEventFriendlyName());
-            }
             if (currentWorkflow == null) {
                 throw new WorkflowClientException("A workflow with ID: " + workflowAssociation.getWorkflowId() +
                         " doesn't exist.");
@@ -244,6 +239,12 @@ public class WorkflowService {
                         " doesn't exist.");
             }
             int tenantId = CarbonContext.getThreadLocalCarbonContext().getTenantId();
+            if (!workflowManagementService.listPaginatedAssociations(tenantId, 1, 0,
+                    "operation eq " + event.getEventId()).isEmpty()) {
+                throw new WorkflowClientException("A workflow association already exist for the event: " +
+                        event.getEventFriendlyName());
+            }
+
             if (!workflowManagementService.listPaginatedAssociations(tenantId, 1, 0,
                     "operation eq " + event.getEventId()).isEmpty()) {
                 throw new WorkflowClientException("A workflow association already exists for the event: " +

--- a/components/org.wso2.carbon.identity.api.server.workflow/org.wso2.carbon.identity.rest.api.server.workflow.v1/src/main/java/org/wso2/carbon/identity/rest/api/server/workflow/v1/core/WorkflowService.java
+++ b/components/org.wso2.carbon.identity.api.server.workflow/org.wso2.carbon.identity.rest.api.server.workflow.v1/src/main/java/org/wso2/carbon/identity/rest/api/server/workflow/v1/core/WorkflowService.java
@@ -234,7 +234,7 @@ public class WorkflowService {
 
             if (!workflowManagementService.listPaginatedAssociations(tenantId, 1, 0,
                     "operation eq " + event.getEventId()).isEmpty()) {
-                throw new WorkflowClientException("A workflow association already exist for the event: " +
+                throw new WorkflowClientException("A workflow association already exists for the event: " +
                         event.getEventFriendlyName());
             }
             if (currentWorkflow == null) {

--- a/components/org.wso2.carbon.identity.api.server.workflow/org.wso2.carbon.identity.rest.api.server.workflow.v1/src/main/java/org/wso2/carbon/identity/rest/api/server/workflow/v1/core/WorkflowService.java
+++ b/components/org.wso2.carbon.identity.api.server.workflow/org.wso2.carbon.identity.rest.api.server.workflow.v1/src/main/java/org/wso2/carbon/identity/rest/api/server/workflow/v1/core/WorkflowService.java
@@ -229,6 +229,14 @@ public class WorkflowService {
         try {
             Workflow currentWorkflow = workflowManagementService.getWorkflow(workflowAssociation.getWorkflowId());
             WorkflowEvent event = workflowManagementService.getEvent(workflowAssociation.getOperation().toString());
+
+            int tenantId = CarbonContext.getThreadLocalCarbonContext().getTenantId();
+
+            if (!workflowManagementService.listPaginatedAssociations(tenantId, 1, 0,
+                    "operation eq " + event.getEventId()).isEmpty()) {
+                throw new WorkflowClientException("A workflow association already exist for the event: " +
+                        event.getEventFriendlyName());
+            }
             if (currentWorkflow == null) {
                 throw new WorkflowClientException("A workflow with ID: " + workflowAssociation.getWorkflowId() +
                         " doesn't exist.");

--- a/components/org.wso2.carbon.identity.api.server.workflow/org.wso2.carbon.identity.rest.api.server.workflow.v1/src/main/java/org/wso2/carbon/identity/rest/api/server/workflow/v1/core/WorkflowService.java
+++ b/components/org.wso2.carbon.identity.api.server.workflow/org.wso2.carbon.identity.rest.api.server.workflow.v1/src/main/java/org/wso2/carbon/identity/rest/api/server/workflow/v1/core/WorkflowService.java
@@ -229,7 +229,6 @@ public class WorkflowService {
         try {
             Workflow currentWorkflow = workflowManagementService.getWorkflow(workflowAssociation.getWorkflowId());
             WorkflowEvent event = workflowManagementService.getEvent(workflowAssociation.getOperation().toString());
-
             if (currentWorkflow == null) {
                 throw new WorkflowClientException("A workflow with ID: " + workflowAssociation.getWorkflowId() +
                         " doesn't exist.");
@@ -239,12 +238,6 @@ public class WorkflowService {
                         " doesn't exist.");
             }
             int tenantId = CarbonContext.getThreadLocalCarbonContext().getTenantId();
-            if (!workflowManagementService.listPaginatedAssociations(tenantId, 1, 0,
-                    "operation eq " + event.getEventId()).isEmpty()) {
-                throw new WorkflowClientException("A workflow association already exist for the event: " +
-                        event.getEventFriendlyName());
-            }
-
             if (!workflowManagementService.listPaginatedAssociations(tenantId, 1, 0,
                     "operation eq " + event.getEventId()).isEmpty()) {
                 throw new WorkflowClientException("A workflow association already exists for the event: " +

--- a/components/org.wso2.carbon.identity.api.server.workflow/org.wso2.carbon.identity.rest.api.server.workflow.v1/src/main/java/org/wso2/carbon/identity/rest/api/server/workflow/v1/core/WorkflowService.java
+++ b/components/org.wso2.carbon.identity.api.server.workflow/org.wso2.carbon.identity.rest.api.server.workflow.v1/src/main/java/org/wso2/carbon/identity/rest/api/server/workflow/v1/core/WorkflowService.java
@@ -230,11 +230,9 @@ public class WorkflowService {
             Workflow currentWorkflow = workflowManagementService.getWorkflow(workflowAssociation.getWorkflowId());
             WorkflowEvent event = workflowManagementService.getEvent(workflowAssociation.getOperation().toString());
 
-            int tenantId = CarbonContext.getThreadLocalCarbonContext().getTenantId();
-
             if (!workflowManagementService.listPaginatedAssociations(tenantId, 1, 0,
                     "operation eq " + event.getEventId()).isEmpty()) {
-                throw new WorkflowClientException("A workflow association already exists for the event: " +
+                throw new WorkflowClientException("A workflow association already exist for the event: " +
                         event.getEventFriendlyName());
             }
             if (currentWorkflow == null) {
@@ -245,6 +243,13 @@ public class WorkflowService {
                 throw new WorkflowClientException("An event with ID: " + workflowAssociation.getOperation().toString() +
                         " doesn't exist.");
             }
+            int tenantId = CarbonContext.getThreadLocalCarbonContext().getTenantId();
+            if (!workflowManagementService.listPaginatedAssociations(tenantId, 1, 0,
+                    "operation eq " + event.getEventId()).isEmpty()) {
+                throw new WorkflowClientException("A workflow association already exists for the event: " +
+                        event.getEventFriendlyName());
+            }
+
             workflowManagementService.addAssociation(workflowAssociation.getAssociationName(),
                     workflowAssociation.getWorkflowId(), workflowAssociation.getOperation().toString(),
                     null);


### PR DESCRIPTION
## Purpose
At the moment, a particular user operation can be configured only for one workflow.

### Related Issues
- https://github.com/wso2/product-is/issues/25920