### PR TITLE
Add client exceptions based on the exception type returning from the service level

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.common/src/main/java/org/wso2/carbon/identity/api/server/configs/common/Constants.java
+++ b/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.common/src/main/java/org/wso2/carbon/identity/api/server/configs/common/Constants.java
@@ -233,7 +233,9 @@ public class Constants {
                 "Unable to delete OAuth2 inbound auth configs.",
                 "Server encountered an error while deleting the OAuth2 inbound auth configs."),
 
-        // Issuer usage scope configuration errors.
+        /**
+        * Issuer usage scope configuration errors.
+        */
         ERROR_CODE_ERROR_ISSUER_USAGE_SCOPE_EMPTY("65028",
                 "Unable to retrieve issuer usage scope configuration.",
                 "The issuer usage scope configuration is empty for the tenant domain %s."),
@@ -243,6 +245,9 @@ public class Constants {
         ERROR_CODE_ERROR_ISSUER_USAGE_SCOPE_UPDATE("65030",
                 "Unable to update issuer usage scope configuration.",
                 "Server encountered an error while updating issuer usage scope configuration. %s"),
+        ERROR_CODE_CLIENT_ERROR_ISSUER_USAGE_SCOPE_UPDATE("60008",
+                "Unable to update issuer usage scope configuration.",
+                "Issuer usage scope config update failed. %s"),
         /**
          * Compatibility Settings errors.
          */

--- a/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/main/java/org/wso2/carbon/identity/api/server/configs/v1/core/ServerConfigManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/main/java/org/wso2/carbon/identity/api/server/configs/v1/core/ServerConfigManagementService.java
@@ -109,6 +109,7 @@ import org.wso2.carbon.identity.fraud.detection.core.model.FraudDetectionConfigD
 import org.wso2.carbon.identity.fraud.detection.core.service.FraudDetectionConfigsService;
 import org.wso2.carbon.identity.oauth.dcr.DCRConfigurationMgtService;
 import org.wso2.carbon.identity.oauth.dcr.exception.DCRMException;
+import org.wso2.carbon.identity.oauth2.config.exceptions.OAuth2OIDCConfigOrgUsageScopeMgtClientException;
 import org.wso2.carbon.identity.oauth2.config.exceptions.OAuth2OIDCConfigOrgUsageScopeMgtException;
 import org.wso2.carbon.identity.oauth2.config.models.IssuerUsageScopeConfig;
 import org.wso2.carbon.identity.oauth2.config.models.UsageScope;
@@ -2392,6 +2393,10 @@ public class ServerConfigManagementService {
                     updateIssuerUsageScopeConfig(tenantDomain, issuerUsageScopeConfig);
             return buildIssuerUsageScopeConfig(updateIssuerUsageScopeConfig, tenantDomain);
         } catch (OAuth2OIDCConfigOrgUsageScopeMgtException | OrganizationManagementException e) {
+            if (e instanceof OAuth2OIDCConfigOrgUsageScopeMgtClientException) {
+                throw handleException(Response.Status.BAD_REQUEST,
+                        Constants.ErrorMessage.ERROR_CODE_CLIENT_ERROR_ISSUER_USAGE_SCOPE_UPDATE, e.getMessage());
+            }
             throw handleException(Response.Status.INTERNAL_SERVER_ERROR,
                     Constants.ErrorMessage.ERROR_CODE_ERROR_ISSUER_USAGE_SCOPE_UPDATE, e.getMessage());
         }


### PR DESCRIPTION
## Purpose
- $subject
- Related to : https://github.com/wso2/product-is/issues/27080

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for issuer usage scope updates: client-side validation failures now return a clear client error response (400) while other failures return server errors (500).
  * Enhanced failure message for update operations to include more descriptive details to help diagnose issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->