### PR TITLE
Remove enhanced org authentication enabling config usages

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/ServerApplicationManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/ServerApplicationManagementService.java
@@ -181,7 +181,6 @@ import static org.wso2.carbon.identity.api.server.application.management.common.
 import static org.wso2.carbon.identity.api.server.application.management.common.ApplicationManagementConstants.APPLICATION_ENABLED;
 import static org.wso2.carbon.identity.api.server.application.management.common.ApplicationManagementConstants.APPLICATION_MANAGEMENT_PATH_COMPONENT;
 import static org.wso2.carbon.identity.api.server.application.management.common.ApplicationManagementConstants.CLIENT_ID;
-import static org.wso2.carbon.identity.api.server.application.management.common.ApplicationManagementConstants.ENHANCED_ORGANIZATION_AUTHENTICATION_FEATURE_ENABLED;
 import static org.wso2.carbon.identity.api.server.application.management.common.ApplicationManagementConstants.ErrorMessage.APPLICATION_CREATION_WITH_TEMPLATES_NOT_IMPLEMENTED;
 import static org.wso2.carbon.identity.api.server.application.management.common.ApplicationManagementConstants.ErrorMessage.BLOCK_RENAME_APP_NAME_TO_RESERVED_APP_NAME;
 import static org.wso2.carbon.identity.api.server.application.management.common.ApplicationManagementConstants.ErrorMessage.BLOCK_SYSTEM_RESERVED_APP_CREATION;
@@ -189,7 +188,6 @@ import static org.wso2.carbon.identity.api.server.application.management.common.
 import static org.wso2.carbon.identity.api.server.application.management.common.ApplicationManagementConstants.ErrorMessage.ERROR_PROCESSING_REQUEST;
 import static org.wso2.carbon.identity.api.server.application.management.common.ApplicationManagementConstants.ErrorMessage.FORBIDDEN_OPERATION;
 import static org.wso2.carbon.identity.api.server.application.management.common.ApplicationManagementConstants.ErrorMessage.INBOUND_NOT_CONFIGURED;
-import static org.wso2.carbon.identity.api.server.application.management.common.ApplicationManagementConstants.ErrorMessage.UNSUPPORTED_ENHANCED_ORGANIZATION_AUTHENTICATION_ENABLED_CONFIGURATION;
 import static org.wso2.carbon.identity.api.server.application.management.common.ApplicationManagementConstants.ErrorMessage.USE_EXTERNAL_CONSENT_PAGE_NOT_SUPPORTED;
 import static org.wso2.carbon.identity.api.server.application.management.common.ApplicationManagementConstants.ISSUER;
 import static org.wso2.carbon.identity.api.server.application.management.common.ApplicationManagementConstants.NAME;
@@ -832,14 +830,7 @@ public class ServerApplicationManagementService {
             }
         }
 
-        if (!isEnhancedOrganizationAuthenticationFeatureEnabled() &&
-                Boolean.TRUE.equals(applicationModel.getEnhancedOrgAuthenticationEnabled())) {
-            throw buildBadRequestError(UNSUPPORTED_ENHANCED_ORGANIZATION_AUTHENTICATION_ENABLED_CONFIGURATION.getCode(),
-                    UNSUPPORTED_ENHANCED_ORGANIZATION_AUTHENTICATION_ENABLED_CONFIGURATION.getDescription());
-        }
-
-        if (applicationModel.getEnhancedOrgAuthenticationEnabled() == null
-                && isEnhancedOrganizationAuthenticationFeatureEnabled()) {
+        if (applicationModel.getEnhancedOrgAuthenticationEnabled() == null) {
             applicationModel.setEnhancedOrgAuthenticationEnabled(isEnhancedOrgAuthEnabledByDefaultForNewApps());
         }
 
@@ -904,12 +895,6 @@ public class ServerApplicationManagementService {
     public void patchApplication(String applicationId, ApplicationPatchModel applicationPatchModel) {
 
         ServiceProvider appToUpdate = cloneApplication(applicationId);
-
-        if (!isEnhancedOrganizationAuthenticationFeatureEnabled() && applicationPatchModel != null &&
-                Boolean.TRUE.equals(applicationPatchModel.getEnhancedOrgAuthenticationEnabled())) {
-            throw buildBadRequestError(UNSUPPORTED_ENHANCED_ORGANIZATION_AUTHENTICATION_ENABLED_CONFIGURATION.getCode(),
-                    UNSUPPORTED_ENHANCED_ORGANIZATION_AUTHENTICATION_ENABLED_CONFIGURATION.getDescription());
-        }
 
         /*
          * Updating the adaptive script requires the internal_application_script_update scope.
@@ -2297,17 +2282,6 @@ public class ServerApplicationManagementService {
                     .parseBoolean(IdentityUtil.getProperty(APPLICATION_BASED_OUTBOUND_PROVISIONING_ENABLED));
         }
         return applicationBasedOutboundProvisioningEnabled;
-    }
-
-    private boolean isEnhancedOrganizationAuthenticationFeatureEnabled() {
-
-        boolean enhancedOrganizationAuthenticationEnabled = false;
-        if (StringUtils.isNotEmpty(
-                IdentityUtil.getProperty(ENHANCED_ORGANIZATION_AUTHENTICATION_FEATURE_ENABLED))) {
-            enhancedOrganizationAuthenticationEnabled = Boolean
-                    .parseBoolean(IdentityUtil.getProperty(ENHANCED_ORGANIZATION_AUTHENTICATION_FEATURE_ENABLED));
-        }
-        return enhancedOrganizationAuthenticationEnabled;
     }
 
     private void blockRenameAppsToSystemReservedApps(String newAppName, String oldAppName) {


### PR DESCRIPTION
## Purpose
> $Subject

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Removed validation that prevented enabling enhanced organization authentication when a feature flag was off.
  * Made defaulting for enhanced organization authentication apply only when no value is provided.
  * Reduced reliance on internal flag parsing so configuration for organization authentication is more consistent and flexible.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->