### PR TITLE
Add FAPI 2.0 configuration models and connector utilities

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.common/src/main/java/org/wso2/carbon/identity/api/server/application/management/common/ApplicationManagementConstants.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.common/src/main/java/org/wso2/carbon/identity/api/server/application/management/common/ApplicationManagementConstants.java
@@ -250,7 +250,17 @@ public class ApplicationManagementConstants {
         // Organization application based issuer configuration related error messages.
         ERROR_RETRIEVING_ALLOWED_ISSUERS("65603",
                 "Error occurred while retrieving allowed issuers for the tenant.",
-                "Unexpected error occurred while retrieving allowed issuers for the tenant.");
+                "Unexpected error occurred while retrieving allowed issuers for the tenant."),
+
+        // FAPI metadata related error messages.
+        ERROR_RETRIEVING_FAPI_METADATA("65604",
+                "Error occurred while retrieving FAPI metadata.",
+                "Unexpected error occurred while retrieving FAPI metadata for tenant: %s."),
+
+        // FAPI profile validation related error messages.
+        UNSUPPORTED_FAPI_PROFILE("65605",
+                "Unsupported FAPI profile.",
+                "The provided FAPI profile '%s' is not supported by the organization. Supported profiles: %s.");
 
         private final String code;
         private final String message;

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.common/src/main/java/org/wso2/carbon/identity/api/server/application/management/common/ApplicationManagementServiceHolder.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.common/src/main/java/org/wso2/carbon/identity/api/server/application/management/common/ApplicationManagementServiceHolder.java
@@ -31,6 +31,7 @@ import org.wso2.carbon.identity.oauth.ciba.api.CibaAuthService;
 import org.wso2.carbon.identity.oauth.ciba.api.CibaAuthServiceImpl;
 import org.wso2.carbon.identity.oauth.config.OAuthServerConfiguration;
 import org.wso2.carbon.identity.oauth2.config.services.OAuth2OIDCConfigOrgUsageScopeMgtService;
+import org.wso2.carbon.identity.oauth2.fapi.services.FapiConfigMgtService;
 import org.wso2.carbon.identity.organization.management.application.OrgApplicationManager;
 import org.wso2.carbon.identity.sso.saml.SAMLSSOConfigServiceImpl;
 import org.wso2.carbon.identity.template.mgt.TemplateManager;
@@ -149,6 +150,12 @@ public class ApplicationManagementServiceHolder {
         static final OAuth2OIDCConfigOrgUsageScopeMgtService SERVICE =
                 (OAuth2OIDCConfigOrgUsageScopeMgtService) PrivilegedCarbonContext.getThreadLocalCarbonContext()
                         .getOSGiService(OAuth2OIDCConfigOrgUsageScopeMgtService.class, null);
+    }
+
+    private static class FapiConfigMgtServiceHolder {
+
+        static final FapiConfigMgtService SERVICE = (FapiConfigMgtService) PrivilegedCarbonContext
+                .getThreadLocalCarbonContext().getOSGiService(FapiConfigMgtService.class, null);
     }
 
     /**
@@ -288,5 +295,15 @@ public class ApplicationManagementServiceHolder {
     public static OAuth2OIDCConfigOrgUsageScopeMgtService getOAuth2OIDCConfigOrgUsageScopeMgtService() {
 
         return OAuthOIDCConfigOrgUsageScopeMgtServiceHolder.SERVICE;
+    }
+
+    /**
+     * Get FapiConfigMgtService.
+     *
+     * @return FapiConfigMgtService.
+     */
+    public static FapiConfigMgtService getFapiConfigMgtService() {
+
+        return FapiConfigMgtServiceHolder.SERVICE;
     }
 }

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/application/management/v1/FapiMetadata.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/application/management/v1/FapiMetadata.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -33,10 +33,29 @@ import javax.validation.Valid;
 import javax.xml.bind.annotation.*;
 
 public class FapiMetadata  {
-  
+
+    private MetadataProperty allowedFapiProfiles;
     private MetadataProperty allowedSignatureAlgorithms;
     private MetadataProperty allowedEncryptionAlgorithms;
     private ClientAuthenticationMethodMetadata tokenEndpointAuthMethod;
+
+    /**
+    **/
+    public FapiMetadata allowedFapiProfiles(MetadataProperty allowedFapiProfiles) {
+
+        this.allowedFapiProfiles = allowedFapiProfiles;
+        return this;
+    }
+
+    @ApiModelProperty(value = "")
+    @JsonProperty("allowedFapiProfiles")
+    @Valid
+    public MetadataProperty getAllowedFapiProfiles() {
+        return allowedFapiProfiles;
+    }
+    public void setAllowedFapiProfiles(MetadataProperty allowedFapiProfiles) {
+        this.allowedFapiProfiles = allowedFapiProfiles;
+    }
 
     /**
     **/
@@ -45,7 +64,7 @@ public class FapiMetadata  {
         this.allowedSignatureAlgorithms = allowedSignatureAlgorithms;
         return this;
     }
-    
+
     @ApiModelProperty(value = "")
     @JsonProperty("allowedSignatureAlgorithms")
     @Valid
@@ -63,7 +82,7 @@ public class FapiMetadata  {
         this.allowedEncryptionAlgorithms = allowedEncryptionAlgorithms;
         return this;
     }
-    
+
     @ApiModelProperty(value = "")
     @JsonProperty("allowedEncryptionAlgorithms")
     @Valid
@@ -81,7 +100,7 @@ public class FapiMetadata  {
         this.tokenEndpointAuthMethod = tokenEndpointAuthMethod;
         return this;
     }
-    
+
     @ApiModelProperty(value = "")
     @JsonProperty("tokenEndpointAuthMethod")
     @Valid
@@ -104,14 +123,15 @@ public class FapiMetadata  {
             return false;
         }
         FapiMetadata fapiMetadata = (FapiMetadata) o;
-        return Objects.equals(this.allowedSignatureAlgorithms, fapiMetadata.allowedSignatureAlgorithms) &&
+        return Objects.equals(this.allowedFapiProfiles, fapiMetadata.allowedFapiProfiles) &&
+            Objects.equals(this.allowedSignatureAlgorithms, fapiMetadata.allowedSignatureAlgorithms) &&
             Objects.equals(this.allowedEncryptionAlgorithms, fapiMetadata.allowedEncryptionAlgorithms) &&
             Objects.equals(this.tokenEndpointAuthMethod, fapiMetadata.tokenEndpointAuthMethod);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(allowedSignatureAlgorithms, allowedEncryptionAlgorithms, tokenEndpointAuthMethod);
+        return Objects.hash(allowedFapiProfiles, allowedSignatureAlgorithms, allowedEncryptionAlgorithms, tokenEndpointAuthMethod);
     }
 
     @Override
