### PR TITLE
Improve action api for provide OAuth2 client Credential based Authentication Support

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.action.management/org.wso2.carbon.identity.api.server.action.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/action/management/v1/AuthenticationType.java
+++ b/components/org.wso2.carbon.identity.api.server.action.management/org.wso2.carbon.identity.api.server.action.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/action/management/v1/AuthenticationType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2024-2026, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -28,14 +28,14 @@ import java.util.Map;
 import javax.validation.constraints.*;
 
 /**
- * The type of authentication required by the action&#39;s endpoint. The following options are supported: - NONE: No authentication is required. &lt;br&gt;   &#x60;&#x60;{     \&quot;type\&quot;: \&quot;NONE\&quot;   }&#x60;&#x60;  - BASIC: Basic authentication with a username and password.&lt;br&gt;   &#x60;&#x60;{     \&quot;type\&quot;: \&quot;BASIC\&quot;,     \&quot;properties\&quot;: {       \&quot;username\&quot;: \&quot;auth_username\&quot;,       \&quot;password\&quot;: \&quot;auth_password\&quot;     }   }&#x60;&#x60;  - API_KEY: API key-based authentication, where the key is provided in an HTTP header.&lt;br&gt;   &#x60;&#x60;{     \&quot;type\&quot;: \&quot;API_KEY\&quot;,     \&quot;properties\&quot;: {       \&quot;header\&quot;: \&quot;X-API-Key\&quot;,       \&quot;value\&quot;: \&quot;12345-abcde-67890\&quot;     }   }&#x60;&#x60;  - BEARER: Bearer token-based authentication.&lt;br/&gt;   &#x60;&#x60;{     \&quot;type\&quot;: \&quot;BEARER\&quot;,     \&quot;properties\&quot;: {       \&quot;accessToken\&quot;: \&quot;0d6fed02-eac0-332b-8998-213a543139a0\&quot;     }   }&#x60;&#x60; 
+ * The type of authentication required by the action&#39;s endpoint. The following options are supported: - NONE: No authentication is required. &lt;br&gt;   &#x60;&#x60;{     \&quot;type\&quot;: \&quot;NONE\&quot;   }&#x60;&#x60;  - BASIC: Basic authentication with a username and password.&lt;br&gt;   &#x60;&#x60;{     \&quot;type\&quot;: \&quot;BASIC\&quot;,     \&quot;properties\&quot;: {       \&quot;username\&quot;: \&quot;auth_username\&quot;,       \&quot;password\&quot;: \&quot;auth_password\&quot;     }   }&#x60;&#x60;  - API_KEY: API key-based authentication, where the key is provided in an HTTP header.&lt;br&gt;   &#x60;&#x60;{     \&quot;type\&quot;: \&quot;API_KEY\&quot;,     \&quot;properties\&quot;: {       \&quot;header\&quot;: \&quot;X-API-Key\&quot;,       \&quot;value\&quot;: \&quot;12345-abcde-67890\&quot;     }   }&#x60;&#x60;  - BEARER: Bearer token-based authentication.&lt;br/&gt;   &#x60;&#x60;{     \&quot;type\&quot;: \&quot;BEARER\&quot;,     \&quot;properties\&quot;: {       \&quot;accessToken\&quot;: \&quot;0d6fed02-eac0-332b-8998-213a543139a0\&quot;     }   }&#x60;&#x60;  - CLIENT_CREDENTIAL: OAuth2 client credentials grant based authentication.&lt;br/&gt;   &#x60;&#x60;{     \&quot;type\&quot;: \&quot;CLIENT_CREDENTIAL\&quot;,     \&quot;properties\&quot;: {       \&quot;clientId\&quot;: \&quot;3e172dd2-901b-43a9-a26a-728466795f01\&quot;,       \&quot;clientSecret\&quot;: \&quot;83cdc120-ccf6-4163-a4a8-c1ba3e872daa\&quot;,       \&quot;tokenEndpoint\&quot;: \&quot;https://custom.idp.com/todos\&quot;,       \&quot;scopes\&quot;: \&quot;send_scope\&quot;     }   }&#x60;&#x60; 
  **/
 
 import io.swagger.annotations.*;
 import java.util.Objects;
 import javax.validation.Valid;
 import javax.xml.bind.annotation.*;
