### PR TITLE
Fixing pagination to use API name instead of cursor key.

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.api.resource/org.wso2.carbon.identity.api.server.api.resource.v1/src/main/java/org/wso2/carbon/identity/api/server/api/resource/v1/core/ServerAPIResourceManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.api.resource/org.wso2.carbon.identity.api.server.api.resource.v1/src/main/java/org/wso2/carbon/identity/api/server/api/resource/v1/core/ServerAPIResourceManagementService.java
@@ -177,14 +177,14 @@ public class ServerAPIResourceManagementService {
                     Collections.reverse(apiResources);
                 }
                 if (!isFirstPage) {
-                    String encodedString = Base64.getEncoder().encodeToString(apiResources.get(0).getCursorKey()
+                    String encodedString = Base64.getEncoder().encodeToString(apiResources.get(0).getName()
                             .toString().getBytes(StandardCharsets.UTF_8));
                     apiResourceListResponse.addLinksItem(buildPaginationLink(url + "&before=" + encodedString,
                             "previous"));
                 }
                 if (!isLastPage) {
                     String encodedString = Base64.getEncoder().encodeToString(apiResources.get(apiResources.size() - 1)
-                            .getCursorKey().toString().getBytes(StandardCharsets.UTF_8));
+                            .getName().toString().getBytes(StandardCharsets.UTF_8));
                     apiResourceListResponse.addLinksItem(buildPaginationLink(url + "&after=" + encodedString, "next"));
                 }
             }

--- a/components/org.wso2.carbon.identity.api.server.api.resource/org.wso2.carbon.identity.api.server.api.resource.v1/src/main/java/org/wso2/carbon/identity/api/server/api/resource/v1/core/ServerAPIResourceManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.api.resource/org.wso2.carbon.identity.api.server.api.resource.v1/src/main/java/org/wso2/carbon/identity/api/server/api/resource/v1/core/ServerAPIResourceManagementService.java
@@ -178,13 +178,13 @@ public class ServerAPIResourceManagementService {
                 }
                 if (!isFirstPage) {
                     String encodedString = Base64.getEncoder().encodeToString(apiResources.get(0).getName()
-                            .toString().getBytes(StandardCharsets.UTF_8));
+                            .getBytes(StandardCharsets.UTF_8));
                     apiResourceListResponse.addLinksItem(buildPaginationLink(url + "&before=" + encodedString,
                             "previous"));
                 }
                 if (!isLastPage) {
                     String encodedString = Base64.getEncoder().encodeToString(apiResources.get(apiResources.size() - 1)
-                            .getName().toString().getBytes(StandardCharsets.UTF_8));
+                            .getName().getBytes(StandardCharsets.UTF_8));
                     apiResourceListResponse.addLinksItem(buildPaginationLink(url + "&after=" + encodedString, "next"));
                 }
             }


### PR DESCRIPTION
## Related Issue
[API resource filter is not working. #24875](https://github.com/wso2/product-is/issues/24875)

## Purpose
> I have changed API resource search UI to sort API resources by Name instead of Cursor Key. To follow up, this change is needed to make sure that the pagination works properly.

## Goals
> This changes the method call from getCursorKey() to getName().

## Approach
> Does not directly affect UI, only fixes an error created by the related PR

### Developer Checklist

- [x] [Behavioural Change] Does this change introduce a behavioral change to the product? 
- [ ] ↳ Approved by team lead
- [ ] ↳ Label impact/behavioral-change added
- [ ] [Migration Impact] Does this change have a migration impact?
- [ ] ↳ Migration label added (e.g., 7.2.0-migration)
- [ ] ↳ Migration issues created and linked
- [ ] [New Configuration] Does this change introduce a new configuration?
- [ ] ↳ Label config added
- [ ] ↳ Configuration is properly documented

## Documentation
> N/A. This only changes the underlying functionality required by the UI. Please correct me if I'm wrong.

## Related PRs
[Adding case insensitive searching and sorting by API name to API Resource Management UI.](https://github.com/wso2/carbon-identity-framework/pull/7578)

## Test environment
> JDK: openjdk version "11.0.19" 2023-04-18 LTS
OS: Windows 11 24H2
Browser: Firefox (144.0) 