### PR TITLE
[Refactor] Move attributes handling to base action models

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.action.management/org.wso2.carbon.identity.api.server.action.management.v1/src/extend/java/org/wso2/carbon/identity/api/server/action/management/v1/PreUpdatePasswordActionModel.java
+++ b/components/org.wso2.carbon.identity.api.server.action.management/org.wso2.carbon.identity.api.server.action.management.v1/src/extend/java/org/wso2/carbon/identity/api/server/action/management/v1/PreUpdatePasswordActionModel.java
@@ -33,7 +33,6 @@ import javax.validation.constraints.NotNull;
 public class PreUpdatePasswordActionModel extends ActionModel {
 
     private PasswordSharing passwordSharing;
-    private List<String> attributes;
 
     public PreUpdatePasswordActionModel() {
         // Default constructor required for Jackson
@@ -45,6 +44,7 @@ public class PreUpdatePasswordActionModel extends ActionModel {
         setDescription(actionModel.getDescription());
         setEndpoint(actionModel.getEndpoint());
         setRule(actionModel.getRule());
+        setAttributes(actionModel.getAttributes());
     }
 
     public PreUpdatePasswordActionModel passwordSharing(PasswordSharing passwordSharing) {
@@ -67,25 +67,6 @@ public class PreUpdatePasswordActionModel extends ActionModel {
         this.passwordSharing = passwordSharing;
     }
 
-    public PreUpdatePasswordActionModel attributes(List<String> attributes) {
-
-        this.attributes = attributes;
-        return this;
-    }
-
-    @ApiModelProperty()
-    @JsonProperty("attributes")
-    @Valid
-    public List<String> getAttributes() {
-
-        return attributes;
-    }
-
-    public void setAttributes(List<String> attributes) {
-
-        this.attributes = attributes;
-    }
-
     @Override
     public boolean equals(java.lang.Object o) {
 
@@ -100,13 +81,13 @@ public class PreUpdatePasswordActionModel extends ActionModel {
                 Objects.equals(this.getDescription(), actionModel.getDescription()) &&
                 Objects.equals(this.getEndpoint(), actionModel.getEndpoint()) &&
                 Objects.equals(this.passwordSharing, actionModel.passwordSharing) &&
-                Objects.equals(this.attributes, actionModel.attributes) &&
+                Objects.equals(this.getAttributes(), actionModel.getAttributes()) &&
                 Objects.equals(this.getRule(), actionModel.getRule());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(getName(), getDescription(), getEndpoint(), passwordSharing, attributes, getRule());
+        return Objects.hash(getName(), getDescription(), getEndpoint(), passwordSharing, getAttributes(), getRule());
     }
 
     @Override
@@ -118,7 +99,7 @@ public class PreUpdatePasswordActionModel extends ActionModel {
         sb.append("    description: ").append(toIndentedString(getDescription())).append("\n");
         sb.append("    endpoint: ").append(toIndentedString(getEndpoint())).append("\n");
         sb.append("    passwordSharing: ").append(toIndentedString(passwordSharing)).append("\n");
-        sb.append("    attributes: ").append(toIndentedString(attributes)).append("\n");
+        sb.append("    attributes: ").append(toIndentedString(getAttributes())).append("\n");
         sb.append("    rule: ").append(toIndentedString(getRule())).append("\n");
         sb.append("}");
         return sb.toString();

--- a/components/org.wso2.carbon.identity.api.server.action.management/org.wso2.carbon.identity.api.server.action.management.v1/src/extend/java/org/wso2/carbon/identity/api/server/action/management/v1/PreUpdatePasswordActionUpdateModel.java
+++ b/components/org.wso2.carbon.identity.api.server.action.management/org.wso2.carbon.identity.api.server.action.management.v1/src/extend/java/org/wso2/carbon/identity/api/server/action/management/v1/PreUpdatePasswordActionUpdateModel.java
@@ -32,7 +32,6 @@ import javax.validation.Valid;
 public class PreUpdatePasswordActionUpdateModel extends ActionUpdateModel {
 
     private PasswordSharingUpdateModel passwordSharing;
-    private List<String> attributes;
 
     public PreUpdatePasswordActionUpdateModel() {
         // Default constructor required for Jackson
@@ -44,6 +43,7 @@ public class PreUpdatePasswordActionUpdateModel extends ActionUpdateModel {
         setDescription(actionUpdateModel.getDescription());
         setEndpoint(actionUpdateModel.getEndpoint());
         setRule(actionUpdateModel.getRule());
+        setAttributes(actionUpdateModel.getAttributes());
     }
 
     public PreUpdatePasswordActionUpdateModel passwordSharing(PasswordSharingUpdateModel passwordSharing) {
@@ -65,25 +65,6 @@ public class PreUpdatePasswordActionUpdateModel extends ActionUpdateModel {
         this.passwordSharing = passwordSharing;
     }
 
-    public PreUpdatePasswordActionUpdateModel attributes(List<String> attributes) {
-
-        this.attributes = attributes;
-        return this;
-    }
-
-    @ApiModelProperty()
-    @JsonProperty("attributes")
-    @Valid
-    public List<String> getAttributes() {
-
-        return attributes;
-    }
-
-    public void setAttributes(List<String> attributes) {
-
-        this.attributes = attributes;
-    }
-
     @Override
     public boolean equals(java.lang.Object o) {
 
@@ -98,13 +79,13 @@ public class PreUpdatePasswordActionUpdateModel extends ActionUpdateModel {
                 Objects.equals(this.getDescription(), actionUpdateModel.getDescription()) &&
                 Objects.equals(this.getEndpoint(), actionUpdateModel.getEndpoint()) &&
                 Objects.equals(this.passwordSharing, actionUpdateModel.passwordSharing) &&
-                Objects.equals(this.attributes, actionUpdateModel.attributes) &&
+                Objects.equals(this.getAttributes(), actionUpdateModel.getAttributes()) &&
                 Objects.equals(this.getRule(), actionUpdateModel.getRule());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(getName(), getDescription(), getEndpoint(), passwordSharing, attributes, getRule());
+        return Objects.hash(getName(), getDescription(), getEndpoint(), passwordSharing, getAttributes(), getRule());
     }
 
     @Override
@@ -116,7 +97,7 @@ public class PreUpdatePasswordActionUpdateModel extends ActionUpdateModel {
         sb.append("    description: ").append(toIndentedString(getDescription())).append("\n");
         sb.append("    endpoint: ").append(toIndentedString(getEndpoint())).append("\n");
         sb.append("    passwordSharing: ").append(toIndentedString(passwordSharing)).append("\n");
-        sb.append("    attributes: ").append(toIndentedString(attributes)).append("\n");
+        sb.append("    attributes: ").append(toIndentedString(getAttributes())).append("\n");
         sb.append("    rule: ").append(toIndentedString(getRule())).append("\n");
         sb.append("}");
         return sb.toString();

--- a/components/org.wso2.carbon.identity.api.server.action.management/org.wso2.carbon.identity.api.server.action.management.v1/src/extend/java/org/wso2/carbon/identity/api/server/action/management/v1/PreUpdateProfileActionModel.java
+++ b/components/org.wso2.carbon.identity.api.server.action.management/org.wso2.carbon.identity.api.server.action.management.v1/src/extend/java/org/wso2/carbon/identity/api/server/action/management/v1/PreUpdateProfileActionModel.java
@@ -31,8 +31,6 @@ import javax.validation.Valid;
  */
 public class PreUpdateProfileActionModel extends ActionModel {
 
-    private List<String> attributes;
-
     public PreUpdateProfileActionModel() {
         // Default constructor required for Jackson
     }
@@ -43,25 +41,7 @@ public class PreUpdateProfileActionModel extends ActionModel {
         setDescription(actionModel.getDescription());
         setEndpoint(actionModel.getEndpoint());
         setRule(actionModel.getRule());
-    }
-
-    public PreUpdateProfileActionModel attributes(List<String> attributes) {
-
-        this.attributes = attributes;
-        return this;
-    }
-
-    @ApiModelProperty(required = true)
-    @JsonProperty("attributes")
-    @Valid
-    public List<String> getAttributes() {
-
-        return attributes;
-    }
-
-    public void setAttributes(List<String> attributes) {
-
-        this.attributes = attributes;
+        setAttributes(actionModel.getAttributes());
     }
 
     @Override
@@ -77,13 +57,13 @@ public class PreUpdateProfileActionModel extends ActionModel {
         return Objects.equals(this.getName(), actionModel.getName()) &&
                 Objects.equals(this.getDescription(), actionModel.getDescription()) &&
                 Objects.equals(this.getEndpoint(), actionModel.getEndpoint()) &&
-                Objects.equals(this.attributes, actionModel.attributes) &&
+                Objects.equals(this.getAttributes(), actionModel.getAttributes()) &&
                 Objects.equals(this.getRule(), actionModel.getRule());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(getName(), getDescription(), getEndpoint(), attributes, getRule());
+        return Objects.hash(getName(), getDescription(), getEndpoint(), getAttributes(), getRule());
     }
 
     @Override
@@ -94,7 +74,7 @@ public class PreUpdateProfileActionModel extends ActionModel {
         sb.append("    name: ").append(toIndentedString(getName())).append("\n");
         sb.append("    description: ").append(toIndentedString(getDescription())).append("\n");
         sb.append("    endpoint: ").append(toIndentedString(getEndpoint())).append("\n");
-        sb.append("    attributes: ").append(toIndentedString(attributes)).append("\n");
+        sb.append("    attributes: ").append(toIndentedString(getAttributes())).append("\n");
         sb.append("    rule: ").append(toIndentedString(getRule())).append("\n");
         sb.append("}");
         return sb.toString();

--- a/components/org.wso2.carbon.identity.api.server.action.management/org.wso2.carbon.identity.api.server.action.management.v1/src/extend/java/org/wso2/carbon/identity/api/server/action/management/v1/PreUpdateProfileActionUpdateModel.java
+++ b/components/org.wso2.carbon.identity.api.server.action.management/org.wso2.carbon.identity.api.server.action.management.v1/src/extend/java/org/wso2/carbon/identity/api/server/action/management/v1/PreUpdateProfileActionUpdateModel.java
@@ -31,8 +31,6 @@ import javax.validation.Valid;
  **/
 public class PreUpdateProfileActionUpdateModel extends ActionUpdateModel {
 
-    private List<String> attributes;
-
     public PreUpdateProfileActionUpdateModel() {
         // Default constructor required for Jackson
     }
@@ -43,25 +41,7 @@ public class PreUpdateProfileActionUpdateModel extends ActionUpdateModel {
         setDescription(actionUpdateModel.getDescription());
         setEndpoint(actionUpdateModel.getEndpoint());
         setRule(actionUpdateModel.getRule());
-    }
-
-    public PreUpdateProfileActionUpdateModel attributes(List<String> attributes) {
-
-        this.attributes = attributes;
-        return this;
-    }
-
-    @ApiModelProperty()
-    @JsonProperty("attributes")
-    @Valid
-    public List<String> getAttributes() {
-
-        return attributes;
-    }
-
-    public void setAttributes(List<String> attributes) {
-
-        this.attributes = attributes;
+        setAttributes(actionUpdateModel.getAttributes());
     }
 
     @Override
@@ -77,13 +57,13 @@ public class PreUpdateProfileActionUpdateModel extends ActionUpdateModel {
         return Objects.equals(this.getName(), actionUpdateModel.getName()) &&
                 Objects.equals(this.getDescription(), actionUpdateModel.getDescription()) &&
                 Objects.equals(this.getEndpoint(), actionUpdateModel.getEndpoint()) &&
-                Objects.equals(this.attributes, actionUpdateModel.attributes) &&
+                Objects.equals(this.getAttributes(), actionUpdateModel.getAttributes()) &&
                 Objects.equals(this.getRule(), actionUpdateModel.getRule());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(getName(), getDescription(), getEndpoint(), attributes, getRule());
+        return Objects.hash(getName(), getDescription(), getEndpoint(), getAttributes(), getRule());
     }
 
     @Override
@@ -94,7 +74,7 @@ public class PreUpdateProfileActionUpdateModel extends ActionUpdateModel {
         sb.append("    name: ").append(toIndentedString(getName())).append("\n");
         sb.append("    description: ").append(toIndentedString(getDescription())).append("\n");
         sb.append("    endpoint: ").append(toIndentedString(getEndpoint())).append("\n");
-        sb.append("    attributes: ").append(toIndentedString(attributes)).append("\n");
+        sb.append("    attributes: ").append(toIndentedString(getAttributes())).append("\n");
         sb.append("    rule: ").append(toIndentedString(getRule())).append("\n");
         sb.append("}");
         return sb.toString();

--- a/components/org.wso2.carbon.identity.api.server.action.management/org.wso2.carbon.identity.api.server.action.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/action/management/v1/ActionModel.java
+++ b/components/org.wso2.carbon.identity.api.server.action.management/org.wso2.carbon.identity.api.server.action.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/action/management/v1/ActionModel.java
@@ -28,6 +28,7 @@ import javax.validation.constraints.*;
 
 
 import io.swagger.annotations.*;
+import java.util.List;
 import java.util.Objects;
 import javax.validation.Valid;
 import javax.xml.bind.annotation.*;
@@ -38,6 +39,7 @@ public class ActionModel  {
     private String description;
     private Endpoint endpoint;
     private ORRule rule;
+    private List<String> attributes;
 
     /**
     * Name of the action.
@@ -117,7 +119,25 @@ public class ActionModel  {
         this.rule = rule;
     }
 
+    /**
+     * Attributes required for the action.
+     */
+    public ActionModel attributes(List<String> attributes) {
 
+        this.attributes = attributes;
+        return this;
+    }
+
+    @ApiModelProperty(value = "Attributes required for the action.")
+    @JsonProperty("attributes")
+    @Valid
+    public List<String> getAttributes() {
+        return attributes;
+    }
+
+    public void setAttributes(List<String> attributes) {
+        this.attributes = attributes;
+    }
 
     @Override
     public boolean equals(java.lang.Object o) {
@@ -130,9 +150,10 @@ public class ActionModel  {
         }
         ActionModel actionModel = (ActionModel) o;
         return Objects.equals(this.name, actionModel.name) &&
-            Objects.equals(this.description, actionModel.description) &&
-            Objects.equals(this.endpoint, actionModel.endpoint) &&
-            Objects.equals(this.rule, actionModel.rule);
+                Objects.equals(this.description, actionModel.description) &&
+                Objects.equals(this.endpoint, actionModel.endpoint) &&
+                Objects.equals(this.attributes, actionModel.attributes) &&
+                Objects.equals(this.rule, actionModel.rule);
     }
 
     @Override
@@ -149,6 +170,7 @@ public class ActionModel  {
         sb.append("    name: ").append(toIndentedString(name)).append("\n");
         sb.append("    description: ").append(toIndentedString(description)).append("\n");
         sb.append("    endpoint: ").append(toIndentedString(endpoint)).append("\n");
+        sb.append("    attributes: ").append(toIndentedString(attributes)).append("\n");
         sb.append("    rule: ").append(toIndentedString(rule)).append("\n");
         sb.append("}");
         return sb.toString();

--- a/components/org.wso2.carbon.identity.api.server.action.management/org.wso2.carbon.identity.api.server.action.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/action/management/v1/ActionResponse.java
+++ b/components/org.wso2.carbon.identity.api.server.action.management/org.wso2.carbon.identity.api.server.action.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/action/management/v1/ActionResponse.java
@@ -29,6 +29,7 @@ import javax.validation.constraints.*;
 
 
 import io.swagger.annotations.*;
+import java.util.List;
 import java.util.Objects;
 import javax.validation.Valid;
 import javax.xml.bind.annotation.*;
@@ -78,6 +79,7 @@ public enum StatusEnum {
     private String updatedAt;
     private EndpointResponse endpoint;
     private ORRuleResponse rule;
+    private List<String> attributes;
 
     /**
     * Unique identifier of the action.
@@ -266,7 +268,24 @@ public enum StatusEnum {
         this.rule = rule;
     }
 
+    /**
+     * Attributes required for the action.
+     **/
+    public ActionResponse attributes(List<String> attributes) {
 
+        this.attributes = attributes;
+        return this;
+    }
+
+    @ApiModelProperty(value = "Attributes required for the action.")
+    @JsonProperty("attributes")
+    @Valid
+    public List<String> getAttributes() {
+        return attributes;
+    }
+    public void setAttributes(List<String> attributes) {
+        this.attributes = attributes;
+    }
 
     @Override
     public boolean equals(java.lang.Object o) {
@@ -279,20 +298,21 @@ public enum StatusEnum {
         }
         ActionResponse actionResponse = (ActionResponse) o;
         return Objects.equals(this.id, actionResponse.id) &&
-            Objects.equals(this.type, actionResponse.type) &&
-            Objects.equals(this.name, actionResponse.name) &&
-            Objects.equals(this.description, actionResponse.description) &&
-            Objects.equals(this.status, actionResponse.status) &&
-            Objects.equals(this.version, actionResponse.version) &&
-            Objects.equals(this.createdAt, actionResponse.createdAt) &&
-            Objects.equals(this.updatedAt, actionResponse.updatedAt) &&
-            Objects.equals(this.endpoint, actionResponse.endpoint) &&
-            Objects.equals(this.rule, actionResponse.rule);
+                Objects.equals(this.type, actionResponse.type) &&
+                Objects.equals(this.name, actionResponse.name) &&
+                Objects.equals(this.description, actionResponse.description) &&
+                Objects.equals(this.status, actionResponse.status) &&
+                Objects.equals(this.version, actionResponse.version) &&
+                Objects.equals(this.createdAt, actionResponse.createdAt) &&
+                Objects.equals(this.updatedAt, actionResponse.updatedAt) &&
+                Objects.equals(this.endpoint, actionResponse.endpoint) &&
+                Objects.equals(this.attributes, actionResponse.attributes) &&
+                Objects.equals(this.rule, actionResponse.rule);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, type, name, description, status, version, createdAt, updatedAt, endpoint, rule);
+        return Objects.hash(id, type, name, description, status, version, createdAt, updatedAt, endpoint, attributes, rule);
     }
 
     @Override
@@ -310,6 +330,7 @@ public enum StatusEnum {
         sb.append("    createdAt: ").append(toIndentedString(createdAt)).append("\n");
         sb.append("    updatedAt: ").append(toIndentedString(updatedAt)).append("\n");
         sb.append("    endpoint: ").append(toIndentedString(endpoint)).append("\n");
+        sb.append("    attributes: ").append(toIndentedString(attributes)).append("\n");
         sb.append("    rule: ").append(toIndentedString(rule)).append("\n");
         sb.append("}");
         return sb.toString();

--- a/components/org.wso2.carbon.identity.api.server.action.management/org.wso2.carbon.identity.api.server.action.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/action/management/v1/ActionUpdateModel.java
+++ b/components/org.wso2.carbon.identity.api.server.action.management/org.wso2.carbon.identity.api.server.action.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/action/management/v1/ActionUpdateModel.java
@@ -39,6 +39,7 @@ public class ActionUpdateModel  {
     private String version;
     private EndpointUpdateModel endpoint;
     private ORRule rule;
+    private java.util.List<String> attributes;
 
     /**
     * Updating name of the action.
@@ -133,7 +134,24 @@ public class ActionUpdateModel  {
         this.rule = rule;
     }
 
+    /**
+     * Attributes required for the action.
+     **/
+    public ActionUpdateModel attributes(java.util.List<String> attributes) {
+        this.attributes = attributes;
+        return this;
+    }
 
+    @ApiModelProperty(value = "Attributes required for the action.")
+    @JsonProperty("attributes")
+    @Valid
+    public java.util.List<String> getAttributes() {
+        return attributes;
+    }
+
+    public void setAttributes(java.util.List<String> attributes) {
+        this.attributes = attributes;
+    }
 
     @Override
     public boolean equals(java.lang.Object o) {
@@ -146,15 +164,16 @@ public class ActionUpdateModel  {
         }
         ActionUpdateModel actionUpdateModel = (ActionUpdateModel) o;
         return Objects.equals(this.name, actionUpdateModel.name) &&
-            Objects.equals(this.description, actionUpdateModel.description) &&
-            Objects.equals(this.version, actionUpdateModel.version) &&
-            Objects.equals(this.endpoint, actionUpdateModel.endpoint) &&
-            Objects.equals(this.rule, actionUpdateModel.rule);
+                Objects.equals(this.description, actionUpdateModel.description) &&
+                Objects.equals(this.version, actionUpdateModel.version) &&
+                Objects.equals(this.endpoint, actionUpdateModel.endpoint) &&
+                Objects.equals(this.attributes, actionUpdateModel.attributes) &&
+                Objects.equals(this.rule, actionUpdateModel.rule);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(name, description, version, endpoint, rule);
+        return Objects.hash(name, description, version, endpoint, attributes, rule);
     }
 
     @Override
@@ -167,6 +186,7 @@ public class ActionUpdateModel  {
         sb.append("    description: ").append(toIndentedString(description)).append("\n");
         sb.append("    version: ").append(toIndentedString(version)).append("\n");
         sb.append("    endpoint: ").append(toIndentedString(endpoint)).append("\n");
+        sb.append("    attributes: ").append(toIndentedString(attributes)).append("\n");
         sb.append("    rule: ").append(toIndentedString(rule)).append("\n");
         sb.append("}");
         return sb.toString();

--- a/components/org.wso2.carbon.identity.api.server.action.management/org.wso2.carbon.identity.api.server.action.management.v1/src/main/java/org/wso2/carbon/identity/api/server/action/management/v1/constants/ActionMgtEndpointConstants.java
+++ b/components/org.wso2.carbon.identity.api.server.action.management/org.wso2.carbon.identity.api.server.action.management.v1/src/main/java/org/wso2/carbon/identity/api/server/action/management/v1/constants/ActionMgtEndpointConstants.java
@@ -67,7 +67,10 @@ public class ActionMgtEndpointConstants {
                 "Rules are not supported for the specified action type by the server."),
         ERROR_WHILE_INITIALIZING_RULE_BUILDER("650017",
                 "Unable to perform the operation.",
-                "Error while retrieving rule metadata for rule validations.");
+                "Error while retrieving rule metadata for rule validations."),
+        ERROR_NOT_IMPLEMENTED_ATTRIBUTES("650018",
+                "Unable to perform the operation.",
+                "Attributes are not currently supported for the action type: %s.");
 
         private final String code;
         private final String message;

--- a/components/org.wso2.carbon.identity.api.server.action.management/org.wso2.carbon.identity.api.server.action.management.v1/src/main/java/org/wso2/carbon/identity/api/server/action/management/v1/core/ServerActionManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.action.management/org.wso2.carbon.identity.api.server.action.management.v1/src/main/java/org/wso2/carbon/identity/api/server/action/management/v1/core/ServerActionManagementService.java
@@ -50,6 +50,7 @@ import javax.ws.rs.core.Response;
 import static org.wso2.carbon.identity.api.server.action.management.v1.constants.ActionMgtEndpointConstants.ErrorMessage.ERROR_INVALID_ACTION_TYPE;
 import static org.wso2.carbon.identity.api.server.action.management.v1.constants.ActionMgtEndpointConstants.ErrorMessage.ERROR_NOT_ALLOWED_ACTION_TYPE_IN_ORG_LEVEL;
 import static org.wso2.carbon.identity.api.server.action.management.v1.constants.ActionMgtEndpointConstants.ErrorMessage.ERROR_NOT_IMPLEMENTED_ACTION_TYPE;
+import static org.wso2.carbon.identity.api.server.action.management.v1.constants.ActionMgtEndpointConstants.ErrorMessage.ERROR_NOT_IMPLEMENTED_ATTRIBUTES;
 import static org.wso2.carbon.identity.api.server.action.management.v1.constants.ActionMgtEndpointConstants.ErrorMessage.ERROR_NO_ACTION_FOUND_ON_GIVEN_ACTION_TYPE_AND_ID;
 
 /**
@@ -61,6 +62,7 @@ public class ServerActionManagementService {
     private static final Log LOG = LogFactory.getLog(ServerActionManagementService.class);
     private static final Set<String> NOT_IMPLEMENTED_ACTION_TYPES = new HashSet<>();
     private static final Set<String> NOT_ALLOWED_ACTION_TYPES_IN_ORG_LEVEL = new HashSet<>();
+    private static final Set<String> ATTRIBUTES_NOT_IMPLEMENTED_ACTION_TYPES = new HashSet<>();
 
     public ServerActionManagementService(ActionManagementService actionManagementService) {
 
@@ -73,6 +75,9 @@ public class ServerActionManagementService {
 
         NOT_ALLOWED_ACTION_TYPES_IN_ORG_LEVEL.add(Action.ActionTypes.PRE_ISSUE_ACCESS_TOKEN.getPathParam());
         NOT_ALLOWED_ACTION_TYPES_IN_ORG_LEVEL.add(Action.ActionTypes.PRE_ISSUE_ID_TOKEN.getPathParam());
+
+        ATTRIBUTES_NOT_IMPLEMENTED_ACTION_TYPES.add(Action.ActionTypes.PRE_ISSUE_ACCESS_TOKEN.getActionType());
+        ATTRIBUTES_NOT_IMPLEMENTED_ACTION_TYPES.add(Action.ActionTypes.PRE_ISSUE_ID_TOKEN.getActionType());
     }
 
     public ActionResponse createAction(String actionType, String jsonBody) {
@@ -80,6 +85,7 @@ public class ServerActionManagementService {
         try {
             Action.ActionTypes validatedActionType = validateActionType(actionType);
             Action action = buildAction(validatedActionType, jsonBody);
+            validateAttributes(validatedActionType, action.getAttributes());
             String tenantDomain = CarbonContext.getThreadLocalCarbonContext().getTenantDomain();
             return buildActionResponse(actionManagementService.addAction(actionType, action, tenantDomain));
         } catch (ActionMgtException e) {
@@ -125,6 +131,7 @@ public class ServerActionManagementService {
         try {
             Action.ActionTypes validatedActionType = validateActionType(actionType);
             Action updatingAction = buildUpdatingAction(validatedActionType, jsonBody);
+            validateAttributes(validatedActionType, updatingAction.getAttributes());
             String tenantDomain = CarbonContext.getThreadLocalCarbonContext().getTenantDomain();
             return buildActionResponse(actionManagementService.updateAction(actionType, actionId, updatingAction, 
                     tenantDomain));
@@ -269,6 +276,15 @@ public class ServerActionManagementService {
         }
 
         return actionTypeEnum;
+    }
+
+    private void validateAttributes(Action.ActionTypes actionType, List<String> attributes) {
+
+        if (attributes != null && !attributes.isEmpty() &&
+                ATTRIBUTES_NOT_IMPLEMENTED_ACTION_TYPES.contains(actionType.getActionType())) {
+            throw ActionMgtEndpointUtil.handleException(Response.Status.NOT_IMPLEMENTED,
+                    ERROR_NOT_IMPLEMENTED_ATTRIBUTES, actionType.getActionType());
+        }
     }
 
     private Action.ActionTypes getActionTypeFromPath(String actionType) {

--- a/components/org.wso2.carbon.identity.api.server.action.management/org.wso2.carbon.identity.api.server.action.management.v1/src/main/java/org/wso2/carbon/identity/api/server/action/management/v1/util/ActionMapperUtil.java
+++ b/components/org.wso2.carbon.identity.api.server.action.management/org.wso2.carbon.identity.api.server.action.management.v1/src/main/java/org/wso2/carbon/identity/api/server/action/management/v1/util/ActionMapperUtil.java
@@ -154,7 +154,8 @@ public class ActionMapperUtil {
                         .allowedHeaders(action.getEndpoint().getAllowedHeaders())
                         .allowedParameters(action.getEndpoint().getAllowedParameters()))
                 .rule((action.getActionRule() != null) ? RuleMapper.toORRuleResponse(action.getActionRule()) :
-                        null);
+                        null)
+                .attributes(action.getAttributes());
     }
 
     /**

--- a/components/org.wso2.carbon.identity.api.server.action.management/org.wso2.carbon.identity.api.server.action.management.v1/src/main/java/org/wso2/carbon/identity/api/server/action/management/v1/util/ActionMapperUtil.java
+++ b/components/org.wso2.carbon.identity.api.server.action.management/org.wso2.carbon.identity.api.server.action.management.v1/src/main/java/org/wso2/carbon/identity/api/server/action/management/v1/util/ActionMapperUtil.java
@@ -80,6 +80,7 @@ public class ActionMapperUtil {
                         .allowedParameters(actionModel.getEndpoint().getAllowedParameters())
                         .build())
                 .rule(actionRule)
+                .attributes(actionModel.getAttributes())
                 .build();
     }
 
@@ -123,6 +124,7 @@ public class ActionMapperUtil {
                 .actionVersion(actionUpdateModel.getVersion())
                 .endpoint(endpointConfig)
                 .rule(actionRule)
+                .attributes(actionUpdateModel.getAttributes())
                 .build();
     }
 
@@ -201,7 +203,7 @@ public class ActionMapperUtil {
      * @return Authentication object.
      */
     private static Authentication buildAuthentication(Authentication.Type authType,
-                                                     Map<String, Object> authPropertiesMap)
+                                                      Map<String, Object> authPropertiesMap)
             throws ActionMgtClientException {
 
         switch (authType) {


### PR DESCRIPTION
This pull request refactors how the `attributes` property is managed across several action model classes in the action management API. The main change is to centralize the handling of `attributes` in the base `ActionModel` and `ActionUpdateModel` classes, removing redundant declarations and methods from child classes. This improves maintainability and ensures consistency in how attributes are accessed and set.

Centralization of `attributes` property:

* Added the `attributes` property and its relevant getter, setter, and annotations to the base `ActionModel` and `ActionUpdateModel` classes. This allows child classes to inherit and use these methods, reducing code duplication.

Refactoring child action model classes:

* Removed redundant `attributes` fields and methods from `PreUpdatePasswordActionModel`, `PreUpdatePasswordActionUpdateModel`, `PreUpdateProfileActionModel`, and `PreUpdateProfileActionUpdateModel`. These classes now use the inherited methods from their base classes. 
* Updated constructors in child classes to use the base class's `getAttributes()` and `setAttributes()` methods, ensuring proper initialization and assignment. 

**Related PRs:**

- https://github.com/wso2/carbon-identity-framework/pull/7895

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved attribute validation for actions: requests that include attributes for unsupported action types now return a clear "not implemented" error stating attributes are not available for that action type.
* **Behavior Changes**
  * Action request/response handling and models now rely on centralized attribute handling; attribute fields are no longer exposed redundantly on some action models, aligning API behavior and responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->