@@ -119,7 +139,8 @@ public class FapiMetadata  {
 
         StringBuilder sb = new StringBuilder();
         sb.append("class FapiMetadata {\n");
-        
+
+        sb.append("    allowedFapiProfiles: ").append(toIndentedString(allowedFapiProfiles)).append("\n");
         sb.append("    allowedSignatureAlgorithms: ").append(toIndentedString(allowedSignatureAlgorithms)).append("\n");
         sb.append("    allowedEncryptionAlgorithms: ").append(toIndentedString(allowedEncryptionAlgorithms)).append("\n");
         sb.append("    tokenEndpointAuthMethod: ").append(toIndentedString(tokenEndpointAuthMethod)).append("\n");

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/application/management/v1/FapiMetadata.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/application/management/v1/FapiMetadata.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2026, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2023-2026, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/application/management/v1/FapiMetadata.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/application/management/v1/FapiMetadata.java
@@ -64,7 +64,7 @@ public class FapiMetadata  {
         this.allowedSignatureAlgorithms = allowedSignatureAlgorithms;
         return this;
     }
-
+    
     @ApiModelProperty(value = "")
     @JsonProperty("allowedSignatureAlgorithms")
     @Valid
@@ -82,7 +82,7 @@ public class FapiMetadata  {
         this.allowedEncryptionAlgorithms = allowedEncryptionAlgorithms;
         return this;
     }
-
+    
     @ApiModelProperty(value = "")
     @JsonProperty("allowedEncryptionAlgorithms")
     @Valid
@@ -100,7 +100,7 @@ public class FapiMetadata  {
         this.tokenEndpointAuthMethod = tokenEndpointAuthMethod;
         return this;
     }
-
+    
     @ApiModelProperty(value = "")
     @JsonProperty("tokenEndpointAuthMethod")
     @Valid

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/application/management/v1/FapiMetadata.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/application/management/v1/FapiMetadata.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2024-2026, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -33,10 +33,29 @@ import javax.validation.Valid;
 import javax.xml.bind.annotation.*;
 
 public class FapiMetadata  {
-  
+
+    private MetadataProperty allowedFapiProfiles;
     private MetadataProperty allowedSignatureAlgorithms;
     private MetadataProperty allowedEncryptionAlgorithms;
     private ClientAuthenticationMethodMetadata tokenEndpointAuthMethod;
+
+    /**
+    **/
+    public FapiMetadata allowedFapiProfiles(MetadataProperty allowedFapiProfiles) {
+
+        this.allowedFapiProfiles = allowedFapiProfiles;
+        return this;
+    }
+
+    @ApiModelProperty(value = "")
+    @JsonProperty("allowedFapiProfiles")
+    @Valid
+    public MetadataProperty getAllowedFapiProfiles() {
+        return allowedFapiProfiles;
+    }
+    public void setAllowedFapiProfiles(MetadataProperty allowedFapiProfiles) {
+        this.allowedFapiProfiles = allowedFapiProfiles;
+    }
 
     /**
     **/
@@ -45,7 +64,7 @@ public class FapiMetadata  {
         this.allowedSignatureAlgorithms = allowedSignatureAlgorithms;
         return this;
     }
-    
+
     @ApiModelProperty(value = "")
     @JsonProperty("allowedSignatureAlgorithms")
     @Valid
@@ -63,7 +82,7 @@ public class FapiMetadata  {
         this.allowedEncryptionAlgorithms = allowedEncryptionAlgorithms;
         return this;
     }
-    
+
     @ApiModelProperty(value = "")
     @JsonProperty("allowedEncryptionAlgorithms")
     @Valid
@@ -81,7 +100,7 @@ public class FapiMetadata  {
         this.tokenEndpointAuthMethod = tokenEndpointAuthMethod;
         return this;
     }
-    
+
     @ApiModelProperty(value = "")
     @JsonProperty("tokenEndpointAuthMethod")
     @Valid
@@ -104,14 +123,15 @@ public class FapiMetadata  {
             return false;
         }
         FapiMetadata fapiMetadata = (FapiMetadata) o;
-        return Objects.equals(this.allowedSignatureAlgorithms, fapiMetadata.allowedSignatureAlgorithms) &&
+        return Objects.equals(this.allowedFapiProfiles, fapiMetadata.allowedFapiProfiles) &&
+            Objects.equals(this.allowedSignatureAlgorithms, fapiMetadata.allowedSignatureAlgorithms) &&
             Objects.equals(this.allowedEncryptionAlgorithms, fapiMetadata.allowedEncryptionAlgorithms) &&
             Objects.equals(this.tokenEndpointAuthMethod, fapiMetadata.tokenEndpointAuthMethod);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(allowedSignatureAlgorithms, allowedEncryptionAlgorithms, tokenEndpointAuthMethod);
+        return Objects.hash(allowedFapiProfiles, allowedSignatureAlgorithms, allowedEncryptionAlgorithms, tokenEndpointAuthMethod);
     }
 
     @Override
@@ -119,7 +139,8 @@ public class FapiMetadata  {
 
         StringBuilder sb = new StringBuilder();
         sb.append("class FapiMetadata {\n");
-        
+
+        sb.append("    allowedFapiProfiles: ").append(toIndentedString(allowedFapiProfiles)).append("\n");
         sb.append("    allowedSignatureAlgorithms: ").append(toIndentedString(allowedSignatureAlgorithms)).append("\n");
         sb.append("    allowedEncryptionAlgorithms: ").append(toIndentedString(allowedEncryptionAlgorithms)).append("\n");
         sb.append("    tokenEndpointAuthMethod: ").append(toIndentedString(tokenEndpointAuthMethod)).append("\n");

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/application/management/v1/FapiProfile.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/application/management/v1/FapiProfile.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.application.management.v1;
+
+import io.swagger.annotations.ApiModel;
+import javax.validation.constraints.*;
+
+/**
+ * FAPI security profile. - &#x60;FAPI1_ADVANCED&#x60;: FAPI 1.0 Advanced Security Profile. - &#x60;FAPI2_SECURITY&#x60;: FAPI 2.0 Security Profile. 
+ **/
+import javax.xml.bind.annotation.XmlType;
+import javax.xml.bind.annotation.XmlEnum;
+import javax.xml.bind.annotation.XmlEnumValue;
+
+@XmlType(name="")
+@XmlEnum(String.class)
+public enum FapiProfile {
+
+    @XmlEnumValue("FAPI1_ADVANCED") FAPI1_ADVANCED(String.valueOf("FAPI1_ADVANCED")), @XmlEnumValue("FAPI2_SECURITY") FAPI2_SECURITY(String.valueOf("FAPI2_SECURITY"));
+
+
+    private String value;
+
+    FapiProfile(String v) {
+        value = v;
+    }
+
+    public String value() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    public static FapiProfile fromValue(String value) {
+        for (FapiProfile b : FapiProfile.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
+}
+
+
+

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/application/management/v1/FapiProfile.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/application/management/v1/FapiProfile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2026, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/application/management/v1/FapiProfile.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/application/management/v1/FapiProfile.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2024-2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.application.management.v1;
+
+import io.swagger.annotations.ApiModel;
+import javax.validation.constraints.*;
+
+/**
+ * FAPI security profile. - &#x60;FAPI1_ADVANCED&#x60;: FAPI 1.0 Advanced Security Profile. - &#x60;FAPI2_SECURITY&#x60;: FAPI 2.0 Security Profile. 
+ **/
+import javax.xml.bind.annotation.XmlType;
+import javax.xml.bind.annotation.XmlEnum;
+import javax.xml.bind.annotation.XmlEnumValue;
+
+@XmlType(name="")
+@XmlEnum(String.class)
+public enum FapiProfile {
+
+    @XmlEnumValue("FAPI1_ADVANCED") FAPI1_ADVANCED(String.valueOf("FAPI1_ADVANCED")), @XmlEnumValue("FAPI2_SECURITY") FAPI2_SECURITY(String.valueOf("FAPI2_SECURITY"));
+
+
+    private String value;
+
+    FapiProfile(String v) {
+        value = v;
+    }
+
+    public String value() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    public static FapiProfile fromValue(String value) {
+        for (FapiProfile b : FapiProfile.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
+}
+
+
+

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/application/management/v1/OpenIDConnectConfiguration.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/application/management/v1/OpenIDConnectConfiguration.java
@@ -104,6 +104,7 @@ public enum StateEnum {
     private SubjectConfiguration subject;
     private Boolean isFAPIApplication = false;
     private FapiMetadata fapiMetadata;
+    private FapiProfile fapiProfile = null;
     private CIBAAuthenticationRequestConfiguration cibaAuthenticationRequest;
     private AllowedIssuer issuer;
 
@@ -539,6 +540,25 @@ public enum StateEnum {
     }
 
     /**
+     * The FAPI security profile applied to the application. Applicable only when isFAPIApplication is true. If isFAPIApplication is true and this property is omitted, &#x60;FAPI1_ADVANCED&#x60; will be applied by default.
+     **/
+    public OpenIDConnectConfiguration fapiProfile(FapiProfile fapiProfile) {
+
+        this.fapiProfile = fapiProfile;
+        return this;
+    }
+
+    @ApiModelProperty(example = "FAPI1_ADVANCED", value = "The FAPI security profile applied to the application. Applicable only when isFAPIApplication is true. If isFAPIApplication is true and this property is omitted, `FAPI1_ADVANCED` will be applied by default. ")
+    @JsonProperty("fapiProfile")
+    @Valid
+    public FapiProfile getFapiProfile() {
+        return fapiProfile;
+    }
+    public void setFapiProfile(FapiProfile fapiProfile) {
+        this.fapiProfile = fapiProfile;
+    }
+
+    /**
     **/
     public OpenIDConnectConfiguration cibaAuthenticationRequest(CIBAAuthenticationRequestConfiguration cibaAuthenticationRequest) {
 
@@ -608,6 +628,7 @@ public enum StateEnum {
             Objects.equals(this.subject, openIDConnectConfiguration.subject) &&
             Objects.equals(this.isFAPIApplication, openIDConnectConfiguration.isFAPIApplication) &&
             Objects.equals(this.fapiMetadata, openIDConnectConfiguration.fapiMetadata) &&
+            Objects.equals(this.fapiProfile, openIDConnectConfiguration.fapiProfile) &&
             Objects.equals(this.cibaAuthenticationRequest, openIDConnectConfiguration.cibaAuthenticationRequest) &&
             Objects.equals(this.issuer, openIDConnectConfiguration.issuer);
     }
@@ -646,6 +667,7 @@ public enum StateEnum {
         sb.append("    subject: ").append(toIndentedString(subject)).append("\n");
         sb.append("    isFAPIApplication: ").append(toIndentedString(isFAPIApplication)).append("\n");
         sb.append("    fapiMetadata: ").append(toIndentedString(fapiMetadata)).append("\n");
+        sb.append("    fapiProfile: ").append(toIndentedString(fapiProfile)).append("\n");
         sb.append("    cibaAuthenticationRequest: ").append(toIndentedString(cibaAuthenticationRequest)).append("\n");
         sb.append("    issuer: ").append(toIndentedString(issuer)).append("\n");
         sb.append("}");

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/ServerApplicationManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/ServerApplicationManagementService.java
@@ -66,7 +66,6 @@ import org.wso2.carbon.identity.api.server.application.management.v1.Role;
 import org.wso2.carbon.identity.api.server.application.management.v1.SAML2Configuration;
 import org.wso2.carbon.identity.api.server.application.management.v1.SAML2ServiceProvider;
 import org.wso2.carbon.identity.api.server.application.management.v1.ScriptUpdateModel;
-import org.wso2.carbon.identity.api.server.application.management.v1.FapiProfile;
 import org.wso2.carbon.identity.api.server.application.management.v1.WSTrustConfiguration;
 import org.wso2.carbon.identity.api.server.application.management.v1.core.functions.Utils;
 import org.wso2.carbon.identity.api.server.application.management.v1.core.functions.application.ApiModelToServiceProvider;
@@ -144,7 +143,6 @@ import org.wso2.carbon.identity.cors.mgt.core.exception.CORSManagementServiceExc
 import org.wso2.carbon.identity.cors.mgt.core.model.CORSOrigin;
 import org.wso2.carbon.identity.oauth.dao.OAuthAppDO;
 import org.wso2.carbon.identity.oauth2.fapi.exceptions.FapiConfigMgtException;
-import org.wso2.carbon.identity.oauth2.fapi.models.FapiConfig;
 import org.wso2.carbon.identity.oauth2.fapi.models.FapiProfileEnum;
 import org.wso2.carbon.identity.oauth2.fapi.services.FapiConfigMgtService;
 import org.wso2.carbon.identity.role.v2.mgt.core.RoleConstants;

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/ServerApplicationManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/ServerApplicationManagementService.java
@@ -66,6 +66,7 @@ import org.wso2.carbon.identity.api.server.application.management.v1.Role;
 import org.wso2.carbon.identity.api.server.application.management.v1.SAML2Configuration;
 import org.wso2.carbon.identity.api.server.application.management.v1.SAML2ServiceProvider;
 import org.wso2.carbon.identity.api.server.application.management.v1.ScriptUpdateModel;
+import org.wso2.carbon.identity.api.server.application.management.v1.FapiProfile;
 import org.wso2.carbon.identity.api.server.application.management.v1.WSTrustConfiguration;
 import org.wso2.carbon.identity.api.server.application.management.v1.core.functions.Utils;
 import org.wso2.carbon.identity.api.server.application.management.v1.core.functions.application.ApiModelToServiceProvider;
@@ -142,6 +143,10 @@ import org.wso2.carbon.identity.cors.mgt.core.exception.CORSManagementServiceCli
 import org.wso2.carbon.identity.cors.mgt.core.exception.CORSManagementServiceException;
 import org.wso2.carbon.identity.cors.mgt.core.model.CORSOrigin;
 import org.wso2.carbon.identity.oauth.dao.OAuthAppDO;
+import org.wso2.carbon.identity.oauth2.fapi.exceptions.FapiConfigMgtException;
+import org.wso2.carbon.identity.oauth2.fapi.models.FapiConfig;
+import org.wso2.carbon.identity.oauth2.fapi.models.FapiProfileEnum;
+import org.wso2.carbon.identity.oauth2.fapi.services.FapiConfigMgtService;
 import org.wso2.carbon.identity.role.v2.mgt.core.RoleConstants;
 import org.wso2.carbon.identity.sso.saml.dto.SAMLSSOServiceProviderDTO;
 import org.wso2.carbon.identity.template.mgt.TemplateManager;
@@ -188,6 +193,7 @@ import static org.wso2.carbon.identity.api.server.application.management.common.
 import static org.wso2.carbon.identity.api.server.application.management.common.ApplicationManagementConstants.ErrorMessage.ERROR_PROCESSING_REQUEST;
 import static org.wso2.carbon.identity.api.server.application.management.common.ApplicationManagementConstants.ErrorMessage.FORBIDDEN_OPERATION;
 import static org.wso2.carbon.identity.api.server.application.management.common.ApplicationManagementConstants.ErrorMessage.INBOUND_NOT_CONFIGURED;
+import static org.wso2.carbon.identity.api.server.application.management.common.ApplicationManagementConstants.ErrorMessage.UNSUPPORTED_FAPI_PROFILE;
 import static org.wso2.carbon.identity.api.server.application.management.common.ApplicationManagementConstants.ErrorMessage.USE_EXTERNAL_CONSENT_PAGE_NOT_SUPPORTED;
 import static org.wso2.carbon.identity.api.server.application.management.common.ApplicationManagementConstants.ISSUER;
 import static org.wso2.carbon.identity.api.server.application.management.common.ApplicationManagementConstants.NAME;
@@ -813,7 +819,10 @@ public class ServerApplicationManagementService {
          */
         if (applicationModel.getInboundProtocolConfiguration() != null &&
                 applicationModel.getInboundProtocolConfiguration().getOidc() != null) {
-            validateCORSOrigins(applicationModel.getInboundProtocolConfiguration().getOidc().getAllowedOrigins());
+            OpenIDConnectConfiguration oidcConfig =
+                    applicationModel.getInboundProtocolConfiguration().getOidc();
+            validateCORSOrigins(oidcConfig.getAllowedOrigins());
+            validateFapiProfile(oidcConfig);
         }
 
         /*
@@ -1220,6 +1229,7 @@ public class ServerApplicationManagementService {
          * But for now we are handling the validation here.
          */
         validateCORSOrigins(oidcConfigModel.getAllowedOrigins());
+        validateFapiProfile(oidcConfigModel);
         putApplicationInbound(applicationId, oidcConfigModel, OAuthInboundFunctions::getInboundProtocolConfig);
     }
 
@@ -2201,6 +2211,56 @@ public class ServerApplicationManagementService {
             return String.format(description, formatData);
         } else {
             return description;
+        }
+    }
+
+    /**
+     * Validates the FAPI profile in the given OIDC configuration.
+     *
+     * <p>Validation: checks the resolved profile against the organisation's allowed list from
+     * {@link FapiConfigMgtService}. Throws a 400 error if the profile is not supported.
+     * No-ops when {@code oidcConfig} is null, FAPI is disabled, or {@link FapiConfigMgtService}
+     * is unavailable (treated as optional OSGi service).
+     *
+     * @param oidcConfig the OIDC configuration from the incoming request; may be null.
+     */
+    private void validateFapiProfile(OpenIDConnectConfiguration oidcConfig) {
+
+        // Validate — only needed when a profile is present.
+        if (oidcConfig.getFapiProfile() == null) {
+            return;
+        }
+
+        FapiConfigMgtService fapiConfigMgtService = ApplicationManagementServiceHolder.getFapiConfigMgtService();
+        if (fapiConfigMgtService == null) {
+            // FapiConfigMgtService is optional. Skip validation rather than blocking all OIDC updates.
+            log.debug("FapiConfigMgtService is unavailable. Skipping fapiProfile validation.");
+            return;
+        }
+
+        String tenantDomain = ContextLoader.getTenantDomainFromContext();
+        try {
+            List<FapiProfileEnum> supportedProfiles =
+                    fapiConfigMgtService.getFapiConfig(tenantDomain).getSupportedProfiles();
+            String requestedProfileValue = oidcConfig.getFapiProfile().toString();
+
+            boolean isSupported = supportedProfiles.stream()
+                    .anyMatch(p -> p.value().equals(requestedProfileValue));
+
+            if (!isSupported) {
+                String supportedProfilesStr = supportedProfiles.stream()
+                        .map(FapiProfileEnum::value)
+                        .collect(Collectors.joining(", "));
+                if (log.isDebugEnabled()) {
+                    log.debug(String.format("Rejected fapiProfile '%s' for tenant '%s'. Supported: [%s]",
+                            requestedProfileValue, tenantDomain, supportedProfilesStr));
+                }
+                throw buildClientError(UNSUPPORTED_FAPI_PROFILE, requestedProfileValue, supportedProfilesStr);
+            }
+        } catch (FapiConfigMgtException e) {
+            throw Utils.buildServerError(
+                    String.format("Error while retrieving FAPI configuration for tenant '%s' during fapiProfile " +
+                            "validation.", tenantDomain), e);
         }
     }
 

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/ServerApplicationManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/ServerApplicationManagementService.java
@@ -66,6 +66,7 @@ import org.wso2.carbon.identity.api.server.application.management.v1.Role;
 import org.wso2.carbon.identity.api.server.application.management.v1.SAML2Configuration;
 import org.wso2.carbon.identity.api.server.application.management.v1.SAML2ServiceProvider;
 import org.wso2.carbon.identity.api.server.application.management.v1.ScriptUpdateModel;
+import org.wso2.carbon.identity.api.server.application.management.v1.FapiProfile;
 import org.wso2.carbon.identity.api.server.application.management.v1.WSTrustConfiguration;
 import org.wso2.carbon.identity.api.server.application.management.v1.core.functions.Utils;
 import org.wso2.carbon.identity.api.server.application.management.v1.core.functions.application.ApiModelToServiceProvider;
@@ -142,6 +143,9 @@ import org.wso2.carbon.identity.cors.mgt.core.exception.CORSManagementServiceCli
 import org.wso2.carbon.identity.cors.mgt.core.exception.CORSManagementServiceException;
 import org.wso2.carbon.identity.cors.mgt.core.model.CORSOrigin;
 import org.wso2.carbon.identity.oauth.dao.OAuthAppDO;
+import org.wso2.carbon.identity.oauth2.fapi.exceptions.FapiConfigMgtException;
+import org.wso2.carbon.identity.oauth2.fapi.models.FapiProfileEnum;
+import org.wso2.carbon.identity.oauth2.fapi.services.FapiConfigMgtService;
 import org.wso2.carbon.identity.role.v2.mgt.core.RoleConstants;
 import org.wso2.carbon.identity.sso.saml.dto.SAMLSSOServiceProviderDTO;
 import org.wso2.carbon.identity.template.mgt.TemplateManager;
@@ -190,6 +194,7 @@ import static org.wso2.carbon.identity.api.server.application.management.common.
 import static org.wso2.carbon.identity.api.server.application.management.common.ApplicationManagementConstants.ErrorMessage.FORBIDDEN_OPERATION;
 import static org.wso2.carbon.identity.api.server.application.management.common.ApplicationManagementConstants.ErrorMessage.INBOUND_NOT_CONFIGURED;
 import static org.wso2.carbon.identity.api.server.application.management.common.ApplicationManagementConstants.ErrorMessage.UNSUPPORTED_ENHANCED_ORGANIZATION_AUTHENTICATION_ENABLED_CONFIGURATION;
+import static org.wso2.carbon.identity.api.server.application.management.common.ApplicationManagementConstants.ErrorMessage.UNSUPPORTED_FAPI_PROFILE;
 import static org.wso2.carbon.identity.api.server.application.management.common.ApplicationManagementConstants.ErrorMessage.USE_EXTERNAL_CONSENT_PAGE_NOT_SUPPORTED;
 import static org.wso2.carbon.identity.api.server.application.management.common.ApplicationManagementConstants.ISSUER;
 import static org.wso2.carbon.identity.api.server.application.management.common.ApplicationManagementConstants.NAME;
@@ -815,7 +820,10 @@ public class ServerApplicationManagementService {
          */
         if (applicationModel.getInboundProtocolConfiguration() != null &&
                 applicationModel.getInboundProtocolConfiguration().getOidc() != null) {
-            validateCORSOrigins(applicationModel.getInboundProtocolConfiguration().getOidc().getAllowedOrigins());
+            OpenIDConnectConfiguration oidcConfig =
+                    applicationModel.getInboundProtocolConfiguration().getOidc();
+            validateCORSOrigins(oidcConfig.getAllowedOrigins());
+            validateFapiProfile(oidcConfig);
         }
 
         /*
@@ -836,11 +844,6 @@ public class ServerApplicationManagementService {
                 Boolean.TRUE.equals(applicationModel.getEnhancedOrgAuthenticationEnabled())) {
             throw buildBadRequestError(UNSUPPORTED_ENHANCED_ORGANIZATION_AUTHENTICATION_ENABLED_CONFIGURATION.getCode(),
                     UNSUPPORTED_ENHANCED_ORGANIZATION_AUTHENTICATION_ENABLED_CONFIGURATION.getDescription());
-        }
-
-        if (applicationModel.getEnhancedOrgAuthenticationEnabled() == null
-                && isEnhancedOrganizationAuthenticationFeatureEnabled()) {
-            applicationModel.setEnhancedOrgAuthenticationEnabled(isEnhancedOrgAuthEnabledByDefaultForNewApps());
         }
 
         // Block application creation with name Console or MyAccount.
@@ -1235,6 +1238,7 @@ public class ServerApplicationManagementService {
          * But for now we are handling the validation here.
          */
         validateCORSOrigins(oidcConfigModel.getAllowedOrigins());
+        validateFapiProfile(oidcConfigModel);
         putApplicationInbound(applicationId, oidcConfigModel, OAuthInboundFunctions::getInboundProtocolConfig);
     }
 
@@ -2216,6 +2220,56 @@ public class ServerApplicationManagementService {
             return String.format(description, formatData);
         } else {
             return description;
+        }
+    }
+
+    /**
+     * Validates the FAPI profile in the given OIDC configuration.
+     *
+     * <p>Validation: checks the resolved profile against the organisation's allowed list from
+     * {@link FapiConfigMgtService}. Throws a 400 error if the profile is not supported.
+     * No-ops when {@code oidcConfig} is null, FAPI is disabled, or {@link FapiConfigMgtService}
+     * is unavailable (treated as optional OSGi service).
+     *
+     * @param oidcConfig the OIDC configuration from the incoming request; may be null.
+     */
+    private void validateFapiProfile(OpenIDConnectConfiguration oidcConfig) {
+
+        // Validate — only needed when a profile is present.
+        if (oidcConfig.getFapiProfile() == null) {
+            return;
+        }
+
+        FapiConfigMgtService fapiConfigMgtService = ApplicationManagementServiceHolder.getFapiConfigMgtService();
+        if (fapiConfigMgtService == null) {
+            // FapiConfigMgtService is optional. Skip validation rather than blocking all OIDC updates.
+            log.debug("FapiConfigMgtService is unavailable. Skipping fapiProfile validation.");
+            return;
+        }
+
+        String tenantDomain = ContextLoader.getTenantDomainFromContext();
+        try {
+            List<FapiProfileEnum> supportedProfiles =
+                    fapiConfigMgtService.getFapiConfig(tenantDomain).getSupportedProfiles();
+            String requestedProfileValue = oidcConfig.getFapiProfile().toString();
+
+            boolean isSupported = supportedProfiles.stream()
+                    .anyMatch(p -> p.value().equals(requestedProfileValue));
+
+            if (!isSupported) {
+                String supportedProfilesStr = supportedProfiles.stream()
+                        .map(FapiProfileEnum::value)
+                        .collect(Collectors.joining(", "));
+                if (log.isDebugEnabled()) {
+                    log.debug(String.format("Rejected fapiProfile '%s' for tenant '%s'. Supported: [%s]",
+                            requestedProfileValue, tenantDomain, supportedProfilesStr));
+                }
+                throw buildClientError(UNSUPPORTED_FAPI_PROFILE, requestedProfileValue, supportedProfilesStr);
+            }
+        } catch (FapiConfigMgtException e) {
+            throw Utils.buildServerError(
+                    String.format("Error while retrieving FAPI configuration for tenant '%s' during fapiProfile " +
+                            "validation.", tenantDomain), e);
         }
     }
 

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/ServerApplicationManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/ServerApplicationManagementService.java
@@ -66,7 +66,6 @@ import org.wso2.carbon.identity.api.server.application.management.v1.Role;
 import org.wso2.carbon.identity.api.server.application.management.v1.SAML2Configuration;
 import org.wso2.carbon.identity.api.server.application.management.v1.SAML2ServiceProvider;
 import org.wso2.carbon.identity.api.server.application.management.v1.ScriptUpdateModel;
-import org.wso2.carbon.identity.api.server.application.management.v1.FapiProfile;
 import org.wso2.carbon.identity.api.server.application.management.v1.WSTrustConfiguration;
 import org.wso2.carbon.identity.api.server.application.management.v1.core.functions.Utils;
 import org.wso2.carbon.identity.api.server.application.management.v1.core.functions.application.ApiModelToServiceProvider;
@@ -844,6 +843,11 @@ public class ServerApplicationManagementService {
                 Boolean.TRUE.equals(applicationModel.getEnhancedOrgAuthenticationEnabled())) {
             throw buildBadRequestError(UNSUPPORTED_ENHANCED_ORGANIZATION_AUTHENTICATION_ENABLED_CONFIGURATION.getCode(),
                     UNSUPPORTED_ENHANCED_ORGANIZATION_AUTHENTICATION_ENABLED_CONFIGURATION.getDescription());
+        }
+
+        if (applicationModel.getEnhancedOrgAuthenticationEnabled() == null
+                && isEnhancedOrganizationAuthenticationFeatureEnabled()) {
+            applicationModel.setEnhancedOrgAuthenticationEnabled(isEnhancedOrgAuthEnabledByDefaultForNewApps());
         }
 
         // Block application creation with name Console or MyAccount.

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/ServerApplicationManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/ServerApplicationManagementService.java
@@ -2239,14 +2239,21 @@ public class ServerApplicationManagementService {
      */
     private void validateFapiProfile(OpenIDConnectConfiguration oidcConfig) {
 
-        // Validate — only needed when a profile is present.
-        if (oidcConfig.getFapiProfile() == null) {
+        // Only validate when the application is marked as FAPI and a specific profile is provided.
+        // If isFAPIApplication is false the profile field is ignored in storage, so validation would
+        // produce a misleading error for a field that has no effect.
+        if (!Boolean.TRUE.equals(oidcConfig.getIsFAPIApplication()) || oidcConfig.getFapiProfile() == null) {
             return;
         }
 
+        /*
+         * FapiConfigMgtService is treated as optional here. Profile validation is an enhancement —
+         * silently skipping it avoids blocking all OIDC application updates in deployments where
+         * the FAPI bundle is not present. The configs API module (/configs/fapi) hard-requires
+         * the service at startup and fails fast if it is absent.
+         */
         FapiConfigMgtService fapiConfigMgtService = ApplicationManagementServiceHolder.getFapiConfigMgtService();
         if (fapiConfigMgtService == null) {
-            // FapiConfigMgtService is optional. Skip validation rather than blocking all OIDC updates.
             log.debug("FapiConfigMgtService is unavailable. Skipping fapiProfile validation.");
             return;
         }

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/ServerApplicationManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/ServerApplicationManagementService.java
@@ -2242,7 +2242,8 @@ public class ServerApplicationManagementService {
         // Only validate when the application is marked as FAPI and a specific profile is provided.
         // If isFAPIApplication is false the profile field is ignored in storage, so validation would
         // produce a misleading error for a field that has no effect.
-        if (!Boolean.TRUE.equals(oidcConfig.getIsFAPIApplication()) || oidcConfig.getFapiProfile() == null) {
+        if (oidcConfig == null || !Boolean.TRUE.equals(oidcConfig.getIsFAPIApplication())
+                || oidcConfig.getFapiProfile() == null) {
             return;
         }
 

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/ServerApplicationMetadataService.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/ServerApplicationMetadataService.java
@@ -41,6 +41,7 @@ import org.wso2.carbon.identity.api.server.application.management.v1.OIDCMetaDat
 import org.wso2.carbon.identity.api.server.application.management.v1.SAMLMetaData;
 import org.wso2.carbon.identity.api.server.application.management.v1.WSTrustMetaData;
 import org.wso2.carbon.identity.api.server.application.management.v1.core.functions.Utils;
+import org.wso2.carbon.identity.api.server.common.ContextLoader;
 import org.wso2.carbon.identity.api.server.common.error.APIError;
 import org.wso2.carbon.identity.application.common.model.Property;
 import org.wso2.carbon.identity.application.mgt.AbstractInboundAuthenticatorConfig;
@@ -55,6 +56,10 @@ import org.wso2.carbon.identity.oauth.dto.TokenBindingMetaDataDTO;
 import org.wso2.carbon.identity.oauth2.config.exceptions.OAuth2OIDCConfigOrgUsageScopeMgtException;
 import org.wso2.carbon.identity.oauth2.config.models.IssuerDetails;
 import org.wso2.carbon.identity.oauth2.config.services.OAuth2OIDCConfigOrgUsageScopeMgtService;
+import org.wso2.carbon.identity.oauth2.fapi.exceptions.FapiConfigMgtException;
+import org.wso2.carbon.identity.oauth2.fapi.models.FapiConfig;
+import org.wso2.carbon.identity.oauth2.fapi.models.FapiProfileEnum;
+import org.wso2.carbon.identity.oauth2.fapi.services.FapiConfigMgtService;
 import org.wso2.carbon.identity.oauth2.model.ClientAuthenticationMethodModel;
 import org.wso2.carbon.identity.oauth2.util.OAuth2Util;
 import org.wso2.carbon.identity.sso.saml.SAMLSSOConfigServiceImpl;
@@ -64,12 +69,14 @@ import org.wso2.carbon.security.sts.service.STSAdminServiceInterface;
 import java.net.URLDecoder;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.stream.Collectors;
+import org.apache.commons.collections.CollectionUtils;
 
 import static org.wso2.carbon.identity.api.server.application.management.common.ApplicationManagementConstants.DEFAULT_CERTIFICATE_ALIAS;
 import static org.wso2.carbon.identity.api.server.application.management.common.ApplicationManagementConstants.DEFAULT_NAME_ID_FORMAT;
@@ -89,6 +96,7 @@ public class ServerApplicationMetadataService {
     private final OAuthAdminServiceImpl oAuthAdminService;
     private final STSAdminServiceInterface sTSAdminServiceInterface;
     private final CibaAuthServiceImpl cibaAuthService;
+    private final FapiConfigMgtService fapiConfigMgtService;
 
     @Deprecated
     public ServerApplicationMetadataService(ApplicationManagementService applicationManagementService,
@@ -101,8 +109,10 @@ public class ServerApplicationMetadataService {
         this.oAuthAdminService = oAuthAdminService;
         this.sTSAdminServiceInterface = sTSAdminServiceInterface;
         this.cibaAuthService = ApplicationManagementServiceHolder.getCibaAuthService();
+        this.fapiConfigMgtService = ApplicationManagementServiceHolder.getFapiConfigMgtService();
     }
 
+    @Deprecated
     public ServerApplicationMetadataService(ApplicationManagementService applicationManagementService,
                                             SAMLSSOConfigServiceImpl samlSSOConfigService,
                                             OAuthAdminServiceImpl oAuthAdminService,
@@ -114,6 +124,22 @@ public class ServerApplicationMetadataService {
         this.oAuthAdminService = oAuthAdminService;
         this.sTSAdminServiceInterface = sTSAdminServiceInterface;
         this.cibaAuthService = cibaAuthService;
+        this.fapiConfigMgtService = ApplicationManagementServiceHolder.getFapiConfigMgtService();
+    }
+
+    public ServerApplicationMetadataService(ApplicationManagementService applicationManagementService,
+                                            SAMLSSOConfigServiceImpl samlSSOConfigService,
+                                            OAuthAdminServiceImpl oAuthAdminService,
+                                            STSAdminServiceInterface sTSAdminServiceInterface,
+                                            CibaAuthServiceImpl cibaAuthService,
+                                            FapiConfigMgtService fapiConfigMgtService) {
+
+        this.applicationManagementService = applicationManagementService;
+        this.samlSSOConfigService = samlSSOConfigService;
+        this.oAuthAdminService = oAuthAdminService;
+        this.sTSAdminServiceInterface = sTSAdminServiceInterface;
+        this.cibaAuthService = cibaAuthService;
+        this.fapiConfigMgtService = fapiConfigMgtService;
     }
 
     private static final Log LOG = LogFactory.getLog(ServerApplicationMetadataService.class);
@@ -261,6 +287,7 @@ public class ServerApplicationMetadataService {
                 supportedClientAuthMethods.stream().filter(clientAuthenticationMethod ->
                 fapiAllowedAuthMethods.contains(clientAuthenticationMethod.getName())).collect(Collectors.toList());
         FapiMetadata fapiMetadata = new FapiMetadata();
+        fapiMetadata.allowedFapiProfiles(new MetadataProperty().options(getAllowedFapiProfiles()));
         fapiMetadata.allowedSignatureAlgorithms(new MetadataProperty().options(fapiAllowedSignatureAlgorithms));
         fapiMetadata.allowedEncryptionAlgorithms(new MetadataProperty().options(fapiAllowedEncryptionAlgorithms));
         fapiMetadata.setTokenEndpointAuthMethod(new ClientAuthenticationMethodMetadata()
@@ -524,6 +551,35 @@ public class ServerApplicationMetadataService {
             return allowedIssuers;
         } catch (OAuth2OIDCConfigOrgUsageScopeMgtException e) {
             throw handleServerError(ERROR_RETRIEVING_ALLOWED_ISSUERS, e);
+        }
+    }
+
+    /**
+     * Retrieves the list of allowed FAPI profiles for the current tenant from FapiConfigMgtService.
+     * Returns an empty list if the service is unavailable or no profiles are configured.
+     *
+     * @return List of allowed FAPI profile string values.
+     */
+    private List<String> getAllowedFapiProfiles() {
+
+        if (fapiConfigMgtService == null) {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("FapiConfigMgtService is not available. Returning empty FAPI profiles list.");
+            }
+            return Collections.emptyList();
+        }
+        String tenantDomain = ContextLoader.getTenantDomainFromContext();
+        try {
+            FapiConfig fapiConfig = fapiConfigMgtService.getFapiConfig(tenantDomain);
+            List<FapiProfileEnum> supportedProfiles = fapiConfig.getSupportedProfiles();
+            if (CollectionUtils.isEmpty(supportedProfiles)) {
+                return Collections.emptyList();
+            }
+            return supportedProfiles.stream()
+                    .map(FapiProfileEnum::value)
+                    .collect(Collectors.toList());
+        } catch (FapiConfigMgtException e) {
+            throw handleServerError(ErrorMessage.ERROR_RETRIEVING_FAPI_METADATA, e);
         }
     }
 

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/ServerApplicationMetadataService.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/ServerApplicationMetadataService.java
@@ -18,6 +18,7 @@
 
 package org.wso2.carbon.identity.api.server.application.management.v1.core;
 
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -76,7 +77,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.stream.Collectors;
-import org.apache.commons.collections.CollectionUtils;
 
 import static org.wso2.carbon.identity.api.server.application.management.common.ApplicationManagementConstants.DEFAULT_CERTIFICATE_ALIAS;
 import static org.wso2.carbon.identity.api.server.application.management.common.ApplicationManagementConstants.DEFAULT_NAME_ID_FORMAT;

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/ServerApplicationMetadataService.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/ServerApplicationMetadataService.java
@@ -77,7 +77,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.stream.Collectors;
-import org.apache.commons.collections.CollectionUtils;
 
 import static org.wso2.carbon.identity.api.server.application.management.common.ApplicationManagementConstants.DEFAULT_CERTIFICATE_ALIAS;
 import static org.wso2.carbon.identity.api.server.application.management.common.ApplicationManagementConstants.DEFAULT_NAME_ID_FORMAT;

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/ServerApplicationMetadataService.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/ServerApplicationMetadataService.java
@@ -18,6 +18,7 @@
 
 package org.wso2.carbon.identity.api.server.application.management.v1.core;
 
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/ServerApplicationMetadataService.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/ServerApplicationMetadataService.java
@@ -42,6 +42,7 @@ import org.wso2.carbon.identity.api.server.application.management.v1.OIDCMetaDat
 import org.wso2.carbon.identity.api.server.application.management.v1.SAMLMetaData;
 import org.wso2.carbon.identity.api.server.application.management.v1.WSTrustMetaData;
 import org.wso2.carbon.identity.api.server.application.management.v1.core.functions.Utils;
+import org.wso2.carbon.identity.api.server.common.ContextLoader;
 import org.wso2.carbon.identity.api.server.common.error.APIError;
 import org.wso2.carbon.identity.application.common.model.Property;
 import org.wso2.carbon.identity.application.mgt.AbstractInboundAuthenticatorConfig;
@@ -56,6 +57,10 @@ import org.wso2.carbon.identity.oauth.dto.TokenBindingMetaDataDTO;
 import org.wso2.carbon.identity.oauth2.config.exceptions.OAuth2OIDCConfigOrgUsageScopeMgtException;
 import org.wso2.carbon.identity.oauth2.config.models.IssuerDetails;
 import org.wso2.carbon.identity.oauth2.config.services.OAuth2OIDCConfigOrgUsageScopeMgtService;
+import org.wso2.carbon.identity.oauth2.fapi.exceptions.FapiConfigMgtException;
+import org.wso2.carbon.identity.oauth2.fapi.models.FapiConfig;
+import org.wso2.carbon.identity.oauth2.fapi.models.FapiProfileEnum;
+import org.wso2.carbon.identity.oauth2.fapi.services.FapiConfigMgtService;
 import org.wso2.carbon.identity.oauth2.model.ClientAuthenticationMethodModel;
 import org.wso2.carbon.identity.oauth2.util.OAuth2Util;
 import org.wso2.carbon.identity.sso.saml.SAMLSSOConfigServiceImpl;
@@ -65,12 +70,14 @@ import org.wso2.carbon.security.sts.service.STSAdminServiceInterface;
 import java.net.URLDecoder;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.stream.Collectors;
+import org.apache.commons.collections.CollectionUtils;
 
 import static org.wso2.carbon.identity.api.server.application.management.common.ApplicationManagementConstants.DEFAULT_CERTIFICATE_ALIAS;
 import static org.wso2.carbon.identity.api.server.application.management.common.ApplicationManagementConstants.DEFAULT_NAME_ID_FORMAT;
@@ -90,6 +97,7 @@ public class ServerApplicationMetadataService {
     private final OAuthAdminServiceImpl oAuthAdminService;
     private final STSAdminServiceInterface sTSAdminServiceInterface;
     private final CibaAuthServiceImpl cibaAuthService;
+    private final FapiConfigMgtService fapiConfigMgtService;
 
     @Deprecated
     public ServerApplicationMetadataService(ApplicationManagementService applicationManagementService,
@@ -102,8 +110,10 @@ public class ServerApplicationMetadataService {
         this.oAuthAdminService = oAuthAdminService;
         this.sTSAdminServiceInterface = sTSAdminServiceInterface;
         this.cibaAuthService = ApplicationManagementServiceHolder.getCibaAuthService();
+        this.fapiConfigMgtService = ApplicationManagementServiceHolder.getFapiConfigMgtService();
     }
 
+    @Deprecated
     public ServerApplicationMetadataService(ApplicationManagementService applicationManagementService,
                                             SAMLSSOConfigServiceImpl samlSSOConfigService,
                                             OAuthAdminServiceImpl oAuthAdminService,
@@ -115,6 +125,22 @@ public class ServerApplicationMetadataService {
         this.oAuthAdminService = oAuthAdminService;
         this.sTSAdminServiceInterface = sTSAdminServiceInterface;
         this.cibaAuthService = cibaAuthService;
+        this.fapiConfigMgtService = ApplicationManagementServiceHolder.getFapiConfigMgtService();
+    }
+
+    public ServerApplicationMetadataService(ApplicationManagementService applicationManagementService,
+                                            SAMLSSOConfigServiceImpl samlSSOConfigService,
+                                            OAuthAdminServiceImpl oAuthAdminService,
+                                            STSAdminServiceInterface sTSAdminServiceInterface,
+                                            CibaAuthServiceImpl cibaAuthService,
+                                            FapiConfigMgtService fapiConfigMgtService) {
+
+        this.applicationManagementService = applicationManagementService;
+        this.samlSSOConfigService = samlSSOConfigService;
+        this.oAuthAdminService = oAuthAdminService;
+        this.sTSAdminServiceInterface = sTSAdminServiceInterface;
+        this.cibaAuthService = cibaAuthService;
+        this.fapiConfigMgtService = fapiConfigMgtService;
     }
 
     private static final Log LOG = LogFactory.getLog(ServerApplicationMetadataService.class);
@@ -262,6 +288,7 @@ public class ServerApplicationMetadataService {
                 supportedClientAuthMethods.stream().filter(clientAuthenticationMethod ->
                 fapiAllowedAuthMethods.contains(clientAuthenticationMethod.getName())).collect(Collectors.toList());
         FapiMetadata fapiMetadata = new FapiMetadata();
+        fapiMetadata.allowedFapiProfiles(new MetadataProperty().options(getAllowedFapiProfiles()));
         fapiMetadata.allowedSignatureAlgorithms(new MetadataProperty().options(fapiAllowedSignatureAlgorithms));
         fapiMetadata.allowedEncryptionAlgorithms(new MetadataProperty().options(fapiAllowedEncryptionAlgorithms));
         fapiMetadata.setTokenEndpointAuthMethod(new ClientAuthenticationMethodMetadata()
@@ -525,6 +552,35 @@ public class ServerApplicationMetadataService {
             return allowedIssuers;
         } catch (OAuth2OIDCConfigOrgUsageScopeMgtException e) {
             throw handleServerError(ERROR_RETRIEVING_ALLOWED_ISSUERS, e);
+        }
+    }
+
+    /**
+     * Retrieves the list of allowed FAPI profiles for the current tenant from FapiConfigMgtService.
+     * Returns an empty list if the service is unavailable or no profiles are configured.
+     *
+     * @return List of allowed FAPI profile string values.
+     */
+    private List<String> getAllowedFapiProfiles() {
+
+        if (fapiConfigMgtService == null) {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("FapiConfigMgtService is not available. Returning empty FAPI profiles list.");
+            }
+            return Collections.emptyList();
+        }
+        String tenantDomain = ContextLoader.getTenantDomainFromContext();
+        try {
+            FapiConfig fapiConfig = fapiConfigMgtService.getFapiConfig(tenantDomain);
+            List<FapiProfileEnum> supportedProfiles = fapiConfig.getSupportedProfiles();
+            if (CollectionUtils.isEmpty(supportedProfiles)) {
+                return Collections.emptyList();
+            }
+            return supportedProfiles.stream()
+                    .map(FapiProfileEnum::value)
+                    .collect(Collectors.toList());
+        } catch (FapiConfigMgtException e) {
+            throw handleServerError(ErrorMessage.ERROR_RETRIEVING_FAPI_METADATA, e);
         }
     }
 

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/ServerApplicationMetadataService.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/ServerApplicationMetadataService.java
@@ -104,12 +104,9 @@ public class ServerApplicationMetadataService {
                                             OAuthAdminServiceImpl oAuthAdminService,
                                             STSAdminServiceInterface sTSAdminServiceInterface) {
 
-        this.applicationManagementService = applicationManagementService;
-        this.samlSSOConfigService = samlSSOConfigService;
-        this.oAuthAdminService = oAuthAdminService;
-        this.sTSAdminServiceInterface = sTSAdminServiceInterface;
-        this.cibaAuthService = ApplicationManagementServiceHolder.getCibaAuthService();
-        this.fapiConfigMgtService = ApplicationManagementServiceHolder.getFapiConfigMgtService();
+        this(applicationManagementService, samlSSOConfigService, oAuthAdminService, sTSAdminServiceInterface,
+                ApplicationManagementServiceHolder.getCibaAuthService(),
+                ApplicationManagementServiceHolder.getFapiConfigMgtService());
     }
 
     @Deprecated
@@ -119,12 +116,8 @@ public class ServerApplicationMetadataService {
                                             STSAdminServiceInterface sTSAdminServiceInterface,
                                             CibaAuthServiceImpl cibaAuthService) {
 
-        this.applicationManagementService = applicationManagementService;
-        this.samlSSOConfigService = samlSSOConfigService;
-        this.oAuthAdminService = oAuthAdminService;
-        this.sTSAdminServiceInterface = sTSAdminServiceInterface;
-        this.cibaAuthService = cibaAuthService;
-        this.fapiConfigMgtService = ApplicationManagementServiceHolder.getFapiConfigMgtService();
+        this(applicationManagementService, samlSSOConfigService, oAuthAdminService, sTSAdminServiceInterface,
+                cibaAuthService, ApplicationManagementServiceHolder.getFapiConfigMgtService());
     }
 
     public ServerApplicationMetadataService(ApplicationManagementService applicationManagementService,
@@ -563,9 +556,7 @@ public class ServerApplicationMetadataService {
     private List<String> getAllowedFapiProfiles() {
 
         if (fapiConfigMgtService == null) {
-            if (LOG.isDebugEnabled()) {
-                LOG.debug("FapiConfigMgtService is not available. Returning empty FAPI profiles list.");
-            }
+            LOG.debug("FapiConfigMgtService is not available. Returning empty FAPI profiles list.");
             return Collections.emptyList();
         }
         String tenantDomain = ContextLoader.getTenantDomainFromContext();

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/functions/application/inbound/oauth2/ApiModelToOAuthConsumerApp.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/functions/application/inbound/oauth2/ApiModelToOAuthConsumerApp.java
@@ -41,6 +41,7 @@ import org.wso2.carbon.identity.oauth.common.OAuthConstants;
 import org.wso2.carbon.identity.oauth.config.OAuthServerConfiguration;
 import org.wso2.carbon.identity.oauth.dto.OAuthConsumerAppDTO;
 import org.wso2.carbon.identity.oauth2.config.models.IssuerDetails;
+import org.wso2.carbon.identity.oauth2.fapi.models.FapiProfileEnum;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -90,12 +91,10 @@ public class ApiModelToOAuthConsumerApp implements ApiModelToOAuthConsumerAppFun
         updatePARConfigurations(consumerAppDTO, oidcModel.getPushAuthorizationRequest());
         updateSubjectConfigurations(consumerAppDTO, oidcModel.getSubject());
         consumerAppDTO.setFapiConformanceEnabled(oidcModel.getIsFAPIApplication());
-        // Map the FAPI profile enum to its String representation for storage.
-        // A null value means the caller did not specify a profile; the default will
-        // be applied by validateFapiProfile() in ServerApplicationManagementService
-        // before this mapper is reached.
-        if (oidcModel.getFapiProfile() != null) {
-            consumerAppDTO.setFapiProfile(oidcModel.getFapiProfile().toString());
+        // Convert FAPI profile enum to String for storage. If no profile specified; default is set to FAPI1_ADVANCED.
+        if (oidcModel.getIsFAPIApplication()) {
+            consumerAppDTO.setFapiProfile(oidcModel.getFapiProfile() != null
+                    ? oidcModel.getFapiProfile().toString() : FapiProfileEnum.FAPI1_ADVANCED.value());
         }
         updateSubjectTokenConfigurations(consumerAppDTO, oidcModel.getSubjectToken());
         updateCIBAAuthenticationRequestConfigurations(consumerAppDTO, oidcModel.getCibaAuthenticationRequest());
@@ -163,7 +162,7 @@ public class ApiModelToOAuthConsumerApp implements ApiModelToOAuthConsumerAppFun
     }
 
     private void updateAllowedOrigins(OAuthConsumerAppDTO consumerAppDTO, List<String> allowedOrigins) {
-        
+
         // Setting the allowed origins since now the cors origin services will be called and handle by the Oauth2
         // Inbound config handler
         consumerAppDTO.setAllowedOrigins(allowedOrigins);

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/functions/application/inbound/oauth2/ApiModelToOAuthConsumerApp.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/functions/application/inbound/oauth2/ApiModelToOAuthConsumerApp.java
@@ -90,6 +90,13 @@ public class ApiModelToOAuthConsumerApp implements ApiModelToOAuthConsumerAppFun
         updatePARConfigurations(consumerAppDTO, oidcModel.getPushAuthorizationRequest());
         updateSubjectConfigurations(consumerAppDTO, oidcModel.getSubject());
         consumerAppDTO.setFapiConformanceEnabled(oidcModel.getIsFAPIApplication());
+        // Map the FAPI profile enum to its String representation for storage.
+        // A null value means the caller did not specify a profile; the default will
+        // be applied by validateFapiProfile() in ServerApplicationManagementService
+        // before this mapper is reached.
+        if (oidcModel.getFapiProfile() != null) {
+            consumerAppDTO.setFapiProfile(oidcModel.getFapiProfile().toString());
+        }
         updateSubjectTokenConfigurations(consumerAppDTO, oidcModel.getSubjectToken());
         updateCIBAAuthenticationRequestConfigurations(consumerAppDTO, oidcModel.getCibaAuthenticationRequest());
         updateIssuerDetails(consumerAppDTO, oidcModel.getIssuer());

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/functions/application/inbound/oauth2/ApiModelToOAuthConsumerApp.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/functions/application/inbound/oauth2/ApiModelToOAuthConsumerApp.java
@@ -173,7 +173,7 @@ public class ApiModelToOAuthConsumerApp implements ApiModelToOAuthConsumerAppFun
     }
 
     private void updateAllowedOrigins(OAuthConsumerAppDTO consumerAppDTO, List<String> allowedOrigins) {
-
+        
         // Setting the allowed origins since now the cors origin services will be called and handle by the Oauth2
         // Inbound config handler
         consumerAppDTO.setAllowedOrigins(allowedOrigins);

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/functions/application/inbound/oauth2/ApiModelToOAuthConsumerApp.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/functions/application/inbound/oauth2/ApiModelToOAuthConsumerApp.java
@@ -41,6 +41,7 @@ import org.wso2.carbon.identity.oauth.common.OAuthConstants;
 import org.wso2.carbon.identity.oauth.config.OAuthServerConfiguration;
 import org.wso2.carbon.identity.oauth.dto.OAuthConsumerAppDTO;
 import org.wso2.carbon.identity.oauth2.config.models.IssuerDetails;
+import org.wso2.carbon.identity.oauth2.fapi.models.FapiProfileEnum;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -90,6 +91,11 @@ public class ApiModelToOAuthConsumerApp implements ApiModelToOAuthConsumerAppFun
         updatePARConfigurations(consumerAppDTO, oidcModel.getPushAuthorizationRequest());
         updateSubjectConfigurations(consumerAppDTO, oidcModel.getSubject());
         consumerAppDTO.setFapiConformanceEnabled(oidcModel.getIsFAPIApplication());
+        // Convert FAPI profile enum to String for storage. If no profile specified; default is set to FAPI1_ADVANCED.
+        if (oidcModel.getIsFAPIApplication()) {
+            consumerAppDTO.setFapiProfile(oidcModel.getFapiProfile() != null
+                    ? oidcModel.getFapiProfile().toString() : FapiProfileEnum.FAPI1_ADVANCED.value());
+        }
         updateSubjectTokenConfigurations(consumerAppDTO, oidcModel.getSubjectToken());
         updateCIBAAuthenticationRequestConfigurations(consumerAppDTO, oidcModel.getCibaAuthenticationRequest());
         updateIssuerDetails(consumerAppDTO, oidcModel.getIssuer());
@@ -167,7 +173,7 @@ public class ApiModelToOAuthConsumerApp implements ApiModelToOAuthConsumerAppFun
     }
 
     private void updateAllowedOrigins(OAuthConsumerAppDTO consumerAppDTO, List<String> allowedOrigins) {
-        
+
         // Setting the allowed origins since now the cors origin services will be called and handle by the Oauth2
         // Inbound config handler
         consumerAppDTO.setAllowedOrigins(allowedOrigins);

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/functions/application/inbound/oauth2/OAuthConsumerAppToApiModel.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/functions/application/inbound/oauth2/OAuthConsumerAppToApiModel.java
@@ -18,10 +18,13 @@
 package org.wso2.carbon.identity.api.server.application.management.v1.core.functions.application.inbound.oauth2;
 
 import org.apache.commons.lang.StringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.identity.api.server.application.management.v1.AccessTokenConfiguration;
 import org.wso2.carbon.identity.api.server.application.management.v1.AllowedIssuer;
 import org.wso2.carbon.identity.api.server.application.management.v1.CIBAAuthenticationRequestConfiguration;
 import org.wso2.carbon.identity.api.server.application.management.v1.ClientAuthenticationConfiguration;
+import org.wso2.carbon.identity.api.server.application.management.v1.FapiProfile;
 import org.wso2.carbon.identity.api.server.application.management.v1.HybridFlowConfiguration;
 import org.wso2.carbon.identity.api.server.application.management.v1.IdTokenConfiguration;
 import org.wso2.carbon.identity.api.server.application.management.v1.IdTokenEncryptionConfiguration;
@@ -48,6 +51,8 @@ import java.util.function.Function;
  */
 public class OAuthConsumerAppToApiModel implements Function<OAuthConsumerAppDTO, OpenIDConnectConfiguration> {
 
+    private static final Log log = LogFactory.getLog(OAuthConsumerAppToApiModel.class);
+
     @Override
     public OpenIDConnectConfiguration apply(OAuthConsumerAppDTO oauthAppDTO) {
 
@@ -72,6 +77,7 @@ public class OAuthConsumerAppToApiModel implements Function<OAuthConsumerAppDTO,
                 .pushAuthorizationRequest(buildPARAuthenticationConfiguration(oauthAppDTO))
                 .subject(buildSubjectConfiguration(oauthAppDTO))
                 .isFAPIApplication(oauthAppDTO.isFapiConformanceEnabled())
+                .fapiProfile(buildFapiProfileConfiguration(oauthAppDTO))
                 .subjectToken(buildSubjectTokenConfiguration(oauthAppDTO))
                 .cibaAuthenticationRequest(buildCIBAAuthenticationRequestConfiguration(oauthAppDTO))
                 .issuer(buildIssuerOrganizationConfiguration(oauthAppDTO));
@@ -267,5 +273,29 @@ public class OAuthConsumerAppToApiModel implements Function<OAuthConsumerAppDTO,
             return allowedIssuer;
         }
         return null;
+    }
+
+    /**
+     * Converts the stored FAPI profile string from the DTO into the API model enum.
+     * Returns null if no profile is stored, which will omit the field from the response.
+     * Logs a warning if an unrecognised value is found (data integrity issue, not an API error).
+     *
+     * @param oauthAppDTO the DTO containing the stored FAPI profile string.
+     * @return the {@link FapiProfile} enum constant, or null if not set.
+     */
+    private FapiProfile buildFapiProfileConfiguration(OAuthConsumerAppDTO oauthAppDTO) {
+
+        String fapiProfileValue = oauthAppDTO.getFapiProfile();
+        if (fapiProfileValue == null) {
+            return null;
+        }
+        try {
+            return FapiProfile.fromValue(fapiProfileValue);
+        } catch (IllegalArgumentException e) {
+            log.warn("Unrecognised fapiProfile value stored for application '"
+                    + oauthAppDTO.getApplicationName() + "': " + fapiProfileValue
+                    + ". Omitting from response.");
+            return null;
+        }
     }
 }

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/functions/application/inbound/oauth2/OAuthConsumerAppToApiModel.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/functions/application/inbound/oauth2/OAuthConsumerAppToApiModel.java
@@ -18,10 +18,13 @@
 package org.wso2.carbon.identity.api.server.application.management.v1.core.functions.application.inbound.oauth2;
 
 import org.apache.commons.lang.StringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.identity.api.server.application.management.v1.AccessTokenConfiguration;
 import org.wso2.carbon.identity.api.server.application.management.v1.AllowedIssuer;
 import org.wso2.carbon.identity.api.server.application.management.v1.CIBAAuthenticationRequestConfiguration;
 import org.wso2.carbon.identity.api.server.application.management.v1.ClientAuthenticationConfiguration;
+import org.wso2.carbon.identity.api.server.application.management.v1.FapiProfile;
 import org.wso2.carbon.identity.api.server.application.management.v1.HybridFlowConfiguration;
 import org.wso2.carbon.identity.api.server.application.management.v1.IdTokenConfiguration;
 import org.wso2.carbon.identity.api.server.application.management.v1.IdTokenEncryptionConfiguration;
@@ -48,6 +51,8 @@ import java.util.function.Function;
  */
 public class OAuthConsumerAppToApiModel implements Function<OAuthConsumerAppDTO, OpenIDConnectConfiguration> {
 
+    private static final Log log = LogFactory.getLog(OAuthConsumerAppToApiModel.class);
+
     @Override
     public OpenIDConnectConfiguration apply(OAuthConsumerAppDTO oauthAppDTO) {
 
@@ -72,6 +77,7 @@ public class OAuthConsumerAppToApiModel implements Function<OAuthConsumerAppDTO,
                 .pushAuthorizationRequest(buildPARAuthenticationConfiguration(oauthAppDTO))
                 .subject(buildSubjectConfiguration(oauthAppDTO))
                 .isFAPIApplication(oauthAppDTO.isFapiConformanceEnabled())
+                .fapiProfile(buildFapiProfileConfiguration(oauthAppDTO))
                 .subjectToken(buildSubjectTokenConfiguration(oauthAppDTO))
                 .cibaAuthenticationRequest(buildCIBAAuthenticationRequestConfiguration(oauthAppDTO))
                 .issuer(buildIssuerOrganizationConfiguration(oauthAppDTO));
@@ -271,5 +277,29 @@ public class OAuthConsumerAppToApiModel implements Function<OAuthConsumerAppDTO,
             return allowedIssuer;
         }
         return null;
+    }
+
+    /**
+     * Converts the stored FAPI profile string from the DTO into the API model enum.
+     * Returns null if no profile is stored, which will omit the field from the response.
+     * Logs a warning if an unrecognised value is found (data integrity issue, not an API error).
+     *
+     * @param oauthAppDTO the DTO containing the stored FAPI profile string.
+     * @return the {@link FapiProfile} enum constant, or null if not set.
+     */
+    private FapiProfile buildFapiProfileConfiguration(OAuthConsumerAppDTO oauthAppDTO) {
+
+        String fapiProfileValue = oauthAppDTO.getFapiProfile();
+        if (fapiProfileValue == null) {
+            return null;
+        }
+        try {
+            return FapiProfile.fromValue(fapiProfileValue);
+        } catch (IllegalArgumentException e) {
+            log.warn("Unrecognised fapiProfile value stored for application '"
+                    + oauthAppDTO.getApplicationName() + "': " + fapiProfileValue
+                    + ". Omitting from response.");
+            return null;
+        }
     }
 }

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/functions/application/inbound/oauth2/OAuthConsumerAppToApiModel.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/functions/application/inbound/oauth2/OAuthConsumerAppToApiModel.java
@@ -296,9 +296,10 @@ public class OAuthConsumerAppToApiModel implements Function<OAuthConsumerAppDTO,
         try {
             return FapiProfile.fromValue(fapiProfileValue);
         } catch (IllegalArgumentException e) {
-            log.warn("Unrecognised fapiProfile value stored for application '"
-                    + oauthAppDTO.getApplicationName() + "': " + fapiProfileValue
-                    + ". Omitting from response.");
+            if (log.isDebugEnabled()) {
+                log.debug(String.format("Unrecognised fapiProfile value stored for application '%s': %s",
+                        oauthAppDTO.getApplicationName(), fapiProfileValue), e);
+            }
             return null;
         }
     }

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/functions/application/inbound/oauth2/OAuthConsumerAppToApiModel.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/functions/application/inbound/oauth2/OAuthConsumerAppToApiModel.java
@@ -51,7 +51,7 @@ import java.util.function.Function;
  */
 public class OAuthConsumerAppToApiModel implements Function<OAuthConsumerAppDTO, OpenIDConnectConfiguration> {
 
-    private static final Log log = LogFactory.getLog(OAuthConsumerAppToApiModel.class);
+    private static final Log LOG = LogFactory.getLog(OAuthConsumerAppToApiModel.class);
 
     @Override
     public OpenIDConnectConfiguration apply(OAuthConsumerAppDTO oauthAppDTO) {
@@ -282,7 +282,6 @@ public class OAuthConsumerAppToApiModel implements Function<OAuthConsumerAppDTO,
     /**
      * Converts the stored FAPI profile string from the DTO into the API model enum.
      * Returns null if no profile is stored, which will omit the field from the response.
-     * Logs a warning if an unrecognised value is found (data integrity issue, not an API error).
      *
      * @param oauthAppDTO the DTO containing the stored FAPI profile string.
      * @return the {@link FapiProfile} enum constant, or null if not set.
@@ -290,14 +289,14 @@ public class OAuthConsumerAppToApiModel implements Function<OAuthConsumerAppDTO,
     private FapiProfile buildFapiProfileConfiguration(OAuthConsumerAppDTO oauthAppDTO) {
 
         String fapiProfileValue = oauthAppDTO.getFapiProfile();
-        if (fapiProfileValue == null) {
+        if (StringUtils.isBlank(fapiProfileValue)) {
             return null;
         }
         try {
             return FapiProfile.fromValue(fapiProfileValue);
         } catch (IllegalArgumentException e) {
-            if (log.isDebugEnabled()) {
-                log.debug(String.format("Unrecognised fapiProfile value stored for application '%s': %s",
+            if (LOG.isDebugEnabled()) {
+                LOG.debug(String.format("Unrecognised fapiProfile value stored for application '%s': %s",
                         oauthAppDTO.getApplicationName(), fapiProfileValue), e);
             }
             return null;

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/factories/ServerApplicationMetadataServiceFactory.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/factories/ServerApplicationMetadataServiceFactory.java
@@ -23,6 +23,7 @@ import org.wso2.carbon.identity.api.server.application.management.v1.core.Server
 import org.wso2.carbon.identity.application.mgt.ApplicationManagementService;
 import org.wso2.carbon.identity.oauth.OAuthAdminServiceImpl;
 import org.wso2.carbon.identity.oauth.ciba.api.CibaAuthServiceImpl;
+import org.wso2.carbon.identity.oauth2.fapi.services.FapiConfigMgtService;
 import org.wso2.carbon.identity.sso.saml.SAMLSSOConfigServiceImpl;
 import org.wso2.carbon.security.sts.service.STSAdminServiceInterface;
 
@@ -40,6 +41,7 @@ public class ServerApplicationMetadataServiceFactory {
         OAuthAdminServiceImpl oAuthAdminService = ApplicationManagementServiceHolder.getOAuthAdminService();
         STSAdminServiceInterface sTSAdminServiceInterface = ApplicationManagementServiceHolder.getStsAdminService();
         CibaAuthServiceImpl cibaAuthService = ApplicationManagementServiceHolder.getCibaAuthService();
+        FapiConfigMgtService fapiConfigMgtService = ApplicationManagementServiceHolder.getFapiConfigMgtService();
 
         if (applicationManagementService == null) {
             throw new IllegalStateException("ApplicationManagementService is not available from OSGi context.");
@@ -56,7 +58,7 @@ public class ServerApplicationMetadataServiceFactory {
         // Null check for STSAdminServiceInterface is not mandatory as per the previous implementation.
 
         SERVICE = new ServerApplicationMetadataService(applicationManagementService, samlSSOConfigService,
-                oAuthAdminService, sTSAdminServiceInterface, cibaAuthService);
+                oAuthAdminService, sTSAdminServiceInterface, cibaAuthService, fapiConfigMgtService);
     }
 
     /**

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/resources/applications.yaml
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/resources/applications.yaml
@@ -3977,6 +3977,14 @@ components:
           default: false
           description: Enabling this option will make the application FAPI conformant.
           example: false
+        fapiProfile:
+          description: |
+            The FAPI security profile applied to the application. Applicable only when isFAPIApplication is true.
+            If isFAPIApplication is true and this property is omitted, `FAPI1_ADVANCED` will be applied by default.
+          allOf:
+            - $ref: '#/components/schemas/FapiProfile'
+          default: FAPI1_ADVANCED
+          example: FAPI1_ADVANCED
         cibaAuthenticationRequest:
           $ref: '#/components/schemas/CIBAAuthenticationRequestConfiguration'
         issuer:
@@ -4291,12 +4299,23 @@ components:
     FapiMetadata:
       type: object
       properties:
+        allowedFapiProfiles:
+          $ref: '#/components/schemas/MetadataProperty'
         allowedSignatureAlgorithms:
           $ref: '#/components/schemas/MetadataProperty'
         allowedEncryptionAlgorithms:
           $ref: '#/components/schemas/MetadataProperty'
         tokenEndpointAuthMethod:
           $ref: '#/components/schemas/ClientAuthenticationMethodMetadata'
+    FapiProfile:
+      type: string
+      description: |
+        FAPI security profile.
+        - `FAPI1_ADVANCED`: FAPI 1.0 Advanced Security Profile.
+        - `FAPI2_SECURITY`: FAPI 2.0 Security Profile.
+      enum:
+        - FAPI1_ADVANCED
+        - FAPI2_SECURITY
     CIBAMetadata:
       type: object
       properties:

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/resources/applications.yaml
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/resources/applications.yaml
@@ -3983,7 +3983,6 @@ components:
             If isFAPIApplication is true and this property is omitted, `FAPI1_ADVANCED` will be applied by default.
           allOf:
             - $ref: '#/components/schemas/FapiProfile'
-          default: FAPI1_ADVANCED
           example: FAPI1_ADVANCED
         cibaAuthenticationRequest:
           $ref: '#/components/schemas/CIBAAuthenticationRequestConfiguration'
@@ -4317,7 +4316,9 @@ components:
       type: object
       properties:
         allowedFapiProfiles:
-          $ref: '#/components/schemas/MetadataProperty'
+          description: The FAPI security profiles supported by the tenant for this application.
+          allOf:
+            - $ref: '#/components/schemas/MetadataProperty'
         allowedSignatureAlgorithms:
           $ref: '#/components/schemas/MetadataProperty'
         allowedEncryptionAlgorithms:

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/resources/applications.yaml
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/resources/applications.yaml
@@ -3977,6 +3977,14 @@ components:
           default: false
           description: Enabling this option will make the application FAPI conformant.
           example: false
+        fapiProfile:
+          description: |
+            The FAPI security profile applied to the application. Applicable only when isFAPIApplication is true.
+            If isFAPIApplication is true and this property is omitted, `FAPI1_ADVANCED` will be applied by default.
+          allOf:
+            - $ref: '#/components/schemas/FapiProfile'
+          default: FAPI1_ADVANCED
+          example: FAPI1_ADVANCED
         cibaAuthenticationRequest:
           $ref: '#/components/schemas/CIBAAuthenticationRequestConfiguration'
         issuer:
@@ -4308,12 +4316,23 @@ components:
     FapiMetadata:
       type: object
       properties:
+        allowedFapiProfiles:
+          $ref: '#/components/schemas/MetadataProperty'
         allowedSignatureAlgorithms:
           $ref: '#/components/schemas/MetadataProperty'
         allowedEncryptionAlgorithms:
           $ref: '#/components/schemas/MetadataProperty'
         tokenEndpointAuthMethod:
           $ref: '#/components/schemas/ClientAuthenticationMethodMetadata'
+    FapiProfile:
+      type: string
+      description: |
+        FAPI security profile.
+        - `FAPI1_ADVANCED`: FAPI 1.0 Advanced Security Profile.
+        - `FAPI2_SECURITY`: FAPI 2.0 Security Profile.
+      enum:
+        - FAPI1_ADVANCED
+        - FAPI2_SECURITY
     CIBAMetadata:
       type: object
       properties:

--- a/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.common/src/main/java/org/wso2/carbon/identity/api/server/configs/common/ConfigsServiceHolder.java
+++ b/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.common/src/main/java/org/wso2/carbon/identity/api/server/configs/common/ConfigsServiceHolder.java
@@ -27,6 +27,7 @@ import org.wso2.carbon.identity.cors.mgt.core.CORSManagementService;
 import org.wso2.carbon.identity.fraud.detection.core.service.FraudDetectionConfigsService;
 import org.wso2.carbon.identity.oauth.dcr.DCRConfigurationMgtService;
 import org.wso2.carbon.identity.oauth2.config.services.OAuth2OIDCConfigOrgUsageScopeMgtService;
+import org.wso2.carbon.identity.oauth2.fapi.services.FapiConfigMgtService;
 import org.wso2.carbon.identity.oauth2.impersonation.services.ImpersonationConfigMgtService;
 import org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.core.JWTClientAuthenticatorMgtService;
 import org.wso2.carbon.idp.mgt.IdentityProviderManager;
@@ -116,6 +117,13 @@ public class ConfigsServiceHolder {
         static final CompatibilitySettingsService SERVICE =
                 (CompatibilitySettingsService) PrivilegedCarbonContext.getThreadLocalCarbonContext()
                         .getOSGiService(CompatibilitySettingsService.class, null);
+    }
+
+    private static class FapiConfigMgtServiceHolder {
+
+        static final FapiConfigMgtService SERVICE =
+                (FapiConfigMgtService) PrivilegedCarbonContext.getThreadLocalCarbonContext()
+                        .getOSGiService(FapiConfigMgtService.class, null);
     }
 
     /**
@@ -236,5 +244,15 @@ public class ConfigsServiceHolder {
     public static CompatibilitySettingsService getIdentityCompatibilitySettingsService() {
 
         return IdentityCompatibilitySettingsServiceHolder.SERVICE;
+    }
+
+    /**
+     * Get FapiConfigMgtService osgi service.
+     *
+     * @return FapiConfigMgtService
+     */
+    public static FapiConfigMgtService getFapiConfigMgtService() {
+
+        return FapiConfigMgtServiceHolder.SERVICE;
     }
 }

--- a/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.common/src/main/java/org/wso2/carbon/identity/api/server/configs/common/Constants.java
+++ b/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.common/src/main/java/org/wso2/carbon/identity/api/server/configs/common/Constants.java
@@ -72,6 +72,7 @@ public class Constants {
     public static final String DCR_CONFIG_SSA_JWKS = "/ssaJwks";
     public static final String DCR_CONFIG_AUTHENTICATION_REQUIRED = "/authenticationRequired";
     public static final String DCR_CONFIG_MANDATE_SSA = "/mandateSSA";
+    public static final String DCR_CONFIG_FAPI_PROFILE = "/fapiProfile";
 
     /**
      * SAML2 metadata endpoint uri path.
@@ -259,7 +260,18 @@ public class Constants {
                 "Server encountered an error while updating the Compatibility Settings."),
         ERROR_CODE_SETTING_GROUP_NOT_FOUND("60007",
                 "Setting group not found.",
-                "Unable to find compatibility settings for the setting group %s.");
+                "Unable to find compatibility settings for the setting group %s."),
+
+        /**
+         * FAPI Configuration errors.
+         */
+        ERROR_CODE_FAPI_CONFIG_RETRIEVE("65033",
+                "Unable to retrieve FAPI configuration.",
+                "Server encountered an error while retrieving the FAPI configuration."),
+
+        ERROR_CODE_FAPI_CONFIG_UPDATE("65034",
+                "Unable to update FAPI configuration.",
+                "Server encountered an error while updating the FAPI configuration.");
 
         private final String code;
         private final String message;

--- a/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/pom.xml
+++ b/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/pom.xml
@@ -30,39 +30,39 @@
 
     <build>
         <plugins>
-            <!--<plugin>-->
-                <!--<groupId>org.openapitools</groupId>-->
-                <!--<artifactId>openapi-generator-maven-plugin</artifactId>-->
-                <!--<version>4.1.2</version>-->
-                <!--<executions>-->
-                    <!--<execution>-->
-                        <!--<goals>-->
-                            <!--<goal>generate</goal>-->
-                        <!--</goals>-->
-                        <!--<configuration>-->
-                            <!--<inputSpec>${project.basedir}/src/main/resources/configs.yaml</inputSpec>-->
-                            <!--<generatorName>org.wso2.carbon.codegen.CxfWso2Generator</generatorName>-->
-                            <!--<configOptions>-->
-                                <!--<sourceFolder>src/gen/java</sourceFolder>-->
-                                <!--<apiPackage>org.wso2.carbon.identity.api.server.configs.v1</apiPackage>-->
-                                <!--<modelPackage>org.wso2.carbon.identity.api.server.configs.v1.model</modelPackage>-->
-                                <!--<packageName>org.wso2.carbon.identity.api.server.configs.v1</packageName>-->
-                                <!--<dateLibrary>java8</dateLibrary>-->
-                                <!--<hideGenerationTimestamp>true</hideGenerationTimestamp>-->
-                            <!--</configOptions>-->
-                            <!--<output>.</output>-->
-                            <!--<skipOverwrite>true</skipOverwrite>-->
-                        <!--</configuration>-->
-                    <!--</execution>-->
-                <!--</executions>-->
-                <!--<dependencies>-->
-                    <!--<dependency>-->
-                        <!--<groupId>org.openapitools</groupId>-->
-                        <!--<artifactId>cxf-wso2-openapi-generator</artifactId>-->
-                        <!--<version>1.0.0</version>-->
-                    <!--</dependency>-->
-                <!--</dependencies>-->
-            <!--</plugin>-->
+            <plugin>
+                <groupId>org.openapitools</groupId>
+                <artifactId>openapi-generator-maven-plugin</artifactId>
+                <version>4.1.2</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>generate</goal>
+                        </goals>
+                        <configuration>
+                            <inputSpec>${project.basedir}/src/main/resources/configs.yaml</inputSpec>
+                            <generatorName>org.wso2.carbon.codegen.CxfWso2Generator</generatorName>
+                            <configOptions>
+                                <sourceFolder>src/gen/java</sourceFolder>
+                                <apiPackage>org.wso2.carbon.identity.api.server.configs.v1</apiPackage>
+                                <modelPackage>org.wso2.carbon.identity.api.server.configs.v1.model</modelPackage>
+                                <packageName>org.wso2.carbon.identity.api.server.configs.v1</packageName>
+                                <dateLibrary>java8</dateLibrary>
+                                <hideGenerationTimestamp>true</hideGenerationTimestamp>
+                            </configOptions>
+                            <output>.</output>
+                            <skipOverwrite>true</skipOverwrite>
+                        </configuration>
+                    </execution>
+                </executions>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.openapitools</groupId>
+                        <artifactId>cxf-wso2-openapi-generator</artifactId>
+                        <version>1.0.0</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>

--- a/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/pom.xml
+++ b/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/pom.xml
@@ -30,39 +30,39 @@
 
     <build>
         <plugins>
-            <plugin>
-                <groupId>org.openapitools</groupId>
-                <artifactId>openapi-generator-maven-plugin</artifactId>
-                <version>4.1.2</version>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>generate</goal>
-                        </goals>
-                        <configuration>
-                            <inputSpec>${project.basedir}/src/main/resources/configs.yaml</inputSpec>
-                            <generatorName>org.wso2.carbon.codegen.CxfWso2Generator</generatorName>
-                            <configOptions>
-                                <sourceFolder>src/gen/java</sourceFolder>
-                                <apiPackage>org.wso2.carbon.identity.api.server.configs.v1</apiPackage>
-                                <modelPackage>org.wso2.carbon.identity.api.server.configs.v1.model</modelPackage>
-                                <packageName>org.wso2.carbon.identity.api.server.configs.v1</packageName>
-                                <dateLibrary>java8</dateLibrary>
-                                <hideGenerationTimestamp>true</hideGenerationTimestamp>
-                            </configOptions>
-                            <output>.</output>
-                            <skipOverwrite>true</skipOverwrite>
-                        </configuration>
-                    </execution>
-                </executions>
-                <dependencies>
-                    <dependency>
-                        <groupId>org.openapitools</groupId>
-                        <artifactId>cxf-wso2-openapi-generator</artifactId>
-                        <version>1.0.0</version>
-                    </dependency>
-                </dependencies>
-            </plugin>
+            <!--<plugin>-->
+                <!--<groupId>org.openapitools</groupId>-->
+                <!--<artifactId>openapi-generator-maven-plugin</artifactId>-->
+                <!--<version>4.1.2</version>-->
+                <!--<executions>-->
+                    <!--<execution>-->
+                        <!--<goals>-->
+                            <!--<goal>generate</goal>-->
+                        <!--</goals>-->
+                        <!--<configuration>-->
+                            <!--<inputSpec>${project.basedir}/src/main/resources/configs.yaml</inputSpec>-->
+                            <!--<generatorName>org.wso2.carbon.codegen.CxfWso2Generator</generatorName>-->
+                            <!--<configOptions>-->
+                                <!--<sourceFolder>src/gen/java</sourceFolder>-->
+                                <!--<apiPackage>org.wso2.carbon.identity.api.server.configs.v1</apiPackage>-->
+                                <!--<modelPackage>org.wso2.carbon.identity.api.server.configs.v1.model</modelPackage>-->
+                                <!--<packageName>org.wso2.carbon.identity.api.server.configs.v1</packageName>-->
+                                <!--<dateLibrary>java8</dateLibrary>-->
+                                <!--<hideGenerationTimestamp>true</hideGenerationTimestamp>-->
+                            <!--</configOptions>-->
+                            <!--<output>.</output>-->
+                            <!--<skipOverwrite>true</skipOverwrite>-->
+                        <!--</configuration>-->
+                    <!--</execution>-->
+                <!--</executions>-->
+                <!--<dependencies>-->
+                    <!--<dependency>-->
+                        <!--<groupId>org.openapitools</groupId>-->
+                        <!--<artifactId>cxf-wso2-openapi-generator</artifactId>-->
+                        <!--<version>1.0.0</version>-->
+                    <!--</dependency>-->
+                <!--</dependencies>-->
+            <!--</plugin>-->
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>

--- a/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/gen/java/org/wso2/carbon/identity/api/server/configs/v1/ConfigsApi.java
+++ b/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/gen/java/org/wso2/carbon/identity/api/server/configs/v1/ConfigsApi.java
@@ -33,6 +33,7 @@ import org.wso2.carbon.identity.api.server.configs.v1.model.CompatibilitySetting
 import org.wso2.carbon.identity.api.server.configs.v1.model.DCRConfig;
 import org.wso2.carbon.identity.api.server.configs.v1.model.DCRPatch;
 import org.wso2.carbon.identity.api.server.configs.v1.model.Error;
+import org.wso2.carbon.identity.api.server.configs.v1.model.FapiConfig;
 import org.wso2.carbon.identity.api.server.configs.v1.model.FraudDetectionConfig;
 import org.wso2.carbon.identity.api.server.configs.v1.model.ImpersonationConfiguration;
 import org.wso2.carbon.identity.api.server.configs.v1.model.ImpersonationPatch;
@@ -1023,5 +1024,53 @@ public class ConfigsApi  {
     public Response getCompatibilitySettingsByGroup(@ApiParam(value = "Setting group name (e.g., scim2, oauth)",required=true) @PathParam("setting-group") String settingGroup) {
 
         return delegate.getCompatibilitySettingsByGroup(settingGroup);
+    }
+
+    @Valid
+    @GET
+    @Path("/fapi")
+
+    @Produces({ "application/json" })
+    @ApiOperation(value = "Retrieve the tenant FAPI configuration.", notes = "Retrieve the tenant Financial-grade API (FAPI) configuration.", response = FapiConfig.class, authorizations = {
+            @Authorization(value = "BasicAuth"),
+            @Authorization(value = "OAuth2", scopes = {
+
+            })
+    }, tags={ "FAPI Configurations", })
+    @ApiResponses(value = {
+            @ApiResponse(code = 200, message = "Successful Response", response = FapiConfig.class),
+            @ApiResponse(code = 400, message = "Bad Request", response = Error.class),
+            @ApiResponse(code = 401, message = "Unauthorized", response = Void.class),
+            @ApiResponse(code = 403, message = "Forbidden", response = Void.class),
+            @ApiResponse(code = 404, message = "Not Found", response = Error.class),
+            @ApiResponse(code = 500, message = "Server Error", response = Error.class)
+    })
+    public Response getFAPIConfiguration() {
+
+        return delegate.getFAPIConfiguration();
+    }
+
+    @Valid
+    @PATCH
+    @Path("/fapi")
+    @Consumes({ "application/json" })
+    @Produces({ "application/json" })
+    @ApiOperation(value = "Patch the tenant FAPI configuration.", notes = "Patch the tenant Financial-grade API (FAPI) configuration. <b>Scope (Permission) required:</b> <br>   * internal_config_update ", response = FapiConfig.class, authorizations = {
+            @Authorization(value = "BasicAuth"),
+            @Authorization(value = "OAuth2", scopes = {
+
+            })
+    }, tags={ "FAPI Configurations", })
+    @ApiResponses(value = {
+            @ApiResponse(code = 200, message = "Successful Response", response = FapiConfig.class),
+            @ApiResponse(code = 400, message = "Bad Request", response = Error.class),
+            @ApiResponse(code = 401, message = "Unauthorized", response = Void.class),
+            @ApiResponse(code = 403, message = "Forbidden", response = Void.class),
+            @ApiResponse(code = 404, message = "Not Found", response = Error.class),
+            @ApiResponse(code = 500, message = "Server Error", response = Error.class)
+    })
+    public Response patchFAPIConfiguration(@ApiParam(value = "" ,required=true) @Valid FapiConfig fapiConfig) {
+
+        return delegate.patchFAPIConfiguration(fapiConfig );
     }
 }

--- a/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/gen/java/org/wso2/carbon/identity/api/server/configs/v1/ConfigsApi.java
+++ b/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/gen/java/org/wso2/carbon/identity/api/server/configs/v1/ConfigsApi.java
@@ -1051,11 +1051,11 @@ public class ConfigsApi  {
     }
 
     @Valid
-    @PATCH
+    @PUT
     @Path("/fapi")
     @Consumes({ "application/json" })
     @Produces({ "application/json" })
-    @ApiOperation(value = "Patch the tenant FAPI configuration.", notes = "Patch the tenant Financial-grade API (FAPI) configuration. <b>Scope (Permission) required:</b> <br>   * internal_config_update ", response = FapiConfig.class, authorizations = {
+    @ApiOperation(value = "Update the tenant FAPI configuration.", notes = "Update the tenant Financial-grade API (FAPI) configuration. <b>Scope (Permission) required:</b> <br>   * internal_config_update ", response = FapiConfig.class, authorizations = {
             @Authorization(value = "BasicAuth"),
             @Authorization(value = "OAuth2", scopes = {
 
@@ -1069,8 +1069,8 @@ public class ConfigsApi  {
             @ApiResponse(code = 404, message = "Not Found", response = Error.class),
             @ApiResponse(code = 500, message = "Server Error", response = Error.class)
     })
-    public Response patchFAPIConfiguration(@ApiParam(value = "" ,required=true) @Valid FapiConfig fapiConfig) {
+    public Response updateFAPIConfiguration(@ApiParam(value = "" ,required=true) @Valid FapiConfig fapiConfig) {
 
-        return delegate.patchFAPIConfiguration(fapiConfig );
+        return delegate.updateFAPIConfiguration(fapiConfig );
     }
 }

--- a/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/gen/java/org/wso2/carbon/identity/api/server/configs/v1/ConfigsApiService.java
+++ b/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/gen/java/org/wso2/carbon/identity/api/server/configs/v1/ConfigsApiService.java
@@ -66,7 +66,10 @@ public interface ConfigsApiService {
       public Response getPassiveSTSInboundAuthConfig();
 
       public Response getPrivatKeyJWTValidationConfiguration();
+
       public Response getDCRConfiguration();
+
+      public Response getFAPIConfiguration();
 
       public Response getRemoteLoggingConfig(String logType);
 
@@ -89,6 +92,8 @@ public interface ConfigsApiService {
       public Response patchPrivatKeyJWTValidationConfiguration(List<JWTKeyValidatorPatch> jwTKeyValidatorPatch);
 
       public Response patchDCRConfiguration(List<DCRPatch> patch);
+
+      public Response patchFAPIConfiguration(FapiConfig fapiConfig);
 
       public Response restoreServerRemoteLoggingConfiguration(String logType);
 

--- a/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/gen/java/org/wso2/carbon/identity/api/server/configs/v1/ConfigsApiService.java
+++ b/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/gen/java/org/wso2/carbon/identity/api/server/configs/v1/ConfigsApiService.java
@@ -93,7 +93,7 @@ public interface ConfigsApiService {
 
       public Response patchDCRConfiguration(List<DCRPatch> patch);
 
-      public Response patchFAPIConfiguration(FapiConfig fapiConfig);
+      public Response updateFAPIConfiguration(FapiConfig fapiConfig);
 
       public Response restoreServerRemoteLoggingConfiguration(String logType);
 

--- a/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/gen/java/org/wso2/carbon/identity/api/server/configs/v1/model/DCRConfig.java
+++ b/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/gen/java/org/wso2/carbon/identity/api/server/configs/v1/model/DCRConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2023-2026, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.wso2.carbon.identity.api.server.configs.v1.model.FapiProfile;
 import javax.validation.constraints.*;
 
 
@@ -35,6 +36,7 @@ public class DCRConfig  {
     private Boolean authenticationRequired;
     private String ssaJwks;
     private Boolean enableFapiEnforcement;
+    private FapiProfile fapiProfile = null;
     private Boolean mandateSSA;
 
     /**
@@ -95,6 +97,25 @@ public class DCRConfig  {
     }
 
     /**
+    * The FAPI security profile to enforce for applications created via DCR. Applicable only when enableFapiEnforcement is true. If enableFapiEnforcement is true and this property is omitted, &#x60;FAPI1_ADVANCED&#x60; will be applied by default. 
+    **/
+    public DCRConfig fapiProfile(FapiProfile fapiProfile) {
+
+        this.fapiProfile = fapiProfile;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "FAPI1_ADVANCED", value = "The FAPI security profile to enforce for applications created via DCR. Applicable only when enableFapiEnforcement is true. If enableFapiEnforcement is true and this property is omitted, `FAPI1_ADVANCED` will be applied by default. ")
+    @JsonProperty("fapiProfile")
+    @Valid
+    public FapiProfile getFapiProfile() {
+        return fapiProfile;
+    }
+    public void setFapiProfile(FapiProfile fapiProfile) {
+        this.fapiProfile = fapiProfile;
+    }
+
+    /**
     * If true, the software_statement parameter is mandatory for the DCR create request.
     **/
     public DCRConfig mandateSSA(Boolean mandateSSA) {
@@ -128,12 +149,13 @@ public class DCRConfig  {
         return Objects.equals(this.authenticationRequired, dcRConfig.authenticationRequired) &&
             Objects.equals(this.ssaJwks, dcRConfig.ssaJwks) &&
             Objects.equals(this.enableFapiEnforcement, dcRConfig.enableFapiEnforcement) &&
+            Objects.equals(this.fapiProfile, dcRConfig.fapiProfile) &&
             Objects.equals(this.mandateSSA, dcRConfig.mandateSSA);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(authenticationRequired, ssaJwks, enableFapiEnforcement, mandateSSA);
+        return Objects.hash(authenticationRequired, ssaJwks, enableFapiEnforcement, fapiProfile, mandateSSA);
     }
 
     @Override
@@ -145,6 +167,7 @@ public class DCRConfig  {
         sb.append("    authenticationRequired: ").append(toIndentedString(authenticationRequired)).append("\n");
         sb.append("    ssaJwks: ").append(toIndentedString(ssaJwks)).append("\n");
         sb.append("    enableFapiEnforcement: ").append(toIndentedString(enableFapiEnforcement)).append("\n");
+        sb.append("    fapiProfile: ").append(toIndentedString(fapiProfile)).append("\n");
         sb.append("    mandateSSA: ").append(toIndentedString(mandateSSA)).append("\n");
         sb.append("}");
         return sb.toString();

--- a/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/gen/java/org/wso2/carbon/identity/api/server/configs/v1/model/FapiConfig.java
+++ b/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/gen/java/org/wso2/carbon/identity/api/server/configs/v1/model/FapiConfig.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.configs.v1.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import java.util.ArrayList;
+import java.util.List;
+import org.wso2.carbon.identity.api.server.configs.v1.model.FapiProfile;
+import javax.validation.constraints.*;
+
+/**
+ * Financial-grade API (FAPI) configuration for the tenant.
+ **/
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+import javax.validation.Valid;
+import javax.xml.bind.annotation.*;
+@ApiModel(description = "Financial-grade API (FAPI) configuration for the tenant.")
+public class FapiConfig  {
+  
+    private Boolean enabled = false;
+    private List<FapiProfile> supportedProfiles = null;
+
+
+    /**
+    * Indicates whether FAPI compliance enforcement is enabled for the tenant.
+    **/
+    public FapiConfig enabled(Boolean enabled) {
+
+        this.enabled = enabled;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "false", value = "Indicates whether FAPI compliance enforcement is enabled for the tenant.")
+    @JsonProperty("enabled")
+    @Valid
+    public Boolean getEnabled() {
+        return enabled;
+    }
+    public void setEnabled(Boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    /**
+    * List of FAPI security profiles supported by the tenant. - &#x60;FAPI1_ADVANCED&#x60;: FAPI 1.0 Advanced Security Profile (Read and Write API Security Profile). - &#x60;FAPI2_SECURITY&#x60;: FAPI 2.0 Security Profile (baseline profile for high-security OAuth 2.0 APIs). 
+    **/
+    public FapiConfig supportedProfiles(List<FapiProfile> supportedProfiles) {
+
+        this.supportedProfiles = supportedProfiles;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "[\"FAPI1_ADVANCED\",\"FAPI2_SECURITY\"]", value = "List of FAPI security profiles supported by the tenant. - `FAPI1_ADVANCED`: FAPI 1.0 Advanced Security Profile (Read and Write API Security Profile). - `FAPI2_SECURITY`: FAPI 2.0 Security Profile (baseline profile for high-security OAuth 2.0 APIs). ")
+    @JsonProperty("supportedProfiles")
+    @Valid
+    public List<FapiProfile> getSupportedProfiles() {
+        return supportedProfiles;
+    }
+    public void setSupportedProfiles(List<FapiProfile> supportedProfiles) {
+        this.supportedProfiles = supportedProfiles;
+    }
+
+    public FapiConfig addSupportedProfilesItem(FapiProfile supportedProfilesItem) {
+        if (this.supportedProfiles == null) {
+            this.supportedProfiles = new ArrayList<>();
+        }
+        this.supportedProfiles.add(supportedProfilesItem);
+        return this;
+    }
+
+    
+
+    @Override
+    public boolean equals(java.lang.Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        FapiConfig fapiConfig = (FapiConfig) o;
+        return Objects.equals(this.enabled, fapiConfig.enabled) &&
+            Objects.equals(this.supportedProfiles, fapiConfig.supportedProfiles);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(enabled, supportedProfiles);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class FapiConfig {\n");
+        
+        sb.append("    enabled: ").append(toIndentedString(enabled)).append("\n");
+        sb.append("    supportedProfiles: ").append(toIndentedString(supportedProfiles)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+    * Convert the given object to string with each line indented by 4 spaces
+    * (except the first line).
+    */
+    private String toIndentedString(java.lang.Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}
+

--- a/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/gen/java/org/wso2/carbon/identity/api/server/configs/v1/model/FapiConfig.java
+++ b/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/gen/java/org/wso2/carbon/identity/api/server/configs/v1/model/FapiConfig.java
@@ -130,7 +130,7 @@ public class FapiConfig  {
         if (o == null) {
             return "null";
         }
-        return o.toString().replace("\n", "\n");
+        return o.toString().replace("\n", "\n    ");
     }
 }
 

--- a/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/gen/java/org/wso2/carbon/identity/api/server/configs/v1/model/FapiConfig.java
+++ b/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/gen/java/org/wso2/carbon/identity/api/server/configs/v1/model/FapiConfig.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.configs.v1.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import java.util.ArrayList;
+import java.util.List;
+import org.wso2.carbon.identity.api.server.configs.v1.model.FapiProfile;
+import javax.validation.constraints.*;
+
+/**
+ * Financial-grade API (FAPI) configuration for the tenant.
+ **/
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+import javax.validation.Valid;
+import javax.xml.bind.annotation.*;
+@ApiModel(description = "Financial-grade API (FAPI) configuration for the tenant.")
+public class FapiConfig  {
+  
+    private Boolean enabled = false;
+    private List<FapiProfile> supportedProfiles = null;
+
+
+    /**
+    * Indicates whether FAPI compliance enforcement is enabled for the tenant.
+    **/
+    public FapiConfig enabled(Boolean enabled) {
+
+        this.enabled = enabled;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "false", value = "Indicates whether FAPI compliance enforcement is enabled for the tenant.")
+    @JsonProperty("enabled")
+    @Valid
+    public Boolean getEnabled() {
+        return enabled;
+    }
+    public void setEnabled(Boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    /**
+    * List of FAPI security profiles supported by the tenant. - &#x60;FAPI1_ADVANCED&#x60;: FAPI 1.0 Advanced Security Profile (Read and Write API Security Profile). - &#x60;FAPI2_SECURITY&#x60;: FAPI 2.0 Security Profile (baseline profile for high-security OAuth 2.0 APIs). 
+    **/
+    public FapiConfig supportedProfiles(List<FapiProfile> supportedProfiles) {
+
+        this.supportedProfiles = supportedProfiles;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "[\"FAPI1_ADVANCED\",\"FAPI2_SECURITY\"]", value = "List of FAPI security profiles supported by the tenant. - `FAPI1_ADVANCED`: FAPI 1.0 Advanced Security Profile (Read and Write API Security Profile). - `FAPI2_SECURITY`: FAPI 2.0 Security Profile (baseline profile for high-security OAuth 2.0 APIs). ")
+    @JsonProperty("supportedProfiles")
+    @Valid
+    public List<FapiProfile> getSupportedProfiles() {
+        return supportedProfiles;
+    }
+    public void setSupportedProfiles(List<FapiProfile> supportedProfiles) {
+        this.supportedProfiles = supportedProfiles;
+    }
+
+    public FapiConfig addSupportedProfilesItem(FapiProfile supportedProfilesItem) {
+        if (this.supportedProfiles == null) {
+            this.supportedProfiles = new ArrayList<>();
+        }
+        this.supportedProfiles.add(supportedProfilesItem);
+        return this;
+    }
+
+    
+
+    @Override
+    public boolean equals(java.lang.Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        FapiConfig fapiConfig = (FapiConfig) o;
+        return Objects.equals(this.enabled, fapiConfig.enabled) &&
+            Objects.equals(this.supportedProfiles, fapiConfig.supportedProfiles);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(enabled, supportedProfiles);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class FapiConfig {\n");
+        
+        sb.append("    enabled: ").append(toIndentedString(enabled)).append("\n");
+        sb.append("    supportedProfiles: ").append(toIndentedString(supportedProfiles)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+    * Convert the given object to string with each line indented by 4 spaces
+    * (except the first line).
+    */
+    private String toIndentedString(java.lang.Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}
+

--- a/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/gen/java/org/wso2/carbon/identity/api/server/configs/v1/model/FapiProfile.java
+++ b/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/gen/java/org/wso2/carbon/identity/api/server/configs/v1/model/FapiProfile.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.configs.v1.model;
+
+import io.swagger.annotations.ApiModel;
+import org.wso2.carbon.identity.oauth2.fapi.models.FapiProfileEnum;
+
+import javax.validation.constraints.*;
+
+/**
+ * FAPI security profile. - &#x60;FAPI1_ADVANCED&#x60;: FAPI 1.0 Advanced Security Profile. - &#x60;FAPI2_SECURITY&#x60;: FAPI 2.0 Security Profile. 
+ **/
+import javax.xml.bind.annotation.XmlType;
+import javax.xml.bind.annotation.XmlEnum;
+import javax.xml.bind.annotation.XmlEnumValue;
+
+@XmlType(name="")
+@XmlEnum(String.class)
+public enum FapiProfile {
+
+    @XmlEnumValue("FAPI1_ADVANCED") FAPI1_ADVANCED(String.valueOf("FAPI1_ADVANCED")), @XmlEnumValue("FAPI2_SECURITY") FAPI2_SECURITY(String.valueOf("FAPI2_SECURITY"));
+
+
+    private String value;
+
+    FapiProfile(String v) {
+        value = v;
+    }
+
+    public String value() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    public static FapiProfile fromValue(String value) {
+
+        for (FapiProfile b : FapiProfile.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        return null;
+    }
+
+    public static FapiProfile fromValue(FapiProfileEnum fapiProfileEnum) {
+
+        if (fapiProfileEnum == null) {
+            return null;
+        }
+        return fromValue(fapiProfileEnum.value());
+    }
+}
+
+
+

--- a/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/gen/java/org/wso2/carbon/identity/api/server/configs/v1/model/FapiProfile.java
+++ b/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/gen/java/org/wso2/carbon/identity/api/server/configs/v1/model/FapiProfile.java
@@ -70,6 +70,3 @@ public enum FapiProfile {
         return fromValue(fapiProfileEnum.value());
     }
 }
-
-
-

--- a/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/main/java/org/wso2/carbon/identity/api/server/configs/v1/core/ServerConfigManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/main/java/org/wso2/carbon/identity/api/server/configs/v1/core/ServerConfigManagementService.java
@@ -119,7 +119,6 @@ import org.wso2.carbon.identity.oauth2.config.models.UsageScope;
 import org.wso2.carbon.identity.oauth2.config.services.OAuth2OIDCConfigOrgUsageScopeMgtService;
 import org.wso2.carbon.identity.oauth2.fapi.exceptions.FapiConfigMgtClientException;
 import org.wso2.carbon.identity.oauth2.fapi.exceptions.FapiConfigMgtException;
-import org.wso2.carbon.identity.oauth2.fapi.exceptions.FapiConfigMgtServerException;
 import org.wso2.carbon.identity.oauth2.fapi.services.FapiConfigMgtService;
 import org.wso2.carbon.identity.oauth2.impersonation.exceptions.ImpersonationConfigMgtClientException;
 import org.wso2.carbon.identity.oauth2.impersonation.exceptions.ImpersonationConfigMgtException;

--- a/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/main/java/org/wso2/carbon/identity/api/server/configs/v1/core/ServerConfigManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/main/java/org/wso2/carbon/identity/api/server/configs/v1/core/ServerConfigManagementService.java
@@ -39,6 +39,7 @@ import org.wso2.carbon.identity.api.server.configs.v1.exception.JWTClientAuthent
 import org.wso2.carbon.identity.api.server.configs.v1.function.CORSConfigurationToCORSConfig;
 import org.wso2.carbon.identity.api.server.configs.v1.function.CompatibilitySettingUtil;
 import org.wso2.carbon.identity.api.server.configs.v1.function.DCRConnectorUtil;
+import org.wso2.carbon.identity.api.server.configs.v1.function.FAPIConnectorUtil;
 import org.wso2.carbon.identity.api.server.configs.v1.function.JWTConnectorUtil;
 import org.wso2.carbon.identity.api.server.configs.v1.model.AuthenticationType;
 import org.wso2.carbon.identity.api.server.configs.v1.model.Authenticator;
@@ -53,6 +54,8 @@ import org.wso2.carbon.identity.api.server.configs.v1.model.DCRPatch;
 import org.wso2.carbon.identity.api.server.configs.v1.model.Endpoint;
 import org.wso2.carbon.identity.api.server.configs.v1.model.EventConfig;
 import org.wso2.carbon.identity.api.server.configs.v1.model.EventProperty;
+import org.wso2.carbon.identity.api.server.configs.v1.model.FapiConfig;
+import org.wso2.carbon.identity.api.server.configs.v1.model.FapiProfile;
 import org.wso2.carbon.identity.api.server.configs.v1.model.FraudDetectionConfig;
 import org.wso2.carbon.identity.api.server.configs.v1.model.ImpersonationConfiguration;
 import org.wso2.carbon.identity.api.server.configs.v1.model.ImpersonationPatch;
@@ -114,6 +117,10 @@ import org.wso2.carbon.identity.oauth2.config.exceptions.OAuth2OIDCConfigOrgUsag
 import org.wso2.carbon.identity.oauth2.config.models.IssuerUsageScopeConfig;
 import org.wso2.carbon.identity.oauth2.config.models.UsageScope;
 import org.wso2.carbon.identity.oauth2.config.services.OAuth2OIDCConfigOrgUsageScopeMgtService;
+import org.wso2.carbon.identity.oauth2.fapi.exceptions.FapiConfigMgtClientException;
+import org.wso2.carbon.identity.oauth2.fapi.exceptions.FapiConfigMgtException;
+import org.wso2.carbon.identity.oauth2.fapi.exceptions.FapiConfigMgtServerException;
+import org.wso2.carbon.identity.oauth2.fapi.services.FapiConfigMgtService;
 import org.wso2.carbon.identity.oauth2.impersonation.exceptions.ImpersonationConfigMgtClientException;
 import org.wso2.carbon.identity.oauth2.impersonation.exceptions.ImpersonationConfigMgtException;
 import org.wso2.carbon.identity.oauth2.impersonation.exceptions.ImpersonationConfigMgtServerException;
@@ -173,6 +180,7 @@ public class ServerConfigManagementService {
     private final DCRConfigurationMgtService dcrConfigurationMgtService;
     private final OAuth2OIDCConfigOrgUsageScopeMgtService oauth2OIDCConfigOrgUsageScopeMgtService;
     private final CompatibilitySettingsService compatibilitySettingsService;
+    private final FapiConfigMgtService fapiConfigMgtService;
 
     private static final Log log = LogFactory.getLog(ServerConfigManagementService.class);
 
@@ -186,7 +194,8 @@ public class ServerConfigManagementService {
                                          FraudDetectionConfigsService fraudDetectionConfigsService,
                                          OAuth2OIDCConfigOrgUsageScopeMgtService
                                                  oauth2OIDCConfigOrgUsageScopeMgtService,
-                                         CompatibilitySettingsService identityCompatibilitySettingsService) {
+                                         CompatibilitySettingsService identityCompatibilitySettingsService,
+                                         FapiConfigMgtService fapiConfigMgtService) {
 
         this.applicationManagementService = applicationManagementService;
         this.idpManager = idpManager;
@@ -198,6 +207,7 @@ public class ServerConfigManagementService {
         this.fraudDetectionConfigsService = fraudDetectionConfigsService;
         this.oauth2OIDCConfigOrgUsageScopeMgtService = oauth2OIDCConfigOrgUsageScopeMgtService;
         this.compatibilitySettingsService = identityCompatibilitySettingsService;
+        this.fapiConfigMgtService = fapiConfigMgtService;
     }
 
     /**
@@ -514,6 +524,52 @@ public class ServerConfigManagementService {
         } catch (ImpersonationConfigMgtException e) {
             throw handleImpersonationConfigException(e, Constants.ErrorMessage.ERROR_CODE_IMP_CONFIG_DELETE,
                     tenantDomain);
+        }
+    }
+
+    /**
+     * Get the FAPI configuration for the current tenant.
+     *
+     * @return FapiConfig API model.
+     */
+    public FapiConfig getFAPIConfiguration() {
+
+        String tenantDomain = ContextLoader.getTenantDomainFromContext();
+        try {
+            org.wso2.carbon.identity.oauth2.fapi.models.FapiConfig fapiConfig =
+                    fapiConfigMgtService.getFapiConfig(tenantDomain);
+            return FAPIConnectorUtil.toApiModel(fapiConfig);
+        } catch (FapiConfigMgtClientException e) {
+            log.error(Constants.ErrorMessage.ERROR_CODE_FAPI_CONFIG_RETRIEVE.message(), e);
+            throw new APIError(Response.Status.BAD_REQUEST, this.getFapiConfigErrorResponse(e,
+                    Constants.ErrorMessage.ERROR_CODE_FAPI_CONFIG_RETRIEVE, tenantDomain));
+        } catch (FapiConfigMgtException e) {
+            log.error(Constants.ErrorMessage.ERROR_CODE_FAPI_CONFIG_RETRIEVE.message(), e);
+            throw new APIError(Response.Status.INTERNAL_SERVER_ERROR, this.getFapiConfigErrorResponse(e,
+                    Constants.ErrorMessage.ERROR_CODE_FAPI_CONFIG_RETRIEVE, tenantDomain));
+        }
+    }
+
+    /**
+     * Update the FAPI configuration for the current tenant.
+     *
+     * @param fapiConfig the API model to persist.
+     * @return the updated FapiConfig API model.
+     */
+    public FapiConfig updateFAPIConfiguration(FapiConfig fapiConfig) {
+
+        String tenantDomain = ContextLoader.getTenantDomainFromContext();
+        try {
+            fapiConfigMgtService.setFapiConfig(FAPIConnectorUtil.toOAuthModel(fapiConfig), tenantDomain);
+            return fapiConfig;
+        } catch (FapiConfigMgtClientException e) {
+            log.error(Constants.ErrorMessage.ERROR_CODE_FAPI_CONFIG_UPDATE.message(), e);
+            throw new APIError(Response.Status.BAD_REQUEST, this.getFapiConfigErrorResponse(e,
+                    Constants.ErrorMessage.ERROR_CODE_FAPI_CONFIG_UPDATE, tenantDomain));
+        } catch (FapiConfigMgtException e) {
+            log.error(Constants.ErrorMessage.ERROR_CODE_FAPI_CONFIG_UPDATE.message(), e);
+            throw new APIError(Response.Status.INTERNAL_SERVER_ERROR, this.getFapiConfigErrorResponse(e,
+                    Constants.ErrorMessage.ERROR_CODE_FAPI_CONFIG_UPDATE, tenantDomain));
         }
     }
 
@@ -1457,6 +1513,22 @@ public class ServerConfigManagementService {
         return new APIError(status, errorResponse);
     }
 
+
+    private ErrorResponse getFapiConfigErrorResponse(FapiConfigMgtException e,
+                                                     Constants.ErrorMessage errorEnum, String data) {
+
+        final ErrorResponse errorResponse = getErrorBuilder(errorEnum, data).build(log, e.getMessage());
+        errorResponse.setDescription(e.getMessage());
+        if (e.getErrorCode() != null) {
+            String errorCode = e.getErrorCode();
+            errorCode = errorCode.contains(
+                    org.wso2.carbon.identity.api.server.common.Constants.ERROR_CODE_DELIMITER)
+                    ? errorCode : Constants.CONFIG_ERROR_PREFIX + errorCode;
+            errorResponse.setCode(errorCode);
+        }
+        return errorResponse;
+    }
+
     /**
      * Handle exceptions generated in API.
      *
@@ -1671,6 +1743,13 @@ public class ServerConfigManagementService {
                     } else if (path.matches(Constants.DCR_CONFIG_SSA_JWKS)) {
                         String value = dcrPatch.getValue();
                         dcrConfig.setSsaJwks(value);
+                    } else if (path.matches(Constants.DCR_CONFIG_FAPI_PROFILE)) {
+                        FapiProfile fapiProfile = FapiProfile.fromValue(dcrPatch.getValue());
+                        if (fapiProfile == null) {
+                            throw handleException(Response.Status.BAD_REQUEST, Constants.ErrorMessage
+                                    .ERROR_CODE_INVALID_INPUT, "Unsupported patch value for the given path");
+                        }
+                        dcrConfig.setFapiProfile(fapiProfile);
                     } else {
                         // Throw an error if any other patch operations are sent in the request.
                         throw handleException(Response.Status.BAD_REQUEST, Constants.ErrorMessage

--- a/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/main/java/org/wso2/carbon/identity/api/server/configs/v1/core/ServerConfigManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/main/java/org/wso2/carbon/identity/api/server/configs/v1/core/ServerConfigManagementService.java
@@ -535,9 +535,7 @@ public class ServerConfigManagementService {
 
         String tenantDomain = ContextLoader.getTenantDomainFromContext();
         try {
-            org.wso2.carbon.identity.oauth2.fapi.models.FapiConfig fapiConfig =
-                    fapiConfigMgtService.getFapiConfig(tenantDomain);
-            return FAPIConnectorUtil.toApiModel(fapiConfig);
+            return FAPIConnectorUtil.toApiModel(fapiConfigMgtService.getFapiConfig(tenantDomain));
         } catch (FapiConfigMgtClientException e) {
             log.error(Constants.ErrorMessage.ERROR_CODE_FAPI_CONFIG_RETRIEVE.message(), e);
             throw new APIError(Response.Status.BAD_REQUEST, this.getFapiConfigErrorResponse(e,
@@ -560,7 +558,7 @@ public class ServerConfigManagementService {
         String tenantDomain = ContextLoader.getTenantDomainFromContext();
         try {
             fapiConfigMgtService.setFapiConfig(FAPIConnectorUtil.toOAuthModel(fapiConfig), tenantDomain);
-            return fapiConfig;
+            return FAPIConnectorUtil.toApiModel(fapiConfigMgtService.getFapiConfig(tenantDomain));
         } catch (FapiConfigMgtClientException e) {
             log.error(Constants.ErrorMessage.ERROR_CODE_FAPI_CONFIG_UPDATE.message(), e);
             throw new APIError(Response.Status.BAD_REQUEST, this.getFapiConfigErrorResponse(e,

--- a/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/main/java/org/wso2/carbon/identity/api/server/configs/v1/core/ServerConfigManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/main/java/org/wso2/carbon/identity/api/server/configs/v1/core/ServerConfigManagementService.java
@@ -39,6 +39,7 @@ import org.wso2.carbon.identity.api.server.configs.v1.exception.JWTClientAuthent
 import org.wso2.carbon.identity.api.server.configs.v1.function.CORSConfigurationToCORSConfig;
 import org.wso2.carbon.identity.api.server.configs.v1.function.CompatibilitySettingUtil;
 import org.wso2.carbon.identity.api.server.configs.v1.function.DCRConnectorUtil;
+import org.wso2.carbon.identity.api.server.configs.v1.function.FAPIConnectorUtil;
 import org.wso2.carbon.identity.api.server.configs.v1.function.JWTConnectorUtil;
 import org.wso2.carbon.identity.api.server.configs.v1.model.AuthenticationType;
 import org.wso2.carbon.identity.api.server.configs.v1.model.Authenticator;
@@ -53,6 +54,8 @@ import org.wso2.carbon.identity.api.server.configs.v1.model.DCRPatch;
 import org.wso2.carbon.identity.api.server.configs.v1.model.Endpoint;
 import org.wso2.carbon.identity.api.server.configs.v1.model.EventConfig;
 import org.wso2.carbon.identity.api.server.configs.v1.model.EventProperty;
+import org.wso2.carbon.identity.api.server.configs.v1.model.FapiConfig;
+import org.wso2.carbon.identity.api.server.configs.v1.model.FapiProfile;
 import org.wso2.carbon.identity.api.server.configs.v1.model.FraudDetectionConfig;
 import org.wso2.carbon.identity.api.server.configs.v1.model.ImpersonationConfiguration;
 import org.wso2.carbon.identity.api.server.configs.v1.model.ImpersonationPatch;
@@ -109,11 +112,13 @@ import org.wso2.carbon.identity.fraud.detection.core.model.FraudDetectionConfigD
 import org.wso2.carbon.identity.fraud.detection.core.service.FraudDetectionConfigsService;
 import org.wso2.carbon.identity.oauth.dcr.DCRConfigurationMgtService;
 import org.wso2.carbon.identity.oauth.dcr.exception.DCRMException;
-import org.wso2.carbon.identity.oauth2.config.exceptions.OAuth2OIDCConfigOrgUsageScopeMgtClientException;
 import org.wso2.carbon.identity.oauth2.config.exceptions.OAuth2OIDCConfigOrgUsageScopeMgtException;
 import org.wso2.carbon.identity.oauth2.config.models.IssuerUsageScopeConfig;
 import org.wso2.carbon.identity.oauth2.config.models.UsageScope;
 import org.wso2.carbon.identity.oauth2.config.services.OAuth2OIDCConfigOrgUsageScopeMgtService;
+import org.wso2.carbon.identity.oauth2.fapi.exceptions.FapiConfigMgtClientException;
+import org.wso2.carbon.identity.oauth2.fapi.exceptions.FapiConfigMgtException;
+import org.wso2.carbon.identity.oauth2.fapi.services.FapiConfigMgtService;
 import org.wso2.carbon.identity.oauth2.impersonation.exceptions.ImpersonationConfigMgtClientException;
 import org.wso2.carbon.identity.oauth2.impersonation.exceptions.ImpersonationConfigMgtException;
 import org.wso2.carbon.identity.oauth2.impersonation.exceptions.ImpersonationConfigMgtServerException;
@@ -173,6 +178,7 @@ public class ServerConfigManagementService {
     private final DCRConfigurationMgtService dcrConfigurationMgtService;
     private final OAuth2OIDCConfigOrgUsageScopeMgtService oauth2OIDCConfigOrgUsageScopeMgtService;
     private final CompatibilitySettingsService compatibilitySettingsService;
+    private final FapiConfigMgtService fapiConfigMgtService;
 
     private static final Log log = LogFactory.getLog(ServerConfigManagementService.class);
 
@@ -186,7 +192,8 @@ public class ServerConfigManagementService {
                                          FraudDetectionConfigsService fraudDetectionConfigsService,
                                          OAuth2OIDCConfigOrgUsageScopeMgtService
                                                  oauth2OIDCConfigOrgUsageScopeMgtService,
-                                         CompatibilitySettingsService identityCompatibilitySettingsService) {
+                                         CompatibilitySettingsService identityCompatibilitySettingsService,
+                                         FapiConfigMgtService fapiConfigMgtService) {
 
         this.applicationManagementService = applicationManagementService;
         this.idpManager = idpManager;
@@ -198,6 +205,7 @@ public class ServerConfigManagementService {
         this.fraudDetectionConfigsService = fraudDetectionConfigsService;
         this.oauth2OIDCConfigOrgUsageScopeMgtService = oauth2OIDCConfigOrgUsageScopeMgtService;
         this.compatibilitySettingsService = identityCompatibilitySettingsService;
+        this.fapiConfigMgtService = fapiConfigMgtService;
     }
 
     /**
@@ -514,6 +522,52 @@ public class ServerConfigManagementService {
         } catch (ImpersonationConfigMgtException e) {
             throw handleImpersonationConfigException(e, Constants.ErrorMessage.ERROR_CODE_IMP_CONFIG_DELETE,
                     tenantDomain);
+        }
+    }
+
+    /**
+     * Get the FAPI configuration for the current tenant.
+     *
+     * @return FapiConfig API model.
+     */
+    public FapiConfig getFAPIConfiguration() {
+
+        String tenantDomain = ContextLoader.getTenantDomainFromContext();
+        try {
+            org.wso2.carbon.identity.oauth2.fapi.models.FapiConfig fapiConfig =
+                    fapiConfigMgtService.getFapiConfig(tenantDomain);
+            return FAPIConnectorUtil.toApiModel(fapiConfig);
+        } catch (FapiConfigMgtClientException e) {
+            log.error(Constants.ErrorMessage.ERROR_CODE_FAPI_CONFIG_RETRIEVE.message(), e);
+            throw new APIError(Response.Status.BAD_REQUEST, this.getFapiConfigErrorResponse(e,
+                    Constants.ErrorMessage.ERROR_CODE_FAPI_CONFIG_RETRIEVE, tenantDomain));
+        } catch (FapiConfigMgtException e) {
+            log.error(Constants.ErrorMessage.ERROR_CODE_FAPI_CONFIG_RETRIEVE.message(), e);
+            throw new APIError(Response.Status.INTERNAL_SERVER_ERROR, this.getFapiConfigErrorResponse(e,
+                    Constants.ErrorMessage.ERROR_CODE_FAPI_CONFIG_RETRIEVE, tenantDomain));
+        }
+    }
+
+    /**
+     * Update the FAPI configuration for the current tenant.
+     *
+     * @param fapiConfig the API model to persist.
+     * @return the updated FapiConfig API model.
+     */
+    public FapiConfig updateFAPIConfiguration(FapiConfig fapiConfig) {
+
+        String tenantDomain = ContextLoader.getTenantDomainFromContext();
+        try {
+            fapiConfigMgtService.setFapiConfig(FAPIConnectorUtil.toOAuthModel(fapiConfig), tenantDomain);
+            return fapiConfig;
+        } catch (FapiConfigMgtClientException e) {
+            log.error(Constants.ErrorMessage.ERROR_CODE_FAPI_CONFIG_UPDATE.message(), e);
+            throw new APIError(Response.Status.BAD_REQUEST, this.getFapiConfigErrorResponse(e,
+                    Constants.ErrorMessage.ERROR_CODE_FAPI_CONFIG_UPDATE, tenantDomain));
+        } catch (FapiConfigMgtException e) {
+            log.error(Constants.ErrorMessage.ERROR_CODE_FAPI_CONFIG_UPDATE.message(), e);
+            throw new APIError(Response.Status.INTERNAL_SERVER_ERROR, this.getFapiConfigErrorResponse(e,
+                    Constants.ErrorMessage.ERROR_CODE_FAPI_CONFIG_UPDATE, tenantDomain));
         }
     }
 
@@ -1454,6 +1508,22 @@ public class ServerConfigManagementService {
         return new APIError(status, errorResponse);
     }
 
+
+    private ErrorResponse getFapiConfigErrorResponse(FapiConfigMgtException e,
+                                                     Constants.ErrorMessage errorEnum, String data) {
+
+        final ErrorResponse errorResponse = getErrorBuilder(errorEnum, data).build(log, e.getMessage());
+        errorResponse.setDescription(e.getMessage());
+        if (e.getErrorCode() != null) {
+            String errorCode = e.getErrorCode();
+            errorCode = errorCode.contains(
+                    org.wso2.carbon.identity.api.server.common.Constants.ERROR_CODE_DELIMITER)
+                    ? errorCode : Constants.CONFIG_ERROR_PREFIX + errorCode;
+            errorResponse.setCode(errorCode);
+        }
+        return errorResponse;
+    }
+
     /**
      * Handle exceptions generated in API.
      *
@@ -1668,6 +1738,13 @@ public class ServerConfigManagementService {
                     } else if (path.matches(Constants.DCR_CONFIG_SSA_JWKS)) {
                         String value = dcrPatch.getValue();
                         dcrConfig.setSsaJwks(value);
+                    } else if (path.matches(Constants.DCR_CONFIG_FAPI_PROFILE)) {
+                        FapiProfile fapiProfile = FapiProfile.fromValue(dcrPatch.getValue());
+                        if (fapiProfile == null) {
+                            throw handleException(Response.Status.BAD_REQUEST, Constants.ErrorMessage
+                                    .ERROR_CODE_INVALID_INPUT, "Unsupported patch value for the given path");
+                        }
+                        dcrConfig.setFapiProfile(fapiProfile);
                     } else {
                         // Throw an error if any other patch operations are sent in the request.
                         throw handleException(Response.Status.BAD_REQUEST, Constants.ErrorMessage
@@ -2390,10 +2467,6 @@ public class ServerConfigManagementService {
                     updateIssuerUsageScopeConfig(tenantDomain, issuerUsageScopeConfig);
             return buildIssuerUsageScopeConfig(updateIssuerUsageScopeConfig, tenantDomain);
         } catch (OAuth2OIDCConfigOrgUsageScopeMgtException | OrganizationManagementException e) {
-            if (e instanceof OAuth2OIDCConfigOrgUsageScopeMgtClientException) {
-                throw handleException(Response.Status.BAD_REQUEST,
-                        Constants.ErrorMessage.ERROR_CODE_CLIENT_ERROR_ISSUER_USAGE_SCOPE_UPDATE, e.getMessage());
-            }
             throw handleException(Response.Status.INTERNAL_SERVER_ERROR,
                     Constants.ErrorMessage.ERROR_CODE_ERROR_ISSUER_USAGE_SCOPE_UPDATE, e.getMessage());
         }

--- a/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/main/java/org/wso2/carbon/identity/api/server/configs/v1/core/ServerConfigManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/main/java/org/wso2/carbon/identity/api/server/configs/v1/core/ServerConfigManagementService.java
@@ -192,8 +192,7 @@ public class ServerConfigManagementService {
                                          FraudDetectionConfigsService fraudDetectionConfigsService,
                                          OAuth2OIDCConfigOrgUsageScopeMgtService
                                                  oauth2OIDCConfigOrgUsageScopeMgtService,
-                                         CompatibilitySettingsService identityCompatibilitySettingsService,
-                                         FapiConfigMgtService fapiConfigMgtService) {
+                                         CompatibilitySettingsService identityCompatibilitySettingsService) {
 
         this.applicationManagementService = applicationManagementService;
         this.idpManager = idpManager;

--- a/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/main/java/org/wso2/carbon/identity/api/server/configs/v1/core/ServerConfigManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/main/java/org/wso2/carbon/identity/api/server/configs/v1/core/ServerConfigManagementService.java
@@ -537,11 +537,9 @@ public class ServerConfigManagementService {
         try {
             return FAPIConnectorUtil.toApiModel(fapiConfigMgtService.getFapiConfig(tenantDomain));
         } catch (FapiConfigMgtClientException e) {
-            log.error(Constants.ErrorMessage.ERROR_CODE_FAPI_CONFIG_RETRIEVE.message(), e);
             throw new APIError(Response.Status.BAD_REQUEST, this.getFapiConfigErrorResponse(e,
                     Constants.ErrorMessage.ERROR_CODE_FAPI_CONFIG_RETRIEVE, tenantDomain));
         } catch (FapiConfigMgtException e) {
-            log.error(Constants.ErrorMessage.ERROR_CODE_FAPI_CONFIG_RETRIEVE.message(), e);
             throw new APIError(Response.Status.INTERNAL_SERVER_ERROR, this.getFapiConfigErrorResponse(e,
                     Constants.ErrorMessage.ERROR_CODE_FAPI_CONFIG_RETRIEVE, tenantDomain));
         }
@@ -555,16 +553,18 @@ public class ServerConfigManagementService {
      */
     public FapiConfig updateFAPIConfiguration(FapiConfig fapiConfig) {
 
-        String tenantDomain = ContextLoader.getTenantDomainFromContext();
+        if (fapiConfig == null) {
+            throw handleException(Response.Status.BAD_REQUEST, Constants.ErrorMessage.ERROR_CODE_INVALID_INPUT,
+                    "FAPI configuration is required in the request body.");
+        }
+        final String tenantDomain = ContextLoader.getTenantDomainFromContext();
         try {
             fapiConfigMgtService.setFapiConfig(FAPIConnectorUtil.toOAuthModel(fapiConfig), tenantDomain);
             return FAPIConnectorUtil.toApiModel(fapiConfigMgtService.getFapiConfig(tenantDomain));
         } catch (FapiConfigMgtClientException e) {
-            log.error(Constants.ErrorMessage.ERROR_CODE_FAPI_CONFIG_UPDATE.message(), e);
             throw new APIError(Response.Status.BAD_REQUEST, this.getFapiConfigErrorResponse(e,
                     Constants.ErrorMessage.ERROR_CODE_FAPI_CONFIG_UPDATE, tenantDomain));
         } catch (FapiConfigMgtException e) {
-            log.error(Constants.ErrorMessage.ERROR_CODE_FAPI_CONFIG_UPDATE.message(), e);
             throw new APIError(Response.Status.INTERNAL_SERVER_ERROR, this.getFapiConfigErrorResponse(e,
                     Constants.ErrorMessage.ERROR_CODE_FAPI_CONFIG_UPDATE, tenantDomain));
         }

--- a/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/main/java/org/wso2/carbon/identity/api/server/configs/v1/core/ServerConfigManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/main/java/org/wso2/carbon/identity/api/server/configs/v1/core/ServerConfigManagementService.java
@@ -112,6 +112,7 @@ import org.wso2.carbon.identity.fraud.detection.core.model.FraudDetectionConfigD
 import org.wso2.carbon.identity.fraud.detection.core.service.FraudDetectionConfigsService;
 import org.wso2.carbon.identity.oauth.dcr.DCRConfigurationMgtService;
 import org.wso2.carbon.identity.oauth.dcr.exception.DCRMException;
+import org.wso2.carbon.identity.oauth2.config.exceptions.OAuth2OIDCConfigOrgUsageScopeMgtClientException;
 import org.wso2.carbon.identity.oauth2.config.exceptions.OAuth2OIDCConfigOrgUsageScopeMgtException;
 import org.wso2.carbon.identity.oauth2.config.models.IssuerUsageScopeConfig;
 import org.wso2.carbon.identity.oauth2.config.models.UsageScope;
@@ -192,7 +193,8 @@ public class ServerConfigManagementService {
                                          FraudDetectionConfigsService fraudDetectionConfigsService,
                                          OAuth2OIDCConfigOrgUsageScopeMgtService
                                                  oauth2OIDCConfigOrgUsageScopeMgtService,
-                                         CompatibilitySettingsService identityCompatibilitySettingsService) {
+                                         CompatibilitySettingsService identityCompatibilitySettingsService,
+                                         FapiConfigMgtService fapiConfigMgtService) {
 
         this.applicationManagementService = applicationManagementService;
         this.idpManager = idpManager;
@@ -2466,6 +2468,10 @@ public class ServerConfigManagementService {
                     updateIssuerUsageScopeConfig(tenantDomain, issuerUsageScopeConfig);
             return buildIssuerUsageScopeConfig(updateIssuerUsageScopeConfig, tenantDomain);
         } catch (OAuth2OIDCConfigOrgUsageScopeMgtException | OrganizationManagementException e) {
+            if (e instanceof OAuth2OIDCConfigOrgUsageScopeMgtClientException) {
+                throw handleException(Response.Status.BAD_REQUEST,
+                        Constants.ErrorMessage.ERROR_CODE_CLIENT_ERROR_ISSUER_USAGE_SCOPE_UPDATE, e.getMessage());
+            }
             throw handleException(Response.Status.INTERNAL_SERVER_ERROR,
                     Constants.ErrorMessage.ERROR_CODE_ERROR_ISSUER_USAGE_SCOPE_UPDATE, e.getMessage());
         }

--- a/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/main/java/org/wso2/carbon/identity/api/server/configs/v1/factories/ServerConfigManagementServiceFactory.java
+++ b/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/main/java/org/wso2/carbon/identity/api/server/configs/v1/factories/ServerConfigManagementServiceFactory.java
@@ -8,6 +8,7 @@ import org.wso2.carbon.identity.cors.mgt.core.CORSManagementService;
 import org.wso2.carbon.identity.fraud.detection.core.service.FraudDetectionConfigsService;
 import org.wso2.carbon.identity.oauth.dcr.DCRConfigurationMgtService;
 import org.wso2.carbon.identity.oauth2.config.services.OAuth2OIDCConfigOrgUsageScopeMgtService;
+import org.wso2.carbon.identity.oauth2.fapi.services.FapiConfigMgtService;
 import org.wso2.carbon.identity.oauth2.impersonation.services.ImpersonationConfigMgtService;
 import org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.core.JWTClientAuthenticatorMgtService;
 import org.wso2.carbon.idp.mgt.IdentityProviderManager;
@@ -39,6 +40,7 @@ public class ServerConfigManagementServiceFactory {
                 ConfigsServiceHolder.getOAuth2OIDCConfigOrgUsageScopeMgtService();
         CompatibilitySettingsService compatibilitySettingsService = ConfigsServiceHolder
                 .getIdentityCompatibilitySettingsService();
+        FapiConfigMgtService fapiConfigMgtService = ConfigsServiceHolder.getFapiConfigMgtService();
 
         if (applicationManagementService == null) {
             throw new IllegalStateException("ApplicationManagementService is not available from OSGi context.");
@@ -81,6 +83,10 @@ public class ServerConfigManagementServiceFactory {
             throw new IllegalStateException("CompatibilitySettingsService is not available from OSGi context.");
         }
 
+        if (fapiConfigMgtService == null) {
+            throw new IllegalStateException("FapiConfigMgtService is not available from OSGi context.");
+        }
+
         SERVICE = new ServerConfigManagementService(applicationManagementService, identityProviderManager,
                 corsManagementService,
                 remoteLoggingConfigService,
@@ -89,7 +95,8 @@ public class ServerConfigManagementServiceFactory {
                 jwtClientAuthenticatorMgtService,
                 fraudDetectionConfigsService,
                 oAuth2OIDCConfigOrgUsageScopeMgtService,
-                compatibilitySettingsService
+                compatibilitySettingsService,
+                fapiConfigMgtService
                 );
     }
 

--- a/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/main/java/org/wso2/carbon/identity/api/server/configs/v1/function/DCRConnectorUtil.java
+++ b/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/main/java/org/wso2/carbon/identity/api/server/configs/v1/function/DCRConnectorUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2024-2026, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -25,11 +25,13 @@ import org.wso2.carbon.identity.api.server.common.error.APIError;
 import org.wso2.carbon.identity.api.server.common.error.ErrorResponse;
 import org.wso2.carbon.identity.api.server.configs.common.Constants;
 import org.wso2.carbon.identity.api.server.configs.v1.model.DCRConfig;
+import org.wso2.carbon.identity.api.server.configs.v1.model.FapiProfile;
 import org.wso2.carbon.identity.oauth.dcr.DCRConfigurationMgtService;
 import org.wso2.carbon.identity.oauth.dcr.exception.DCRMClientException;
 import org.wso2.carbon.identity.oauth.dcr.exception.DCRMException;
 import org.wso2.carbon.identity.oauth.dcr.exception.DCRMServerException;
 import org.wso2.carbon.identity.oauth.dcr.model.DCRConfiguration;
+import org.wso2.carbon.identity.oauth2.fapi.models.FapiProfileEnum;
 
 import javax.ws.rs.core.Response;
 
@@ -72,6 +74,7 @@ public class DCRConnectorUtil {
         dcrConfig.setEnableFapiEnforcement(dcrConfiguration.getEnableFapiEnforcement());
         dcrConfig.setSsaJwks(dcrConfiguration.getSsaJwks());
         dcrConfig.setMandateSSA(dcrConfiguration.getMandateSSA());
+        dcrConfig.setFapiProfile(FapiProfile.fromValue(dcrConfiguration.getFapiProfile()));
 
         return dcrConfig;
     }
@@ -166,6 +169,8 @@ public class DCRConnectorUtil {
         dcrConfiguration.setSsaJwks(dcrConfig.getSsaJwks());
         dcrConfiguration.setAuthenticationRequired(dcrConfig.getAuthenticationRequired());
         dcrConfiguration.setMandateSSA(dcrConfig.getMandateSSA());
+        dcrConfiguration.setFapiProfile(dcrConfig.getFapiProfile() == null ?
+                null : FapiProfileEnum.fromValue(dcrConfig.getFapiProfile().value()));
         return dcrConfiguration;
     }
 }

--- a/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/main/java/org/wso2/carbon/identity/api/server/configs/v1/function/FAPIConnectorUtil.java
+++ b/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/main/java/org/wso2/carbon/identity/api/server/configs/v1/function/FAPIConnectorUtil.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.configs.v1.function;
+
+import org.wso2.carbon.identity.api.server.configs.v1.model.FapiConfig;
+import org.wso2.carbon.identity.api.server.configs.v1.model.FapiProfile;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+/**
+ * Utility class for converting between the API-layer FAPI model and the OAuth-bundle FAPI model.
+ */
+public class FAPIConnectorUtil {
+
+    private FAPIConnectorUtil() {
+        // Utility class — no instantiation.
+    }
+
+    /**
+     * Convert an OAuth-bundle {@link org.wso2.carbon.identity.oauth2.fapi.models.FapiConfig}
+     * to the API-layer {@link FapiConfig}.
+     *
+     * @param oauthModel the OAuth bundle model; may be null.
+     * @return the API model; never null.
+     */
+    public static FapiConfig toApiModel(
+            org.wso2.carbon.identity.oauth2.fapi.models.FapiConfig oauthModel) {
+
+        FapiConfig apiModel = new FapiConfig();
+        if (oauthModel == null) {
+            apiModel.setEnabled(false);
+            apiModel.setSupportedProfiles(Collections.emptyList());
+            return apiModel;
+        }
+        apiModel.setEnabled(oauthModel.isEnabled());
+        List<org.wso2.carbon.identity.oauth2.fapi.models.FapiProfileEnum> oauthProfiles =
+                oauthModel.getSupportedProfiles();
+        if (oauthProfiles == null || oauthProfiles.isEmpty()) {
+            apiModel.setSupportedProfiles(Collections.emptyList());
+        } else {
+            apiModel.setSupportedProfiles(
+                    oauthProfiles.stream()
+                            .map(p -> FapiProfile.fromValue(p.value()))
+                            .filter(Objects::nonNull)
+                            .collect(Collectors.toList()));
+        }
+        return apiModel;
+    }
+
+    /**
+     * Convert an API-layer {@link FapiConfig} to the OAuth-bundle
+     * {@link org.wso2.carbon.identity.oauth2.fapi.models.FapiConfig}.
+     *
+     * @param apiModel the API layer model; may be null.
+     * @return the OAuth model; never null.
+     */
+    public static org.wso2.carbon.identity.oauth2.fapi.models.FapiConfig toOAuthModel(FapiConfig apiModel) {
+
+        org.wso2.carbon.identity.oauth2.fapi.models.FapiConfig oauthModel =
+                new org.wso2.carbon.identity.oauth2.fapi.models.FapiConfig();
+        if (apiModel == null) {
+            return oauthModel;
+        }
+        oauthModel.setEnabled(Boolean.TRUE.equals(apiModel.getEnabled()));
+        List<FapiProfile> apiProfiles = apiModel.getSupportedProfiles();
+        if (apiProfiles == null || apiProfiles.isEmpty()) {
+            oauthModel.setSupportedProfiles(Collections.emptyList());
+        } else {
+            oauthModel.setSupportedProfiles(
+                    apiProfiles.stream()
+                            .map(p -> org.wso2.carbon.identity.oauth2.fapi.models.FapiProfileEnum.fromValue(
+                                    p.value()))
+                            .filter(Objects::nonNull)
+                            .collect(Collectors.toList()));
+        }
+        return oauthModel;
+    }
+}

--- a/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/main/java/org/wso2/carbon/identity/api/server/configs/v1/impl/ConfigsApiServiceImpl.java
+++ b/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/main/java/org/wso2/carbon/identity/api/server/configs/v1/impl/ConfigsApiServiceImpl.java
@@ -24,6 +24,7 @@ import org.wso2.carbon.identity.api.server.configs.v1.factories.ServerConfigMana
 import org.wso2.carbon.identity.api.server.configs.v1.model.CORSPatch;
 import org.wso2.carbon.identity.api.server.configs.v1.model.CompatibilitySettings;
 import org.wso2.carbon.identity.api.server.configs.v1.model.DCRPatch;
+import org.wso2.carbon.identity.api.server.configs.v1.model.FapiConfig;
 import org.wso2.carbon.identity.api.server.configs.v1.model.FraudDetectionConfig;
 import org.wso2.carbon.identity.api.server.configs.v1.model.ImpersonationPatch;
 import org.wso2.carbon.identity.api.server.configs.v1.model.InboundAuthOAuth2Config;
@@ -120,6 +121,12 @@ public class ConfigsApiServiceImpl implements ConfigsApiService {
     }
 
     @Override
+    public Response getFAPIConfiguration() {
+
+        return Response.ok().entity(configManagementService.getFAPIConfiguration()).build();
+    }
+
+    @Override
     public Response getRemoteLoggingConfig(String logType) {
 
         RemoteServerLoggerData remoteServerLoggerResponseData =
@@ -159,6 +166,12 @@ public class ConfigsApiServiceImpl implements ConfigsApiService {
 
         configManagementService.patchDCRConfig(dcrPatch);
         return Response.ok().build();
+    }
+
+    @Override
+    public Response patchFAPIConfiguration(final FapiConfig fapiConfig) {
+
+        return Response.ok().entity(configManagementService.updateFAPIConfiguration(fapiConfig)).build();
     }
 
     @Override

--- a/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/main/java/org/wso2/carbon/identity/api/server/configs/v1/impl/ConfigsApiServiceImpl.java
+++ b/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/main/java/org/wso2/carbon/identity/api/server/configs/v1/impl/ConfigsApiServiceImpl.java
@@ -169,7 +169,7 @@ public class ConfigsApiServiceImpl implements ConfigsApiService {
     }
 
     @Override
-    public Response patchFAPIConfiguration(final FapiConfig fapiConfig) {
+    public Response updateFAPIConfiguration(final FapiConfig fapiConfig) {
 
         return Response.ok().entity(configManagementService.updateFAPIConfiguration(fapiConfig)).build();
     }

--- a/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/main/resources/configs.yaml
+++ b/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/main/resources/configs.yaml
@@ -1402,6 +1402,87 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
 
+  /configs/fapi:
+    get:
+      tags:
+        - FAPI Configurations
+      summary: Retrieve the tenant FAPI configuration.
+      operationId: getFAPIConfiguration
+      description: Retrieve the tenant Financial-grade API (FAPI) configuration.
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FapiConfig'
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '500':
+          description: Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+    patch:
+      tags:
+        - FAPI Configurations
+      summary: Patch the tenant FAPI configuration.
+      operationId: patchFAPIConfiguration
+      description: |
+        Patch the tenant Financial-grade API (FAPI) configuration.
+        <b>Scope (Permission) required:</b> <br>
+          * internal_config_update
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/FapiConfig'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FapiConfig'
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '500':
+          description: Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
   /configs/compatibility-settings:
     get:
       tags:
@@ -1606,20 +1687,20 @@ components:
       type: object
       properties:
         adminUser:
-            type: string
-            description: "Username of the super admin user in the system."
-            example: "admin"
-            readOnly: true
+          type: string
+          description: "Username of the super admin user in the system."
+          example: "admin"
+          readOnly: true
         adminRole:
-            type: string
-            description: "Name of the super admin role in the system."
-            example: "Internal/admin"
-            readOnly: true
+          type: string
+          description: "Name of the super admin role in the system."
+          example: "Internal/admin"
+          readOnly: true
         everyoneRole:
-            type: string
-            description: "Name of the everyone role in the system."
-            example: "Internal/everyone"
-            readOnly: true
+          type: string
+          description: "Name of the everyone role in the system."
+          example: "Internal/everyone"
+          readOnly: true
     ProvisioningConfig:
       type: object
       properties:
@@ -1732,7 +1813,7 @@ components:
           items:
             $ref: '#/components/schemas/AuthenticatorProperty'
         endpoint:
-            $ref: '#/components/schemas/Endpoint'
+          $ref: '#/components/schemas/Endpoint'
       required:
         - name
         - displayName
@@ -1881,6 +1962,14 @@ components:
           type: boolean
           description: If true, a FAPI compliant app will be create with DCR create request.
           example: true
+        fapiProfile:
+          description: |
+            The FAPI security profile to enforce for applications created via DCR. Applicable only when enableFapiEnforcement is true.
+            If enableFapiEnforcement is true and this property is omitted, `FAPI1_ADVANCED` will be applied by default.
+          allOf:
+            - $ref: '#/components/schemas/FapiProfile'
+          default: FAPI1_ADVANCED
+          example: FAPI1_ADVANCED
         mandateSSA:
           type: boolean
           description: If true, the software_statement parameter is mandatory for the DCR create request.
@@ -2232,3 +2321,32 @@ components:
       additionalProperties: true
       example:
         conflictOnClaimUniquenessViolation: true
+    FapiProfile:
+      type: string
+      description: |
+        FAPI security profile.
+        - `FAPI1_ADVANCED`: FAPI 1.0 Advanced Security Profile.
+        - `FAPI2_SECURITY`: FAPI 2.0 Security Profile.
+      enum:
+        - FAPI1_ADVANCED
+        - FAPI2_SECURITY
+    FapiConfig:
+      type: object
+      description: Financial-grade API (FAPI) configuration for the tenant.
+      properties:
+        enabled:
+          type: boolean
+          description: Indicates whether FAPI compliance enforcement is enabled for the tenant.
+          example: false
+          default: false
+        supportedProfiles:
+          type: array
+          description: |
+            List of FAPI security profiles supported by the tenant.
+            - `FAPI1_ADVANCED`: FAPI 1.0 Advanced Security Profile (Read and Write API Security Profile).
+            - `FAPI2_SECURITY`: FAPI 2.0 Security Profile (baseline profile for high-security OAuth 2.0 APIs).
+          items:
+            $ref: '#/components/schemas/FapiProfile'
+          example:
+            - FAPI1_ADVANCED
+            - FAPI2_SECURITY

--- a/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/main/resources/configs.yaml
+++ b/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/main/resources/configs.yaml
@@ -1402,6 +1402,87 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
 
+  /configs/fapi:
+    get:
+      tags:
+        - FAPI Configurations
+      summary: Retrieve the tenant FAPI configuration.
+      operationId: getFAPIConfiguration
+      description: Retrieve the tenant Financial-grade API (FAPI) configuration.
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FapiConfig'
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '500':
+          description: Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+    patch:
+      tags:
+        - FAPI Configurations
+      summary: Patch the tenant FAPI configuration.
+      operationId: patchFAPIConfiguration
+      description: |
+        Patch the tenant Financial-grade API (FAPI) configuration.
+        <b>Scope (Permission) required:</b> <br>
+          * internal_config_update
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/FapiConfig'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FapiConfig'
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '500':
+          description: Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
   /configs/compatibility-settings:
     get:
       tags:
@@ -1606,20 +1687,20 @@ components:
       type: object
       properties:
         adminUser:
-            type: string
-            description: "Username of the super admin user in the system."
-            example: "admin"
-            readOnly: true
+          type: string
+          description: "Username of the super admin user in the system."
+          example: "admin"
+          readOnly: true
         adminRole:
-            type: string
-            description: "Name of the super admin role in the system."
-            example: "Internal/admin"
-            readOnly: true
+          type: string
+          description: "Name of the super admin role in the system."
+          example: "Internal/admin"
+          readOnly: true
         everyoneRole:
-            type: string
-            description: "Name of the everyone role in the system."
-            example: "Internal/everyone"
-            readOnly: true
+          type: string
+          description: "Name of the everyone role in the system."
+          example: "Internal/everyone"
+          readOnly: true
     ProvisioningConfig:
       type: object
       properties:
@@ -1732,7 +1813,7 @@ components:
           items:
             $ref: '#/components/schemas/AuthenticatorProperty'
         endpoint:
-            $ref: '#/components/schemas/Endpoint'
+          $ref: '#/components/schemas/Endpoint'
       required:
         - name
         - displayName
@@ -1883,6 +1964,14 @@ components:
           type: boolean
           description: If true, a FAPI compliant app will be create with DCR create request.
           example: true
+        fapiProfile:
+          description: |
+            The FAPI security profile to enforce for applications created via DCR. Applicable only when enableFapiEnforcement is true.
+            If enableFapiEnforcement is true and this property is omitted, `FAPI1_ADVANCED` will be applied by default.
+          allOf:
+            - $ref: '#/components/schemas/FapiProfile'
+          default: FAPI1_ADVANCED
+          example: FAPI1_ADVANCED
         mandateSSA:
           type: boolean
           description: If true, the software_statement parameter is mandatory for the DCR create request.
@@ -2234,3 +2323,32 @@ components:
       additionalProperties: true
       example:
         conflictOnClaimUniquenessViolation: true
+    FapiProfile:
+      type: string
+      description: |
+        FAPI security profile.
+        - `FAPI1_ADVANCED`: FAPI 1.0 Advanced Security Profile.
+        - `FAPI2_SECURITY`: FAPI 2.0 Security Profile.
+      enum:
+        - FAPI1_ADVANCED
+        - FAPI2_SECURITY
+    FapiConfig:
+      type: object
+      description: Financial-grade API (FAPI) configuration for the tenant.
+      properties:
+        enabled:
+          type: boolean
+          description: Indicates whether FAPI compliance enforcement is enabled for the tenant.
+          example: false
+          default: false
+        supportedProfiles:
+          type: array
+          description: |
+            List of FAPI security profiles supported by the tenant.
+            - `FAPI1_ADVANCED`: FAPI 1.0 Advanced Security Profile (Read and Write API Security Profile).
+            - `FAPI2_SECURITY`: FAPI 2.0 Security Profile (baseline profile for high-security OAuth 2.0 APIs).
+          items:
+            $ref: '#/components/schemas/FapiProfile'
+          example:
+            - FAPI1_ADVANCED
+            - FAPI2_SECURITY

--- a/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/main/resources/configs.yaml
+++ b/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/main/resources/configs.yaml
@@ -1408,7 +1408,9 @@ paths:
         - FAPI Configurations
       summary: Retrieve the tenant FAPI configuration.
       operationId: getFAPIConfiguration
-      description: Retrieve the tenant Financial-grade API (FAPI) configuration.
+      description: |
+        Retrieve the tenant Financial-grade API (FAPI) configuration.
+        <b>Scope (Permission) required:</b> `internal_config_view`
       responses:
         '200':
           description: Successful Response
@@ -1438,13 +1440,13 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-    patch:
+    put:
       tags:
         - FAPI Configurations
-      summary: Patch the tenant FAPI configuration.
-      operationId: patchFAPIConfiguration
+      summary: Update the tenant FAPI configuration.
+      operationId: updateFAPIConfiguration
       description: |
-        Patch the tenant Financial-grade API (FAPI) configuration.
+        Update the tenant Financial-grade API (FAPI) configuration.
         <b>Scope (Permission) required:</b> <br>
           * internal_config_update
       requestBody:
@@ -1970,7 +1972,6 @@ components:
             If enableFapiEnforcement is true and this property is omitted, `FAPI1_ADVANCED` will be applied by default.
           allOf:
             - $ref: '#/components/schemas/FapiProfile'
-          default: FAPI1_ADVANCED
           example: FAPI1_ADVANCED
         mandateSSA:
           type: boolean

--- a/pom.xml
+++ b/pom.xml
@@ -1109,7 +1109,7 @@
         <maven.buildnumber.plugin.version>1.4</maven.buildnumber.plugin.version>
         <org.apache.felix.annotations.version>1.2.4</org.apache.felix.annotations.version>
         <identity.governance.version>1.11.103</identity.governance.version>
-        <carbon.identity.framework.version>7.11.112</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.11.115</carbon.identity.framework.version>
         <maven.findbugsplugin.version>3.0.5</maven.findbugsplugin.version>
         <spotbugs.maven.plugin.version>4.9.8.2</spotbugs.maven.plugin.version>
         <spotbugs.annotations.version>4.9.8</spotbugs.annotations.version>
@@ -1118,7 +1118,7 @@
         <maven.checkstyleplugin.excludes>**/gen/**/*</maven.checkstyleplugin.excludes>
         <identity.event.handler.version>1.12.4</identity.event.handler.version>
         <identity.data.publisher.authentication.version>5.10.1</identity.data.publisher.authentication.version>
-        <identity.inbound.oauth2.version>7.5.46</identity.inbound.oauth2.version>
+        <identity.inbound.oauth2.version>7.5.49</identity.inbound.oauth2.version>
         <identity.inbound.saml2.version>5.11.51</identity.inbound.saml2.version>
         <identity.x509Certificate.validation.version>1.1.19</identity.x509Certificate.validation.version>
         <commons.beanutils.version>1.9.4</commons.beanutils.version>


### PR DESCRIPTION
## Purpose
 Adds tenant-level Financial-grade API (FAPI) configuration support to the Identity Server REST API. The missing model layer between the configs API and the OAuth bundle for FAPI compliance settings is introduced.

Resolves wso2-enterprise/iam-product-management#601
 
 ## Goals
 - Expose tenant-level FAPI configuration (enabled flag + supported security profiles)
   via the configs API model layer.
 - Add `FapiProfile` enum to both the application management and configs API modules.
 - Provide `FAPIConnectorUtil` to cleanly convert between API-layer FAPI models and
   OAuth bundle FAPI models.
 - Default the FAPI security profile to `FAPI1_ADVANCED` when an application is marked
   as FAPI-enabled but no profile is explicitly provided.
 
 ## Approach
 - Added generated model classes `FapiConfig` and `FapiProfile` under
   `org.wso2.carbon.identity.api.server.configs.v1.model` for tenant-level FAPI config.
 - Added `FapiProfile` enum under
   `org.wso2.carbon.identity.api.server.application.management.v1`.
 - Introduced `FAPIConnectorUtil` with `toApiModel()` and `toOAuthModel()` methods for
   bi-directional conversion between the API layer and the OAuth bundle.
 - Updated `ApiModelToOAuthConsumerApp` to apply the `FAPI1_ADVANCED` default when
   `isFAPIApplication` is `true` and no profile is specified, replacing verbose conditional
   comment logic.
 
 ## User stories
 > As a tenant admin, I want to configure FAPI compliance settings at the tenant level
 > so that applications within my tenant adhere to the required financial-grade security profiles.
 
 ## Developer Checklist (Mandatory)
 - [ ] Complete the **Developer Checklist** in the related `product-is` issue to track
   any behavioral change or migration impact.
 
 ## Release note
 Added tenant-level FAPI (Financial-grade API) configuration model support, including
 enabled/disabled toggle and supported security profiles (`FAPI1_ADVANCED`, `FAPI2_SECURITY`).
 Applications are now defaulted to `FAPI1_ADVANCED` when FAPI is enabled but no profile
 is specified.
 
 ## Documentation
 > N/A — Internal model/utility layer; no user-facing documentation change required.
 
 ## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes