### PR TITLE
Add support to set enhanced org authentication enabled based on server config

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/ServerApplicationManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/ServerApplicationManagementService.java
@@ -217,6 +217,7 @@ import static org.wso2.carbon.identity.application.mgt.ApplicationConstants.Erro
 import static org.wso2.carbon.identity.application.mgt.ApplicationConstants.FILTER_CO;
 import static org.wso2.carbon.identity.configuration.mgt.core.search.constant.ConditionType.PrimitiveOperator.EQUALS;
 import static org.wso2.carbon.identity.cors.mgt.core.constant.ErrorMessages.ERROR_CODE_INVALID_APP_ID;
+import static org.wso2.carbon.identity.organization.management.service.util.Utils.isEnhancedOrgAuthEnabledByDefaultForNewApps;
 import static org.wso2.carbon.identity.organization.management.service.util.Utils.isLegacyAuthzRuntime;
 
 /**
@@ -835,6 +836,11 @@ public class ServerApplicationManagementService {
                 Boolean.TRUE.equals(applicationModel.getEnhancedOrgAuthenticationEnabled())) {
             throw buildBadRequestError(UNSUPPORTED_ENHANCED_ORGANIZATION_AUTHENTICATION_ENABLED_CONFIGURATION.getCode(),
                     UNSUPPORTED_ENHANCED_ORGANIZATION_AUTHENTICATION_ENABLED_CONFIGURATION.getDescription());
+        }
+
+        if (applicationModel.getEnhancedOrgAuthenticationEnabled() == null
+                && isEnhancedOrganizationAuthenticationFeatureEnabled()) {
+            applicationModel.setEnhancedOrgAuthenticationEnabled(isEnhancedOrgAuthEnabledByDefaultForNewApps());
         }
 
         // Block application creation with name Console or MyAccount.

--- a/pom.xml
+++ b/pom.xml
@@ -1089,7 +1089,7 @@
         <identity.local.auth.fido.version>6.0.3</identity.local.auth.fido.version>
 
         <!-- Organization management core Version -->
-        <org.wso2.carbon.identity.organization.management.core.version>1.1.41
+        <org.wso2.carbon.identity.organization.management.core.version>1.5.1
         </org.wso2.carbon.identity.organization.management.core.version>
         <org.wso2.carbon.identity.organization.management.core.version.range>[1.0.0, 2.0.0)
         </org.wso2.carbon.identity.organization.management.core.version.range>


### PR DESCRIPTION
## Purpose
> $Subject

Issue - https://github.com/wso2/product-is/issues/27167

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced organization authentication now automatically defaults to enabled for newly created applications when the feature is available.

* **Chores**
  * Updated organization management core component dependency to version 1.5.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->