-@ApiModel(description = "The type of authentication required by the action's endpoint. The following options are supported: - NONE: No authentication is required. <br>   ``{     \"type\": \"NONE\"   }``  - BASIC: Basic authentication with a username and password.<br>   ``{     \"type\": \"BASIC\",     \"properties\": {       \"username\": \"auth_username\",       \"password\": \"auth_password\"     }   }``  - API_KEY: API key-based authentication, where the key is provided in an HTTP header.<br>   ``{     \"type\": \"API_KEY\",     \"properties\": {       \"header\": \"X-API-Key\",       \"value\": \"12345-abcde-67890\"     }   }``  - BEARER: Bearer token-based authentication.<br/>   ``{     \"type\": \"BEARER\",     \"properties\": {       \"accessToken\": \"0d6fed02-eac0-332b-8998-213a543139a0\"     }   }`` ")
+@ApiModel(description = "The type of authentication required by the action's endpoint. The following options are supported: - NONE: No authentication is required. <br>   ``{     \"type\": \"NONE\"   }``  - BASIC: Basic authentication with a username and password.<br>   ``{     \"type\": \"BASIC\",     \"properties\": {       \"username\": \"auth_username\",       \"password\": \"auth_password\"     }   }``  - API_KEY: API key-based authentication, where the key is provided in an HTTP header.<br>   ``{     \"type\": \"API_KEY\",     \"properties\": {       \"header\": \"X-API-Key\",       \"value\": \"12345-abcde-67890\"     }   }``  - BEARER: Bearer token-based authentication.<br/>   ``{     \"type\": \"BEARER\",     \"properties\": {       \"accessToken\": \"0d6fed02-eac0-332b-8998-213a543139a0\"     }   }``  - CLIENT_CREDENTIAL: OAuth2 client credentials grant based authentication.<br/>   ``{     \"type\": \"CLIENT_CREDENTIAL\",     \"properties\": {       \"clientId\": \"3e172dd2-901b-43a9-a26a-728466795f01\",       \"clientSecret\": \"83cdc120-ccf6-4163-a4a8-c1ba3e872daa\",       \"tokenEndpoint\": \"https://custom.idp.com/todos\",       \"scopes\": \"send_scope\"     }   }`` ")
 public class AuthenticationType  {
   
 
@@ -43,7 +43,7 @@ public class AuthenticationType  {
 @XmlEnum(String.class)
 public enum TypeEnum {
 
-    @XmlEnumValue("NONE") NONE(String.valueOf("NONE")), @XmlEnumValue("BEARER") BEARER(String.valueOf("BEARER")), @XmlEnumValue("API_KEY") API_KEY(String.valueOf("API_KEY")), @XmlEnumValue("BASIC") BASIC(String.valueOf("BASIC"));
+    @XmlEnumValue("NONE") NONE(String.valueOf("NONE")), @XmlEnumValue("BEARER") BEARER(String.valueOf("BEARER")), @XmlEnumValue("API_KEY") API_KEY(String.valueOf("API_KEY")), @XmlEnumValue("BASIC") BASIC(String.valueOf("BASIC")), @XmlEnumValue("CLIENT_CREDENTIAL") CLIENT_CREDENTIAL(String.valueOf("CLIENT_CREDENTIAL"));
 
 
     private String value;

--- a/components/org.wso2.carbon.identity.api.server.action.management/org.wso2.carbon.identity.api.server.action.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/action/management/v1/AuthenticationTypeResponse.java
+++ b/components/org.wso2.carbon.identity.api.server.action.management/org.wso2.carbon.identity.api.server.action.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/action/management/v1/AuthenticationTypeResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2024-2026, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -22,6 +22,9 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import javax.validation.constraints.*;
 
 /**
@@ -40,7 +43,7 @@ public class AuthenticationTypeResponse  {
 @XmlEnum(String.class)
 public enum TypeEnum {
 
-    @XmlEnumValue("NONE") NONE(String.valueOf("NONE")), @XmlEnumValue("BEARER") BEARER(String.valueOf("BEARER")), @XmlEnumValue("API_KEY") API_KEY(String.valueOf("API_KEY")), @XmlEnumValue("BASIC") BASIC(String.valueOf("BASIC"));
+    @XmlEnumValue("NONE") NONE(String.valueOf("NONE")), @XmlEnumValue("BEARER") BEARER(String.valueOf("BEARER")), @XmlEnumValue("API_KEY") API_KEY(String.valueOf("API_KEY")), @XmlEnumValue("BASIC") BASIC(String.valueOf("BASIC")), @XmlEnumValue("CLIENT_CREDENTIAL") CLIENT_CREDENTIAL(String.valueOf("CLIENT_CREDENTIAL"));
 
 
     private String value;
@@ -69,6 +72,8 @@ public enum TypeEnum {
 }
 
     private TypeEnum type;
+    private Map<String, Object> properties = null;
+
 
     /**
     * Type of the authentication.
@@ -91,6 +96,34 @@ public enum TypeEnum {
         this.type = type;
     }
 
+    /**
+    * Authentication properties(without secrets) specific to the selected type.
+    **/
+    public AuthenticationTypeResponse properties(Map<String, Object> properties) {
+
+        this.properties = properties;
+        return this;
+    }
+
+    @ApiModelProperty(value = "Authentication properties(without secrets) specific to the selected type.")
+    @JsonProperty("properties")
+    @Valid
+    public Map<String, Object> getProperties() {
+        return properties;
+    }
+    public void setProperties(Map<String, Object> properties) {
+        this.properties = properties;
+    }
+
+
+    public AuthenticationTypeResponse putPropertiesItem(String key, Object propertiesItem) {
+        if (this.properties == null) {
+            this.properties = new HashMap<String, Object>();
+        }
+        this.properties.put(key, propertiesItem);
+        return this;
+    }
+
 
 
     @Override
@@ -103,12 +136,13 @@ public enum TypeEnum {
             return false;
         }
         AuthenticationTypeResponse authenticationTypeResponse = (AuthenticationTypeResponse) o;
-        return Objects.equals(this.type, authenticationTypeResponse.type);
+        return Objects.equals(this.type, authenticationTypeResponse.type) &&
+            Objects.equals(this.properties, authenticationTypeResponse.properties);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(type);
+        return Objects.hash(type, properties);
     }
 
     @Override
@@ -118,6 +152,7 @@ public enum TypeEnum {
         sb.append("class AuthenticationTypeResponse {\n");
         
         sb.append("    type: ").append(toIndentedString(type)).append("\n");
+        sb.append("    properties: ").append(toIndentedString(properties)).append("\n");
         sb.append("}");
         return sb.toString();
     }

--- a/components/org.wso2.carbon.identity.api.server.action.management/org.wso2.carbon.identity.api.server.action.management.v1/src/main/java/org/wso2/carbon/identity/api/server/action/management/v1/util/ActionMapperUtil.java
+++ b/components/org.wso2.carbon.identity.api.server.action.management/org.wso2.carbon.identity.api.server.action.management.v1/src/main/java/org/wso2/carbon/identity/api/server/action/management/v1/util/ActionMapperUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2024-2026, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -37,6 +37,7 @@ import org.wso2.carbon.identity.api.server.action.management.v1.Link;
 import org.wso2.carbon.identity.api.server.action.management.v1.constants.ActionMgtEndpointConstants;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -146,13 +147,51 @@ public class ActionMapperUtil {
                 .updatedAt(action.getUpdatedAt() != null ? action.getUpdatedAt().toInstant().toString() : null)
                 .endpoint(new EndpointResponse()
                         .uri(action.getEndpoint().getUri())
-                        .authentication(new AuthenticationTypeResponse()
-                                .type(AuthenticationTypeResponse.TypeEnum.valueOf(action.getEndpoint()
-                                        .getAuthentication().getType().toString())))
+                        .authentication(buildAuthenticationTypeResponse(action.getEndpoint().getAuthentication(),
+                                action.getId()))
                         .allowedHeaders(action.getEndpoint().getAllowedHeaders())
                         .allowedParameters(action.getEndpoint().getAllowedParameters()))
                 .rule((action.getActionRule() != null) ? RuleMapper.toORRuleResponse(action.getActionRule()) :
                         null);
+    }
+
+    public static AuthenticationTypeResponse buildAuthenticationTypeResponse(Authentication authentication,
+                                                                             String actionId) {
+
+        AuthenticationTypeResponse authenticationTypeResponse = new AuthenticationTypeResponse()
+                .type(AuthenticationTypeResponse.TypeEnum.valueOf(authentication.getType().toString()));
+        Map<String, Object> authenticationProperties = new HashMap<>();
+
+        switch (authentication.getType()) {
+            case BASIC:
+                authenticationProperties.put(Authentication.Property.USERNAME.getName(),
+                        authentication.getPropertyWithDecryptedValue(
+                                actionId, Authentication.Property.USERNAME.getName()).getValue());
+                authenticationTypeResponse.setProperties(authenticationProperties);
+                break;
+            case BEARER:
+                break;
+            case API_KEY:
+                authenticationProperties.put(Authentication.Property.HEADER.getName(),
+                        authentication.getProperty(Authentication.Property.HEADER).getValue());
+                authenticationTypeResponse.setProperties(authenticationProperties);
+                break;
+            case CLIENT_CREDENTIAL:
+                authenticationProperties.put(Authentication.Property.CLIENT_ID.getName(),
+                        authentication.getPropertyWithDecryptedValue(
+                                actionId, Authentication.Property.CLIENT_ID.getName()).getValue());
+                authenticationProperties.put(Authentication.Property.TOKEN_ENDPOINT.getName(),
+                        authentication.getProperty(Authentication.Property.TOKEN_ENDPOINT).getValue());
+                if (authentication.getProperty(Authentication.Property.SCOPES) != null) {
+                    authenticationProperties.put(Authentication.Property.SCOPES.getName(),
+                            authentication.getProperty(Authentication.Property.SCOPES).getValue());
+                }
+                authenticationTypeResponse.setProperties(authenticationProperties);
+                break;
+            case NONE:
+                break;
+        }
+        return authenticationTypeResponse;
     }
 
     /**
@@ -253,6 +292,30 @@ public class ActionMapperUtil {
                 }
 
                 return new Authentication.APIKeyAuthBuilder(header, value).build();
+            case CLIENT_CREDENTIAL:
+                if (authPropertiesMap == null
+                        || !authPropertiesMap.containsKey(Authentication.Property.CLIENT_ID.getName())
+                        || !authPropertiesMap.containsKey(Authentication.Property.CLIENT_SECRET.getName())
+                        || !authPropertiesMap.containsKey(Authentication.Property.TOKEN_ENDPOINT.getName())) {
+                    throw ActionMgtEndpointUtil.handleException(Response.Status.BAD_REQUEST,
+                            ERROR_INVALID_ACTION_ENDPOINT_AUTHENTICATION_PROPERTIES);
+                }
+                String clientId = (String) authPropertiesMap.get(Authentication.Property.CLIENT_ID.getName());
+                String clientSecret = (String) authPropertiesMap.get(Authentication.Property.CLIENT_SECRET.getName());
+                String tokenEndpoint = (String) authPropertiesMap.get(Authentication.Property.TOKEN_ENDPOINT.getName());
+                String scopes = StringUtils.EMPTY;
+                if (authPropertiesMap.containsKey(Authentication.Property.SCOPES.getName())) {
+                    scopes = (String) authPropertiesMap.get(Authentication.Property.SCOPES.getName());
+                }
+
+                if (StringUtils.isEmpty(clientId) || StringUtils.isEmpty(clientSecret) ||
+                        StringUtils.isEmpty(tokenEndpoint)) {
+                    throw ActionMgtEndpointUtil.handleException(Response.Status.BAD_REQUEST,
+                            ERROR_EMPTY_ACTION_ENDPOINT_AUTHENTICATION_PROPERTIES);
+                }
+
+                return new Authentication.ClientCredentialAuthBuilder(clientId, clientSecret, tokenEndpoint,
+                        scopes).build();
             case NONE:
                 return new Authentication.NoneAuthBuilder().build();
             default:

--- a/components/org.wso2.carbon.identity.api.server.action.management/org.wso2.carbon.identity.api.server.action.management.v1/src/main/resources/Actions.yaml
+++ b/components/org.wso2.carbon.identity.api.server.action.management/org.wso2.carbon.identity.api.server.action.management.v1/src/main/resources/Actions.yaml
@@ -1767,6 +1767,17 @@ components:
               "accessToken": "0d6fed02-eac0-332b-8998-213a543139a0"
             }
           }``
+        
+        - CLIENT_CREDENTIAL: OAuth2 client credentials grant based authentication.<br/>
+          ``{
+            "type": "CLIENT_CREDENTIAL",
+            "properties": {
+              "clientId": "3e172dd2-901b-43a9-a26a-728466795f01",
+              "clientSecret": "83cdc120-ccf6-4163-a4a8-c1ba3e872daa",
+              "tokenEndpoint": "https://custom.idp.com/todos",
+              "scopes": "send_scope"
+            }
+          }``
       required:
         - type
       properties:
@@ -1777,6 +1788,7 @@ components:
             - BEARER
             - API_KEY
             - BASIC
+            - CLIENT_CREDENTIAL
           example: BASIC
         properties:
           type: object
@@ -1801,8 +1813,17 @@ components:
             - BEARER
             - API_KEY
             - BASIC
+            - CLIENT_CREDENTIAL
           description: Type of the authentication.
           example: BASIC
+        properties:
+          type: object
+          description: Authentication properties(without secrets) specific to the selected type.
+          additionalProperties: true
+      example:
+        type: BASIC
+        properties:
+          username: "auth_username"
 
     ActionUpdateModel:
       type: object

--- a/pom.xml
+++ b/pom.xml
@@ -1057,7 +1057,7 @@
         <maven.buildnumber.plugin.version>1.4</maven.buildnumber.plugin.version>
         <org.apache.felix.annotations.version>1.2.4</org.apache.felix.annotations.version>
         <identity.governance.version>1.11.103</identity.governance.version>
-        <carbon.identity.framework.version>7.10.68</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.11.68</carbon.identity.framework.version>
         <maven.findbugsplugin.version>3.0.5</maven.findbugsplugin.version>
         <spotbugs.maven.plugin.version>4.9.8.2</spotbugs.maven.plugin.version>
         <spotbugs.annotations.version>4.9.8</spotbugs.annotations.version>


### PR DESCRIPTION
## Purpose
- Improve action api for provide OAuth2 client Credential based Authentication Support.
- Related Issue: https://github.com/wso2/product-is/issues/27681

## Summary

This pull request enhances the Action Management API by adding support for OAuth2 client credentials (CLIENT_CREDENTIAL) as a new authentication type for action endpoints. It updates the OpenAPI specification, backend model classes, and mapping utilities to handle the new authentication type and its properties, ensuring that relevant properties are processed and exposed correctly in API responses.

**Authentication Enhancements:**

* Added support for the `CLIENT_CREDENTIAL` authentication type (OAuth2 client credentials grant) in both the API specification (`Actions.yaml`) and backend model classes (`AuthenticationType`, `AuthenticationTypeResponse`). This includes updates to enums, documentation, and examples. [[1]](diffhunk://#diff-26a483ba5ce72ca814171ebfb2bfb92cf1b21ed743d41c4bd1c6f0c1a298101eL31-R46) [[2]](diffhunk://#diff-ac858e1a82cd6042cc8a00825b45654f5d268074fe8f69cca751ec511ea2d157L43-R46) [[3]](diffhunk://#diff-b37a76dc460431f4a8520694cad363f85f33806fe61dc5921d022841bfba8c26R1773-R1783) [[4]](diffhunk://#diff-b37a76dc460431f4a8520694cad363f85f33806fe61dc5921d022841bfba8c26R1794)
* Updated the backend logic in `ActionMapperUtil.java` to build and validate `CLIENT_CREDENTIAL` authentication types, including mapping and extracting relevant properties (clientId, clientSecret, tokenEndpoint, scopes) and ensuring required fields are present. [[1]](diffhunk://#diff-bdc8c90629b116f3370d9318fb8c9008148411558008447a823d569e72892f7eL149-R194) [[2]](diffhunk://#diff-bdc8c90629b116f3370d9318fb8c9008148411558008447a823d569e72892f7eR293-R316)

**API Model and Response Improvements:**

* Extended `AuthenticationTypeResponse` to include a flexible `properties` map for authentication-type-specific properties (excluding secrets), with new getter/setter methods and improved equality/hashCode logic. [[1]](diffhunk://#diff-ac858e1a82cd6042cc8a00825b45654f5d268074fe8f69cca751ec511ea2d157R75) [[2]](diffhunk://#diff-ac858e1a82cd6042cc8a00825b45654f5d268074fe8f69cca751ec511ea2d157R98-R125) [[3]](diffhunk://#diff-ac858e1a82cd6042cc8a00825b45654f5d268074fe8f69cca751ec511ea2d157L106-R144) [[4]](diffhunk://#diff-ac858e1a82cd6042cc8a00825b45654f5d268074fe8f69cca751ec511ea2d157R154)

**OpenAPI/Documentation Updates:**

* Expanded the OpenAPI spec (`Actions.yaml`) to document the new authentication type, its required properties, and provide examples for `CLIENT_CREDENTIAL`. Also added a mock server entry and updated the API version. [[1]](diffhunk://#diff-b37a76dc460431f4a8520694cad363f85f33806fe61dc5921d022841bfba8c26L3-R3) [[2]](diffhunk://#diff-b37a76dc460431f4a8520694cad363f85f33806fe61dc5921d022841bfba8c26R12-R14) [[3]](diffhunk://#diff-b37a76dc460431f4a8520694cad363f85f33806fe61dc5921d022841bfba8c26R1819-R1829)

**Dependency Updates:**

* Updated the `carbon.identity.framework.version` dependency in `pom.xml` to a newer snapshot version, likely to support the new features.

**Minor/Housekeeping:**

* Updated copyright years in generated Java files.
* Added necessary imports for new features. [[1]](diffhunk://#diff-26a483ba5ce72ca814171ebfb2bfb92cf1b21ed743d41c4bd1c6f0c1a298101eL2-R2) [[2]](diffhunk://#diff-ac858e1a82cd6042cc8a00825b45654f5d268074fe8f69cca751ec511ea2d157L2-R2) [[3]](diffhunk://#diff-ac858e1a82cd6042cc8a00825b45654f5d268074fe8f69cca751ec511ea2d157R25-R27) [[4]](diffhunk://#diff-bdc8c90629b116f3370d9318fb8c9008148411558008447a823d569e72892f7eR40)

