### PR TITLE
Support reverting flows in sub orgs

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.flow.management/org.wso2.carbon.identity.api.server.flow.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/flow/management/v1/FlowApi.java
+++ b/components/org.wso2.carbon.identity.api.server.flow.management/org.wso2.carbon.identity.api.server.flow.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/flow/management/v1/FlowApi.java
@@ -29,6 +29,7 @@ import org.wso2.carbon.identity.api.server.flow.management.v1.factories.FlowApiS
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
 import javax.ws.rs.PATCH;
 import javax.ws.rs.POST;
@@ -48,6 +49,30 @@ public class FlowApi {
     public FlowApi() {
 
         this.delegate = FlowApiServiceFactory.getFlowApi();
+    }
+
+    @Valid
+    @DELETE
+
+
+    @Produces({"application/json"})
+    @ApiOperation(value = "Delete the flow", notes = "", response = Void.class, authorizations = {
+            @Authorization(value = "BasicAuth"),
+            @Authorization(value = "OAuth2", scopes = {
+
+            })
+    }, tags = {"Flow Composer",})
+    @ApiResponses(value = {
+            @ApiResponse(code = 204, message = "Flow successfully deleted", response = Void.class),
+            @ApiResponse(code = 400, message = "Invalid request body or unsupported flow type", response = Error.class),
+            @ApiResponse(code = 401, message = "Unauthorized", response = Error.class),
+            @ApiResponse(code = 403, message = "Forbidden", response = Error.class),
+            @ApiResponse(code = 500, message = "Encountered a server error", response = Error.class)
+    })
+    public Response deleteFlow(@Valid @NotNull(message = "Property  cannot be null.") @ApiParam(value = "Type of the " +
+            "flow to delete", required = true, allowableValues = "REGISTRATION, PASSWORD_RECOVERY, ASK_PASSWORD") @QueryParam("flowType") String flowType) {
+
+        return delegate.deleteFlow(flowType);
     }
 
     @Valid

--- a/components/org.wso2.carbon.identity.api.server.flow.management/org.wso2.carbon.identity.api.server.flow.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/flow/management/v1/FlowApiService.java
+++ b/components/org.wso2.carbon.identity.api.server.flow.management/org.wso2.carbon.identity.api.server.flow.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/flow/management/v1/FlowApiService.java
@@ -23,6 +23,8 @@ import javax.ws.rs.core.Response;
 
 public interface FlowApiService {
 
+    public Response deleteFlow(String flowType);
+
     public Response generateFlow(FlowGenerateRequest flowGenerateRequest);
 
     public Response getFlow(String flowType);

--- a/components/org.wso2.carbon.identity.api.server.flow.management/org.wso2.carbon.identity.api.server.flow.management.v1/src/main/java/org/wso2/carbon/identity/api/server/flow/management/v1/core/ServerFlowMgtService.java
+++ b/components/org.wso2.carbon.identity.api.server.flow.management/org.wso2.carbon.identity.api.server.flow.management.v1/src/main/java/org/wso2/carbon/identity/api/server/flow/management/v1/core/ServerFlowMgtService.java
@@ -117,6 +117,17 @@ public class ServerFlowMgtService {
         }
     }
 
+    public void deleteFlow(String flowType) {
+
+        try {
+            Utils.validateFlowType(flowType);
+            flowMgtService.deleteFlow(flowType,
+                    PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantId());
+        } catch (FlowMgtFrameworkException e) {
+            throw Utils.handleFlowMgtException(e);
+        }
+    }
+
     /**
      * Retrieve the flow configurations.
      *

--- a/components/org.wso2.carbon.identity.api.server.flow.management/org.wso2.carbon.identity.api.server.flow.management.v1/src/main/java/org/wso2/carbon/identity/api/server/flow/management/v1/core/ServerFlowMgtService.java
+++ b/components/org.wso2.carbon.identity.api.server.flow.management/org.wso2.carbon.identity.api.server.flow.management.v1/src/main/java/org/wso2/carbon/identity/api/server/flow/management/v1/core/ServerFlowMgtService.java
@@ -117,6 +117,11 @@ public class ServerFlowMgtService {
         }
     }
 
+    /**
+     * Delete the flow for a specific flow type.
+     *
+     * @param flowType Type of the flow.
+     */
     public void deleteFlow(String flowType) {
 
         try {

--- a/components/org.wso2.carbon.identity.api.server.flow.management/org.wso2.carbon.identity.api.server.flow.management.v1/src/main/java/org/wso2/carbon/identity/api/server/flow/management/v1/impl/FlowApiServiceImpl.java
+++ b/components/org.wso2.carbon.identity.api.server.flow.management/org.wso2.carbon.identity.api.server.flow.management.v1/src/main/java/org/wso2/carbon/identity/api/server/flow/management/v1/impl/FlowApiServiceImpl.java
@@ -56,6 +56,13 @@ public class FlowApiServiceImpl implements FlowApiService {
     }
 
     @Override
+    public Response deleteFlow(String flowType) {
+
+        flowMgtService.deleteFlow(flowType);
+        return Response.noContent().build();
+    }
+
+    @Override
     public Response generateFlow(FlowGenerateRequest flowGenerateRequest) {
 
         FlowGenerateResponse flowResponse = flowAIServiceCore.generateFlow(flowGenerateRequest);

--- a/components/org.wso2.carbon.identity.api.server.flow.management/org.wso2.carbon.identity.api.server.flow.management.v1/src/main/resources/flow.yaml
+++ b/components/org.wso2.carbon.identity.api.server.flow.management/org.wso2.carbon.identity.api.server.flow.management.v1/src/main/resources/flow.yaml
@@ -86,7 +86,7 @@ paths:
           required: true
           schema:
             type: string
-            enum: [SELF_REGISTRATION, PASSWORD_RECOVERY, ASK_PASSWORD]
+            enum: [REGISTRATION, PASSWORD_RECOVERY, ASK_PASSWORD]
           description: Type of the flow to retrieve
       responses:
         '200':
@@ -120,6 +120,47 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
 
+    delete:
+      summary: Delete the flow
+      operationId: deleteFlow
+      tags:
+        - Flow Composer
+      parameters:
+        - in: query
+          name: flowType
+          required: true
+          schema:
+            type: string
+            enum: [REGISTRATION, PASSWORD_RECOVERY, ASK_PASSWORD]
+          description: Type of the flow to delete
+      responses:
+        '204':
+          description: Flow successfully deleted
+        '400':
+          description: Invalid request body or unsupported flow type
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '500':
+          description: Encountered a server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
   /flow/meta:
     get:
       summary: Retrieve metadata related to a flow type
@@ -132,7 +173,7 @@ paths:
           required: true
           schema:
             type: string
-            enum: [SELF_REGISTRATION, PASSWORD_RECOVERY, ASK_PASSWORD]
+            enum: [REGISTRATION, PASSWORD_RECOVERY, ASK_PASSWORD]
           description: Type of the flow to get metadata for
       responses:
         '200':
@@ -206,7 +247,7 @@ paths:
           required: true
           schema:
             type: string
-            enum: [SELF_REGISTRATION, PASSWORD_RECOVERY, ASK_PASSWORD]
+            enum: [REGISTRATION, PASSWORD_RECOVERY, ASK_PASSWORD]
           description: Type of the flow to get configurations for
       responses:
         '200':

--- a/pom.xml
+++ b/pom.xml
@@ -958,7 +958,7 @@
         <maven.buildnumber.plugin.version>1.4</maven.buildnumber.plugin.version>
         <org.apache.felix.annotations.version>1.2.4</org.apache.felix.annotations.version>
         <identity.governance.version>1.11.103</identity.governance.version>
-        <carbon.identity.framework.version>7.8.528</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.8.541</carbon.identity.framework.version>
         <maven.findbugsplugin.version>3.0.5</maven.findbugsplugin.version>
         <findsecbugs-plugin.version>1.12.0</findsecbugs-plugin.version>
         <maven.checkstyleplugin.excludes>**/gen/**/*</maven.checkstyleplugin.excludes>

--- a/pom.xml
+++ b/pom.xml
@@ -958,7 +958,7 @@
         <maven.buildnumber.plugin.version>1.4</maven.buildnumber.plugin.version>
         <org.apache.felix.annotations.version>1.2.4</org.apache.felix.annotations.version>
         <identity.governance.version>1.11.103</identity.governance.version>
-        <carbon.identity.framework.version>7.8.541</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.8.544</carbon.identity.framework.version>
         <maven.findbugsplugin.version>3.0.5</maven.findbugsplugin.version>
         <findsecbugs-plugin.version>1.12.0</findsecbugs-plugin.version>
         <maven.checkstyleplugin.excludes>**/gen/**/*</maven.checkstyleplugin.excludes>


### PR DESCRIPTION
### Issue

https://github.com/wso2/product-is/issues/25328

This pull request introduces a new API endpoint to support deleting authentication flows, updates the OpenAPI specification to reflect this, and standardizes the flow type enum values across the API. Additionally, it bumps the `carbon.identity.framework` dependency version. These changes enhance the flow management API by providing full CRUD support and improving consistency in flow type handling.

**New API Endpoint and Implementation:**

* Added a `DELETE /flow` endpoint to allow deletion of flows by `flowType`, including OpenAPI (`flow.yaml`), resource interface (`FlowApi.java`), service interface (`FlowApiService.java`), service implementation (`FlowApiServiceImpl.java`), and core logic (`ServerFlowMgtService.java`). [[1]](diffhunk://#diff-0ba7948a5b4dcc1b0402233a099b404af8cd620ef48f90ac69775be8af88bdeaR32) [[2]](diffhunk://#diff-0ba7948a5b4dcc1b0402233a099b404af8cd620ef48f90ac69775be8af88bdeaR54-R77) [[3]](diffhunk://#diff-2a0210a054c88f36bdf706f228fb735e231eb19e9b945043c22962ac1cdbcb01R26-R27) [[4]](diffhunk://#diff-f29c4b5b0ca72f308b2abad03d558d82987097df4b3d54c4cfa22ef88b3c7a4eR120-R130) [[5]](diffhunk://#diff-80aaf23f01391e8152373b3a6b375abbcbb490d82ab79c05be5e8d9514e29ea0R58-R64) [[6]](diffhunk://#diff-040600cbaf12bdca306833790813f7404c89d0dcfe191d8aa31bb3880fecb048R123-R163)

**API Consistency Improvements:**

* Standardized the `flowType` enum values from `SELF_REGISTRATION` to `REGISTRATION` throughout the OpenAPI specification to ensure consistency across all endpoints. [[1]](diffhunk://#diff-040600cbaf12bdca306833790813f7404c89d0dcfe191d8aa31bb3880fecb048L89-R89) [[2]](diffhunk://#diff-040600cbaf12bdca306833790813f7404c89d0dcfe191d8aa31bb3880fecb048L135-R176) [[3]](diffhunk://#diff-040600cbaf12bdca306833790813f7404c89d0dcfe191d8aa31bb3880fecb048L209-R250)

**Dependency Updates:**

* Upgraded the `carbon.identity.framework` dependency version in `pom.xml` from `7.8.528` to `7.8.541`.