### PR TITLE
Improve the webhook update error status code

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.webhook.management/org.wso2.carbon.identity.api.server.webhook.management.v1/src/main/java/org/wso2/carbon/identity/api/server/webhook/management/v1/core/ServerWebhookManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.webhook.management/org.wso2.carbon.identity.api.server.webhook.management.v1/src/main/java/org/wso2/carbon/identity/api/server/webhook/management/v1/core/ServerWebhookManagementService.java
@@ -120,6 +120,11 @@ public class ServerWebhookManagementService {
     public WebhookResponse updateWebhook(String webhookId, WebhookRequest webhookRequest) {
 
         try {
+            if (webhookManagementService.getWebhook(webhookId,
+                    CarbonContext.getThreadLocalCarbonContext().getTenantDomain()) == null) {
+                throw WebhookManagementAPIErrorBuilder.buildAPIError(Response.Status.NOT_FOUND,
+                        ERROR_NO_WEBHOOK_FOUND_ON_GIVEN_ID, webhookId);
+            }
             Webhook webhook = buildWebhook(webhookId, webhookRequest);
             return getWebhookResponse(webhookManagementService.updateWebhook(webhookId, webhook,
                     CarbonContext.getThreadLocalCarbonContext().getTenantDomain()));


### PR DESCRIPTION
## Purpose

- https://github.com/wso2/product-is/issues/25957

This pull request adds validation to the `updateWebhook` method to ensure that a webhook exists before attempting to update it. If the webhook with the specified ID is not found, the method now throws a `NOT_FOUND` error, improving error handling and API reliability.

* Error handling improvement:
  * Added a check in the `updateWebhook` method in `ServerWebhookManagementService.java` to verify if the webhook exists before updating, and throws a `NOT_FOUND` error if not found.