### PR TITLE
Add REST API for connection sharing management

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.organization.connection.sharing.management/org.wso2.carbon.identity.api.server.organization.connection.sharing.management.common/pom.xml
+++ b/components/org.wso2.carbon.identity.api.server.organization.connection.sharing.management/org.wso2.carbon.identity.api.server.organization.connection.sharing.management.common/pom.xml
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+  ~
+  ~ WSO2 LLC. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.wso2.carbon.identity.server.api</groupId>
+        <artifactId>org.wso2.carbon.identity.api.server.organization.connection.sharing.management</artifactId>
+        <version>1.6.8-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>org.wso2.carbon.identity.api.server.organization.connection.sharing.management.common</artifactId>
+    <packaging>jar</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.organization.management</groupId>
+            <artifactId>org.wso2.carbon.identity.organization.management.organization.connection.sharing</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon</groupId>
+            <artifactId>org.wso2.carbon.utils</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.cxf</groupId>
+            <artifactId>cxf-rt-frontend-jaxrs</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.cxf</groupId>
+            <artifactId>cxf-rt-rs-service-description</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>javax.ws.rs</groupId>
+            <artifactId>javax.ws.rs-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.jaxrs</groupId>
+            <artifactId>jackson-jaxrs-json-provider</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.swagger</groupId>
+            <artifactId>swagger-jaxrs</artifactId>
+            <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-databind</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-annotations</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.dataformat</groupId>
+                    <artifactId>jackson-dataformat-yaml</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>javax.ws.rs</groupId>
+                    <artifactId>jsr311-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.google.guava</groupId>
+                    <artifactId>guava</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
+
+    <properties>
+        <maven.compiler.source>8</maven.compiler.source>
+        <maven.compiler.target>8</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+</project>

--- a/components/org.wso2.carbon.identity.api.server.organization.connection.sharing.management/org.wso2.carbon.identity.api.server.organization.connection.sharing.management.common/src/main/java/org/wso2/carbon/identity/api/server/organization/connection/sharing/management/common/ConnectionSharingMgtServiceHolder.java
+++ b/components/org.wso2.carbon.identity.api.server.organization.connection.sharing.management/org.wso2.carbon.identity.api.server.organization.connection.sharing.management.common/src/main/java/org/wso2/carbon/identity/api/server/organization/connection/sharing/management/common/ConnectionSharingMgtServiceHolder.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.organization.connection.sharing.management.common;
+
+import org.wso2.carbon.context.PrivilegedCarbonContext;
+import org.wso2.carbon.identity.organization.management.organization.connection.sharing.ConnectionSharingPolicyHandlerService;
+
+/**
+ * Holds the services which the connection sharing management API component is using.
+ */
+public class ConnectionSharingMgtServiceHolder {
+
+    private ConnectionSharingMgtServiceHolder() {
+
+    }
+
+    private static class ConnectionSharingPolicyHandlerServiceHolder {
+
+        private static final ConnectionSharingPolicyHandlerService SERVICE =
+                (ConnectionSharingPolicyHandlerService) PrivilegedCarbonContext
+                        .getThreadLocalCarbonContext()
+                        .getOSGiService(ConnectionSharingPolicyHandlerService.class, null);
+    }
+
+    /**
+     * Get ConnectionSharingPolicyHandlerService.
+     *
+     * @return ConnectionSharingPolicyHandlerService.
+     */
+    public static ConnectionSharingPolicyHandlerService getConnectionSharingPolicyHandlerService() {
+
+        return ConnectionSharingMgtServiceHolder.ConnectionSharingPolicyHandlerServiceHolder.SERVICE;
+    }
+}

--- a/components/org.wso2.carbon.identity.api.server.organization.connection.sharing.management/org.wso2.carbon.identity.api.server.organization.connection.sharing.management.common/src/main/java/org/wso2/carbon/identity/api/server/organization/connection/sharing/management/common/constants/ConnectionSharingMgtConstants.java
+++ b/components/org.wso2.carbon.identity.api.server.organization.connection.sharing.management/org.wso2.carbon.identity.api.server.organization.connection.sharing.management.common/src/main/java/org/wso2/carbon/identity/api/server/organization/connection/sharing/management/common/constants/ConnectionSharingMgtConstants.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.organization.connection.sharing.management.common.constants;
+
+/**
+ * Holds the constants which the connection sharing management API component is using.
+ */
+public class ConnectionSharingMgtConstants {
+
+    public static final String ERROR_PREFIX = "CSM-";
+
+    public static final String CONNECTION_IDS = "CONNECTION_IDS";
+    public static final String CONNECTION_NAMES = "CONNECTION_NAMES";
+
+    public static final String RESPONSE_STATUS_PROCESSING = "Processing";
+    public static final String RESPONSE_DETAIL_CONNECTION_SHARE = "Connection sharing process triggered successfully.";
+    public static final String RESPONSE_DETAIL_CONNECTION_UNSHARE =
+            "Connection unsharing process triggered successfully.";
+
+    /**
+     * Enum for connection sharing management related errors.
+     * Error Code - code to identify the error.
+     * Error Message - What went wrong.
+     * Error Description - Why it went wrong.
+     */
+    public enum ErrorMessage {
+
+        // Client errors.
+        INVALID_SELECTIVE_CONNECTION_SHARE_REQUEST_BODY("60000",
+                "Invalid selective connection share request body.",
+                "The connection criteria provided for selective sharing is either null or empty. " +
+                        "Please provide valid selective connection sharing criteria."),
+        INVALID_GENERAL_CONNECTION_SHARE_REQUEST_BODY("60001",
+                "Invalid general connection share request body.",
+                "The connection criteria provided for general sharing is either null or empty. " +
+                        "Please provide valid general connection sharing criteria."),
+        INVALID_SELECTIVE_CONNECTION_UNSHARE_REQUEST_BODY("60002",
+                "Invalid selective connection unshare request body.",
+                "The connection criteria provided for selective unsharing is either null or empty. " +
+                        "Please provide valid selective connection unsharing criteria."),
+        INVALID_GENERAL_CONNECTION_UNSHARE_REQUEST_BODY("60003",
+                "Invalid general connection unshare request body.",
+                "The connection criteria provided for general unsharing is either null or empty. " +
+                        "Please provide valid general connection unsharing criteria."),
+        ERROR_MISSING_CONNECTION_CRITERIA("60004",
+                "Missing connection criteria in the request body.",
+                "The connection criteria is missing in the request body. " +
+                        "Please provide the connection criteria to proceed."),
+        ERROR_UNSUPPORTED_CONNECTION_SHARE_POLICY("60005",
+                "Unsupported connection share policy.",
+                "The provided connection share policy is not supported. " +
+                        "Please provide a valid connection share policy."),
+        INVALID_UUID_FORMAT("60006",
+                "Invalid UUID format.",
+                "The UUID provided in the request is not in a valid format. " +
+                        "Please provide a valid UUID."),
+        ERROR_INVALID_LIMIT("60007",
+                "Invalid limit value.",
+                "The limit value provided in the request is invalid. " +
+                        "Please provide a valid limit value."),
+        ERROR_INVALID_CURSOR("60008",
+                "Invalid cursor value.",
+                "The cursor value provided in the request is invalid. " +
+                        "Please provide a valid cursor value."),
+
+        // Server errors.
+        ERROR_INITIATING_CONNECTIONS_API_SERVICE("65001",
+                "Error initiating ConnectionsApiService.",
+                "Error occurred while initiating ConnectionsApiService.");
+
+        private final String code;
+        private final String message;
+        private final String description;
+
+        ErrorMessage(String code, String message, String description) {
+
+            this.code = code;
+            this.message = message;
+            this.description = description;
+        }
+
+        public String getCode() {
+
+            return ERROR_PREFIX + code;
+        }
+
+        public String getMessage() {
+
+            return message;
+        }
+
+        public String getDescription() {
+
+            return description;
+        }
+
+        @Override
+        public String toString() {
+
+            return code + " | " + message;
+        }
+    }
+}

--- a/components/org.wso2.carbon.identity.api.server.organization.connection.sharing.management/org.wso2.carbon.identity.api.server.organization.connection.sharing.management.v1/pom.xml
+++ b/components/org.wso2.carbon.identity.api.server.organization.connection.sharing.management/org.wso2.carbon.identity.api.server.organization.connection.sharing.management.v1/pom.xml
@@ -1,0 +1,172 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+  ~
+  ~ WSO2 LLC. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.wso2.carbon.identity.server.api</groupId>
+        <artifactId>org.wso2.carbon.identity.api.server.organization.connection.sharing.management</artifactId>
+        <version>1.6.8-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>org.wso2.carbon.identity.api.server.organization.connection.sharing.management.v1</artifactId>
+    <packaging>jar</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>javax.ws.rs</groupId>
+            <artifactId>javax.ws.rs-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.jaxrs</groupId>
+            <artifactId>jackson-jaxrs-json-provider</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.cxf</groupId>
+            <artifactId>cxf-rt-frontend-jaxrs</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.cxf</groupId>
+            <artifactId>cxf-rt-rs-service-description</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.swagger</groupId>
+            <artifactId>swagger-jaxrs</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-databind</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-annotations</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.dataformat</groupId>
+                    <artifactId>jackson-dataformat-yaml</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>javax.ws.rs</groupId>
+                    <artifactId>jsr311-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.google.guava</groupId>
+                    <artifactId>guava</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.server.api</groupId>
+            <artifactId>org.wso2.carbon.identity.api.server.organization.connection.sharing.management.common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.server.api</groupId>
+            <artifactId>org.wso2.carbon.identity.api.server.common</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.organization.management</groupId>
+            <artifactId>org.wso2.carbon.identity.organization.management.organization.connection.sharing</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.organization.management</groupId>
+            <artifactId>org.wso2.carbon.identity.organization.resource.sharing.policy.management</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.organization.management.core</groupId>
+            <artifactId>org.wso2.carbon.identity.organization.management.service</artifactId>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <!--<plugin>
+                <groupId>org.openapitools</groupId>
+                <artifactId>openapi-generator-maven-plugin</artifactId>
+                <version>4.1.2</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>generate</goal>
+                        </goals>
+                        <configuration>
+                            <inputSpec>${project.basedir}/src/main/resources/connection-sharing-v1.yaml</inputSpec>
+                            <generatorName>org.wso2.carbon.codegen.CxfWso2Generator</generatorName>
+                            <configOptions>
+                                <sourceFolder>src/gen/java</sourceFolder>
+                                <apiPackage>org.wso2.carbon.identity.api.server.organization.connection.sharing.management.v1</apiPackage>
+                                <modelPackage>org.wso2.carbon.identity.api.server.organization.connection.sharing.management.v1.model</modelPackage>
+                                <packageName>org.wso2.carbon.identity.api.server.organization.connection.sharing.management.v1</packageName>
+                                <dateLibrary>java8</dateLibrary>
+                                <hideGenerationTimestamp>true</hideGenerationTimestamp>
+                            </configOptions>
+                            <output>.</output>
+                            <skipOverwrite>false</skipOverwrite>
+                        </configuration>
+                    </execution>
+                </executions>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.openapitools</groupId>
+                        <artifactId>cxf-wso2-openapi-generator</artifactId>
+                        <version>1.0.0</version>
+                    </dependency>
+                </dependencies>
+            </plugin>-->
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <version>1.8</version>
+                <executions>
+                    <execution>
+                        <id>add-source</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>add-source</goal>
+                        </goals>
+                        <configuration>
+                            <sources>
+                                <source>src/gen/java</source>
+                            </sources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>${maven.compiler.plugin.version}</version>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/components/org.wso2.carbon.identity.api.server.organization.connection.sharing.management/org.wso2.carbon.identity.api.server.organization.connection.sharing.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/connection/sharing/management/v1/ConnectionsApi.java
+++ b/components/org.wso2.carbon.identity.api.server.organization.connection.sharing.management/org.wso2.carbon.identity.api.server.organization.connection.sharing.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/connection/sharing/management/v1/ConnectionsApi.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.organization.connection.sharing.management.v1;
+
+import org.wso2.carbon.identity.api.server.organization.connection.sharing.management.v1.factories.ConnectionsApiServiceFactory;
+import org.wso2.carbon.identity.api.server.organization.connection.sharing.management.v1.model.ConnectionShareSelectedRequestBody;
+import org.wso2.carbon.identity.api.server.organization.connection.sharing.management.v1.model.ConnectionShareWithAllRequestBody;
+import org.wso2.carbon.identity.api.server.organization.connection.sharing.management.v1.model.ConnectionSharedOrganizationsResponse;
+import org.wso2.carbon.identity.api.server.organization.connection.sharing.management.v1.model.ConnectionUnshareSelectedRequestBody;
+import org.wso2.carbon.identity.api.server.organization.connection.sharing.management.v1.model.ConnectionUnshareWithAllRequestBody;
+import org.wso2.carbon.identity.api.server.organization.connection.sharing.management.v1.model.Error;
+import org.wso2.carbon.identity.api.server.organization.connection.sharing.management.v1.model.ProcessSuccessResponse;
+
+import javax.validation.Valid;
+import javax.ws.rs.*;
+import javax.ws.rs.core.Response;
+import io.swagger.annotations.*;
+
+@Path("/connections")
+@Api(description = "The connections API")
+
+public class ConnectionsApi  {
+
+    private final ConnectionsApiService delegate;
+
+    public ConnectionsApi() {
+
+        this.delegate = ConnectionsApiServiceFactory.getConnectionsApi();
+    }
+
+    @Valid
+    @GET
+    @Path("/{connectionId}/share")
+    
+    @Produces({ "application/json" })
+    @ApiOperation(value = "List organizations a connection has been shared with", notes = "Retrieve the list of organizations that the specified connection has been shared with, including per-organization sharing mode where applicable.  The response shape depends on how the connection was shared: - If the connection was shared via **`ALL_EXISTING_AND_FUTURE_ORGS`** policy → a top-level   `sharingMode` is returned in the response (only when `attributes=sharingMode` is requested),   and no per-org `sharingMode` is present on each organization entry. - If the connection was shared via **`SELECTED_ORG_WITH_ALL_EXISTING_AND_FUTURE_CHILDREN`**   policy → no top-level `sharingMode` is returned, and each matching organization entry   includes its own `sharingMode` (only when `attributes=sharingMode` is requested). - If the connection was shared via **`SELECTED_ORG_ONLY`** policy → no `sharingMode` is   returned at either level, even if `attributes=sharingMode` is requested.  **Scope required:** `internal_connection_shared_access_view`", response = ConnectionSharedOrganizationsResponse.class, authorizations = {
+        @Authorization(value = "BasicAuth"),
+        @Authorization(value = "OAuth2", scopes = {
+            
+        })
+    }, tags={ "Connection Shared Organizations", })
+    @ApiResponses(value = { 
+        @ApiResponse(code = 200, message = "Successful response with the list of organizations the connection is shared with.", response = ConnectionSharedOrganizationsResponse.class),
+        @ApiResponse(code = 400, message = "Bad Request", response = Error.class),
+        @ApiResponse(code = 404, message = "Not Found — the specified connection does not exist.", response = Error.class),
+        @ApiResponse(code = 500, message = "Internal Server Error", response = Error.class)
+    })
+    public Response getConnectionSharedOrganizations(@ApiParam(value = "The unique identifier (UUID) of the connection.",required=true) @PathParam("connectionId") String connectionId,     @Valid@ApiParam(value = "Base64 encoded cursor value for backward pagination.")  @QueryParam("before") String before,     @Valid@ApiParam(value = "Base64 encoded cursor value for forward pagination.")  @QueryParam("after") String after,     @Valid@ApiParam(value = "Condition to filter the retrieval of records. Supports `sw`, `co`, `ew`, and `eq` operations.")  @QueryParam("filter") String filter,     @Valid@ApiParam(value = "Maximum number of records to return. If not specified, all shared organizations are returned.")  @QueryParam("limit") Integer limit,     @Valid@ApiParam(value = "Determines whether a recursive search should happen. If set to `true`, includes shared organizations at all levels of the hierarchy; if set to `false`, includes only shared organizations at the next level of the hierarchy.")  @QueryParam("recursive") Boolean recursive,     @Valid@ApiParam(value = "Specifies the additional parameters to include in the response. Supported value: `sharingMode`.  When `sharingMode` is requested: - For connections shared via `ALL_EXISTING_AND_FUTURE_ORGS`, a top-level `sharingMode`   is included in the response. - For connections shared via `SELECTED_ORG_WITH_ALL_EXISTING_AND_FUTURE_CHILDREN`,   a `sharingMode` is included on each applicable organization entry. - For connections shared via `SELECTED_ORG_ONLY`, no `sharingMode` is returned.")  @QueryParam("attributes") String attributes) {
+
+        return delegate.getConnectionSharedOrganizations(connectionId,  before,  after,  filter,  limit,  recursive,  attributes );
+    }
+
+    @Valid
+    @POST
+    @Path("/share-with-all")
+    @Consumes({ "application/json" })
+    @Produces({ "application/json" })
+    @ApiOperation(value = "Share connections with all organizations", notes = "Share one or more federated identity provider connections with **all child organizations** according to the specified policy.  Once shared, a shadow connection is created in each matching sub-organization. Sub-organization users can then add the shared connection to their application login flows and authenticate through it.  This endpoint is treated as a **processing function** and responds with `202 Accepted`.  **Scope required:** `internal_connection_share`", response = ProcessSuccessResponse.class, authorizations = {
+        @Authorization(value = "BasicAuth"),
+        @Authorization(value = "OAuth2", scopes = {
+            
+        })
+    }, tags={ "Connection Sharing", })
+    @ApiResponses(value = { 
+        @ApiResponse(code = 202, message = "Connection share-with-all process triggered successfully.", response = ProcessSuccessResponse.class),
+        @ApiResponse(code = 400, message = "Bad Request", response = Error.class),
+        @ApiResponse(code = 500, message = "Internal Server Error", response = Error.class)
+    })
+    public Response shareConnectionsWithAll(@ApiParam(value = "" ,required=true) @Valid ConnectionShareWithAllRequestBody connectionShareWithAllRequestBody) {
+
+        return delegate.shareConnectionsWithAll(connectionShareWithAllRequestBody );
+    }
+
+    @Valid
+    @POST
+    @Path("/share")
+    @Consumes({ "application/json" })
+    @Produces({ "application/json" })
+    @ApiOperation(value = "Share connections with specific organizations", notes = "Share one or more federated identity provider connections with a selected set of child organizations.  Once shared, a shadow connection is created in each target sub-organization. Sub-organization users can then add the shared connection to their application login flows and authenticate through it.  This endpoint is treated as a **processing function**: it triggers a sharing process and responds with `202 Accepted`.  **Scope required:** `internal_connection_share`", response = ProcessSuccessResponse.class, authorizations = {
+        @Authorization(value = "BasicAuth"),
+        @Authorization(value = "OAuth2", scopes = {
+            
+        })
+    }, tags={ "Connection Sharing", })
+    @ApiResponses(value = { 
+        @ApiResponse(code = 202, message = "Connection sharing process triggered successfully.", response = ProcessSuccessResponse.class),
+        @ApiResponse(code = 400, message = "Bad Request", response = Error.class),
+        @ApiResponse(code = 500, message = "Internal Server Error", response = Error.class)
+    })
+    public Response shareConnectionsWithSelected(@ApiParam(value = "" ,required=true) @Valid ConnectionShareSelectedRequestBody connectionShareSelectedRequestBody) {
+
+        return delegate.shareConnectionsWithSelected(connectionShareSelectedRequestBody );
+    }
+
+    @Valid
+    @POST
+    @Path("/unshare-with-all")
+    @Consumes({ "application/json" })
+    @Produces({ "application/json" })
+    @ApiOperation(value = "Unshare connections from all organizations", notes = "Completely remove shared access for one or more federated identity provider connections from **all child organizations**.  This endpoint is treated as a **processing function** and responds with `202 Accepted`.  **Scope required:** `internal_connection_unshare`", response = ProcessSuccessResponse.class, authorizations = {
+        @Authorization(value = "BasicAuth"),
+        @Authorization(value = "OAuth2", scopes = {
+            
+        })
+    }, tags={ "Connection Sharing", })
+    @ApiResponses(value = { 
+        @ApiResponse(code = 202, message = "Connection unshare-with-all process triggered successfully.", response = ProcessSuccessResponse.class),
+        @ApiResponse(code = 400, message = "Bad Request", response = Error.class),
+        @ApiResponse(code = 500, message = "Internal Server Error", response = Error.class)
+    })
+    public Response unshareConnectionsFromAll(@ApiParam(value = "" ,required=true) @Valid ConnectionUnshareWithAllRequestBody connectionUnshareWithAllRequestBody) {
+
+        return delegate.unshareConnectionsFromAll(connectionUnshareWithAllRequestBody );
+    }
+
+    @Valid
+    @POST
+    @Path("/unshare")
+    @Consumes({ "application/json" })
+    @Produces({ "application/json" })
+    @ApiOperation(value = "Unshare connections from specific organizations", notes = "Unshare one or more federated identity provider connections from a selected set of child organizations.  > **Note:** > This only removes the shared connection from the specified organizations. If a connection > was shared with a parent org and its children via a broader policy, you must explicitly > include all relevant organization IDs when unsharing.  This endpoint is treated as a **processing function** and responds with `202 Accepted`.  **Scope required:** `internal_connection_unshare`", response = ProcessSuccessResponse.class, authorizations = {
+        @Authorization(value = "BasicAuth"),
+        @Authorization(value = "OAuth2", scopes = {
+            
+        })
+    }, tags={ "Connection Sharing" })
+    @ApiResponses(value = { 
+        @ApiResponse(code = 202, message = "Connection unsharing process triggered successfully.", response = ProcessSuccessResponse.class),
+        @ApiResponse(code = 400, message = "Bad Request", response = Error.class),
+        @ApiResponse(code = 500, message = "Internal Server Error", response = Error.class)
+    })
+    public Response unshareConnectionsFromSelected(@ApiParam(value = "" ,required=true) @Valid ConnectionUnshareSelectedRequestBody connectionUnshareSelectedRequestBody) {
+
+        return delegate.unshareConnectionsFromSelected(connectionUnshareSelectedRequestBody );
+    }
+
+}

--- a/components/org.wso2.carbon.identity.api.server.organization.connection.sharing.management/org.wso2.carbon.identity.api.server.organization.connection.sharing.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/connection/sharing/management/v1/ConnectionsApiService.java
+++ b/components/org.wso2.carbon.identity.api.server.organization.connection.sharing.management/org.wso2.carbon.identity.api.server.organization.connection.sharing.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/connection/sharing/management/v1/ConnectionsApiService.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.organization.connection.sharing.management.v1;
+
+import org.wso2.carbon.identity.api.server.organization.connection.sharing.management.v1.*;
+import org.wso2.carbon.identity.api.server.organization.connection.sharing.management.v1.model.*;
+import org.apache.cxf.jaxrs.ext.multipart.Attachment;
+import org.apache.cxf.jaxrs.ext.multipart.Multipart;
+import java.io.InputStream;
+import java.util.List;
+import org.wso2.carbon.identity.api.server.organization.connection.sharing.management.v1.model.ConnectionShareSelectedRequestBody;
+import org.wso2.carbon.identity.api.server.organization.connection.sharing.management.v1.model.ConnectionShareWithAllRequestBody;
+import org.wso2.carbon.identity.api.server.organization.connection.sharing.management.v1.model.ConnectionSharedOrganizationsResponse;
+import org.wso2.carbon.identity.api.server.organization.connection.sharing.management.v1.model.ConnectionUnshareSelectedRequestBody;
+import org.wso2.carbon.identity.api.server.organization.connection.sharing.management.v1.model.ConnectionUnshareWithAllRequestBody;
+import org.wso2.carbon.identity.api.server.organization.connection.sharing.management.v1.model.Error;
+import org.wso2.carbon.identity.api.server.organization.connection.sharing.management.v1.model.ProcessSuccessResponse;
+import javax.ws.rs.core.Response;
+
+
+public interface ConnectionsApiService {
+
+      public Response getConnectionSharedOrganizations(String connectionId, String before, String after, String filter, Integer limit, Boolean recursive, String attributes);
+
+      public Response shareConnectionsWithAll(ConnectionShareWithAllRequestBody connectionShareWithAllRequestBody);
+
+      public Response shareConnectionsWithSelected(ConnectionShareSelectedRequestBody connectionShareSelectedRequestBody);
+
+      public Response unshareConnectionsFromAll(ConnectionUnshareWithAllRequestBody connectionUnshareWithAllRequestBody);
+
+      public Response unshareConnectionsFromSelected(ConnectionUnshareSelectedRequestBody connectionUnshareSelectedRequestBody);
+}

--- a/components/org.wso2.carbon.identity.api.server.organization.connection.sharing.management/org.wso2.carbon.identity.api.server.organization.connection.sharing.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/connection/sharing/management/v1/factories/ConnectionsApiServiceFactory.java
+++ b/components/org.wso2.carbon.identity.api.server.organization.connection.sharing.management/org.wso2.carbon.identity.api.server.organization.connection.sharing.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/connection/sharing/management/v1/factories/ConnectionsApiServiceFactory.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.organization.connection.sharing.management.v1.factories;
+
+import org.wso2.carbon.identity.api.server.organization.connection.sharing.management.v1.ConnectionsApiService;
+import org.wso2.carbon.identity.api.server.organization.connection.sharing.management.v1.impl.ConnectionsApiServiceImpl;
+
+public class ConnectionsApiServiceFactory {
+
+   private final static ConnectionsApiService service = new ConnectionsApiServiceImpl();
+
+   public static ConnectionsApiService getConnectionsApi()
+   {
+      return service;
+   }
+}

--- a/components/org.wso2.carbon.identity.api.server.organization.connection.sharing.management/org.wso2.carbon.identity.api.server.organization.connection.sharing.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/connection/sharing/management/v1/model/ConnectionCriteria.java
+++ b/components/org.wso2.carbon.identity.api.server.organization.connection.sharing.management/org.wso2.carbon.identity.api.server.organization.connection.sharing.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/connection/sharing/management/v1/model/ConnectionCriteria.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.organization.connection.sharing.management.v1.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import java.util.ArrayList;
+import java.util.List;
+import javax.validation.constraints.*;
+
+/**
+ * Criteria for selecting the connections to share or unshare.  At least one of &#x60;connectionIds&#x60; or &#x60;connectionNames&#x60; must be provided. Both can be supplied simultaneously, in which case the union of matched connections is used. Validation that at least one field is populated is enforced at the service layer.
+ **/
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+import javax.validation.Valid;
+import javax.xml.bind.annotation.*;
+@ApiModel(description = "Criteria for selecting the connections to share or unshare.  At least one of `connectionIds` or `connectionNames` must be provided. Both can be supplied simultaneously, in which case the union of matched connections is used. Validation that at least one field is populated is enforced at the service layer.")
+public class ConnectionCriteria  {
+  
+    private List<String> connectionIds = null;
+
+    private List<String> connectionNames = null;
+
+
+    /**
+    * List of connection UUIDs.
+    **/
+    public ConnectionCriteria connectionIds(List<String> connectionIds) {
+
+        this.connectionIds = connectionIds;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "[\"7a1b7d63-8cfc-4dc9-9332-3f84641b72d8\",\"5d2a1c84-9f7a-43cd-b12e-6e52d7f87e16\"]", value = "List of connection UUIDs.")
+    @JsonProperty("connectionIds")
+    @Valid
+    public List<String> getConnectionIds() {
+        return connectionIds;
+    }
+    public void setConnectionIds(List<String> connectionIds) {
+        this.connectionIds = connectionIds;
+    }
+
+    public ConnectionCriteria addConnectionIdsItem(String connectionIdsItem) {
+        if (this.connectionIds == null) {
+            this.connectionIds = new ArrayList<>();
+        }
+        this.connectionIds.add(connectionIdsItem);
+        return this;
+    }
+
+        /**
+    * List of connection names.
+    **/
+    public ConnectionCriteria connectionNames(List<String> connectionNames) {
+
+        this.connectionNames = connectionNames;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "[\"Google\",\"Facebook\"]", value = "List of connection names.")
+    @JsonProperty("connectionNames")
+    @Valid
+    public List<String> getConnectionNames() {
+        return connectionNames;
+    }
+    public void setConnectionNames(List<String> connectionNames) {
+        this.connectionNames = connectionNames;
+    }
+
+    public ConnectionCriteria addConnectionNamesItem(String connectionNamesItem) {
+        if (this.connectionNames == null) {
+            this.connectionNames = new ArrayList<>();
+        }
+        this.connectionNames.add(connectionNamesItem);
+        return this;
+    }
+
+    
+
+    @Override
+    public boolean equals(java.lang.Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ConnectionCriteria connectionCriteria = (ConnectionCriteria) o;
+        return Objects.equals(this.connectionIds, connectionCriteria.connectionIds) &&
+            Objects.equals(this.connectionNames, connectionCriteria.connectionNames);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(connectionIds, connectionNames);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class ConnectionCriteria {\n");
+        
+        sb.append("    connectionIds: ").append(toIndentedString(connectionIds)).append("\n");
+        sb.append("    connectionNames: ").append(toIndentedString(connectionNames)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+    * Convert the given object to string with each line indented by 4 spaces
+    * (except the first line).
+    */
+    private String toIndentedString(java.lang.Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}
+

--- a/components/org.wso2.carbon.identity.api.server.organization.connection.sharing.management/org.wso2.carbon.identity.api.server.organization.connection.sharing.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/connection/sharing/management/v1/model/ConnectionOrgShareConfig.java
+++ b/components/org.wso2.carbon.identity.api.server.organization.connection.sharing.management/org.wso2.carbon.identity.api.server.organization.connection.sharing.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/connection/sharing/management/v1/model/ConnectionOrgShareConfig.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.organization.connection.sharing.management.v1.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import javax.validation.constraints.*;
+
+/**
+ * Per-organization sharing configuration for selected organizations.
+ **/
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+import javax.validation.Valid;
+import javax.xml.bind.annotation.*;
+@ApiModel(description = "Per-organization sharing configuration for selected organizations.")
+public class ConnectionOrgShareConfig  {
+  
+    private String orgId;
+
+@XmlType(name="PolicyEnum")
+@XmlEnum(String.class)
+public enum PolicyEnum {
+
+    @XmlEnumValue("SELECTED_ORG_ONLY") SELECTED_ORG_ONLY(String.valueOf("SELECTED_ORG_ONLY")), @XmlEnumValue("SELECTED_ORG_WITH_ALL_EXISTING_AND_FUTURE_CHILDREN") SELECTED_ORG_WITH_ALL_EXISTING_AND_FUTURE_CHILDREN(String.valueOf("SELECTED_ORG_WITH_ALL_EXISTING_AND_FUTURE_CHILDREN"));
+
+
+    private String value;
+
+    PolicyEnum(String v) {
+        value = v;
+    }
+
+    public String value() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    public static PolicyEnum fromValue(String value) {
+        for (PolicyEnum b : PolicyEnum.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
+}
+
+    private PolicyEnum policy;
+
+    /**
+    * The ID of the organization to share the connection with.
+    **/
+    public ConnectionOrgShareConfig orgId(String orgId) {
+
+        this.orgId = orgId;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "b028ca17-8f89-449c-ae27-fa955e66465d", required = true, value = "The ID of the organization to share the connection with.")
+    @JsonProperty("orgId")
+    @Valid
+    @NotNull(message = "Property orgId cannot be null.")
+
+    public String getOrgId() {
+        return orgId;
+    }
+    public void setOrgId(String orgId) {
+        this.orgId = orgId;
+    }
+
+    /**
+    * Sharing scope for this organization.  Possible values: - &#x60;SELECTED_ORG_ONLY&#x60; — Share with only this specific organization. Sub-organizations   created under it will not automatically receive the shared connection. - &#x60;SELECTED_ORG_WITH_ALL_EXISTING_AND_FUTURE_CHILDREN&#x60; — Share with this organization   and all of its child organizations, including those created in the future.
+    **/
+    public ConnectionOrgShareConfig policy(PolicyEnum policy) {
+
+        this.policy = policy;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "SELECTED_ORG_ONLY", required = true, value = "Sharing scope for this organization.  Possible values: - `SELECTED_ORG_ONLY` — Share with only this specific organization. Sub-organizations   created under it will not automatically receive the shared connection. - `SELECTED_ORG_WITH_ALL_EXISTING_AND_FUTURE_CHILDREN` — Share with this organization   and all of its child organizations, including those created in the future.")
+    @JsonProperty("policy")
+    @Valid
+    @NotNull(message = "Property policy cannot be null.")
+
+    public PolicyEnum getPolicy() {
+        return policy;
+    }
+    public void setPolicy(PolicyEnum policy) {
+        this.policy = policy;
+    }
+
+
+
+    @Override
+    public boolean equals(java.lang.Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ConnectionOrgShareConfig connectionOrgShareConfig = (ConnectionOrgShareConfig) o;
+        return Objects.equals(this.orgId, connectionOrgShareConfig.orgId) &&
+            Objects.equals(this.policy, connectionOrgShareConfig.policy);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(orgId, policy);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class ConnectionOrgShareConfig {\n");
+        
+        sb.append("    orgId: ").append(toIndentedString(orgId)).append("\n");
+        sb.append("    policy: ").append(toIndentedString(policy)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+    * Convert the given object to string with each line indented by 4 spaces
+    * (except the first line).
+    */
+    private String toIndentedString(java.lang.Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}
+

--- a/components/org.wso2.carbon.identity.api.server.organization.connection.sharing.management/org.wso2.carbon.identity.api.server.organization.connection.sharing.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/connection/sharing/management/v1/model/ConnectionShareSelectedRequestBody.java
+++ b/components/org.wso2.carbon.identity.api.server.organization.connection.sharing.management/org.wso2.carbon.identity.api.server.organization.connection.sharing.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/connection/sharing/management/v1/model/ConnectionShareSelectedRequestBody.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.organization.connection.sharing.management.v1.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import java.util.ArrayList;
+import java.util.List;
+import org.wso2.carbon.identity.api.server.organization.connection.sharing.management.v1.model.ConnectionCriteria;
+import org.wso2.carbon.identity.api.server.organization.connection.sharing.management.v1.model.ConnectionOrgShareConfig;
+import javax.validation.constraints.*;
+
+/**
+ * Request body for sharing connections with a **selected set of organizations**.
+ **/
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+import javax.validation.Valid;
+import javax.xml.bind.annotation.*;
+@ApiModel(description = "Request body for sharing connections with a **selected set of organizations**.")
+public class ConnectionShareSelectedRequestBody  {
+  
+    private ConnectionCriteria connectionCriteria;
+    private List<ConnectionOrgShareConfig> organizations = new ArrayList<>();
+
+
+    /**
+    **/
+    public ConnectionShareSelectedRequestBody connectionCriteria(ConnectionCriteria connectionCriteria) {
+
+        this.connectionCriteria = connectionCriteria;
+        return this;
+    }
+    
+    @ApiModelProperty(required = true, value = "")
+    @JsonProperty("connectionCriteria")
+    @Valid
+    @NotNull(message = "Property connectionCriteria cannot be null.")
+
+    public ConnectionCriteria getConnectionCriteria() {
+        return connectionCriteria;
+    }
+    public void setConnectionCriteria(ConnectionCriteria connectionCriteria) {
+        this.connectionCriteria = connectionCriteria;
+    }
+
+    /**
+    * List of organizations to share the connections with, along with the sharing policy for each organization.
+    **/
+    public ConnectionShareSelectedRequestBody organizations(List<ConnectionOrgShareConfig> organizations) {
+
+        this.organizations = organizations;
+        return this;
+    }
+    
+    @ApiModelProperty(required = true, value = "List of organizations to share the connections with, along with the sharing policy for each organization.")
+    @JsonProperty("organizations")
+    @Valid
+    @NotNull(message = "Property organizations cannot be null.")
+
+    public List<ConnectionOrgShareConfig> getOrganizations() {
+        return organizations;
+    }
+    public void setOrganizations(List<ConnectionOrgShareConfig> organizations) {
+        this.organizations = organizations;
+    }
+
+    public ConnectionShareSelectedRequestBody addOrganizationsItem(ConnectionOrgShareConfig organizationsItem) {
+        this.organizations.add(organizationsItem);
+        return this;
+    }
+
+    
+
+    @Override
+    public boolean equals(java.lang.Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ConnectionShareSelectedRequestBody connectionShareSelectedRequestBody = (ConnectionShareSelectedRequestBody) o;
+        return Objects.equals(this.connectionCriteria, connectionShareSelectedRequestBody.connectionCriteria) &&
+            Objects.equals(this.organizations, connectionShareSelectedRequestBody.organizations);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(connectionCriteria, organizations);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class ConnectionShareSelectedRequestBody {\n");
+        
+        sb.append("    connectionCriteria: ").append(toIndentedString(connectionCriteria)).append("\n");
+        sb.append("    organizations: ").append(toIndentedString(organizations)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+    * Convert the given object to string with each line indented by 4 spaces
+    * (except the first line).
+    */
+    private String toIndentedString(java.lang.Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}
+

--- a/components/org.wso2.carbon.identity.api.server.organization.connection.sharing.management/org.wso2.carbon.identity.api.server.organization.connection.sharing.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/connection/sharing/management/v1/model/ConnectionShareWithAllRequestBody.java
+++ b/components/org.wso2.carbon.identity.api.server.organization.connection.sharing.management/org.wso2.carbon.identity.api.server.organization.connection.sharing.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/connection/sharing/management/v1/model/ConnectionShareWithAllRequestBody.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.organization.connection.sharing.management.v1.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import org.wso2.carbon.identity.api.server.organization.connection.sharing.management.v1.model.ConnectionCriteria;
+import javax.validation.constraints.*;
+
+/**
+ * Request body for sharing connections with **all child organizations** controlled by the specified policy.
+ **/
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+import javax.validation.Valid;
+import javax.xml.bind.annotation.*;
+@ApiModel(description = "Request body for sharing connections with **all child organizations** controlled by the specified policy.")
+public class ConnectionShareWithAllRequestBody  {
+  
+    private ConnectionCriteria connectionCriteria;
+
+@XmlType(name="PolicyEnum")
+@XmlEnum(String.class)
+public enum PolicyEnum {
+
+    @XmlEnumValue("ALL_EXISTING_AND_FUTURE_ORGS") ALL_EXISTING_AND_FUTURE_ORGS(String.valueOf("ALL_EXISTING_AND_FUTURE_ORGS"));
+
+
+    private String value;
+
+    PolicyEnum(String v) {
+        value = v;
+    }
+
+    public String value() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    public static PolicyEnum fromValue(String value) {
+        for (PolicyEnum b : PolicyEnum.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
+}
+
+    private PolicyEnum policy;
+
+    /**
+    **/
+    public ConnectionShareWithAllRequestBody connectionCriteria(ConnectionCriteria connectionCriteria) {
+
+        this.connectionCriteria = connectionCriteria;
+        return this;
+    }
+    
+    @ApiModelProperty(required = true, value = "")
+    @JsonProperty("connectionCriteria")
+    @Valid
+    @NotNull(message = "Property connectionCriteria cannot be null.")
+
+    public ConnectionCriteria getConnectionCriteria() {
+        return connectionCriteria;
+    }
+    public void setConnectionCriteria(ConnectionCriteria connectionCriteria) {
+        this.connectionCriteria = connectionCriteria;
+    }
+
+    /**
+    * Global sharing policy.  Possible values: - &#x60;ALL_EXISTING_AND_FUTURE_ORGS&#x60; — Share with all sub-organizations that currently   exist **and** any sub-organizations created in the future. This is the recommended   policy for connections intended to be used across the entire organization hierarchy.
+    **/
+    public ConnectionShareWithAllRequestBody policy(PolicyEnum policy) {
+
+        this.policy = policy;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "ALL_EXISTING_AND_FUTURE_ORGS", required = true, value = "Global sharing policy.  Possible values: - `ALL_EXISTING_AND_FUTURE_ORGS` — Share with all sub-organizations that currently   exist **and** any sub-organizations created in the future. This is the recommended   policy for connections intended to be used across the entire organization hierarchy.")
+    @JsonProperty("policy")
+    @Valid
+    @NotNull(message = "Property policy cannot be null.")
+
+    public PolicyEnum getPolicy() {
+        return policy;
+    }
+    public void setPolicy(PolicyEnum policy) {
+        this.policy = policy;
+    }
+
+
+
+    @Override
+    public boolean equals(java.lang.Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ConnectionShareWithAllRequestBody connectionShareWithAllRequestBody = (ConnectionShareWithAllRequestBody) o;
+        return Objects.equals(this.connectionCriteria, connectionShareWithAllRequestBody.connectionCriteria) &&
+            Objects.equals(this.policy, connectionShareWithAllRequestBody.policy);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(connectionCriteria, policy);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class ConnectionShareWithAllRequestBody {\n");
+        
+        sb.append("    connectionCriteria: ").append(toIndentedString(connectionCriteria)).append("\n");
+        sb.append("    policy: ").append(toIndentedString(policy)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+    * Convert the given object to string with each line indented by 4 spaces
+    * (except the first line).
+    */
+    private String toIndentedString(java.lang.Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}
+

--- a/components/org.wso2.carbon.identity.api.server.organization.connection.sharing.management/org.wso2.carbon.identity.api.server.organization.connection.sharing.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/connection/sharing/management/v1/model/ConnectionSharedOrganization.java
+++ b/components/org.wso2.carbon.identity.api.server.organization.connection.sharing.management/org.wso2.carbon.identity.api.server.organization.connection.sharing.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/connection/sharing/management/v1/model/ConnectionSharedOrganization.java
@@ -1,0 +1,322 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.organization.connection.sharing.management.v1.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import org.wso2.carbon.identity.api.server.organization.connection.sharing.management.v1.model.ConnectionSharingMode;
+import javax.validation.constraints.*;
+
+/**
+ * Represents a single organization that a connection has been shared with, including organization metadata and optionally the sharing mode.
+ **/
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+import javax.validation.Valid;
+import javax.xml.bind.annotation.*;
+@ApiModel(description = "Represents a single organization that a connection has been shared with, including organization metadata and optionally the sharing mode.")
+public class ConnectionSharedOrganization  {
+  
+    private String orgId;
+    private String orgName;
+    private String orgHandle;
+    private String orgStatus;
+    private String orgRef;
+    private Boolean hasChildren;
+    private Integer depthFromRoot;
+    private String parentOrgId;
+    private String parentConnectionId;
+    private String sharedConnectionId;
+    private ConnectionSharingMode sharingMode;
+
+    /**
+    * ID of the child organization.
+    **/
+    public ConnectionSharedOrganization orgId(String orgId) {
+
+        this.orgId = orgId;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "b028ca17-8f89-449c-ae27-fa955e66465d", value = "ID of the child organization.")
+    @JsonProperty("orgId")
+    @Valid
+    public String getOrgId() {
+        return orgId;
+    }
+    public void setOrgId(String orgId) {
+        this.orgId = orgId;
+    }
+
+    /**
+    * Name of the child organization.
+    **/
+    public ConnectionSharedOrganization orgName(String orgName) {
+
+        this.orgName = orgName;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "Child Org 1", value = "Name of the child organization.")
+    @JsonProperty("orgName")
+    @Valid
+    public String getOrgName() {
+        return orgName;
+    }
+    public void setOrgName(String orgName) {
+        this.orgName = orgName;
+    }
+
+    /**
+    * Unique, human-readable handle of the organization.
+    **/
+    public ConnectionSharedOrganization orgHandle(String orgHandle) {
+
+        this.orgHandle = orgHandle;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "child-org-1", value = "Unique, human-readable handle of the organization.")
+    @JsonProperty("orgHandle")
+    @Valid
+    public String getOrgHandle() {
+        return orgHandle;
+    }
+    public void setOrgHandle(String orgHandle) {
+        this.orgHandle = orgHandle;
+    }
+
+    /**
+    * Current status of the organization.
+    **/
+    public ConnectionSharedOrganization orgStatus(String orgStatus) {
+
+        this.orgStatus = orgStatus;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "ACTIVE", value = "Current status of the organization.")
+    @JsonProperty("orgStatus")
+    @Valid
+    public String getOrgStatus() {
+        return orgStatus;
+    }
+    public void setOrgStatus(String orgStatus) {
+        this.orgStatus = orgStatus;
+    }
+
+    /**
+    * API reference URL of the organization resource.
+    **/
+    public ConnectionSharedOrganization orgRef(String orgRef) {
+
+        this.orgRef = orgRef;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "/t/wso2.com/api/server/v1/organizations/b028ca17-8f89-449c-ae27-fa955e66465d", value = "API reference URL of the organization resource.")
+    @JsonProperty("orgRef")
+    @Valid
+    public String getOrgRef() {
+        return orgRef;
+    }
+    public void setOrgRef(String orgRef) {
+        this.orgRef = orgRef;
+    }
+
+    /**
+    * Indicates whether the organization has child organizations.
+    **/
+    public ConnectionSharedOrganization hasChildren(Boolean hasChildren) {
+
+        this.hasChildren = hasChildren;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "true", value = "Indicates whether the organization has child organizations.")
+    @JsonProperty("hasChildren")
+    @Valid
+    public Boolean getHasChildren() {
+        return hasChildren;
+    }
+    public void setHasChildren(Boolean hasChildren) {
+        this.hasChildren = hasChildren;
+    }
+
+    /**
+    * Depth of the organization in the hierarchy, where the root organization is 0.
+    **/
+    public ConnectionSharedOrganization depthFromRoot(Integer depthFromRoot) {
+
+        this.depthFromRoot = depthFromRoot;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "1", value = "Depth of the organization in the hierarchy, where the root organization is 0.")
+    @JsonProperty("depthFromRoot")
+    @Valid
+    public Integer getDepthFromRoot() {
+        return depthFromRoot;
+    }
+    public void setDepthFromRoot(Integer depthFromRoot) {
+        this.depthFromRoot = depthFromRoot;
+    }
+
+    /**
+    * ID of the parent (sharing-initiated) organization.
+    **/
+    public ConnectionSharedOrganization parentOrgId(String parentOrgId) {
+
+        this.parentOrgId = parentOrgId;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "08f8c1d2-4b3e-4c5a-9f6b-7d8e9f0a1b2c", value = "ID of the parent (sharing-initiated) organization.")
+    @JsonProperty("parentOrgId")
+    @Valid
+    public String getParentOrgId() {
+        return parentOrgId;
+    }
+    public void setParentOrgId(String parentOrgId) {
+        this.parentOrgId = parentOrgId;
+    }
+
+    /**
+    * UUID of the original connection in the parent (sharing-initiated) organization.
+    **/
+    public ConnectionSharedOrganization parentConnectionId(String parentConnectionId) {
+
+        this.parentConnectionId = parentConnectionId;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "7a1b7d63-8cfc-4dc9-9332-3f84641b72d8", value = "UUID of the original connection in the parent (sharing-initiated) organization.")
+    @JsonProperty("parentConnectionId")
+    @Valid
+    public String getParentConnectionId() {
+        return parentConnectionId;
+    }
+    public void setParentConnectionId(String parentConnectionId) {
+        this.parentConnectionId = parentConnectionId;
+    }
+
+    /**
+    * UUID of the shadow connection created in this child organization.
+    **/
+    public ConnectionSharedOrganization sharedConnectionId(String sharedConnectionId) {
+
+        this.sharedConnectionId = sharedConnectionId;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "550e8400-e29b-41d4-a716-446655440000", value = "UUID of the shadow connection created in this child organization.")
+    @JsonProperty("sharedConnectionId")
+    @Valid
+    public String getSharedConnectionId() {
+        return sharedConnectionId;
+    }
+    public void setSharedConnectionId(String sharedConnectionId) {
+        this.sharedConnectionId = sharedConnectionId;
+    }
+
+    /**
+    **/
+    public ConnectionSharedOrganization sharingMode(ConnectionSharingMode sharingMode) {
+
+        this.sharingMode = sharingMode;
+        return this;
+    }
+    
+    @ApiModelProperty(value = "")
+    @JsonProperty("sharingMode")
+    @Valid
+    public ConnectionSharingMode getSharingMode() {
+        return sharingMode;
+    }
+    public void setSharingMode(ConnectionSharingMode sharingMode) {
+        this.sharingMode = sharingMode;
+    }
+
+
+
+    @Override
+    public boolean equals(java.lang.Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ConnectionSharedOrganization connectionSharedOrganization = (ConnectionSharedOrganization) o;
+        return Objects.equals(this.orgId, connectionSharedOrganization.orgId) &&
+            Objects.equals(this.orgName, connectionSharedOrganization.orgName) &&
+            Objects.equals(this.orgHandle, connectionSharedOrganization.orgHandle) &&
+            Objects.equals(this.orgStatus, connectionSharedOrganization.orgStatus) &&
+            Objects.equals(this.orgRef, connectionSharedOrganization.orgRef) &&
+            Objects.equals(this.hasChildren, connectionSharedOrganization.hasChildren) &&
+            Objects.equals(this.depthFromRoot, connectionSharedOrganization.depthFromRoot) &&
+            Objects.equals(this.parentOrgId, connectionSharedOrganization.parentOrgId) &&
+            Objects.equals(this.parentConnectionId, connectionSharedOrganization.parentConnectionId) &&
+            Objects.equals(this.sharedConnectionId, connectionSharedOrganization.sharedConnectionId) &&
+            Objects.equals(this.sharingMode, connectionSharedOrganization.sharingMode);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(orgId, orgName, orgHandle, orgStatus, orgRef, hasChildren, depthFromRoot, parentOrgId, parentConnectionId, sharedConnectionId, sharingMode);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class ConnectionSharedOrganization {\n");
+        
+        sb.append("    orgId: ").append(toIndentedString(orgId)).append("\n");
+        sb.append("    orgName: ").append(toIndentedString(orgName)).append("\n");
+        sb.append("    orgHandle: ").append(toIndentedString(orgHandle)).append("\n");
+        sb.append("    orgStatus: ").append(toIndentedString(orgStatus)).append("\n");
+        sb.append("    orgRef: ").append(toIndentedString(orgRef)).append("\n");
+        sb.append("    hasChildren: ").append(toIndentedString(hasChildren)).append("\n");
+        sb.append("    depthFromRoot: ").append(toIndentedString(depthFromRoot)).append("\n");
+        sb.append("    parentOrgId: ").append(toIndentedString(parentOrgId)).append("\n");
+        sb.append("    parentConnectionId: ").append(toIndentedString(parentConnectionId)).append("\n");
+        sb.append("    sharedConnectionId: ").append(toIndentedString(sharedConnectionId)).append("\n");
+        sb.append("    sharingMode: ").append(toIndentedString(sharingMode)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+    * Convert the given object to string with each line indented by 4 spaces
+    * (except the first line).
+    */
+    private String toIndentedString(java.lang.Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}
+

--- a/components/org.wso2.carbon.identity.api.server.organization.connection.sharing.management/org.wso2.carbon.identity.api.server.organization.connection.sharing.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/connection/sharing/management/v1/model/ConnectionSharedOrganizationsResponse.java
+++ b/components/org.wso2.carbon.identity.api.server.organization.connection.sharing.management/org.wso2.carbon.identity.api.server.organization.connection.sharing.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/connection/sharing/management/v1/model/ConnectionSharedOrganizationsResponse.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.organization.connection.sharing.management.v1.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import java.util.ArrayList;
+import java.util.List;
+import org.wso2.carbon.identity.api.server.organization.connection.sharing.management.v1.model.ConnectionSharedOrganization;
+import org.wso2.carbon.identity.api.server.organization.connection.sharing.management.v1.model.ConnectionSharingMode;
+import org.wso2.carbon.identity.api.server.organization.connection.sharing.management.v1.model.Link;
+import javax.validation.constraints.*;
+
+/**
+ * Response listing the organizations that a connection has been shared with.  - &#x60;sharingMode&#x60; at the top level is only present when the connection was shared   via &#x60;ALL_EXISTING_AND_FUTURE_ORGS&#x60; policy **and** &#x60;attributes&#x3D;sharingMode&#x60;   was requested. - &#x60;sharingMode&#x60; on each organization entry is only present when the connection   was shared via &#x60;SELECTED_ORG_WITH_ALL_EXISTING_AND_FUTURE_CHILDREN&#x60; policy   **and** &#x60;attributes&#x3D;sharingMode&#x60; was requested.
+ **/
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+import javax.validation.Valid;
+import javax.xml.bind.annotation.*;
+@ApiModel(description = "Response listing the organizations that a connection has been shared with.  - `sharingMode` at the top level is only present when the connection was shared   via `ALL_EXISTING_AND_FUTURE_ORGS` policy **and** `attributes=sharingMode`   was requested. - `sharingMode` on each organization entry is only present when the connection   was shared via `SELECTED_ORG_WITH_ALL_EXISTING_AND_FUTURE_CHILDREN` policy   **and** `attributes=sharingMode` was requested.")
+public class ConnectionSharedOrganizationsResponse  {
+  
+    private List<Link> links = null;
+
+    private ConnectionSharingMode sharingMode;
+    private List<ConnectionSharedOrganization> organizations = null;
+
+
+    /**
+    **/
+    public ConnectionSharedOrganizationsResponse links(List<Link> links) {
+
+        this.links = links;
+        return this;
+    }
+    
+    @ApiModelProperty(value = "")
+    @JsonProperty("links")
+    @Valid
+    public List<Link> getLinks() {
+        return links;
+    }
+    public void setLinks(List<Link> links) {
+        this.links = links;
+    }
+
+    public ConnectionSharedOrganizationsResponse addLinksItem(Link linksItem) {
+        if (this.links == null) {
+            this.links = new ArrayList<>();
+        }
+        this.links.add(linksItem);
+        return this;
+    }
+
+        /**
+    **/
+    public ConnectionSharedOrganizationsResponse sharingMode(ConnectionSharingMode sharingMode) {
+
+        this.sharingMode = sharingMode;
+        return this;
+    }
+    
+    @ApiModelProperty(value = "")
+    @JsonProperty("sharingMode")
+    @Valid
+    public ConnectionSharingMode getSharingMode() {
+        return sharingMode;
+    }
+    public void setSharingMode(ConnectionSharingMode sharingMode) {
+        this.sharingMode = sharingMode;
+    }
+
+    /**
+    **/
+    public ConnectionSharedOrganizationsResponse organizations(List<ConnectionSharedOrganization> organizations) {
+
+        this.organizations = organizations;
+        return this;
+    }
+    
+    @ApiModelProperty(value = "")
+    @JsonProperty("organizations")
+    @Valid
+    public List<ConnectionSharedOrganization> getOrganizations() {
+        return organizations;
+    }
+    public void setOrganizations(List<ConnectionSharedOrganization> organizations) {
+        this.organizations = organizations;
+    }
+
+    public ConnectionSharedOrganizationsResponse addOrganizationsItem(ConnectionSharedOrganization organizationsItem) {
+        if (this.organizations == null) {
+            this.organizations = new ArrayList<>();
+        }
+        this.organizations.add(organizationsItem);
+        return this;
+    }
+
+    
+
+    @Override
+    public boolean equals(java.lang.Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ConnectionSharedOrganizationsResponse connectionSharedOrganizationsResponse = (ConnectionSharedOrganizationsResponse) o;
+        return Objects.equals(this.links, connectionSharedOrganizationsResponse.links) &&
+            Objects.equals(this.sharingMode, connectionSharedOrganizationsResponse.sharingMode) &&
+            Objects.equals(this.organizations, connectionSharedOrganizationsResponse.organizations);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(links, sharingMode, organizations);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class ConnectionSharedOrganizationsResponse {\n");
+        
+        sb.append("    links: ").append(toIndentedString(links)).append("\n");
+        sb.append("    sharingMode: ").append(toIndentedString(sharingMode)).append("\n");
+        sb.append("    organizations: ").append(toIndentedString(organizations)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+    * Convert the given object to string with each line indented by 4 spaces
+    * (except the first line).
+    */
+    private String toIndentedString(java.lang.Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}
+

--- a/components/org.wso2.carbon.identity.api.server.organization.connection.sharing.management/org.wso2.carbon.identity.api.server.organization.connection.sharing.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/connection/sharing/management/v1/model/ConnectionSharingMode.java
+++ b/components/org.wso2.carbon.identity.api.server.organization.connection.sharing.management/org.wso2.carbon.identity.api.server.organization.connection.sharing.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/connection/sharing/management/v1/model/ConnectionSharingMode.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.organization.connection.sharing.management.v1.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import javax.validation.constraints.*;
+
+/**
+ * Represents the sharing policy under which a connection has been shared. Only returned when &#x60;attributes&#x3D;sharingMode&#x60; is explicitly requested in the GET call.  - When present at the **top level** of the response, the policy is always   &#x60;ALL_EXISTING_AND_FUTURE_ORGS&#x60;. - When present **per organization**, the policy is always   &#x60;SELECTED_ORG_WITH_ALL_EXISTING_AND_FUTURE_CHILDREN&#x60;. - Connections shared via &#x60;SELECTED_ORG_ONLY&#x60; will not have a &#x60;sharingMode&#x60;   returned at either level.
+ **/
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+import javax.validation.Valid;
+import javax.xml.bind.annotation.*;
+@ApiModel(description = "Represents the sharing policy under which a connection has been shared. Only returned when `attributes=sharingMode` is explicitly requested in the GET call.  - When present at the **top level** of the response, the policy is always   `ALL_EXISTING_AND_FUTURE_ORGS`. - When present **per organization**, the policy is always   `SELECTED_ORG_WITH_ALL_EXISTING_AND_FUTURE_CHILDREN`. - Connections shared via `SELECTED_ORG_ONLY` will not have a `sharingMode`   returned at either level.")
+public class ConnectionSharingMode  {
+  
+
+@XmlType(name="PolicyEnum")
+@XmlEnum(String.class)
+public enum PolicyEnum {
+
+    @XmlEnumValue("ALL_EXISTING_AND_FUTURE_ORGS") ALL_EXISTING_AND_FUTURE_ORGS(String.valueOf("ALL_EXISTING_AND_FUTURE_ORGS")), @XmlEnumValue("SELECTED_ORG_WITH_ALL_EXISTING_AND_FUTURE_CHILDREN") SELECTED_ORG_WITH_ALL_EXISTING_AND_FUTURE_CHILDREN(String.valueOf("SELECTED_ORG_WITH_ALL_EXISTING_AND_FUTURE_CHILDREN"));
+
+
+    private String value;
+
+    PolicyEnum(String v) {
+        value = v;
+    }
+
+    public String value() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    public static PolicyEnum fromValue(String value) {
+        for (PolicyEnum b : PolicyEnum.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
+}
+
+    private PolicyEnum policy;
+
+    /**
+    * The sharing policy under which this connection was shared.  Possible values: - &#x60;ALL_EXISTING_AND_FUTURE_ORGS&#x60; - &#x60;SELECTED_ORG_WITH_ALL_EXISTING_AND_FUTURE_CHILDREN&#x60;
+    **/
+    public ConnectionSharingMode policy(PolicyEnum policy) {
+
+        this.policy = policy;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "ALL_EXISTING_AND_FUTURE_ORGS", required = true, value = "The sharing policy under which this connection was shared.  Possible values: - `ALL_EXISTING_AND_FUTURE_ORGS` - `SELECTED_ORG_WITH_ALL_EXISTING_AND_FUTURE_CHILDREN`")
+    @JsonProperty("policy")
+    @Valid
+    @NotNull(message = "Property policy cannot be null.")
+
+    public PolicyEnum getPolicy() {
+        return policy;
+    }
+    public void setPolicy(PolicyEnum policy) {
+        this.policy = policy;
+    }
+
+
+
+    @Override
+    public boolean equals(java.lang.Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ConnectionSharingMode connectionSharingMode = (ConnectionSharingMode) o;
+        return Objects.equals(this.policy, connectionSharingMode.policy);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(policy);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class ConnectionSharingMode {\n");
+        
+        sb.append("    policy: ").append(toIndentedString(policy)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+    * Convert the given object to string with each line indented by 4 spaces
+    * (except the first line).
+    */
+    private String toIndentedString(java.lang.Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}
+

--- a/components/org.wso2.carbon.identity.api.server.organization.connection.sharing.management/org.wso2.carbon.identity.api.server.organization.connection.sharing.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/connection/sharing/management/v1/model/ConnectionUnshareSelectedRequestBody.java
+++ b/components/org.wso2.carbon.identity.api.server.organization.connection.sharing.management/org.wso2.carbon.identity.api.server.organization.connection.sharing.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/connection/sharing/management/v1/model/ConnectionUnshareSelectedRequestBody.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.organization.connection.sharing.management.v1.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import java.util.ArrayList;
+import java.util.List;
+import org.wso2.carbon.identity.api.server.organization.connection.sharing.management.v1.model.ConnectionCriteria;
+import javax.validation.constraints.*;
+
+/**
+ * Request body for unsharing connections from a selected set of organizations.
+ **/
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+import javax.validation.Valid;
+import javax.xml.bind.annotation.*;
+@ApiModel(description = "Request body for unsharing connections from a selected set of organizations.")
+public class ConnectionUnshareSelectedRequestBody  {
+  
+    private ConnectionCriteria connectionCriteria;
+    private List<String> orgIds = new ArrayList<>();
+
+
+    /**
+    **/
+    public ConnectionUnshareSelectedRequestBody connectionCriteria(ConnectionCriteria connectionCriteria) {
+
+        this.connectionCriteria = connectionCriteria;
+        return this;
+    }
+    
+    @ApiModelProperty(required = true, value = "")
+    @JsonProperty("connectionCriteria")
+    @Valid
+    @NotNull(message = "Property connectionCriteria cannot be null.")
+
+    public ConnectionCriteria getConnectionCriteria() {
+        return connectionCriteria;
+    }
+    public void setConnectionCriteria(ConnectionCriteria connectionCriteria) {
+        this.connectionCriteria = connectionCriteria;
+    }
+
+    /**
+    * List of organization IDs from which the connections should be unshared.
+    **/
+    public ConnectionUnshareSelectedRequestBody orgIds(List<String> orgIds) {
+
+        this.orgIds = orgIds;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "[\"b028ca17-8f89-449c-ae27-fa955e66465d\",\"a17b28ca-9f89-449c-ae27-fa955e66465f\"]", required = true, value = "List of organization IDs from which the connections should be unshared.")
+    @JsonProperty("orgIds")
+    @Valid
+    @NotNull(message = "Property orgIds cannot be null.")
+
+    public List<String> getOrgIds() {
+        return orgIds;
+    }
+    public void setOrgIds(List<String> orgIds) {
+        this.orgIds = orgIds;
+    }
+
+    public ConnectionUnshareSelectedRequestBody addOrgIdsItem(String orgIdsItem) {
+        this.orgIds.add(orgIdsItem);
+        return this;
+    }
+
+    
+
+    @Override
+    public boolean equals(java.lang.Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ConnectionUnshareSelectedRequestBody connectionUnshareSelectedRequestBody = (ConnectionUnshareSelectedRequestBody) o;
+        return Objects.equals(this.connectionCriteria, connectionUnshareSelectedRequestBody.connectionCriteria) &&
+            Objects.equals(this.orgIds, connectionUnshareSelectedRequestBody.orgIds);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(connectionCriteria, orgIds);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class ConnectionUnshareSelectedRequestBody {\n");
+        
+        sb.append("    connectionCriteria: ").append(toIndentedString(connectionCriteria)).append("\n");
+        sb.append("    orgIds: ").append(toIndentedString(orgIds)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+    * Convert the given object to string with each line indented by 4 spaces
+    * (except the first line).
+    */
+    private String toIndentedString(java.lang.Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}
+

--- a/components/org.wso2.carbon.identity.api.server.organization.connection.sharing.management/org.wso2.carbon.identity.api.server.organization.connection.sharing.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/connection/sharing/management/v1/model/ConnectionUnshareWithAllRequestBody.java
+++ b/components/org.wso2.carbon.identity.api.server.organization.connection.sharing.management/org.wso2.carbon.identity.api.server.organization.connection.sharing.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/connection/sharing/management/v1/model/ConnectionUnshareWithAllRequestBody.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.organization.connection.sharing.management.v1.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import org.wso2.carbon.identity.api.server.organization.connection.sharing.management.v1.model.ConnectionCriteria;
+import javax.validation.constraints.*;
+
+/**
+ * Request body for unsharing connections from **all child organizations**.
+ **/
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+import javax.validation.Valid;
+import javax.xml.bind.annotation.*;
+@ApiModel(description = "Request body for unsharing connections from **all child organizations**.")
+public class ConnectionUnshareWithAllRequestBody  {
+  
+    private ConnectionCriteria connectionCriteria;
+
+    /**
+    **/
+    public ConnectionUnshareWithAllRequestBody connectionCriteria(ConnectionCriteria connectionCriteria) {
+
+        this.connectionCriteria = connectionCriteria;
+        return this;
+    }
+    
+    @ApiModelProperty(required = true, value = "")
+    @JsonProperty("connectionCriteria")
+    @Valid
+    @NotNull(message = "Property connectionCriteria cannot be null.")
+
+    public ConnectionCriteria getConnectionCriteria() {
+        return connectionCriteria;
+    }
+    public void setConnectionCriteria(ConnectionCriteria connectionCriteria) {
+        this.connectionCriteria = connectionCriteria;
+    }
+
+
+
+    @Override
+    public boolean equals(java.lang.Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ConnectionUnshareWithAllRequestBody connectionUnshareWithAllRequestBody = (ConnectionUnshareWithAllRequestBody) o;
+        return Objects.equals(this.connectionCriteria, connectionUnshareWithAllRequestBody.connectionCriteria);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(connectionCriteria);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class ConnectionUnshareWithAllRequestBody {\n");
+        
+        sb.append("    connectionCriteria: ").append(toIndentedString(connectionCriteria)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+    * Convert the given object to string with each line indented by 4 spaces
+    * (except the first line).
+    */
+    private String toIndentedString(java.lang.Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}
+

--- a/components/org.wso2.carbon.identity.api.server.organization.connection.sharing.management/org.wso2.carbon.identity.api.server.organization.connection.sharing.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/connection/sharing/management/v1/model/Error.java
+++ b/components/org.wso2.carbon.identity.api.server.organization.connection.sharing.management/org.wso2.carbon.identity.api.server.organization.connection.sharing.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/connection/sharing/management/v1/model/Error.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.organization.connection.sharing.management.v1.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import javax.validation.constraints.*;
+
+/**
+ * Error response model with a code, message, description, and trace ID.
+ **/
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+import javax.validation.Valid;
+import javax.xml.bind.annotation.*;
+@ApiModel(description = "Error response model with a code, message, description, and trace ID.")
+public class Error  {
+  
+    private String code;
+    private String message;
+    private String description;
+    private String traceId;
+
+    /**
+    **/
+    public Error code(String code) {
+
+        this.code = code;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "CS-00000", required = true, value = "")
+    @JsonProperty("code")
+    @Valid
+    @NotNull(message = "Property code cannot be null.")
+
+    public String getCode() {
+        return code;
+    }
+    public void setCode(String code) {
+        this.code = code;
+    }
+
+    /**
+    **/
+    public Error message(String message) {
+
+        this.message = message;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "Some error message.", required = true, value = "")
+    @JsonProperty("message")
+    @Valid
+    @NotNull(message = "Property message cannot be null.")
+
+    public String getMessage() {
+        return message;
+    }
+    public void setMessage(String message) {
+        this.message = message;
+    }
+
+    /**
+    **/
+    public Error description(String description) {
+
+        this.description = description;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "Some error description.", value = "")
+    @JsonProperty("description")
+    @Valid
+    public String getDescription() {
+        return description;
+    }
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    /**
+    **/
+    public Error traceId(String traceId) {
+
+        this.traceId = traceId;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "e0fbcfeb-7fc2-4b62-8b82-72d3c5fbcdeb", required = true, value = "")
+    @JsonProperty("traceId")
+    @Valid
+    @NotNull(message = "Property traceId cannot be null.")
+
+    public String getTraceId() {
+        return traceId;
+    }
+    public void setTraceId(String traceId) {
+        this.traceId = traceId;
+    }
+
+
+
+    @Override
+    public boolean equals(java.lang.Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Error error = (Error) o;
+        return Objects.equals(this.code, error.code) &&
+            Objects.equals(this.message, error.message) &&
+            Objects.equals(this.description, error.description) &&
+            Objects.equals(this.traceId, error.traceId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(code, message, description, traceId);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class Error {\n");
+        
+        sb.append("    code: ").append(toIndentedString(code)).append("\n");
+        sb.append("    message: ").append(toIndentedString(message)).append("\n");
+        sb.append("    description: ").append(toIndentedString(description)).append("\n");
+        sb.append("    traceId: ").append(toIndentedString(traceId)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+    * Convert the given object to string with each line indented by 4 spaces
+    * (except the first line).
+    */
+    private String toIndentedString(java.lang.Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}
+

--- a/components/org.wso2.carbon.identity.api.server.organization.connection.sharing.management/org.wso2.carbon.identity.api.server.organization.connection.sharing.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/connection/sharing/management/v1/model/Link.java
+++ b/components/org.wso2.carbon.identity.api.server.organization.connection.sharing.management/org.wso2.carbon.identity.api.server.organization.connection.sharing.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/connection/sharing/management/v1/model/Link.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.organization.connection.sharing.management.v1.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import javax.validation.constraints.*;
+
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+import javax.validation.Valid;
+import javax.xml.bind.annotation.*;
+
+public class Link  {
+  
+    private String href;
+    private String rel;
+
+    /**
+    **/
+    public Link href(String href) {
+
+        this.href = href;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "/t/{tenant-domain}/api/server/v1/connections/7a1b7d63-8cfc-4dc9-9332-3f84641b72d8/share?limit=10&after=MTA=", value = "")
+    @JsonProperty("href")
+    @Valid
+    public String getHref() {
+        return href;
+    }
+    public void setHref(String href) {
+        this.href = href;
+    }
+
+    /**
+    **/
+    public Link rel(String rel) {
+
+        this.rel = rel;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "next", value = "")
+    @JsonProperty("rel")
+    @Valid
+    public String getRel() {
+        return rel;
+    }
+    public void setRel(String rel) {
+        this.rel = rel;
+    }
+
+
+
+    @Override
+    public boolean equals(java.lang.Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Link link = (Link) o;
+        return Objects.equals(this.href, link.href) &&
+            Objects.equals(this.rel, link.rel);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(href, rel);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class Link {\n");
+        
+        sb.append("    href: ").append(toIndentedString(href)).append("\n");
+        sb.append("    rel: ").append(toIndentedString(rel)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+    * Convert the given object to string with each line indented by 4 spaces
+    * (except the first line).
+    */
+    private String toIndentedString(java.lang.Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}
+

--- a/components/org.wso2.carbon.identity.api.server.organization.connection.sharing.management/org.wso2.carbon.identity.api.server.organization.connection.sharing.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/connection/sharing/management/v1/model/ProcessSuccessResponse.java
+++ b/components/org.wso2.carbon.identity.api.server.organization.connection.sharing.management/org.wso2.carbon.identity.api.server.organization.connection.sharing.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/organization/connection/sharing/management/v1/model/ProcessSuccessResponse.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.organization.connection.sharing.management.v1.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import javax.validation.constraints.*;
+
+/**
+ * Indicates that a sharing or unsharing process has been triggered successfully.
+ **/
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+import javax.validation.Valid;
+import javax.xml.bind.annotation.*;
+@ApiModel(description = "Indicates that a sharing or unsharing process has been triggered successfully.")
+public class ProcessSuccessResponse  {
+  
+    private String status;
+    private String details;
+
+    /**
+    **/
+    public ProcessSuccessResponse status(String status) {
+
+        this.status = status;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "Processing", value = "")
+    @JsonProperty("status")
+    @Valid
+    public String getStatus() {
+        return status;
+    }
+    public void setStatus(String status) {
+        this.status = status;
+    }
+
+    /**
+    **/
+    public ProcessSuccessResponse details(String details) {
+
+        this.details = details;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "Connection sharing process triggered successfully.", value = "")
+    @JsonProperty("details")
+    @Valid
+    public String getDetails() {
+        return details;
+    }
+    public void setDetails(String details) {
+        this.details = details;
+    }
+
+
+
+    @Override
+    public boolean equals(java.lang.Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ProcessSuccessResponse processSuccessResponse = (ProcessSuccessResponse) o;
+        return Objects.equals(this.status, processSuccessResponse.status) &&
+            Objects.equals(this.details, processSuccessResponse.details);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(status, details);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class ProcessSuccessResponse {\n");
+        
+        sb.append("    status: ").append(toIndentedString(status)).append("\n");
+        sb.append("    details: ").append(toIndentedString(details)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+    * Convert the given object to string with each line indented by 4 spaces
+    * (except the first line).
+    */
+    private String toIndentedString(java.lang.Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}
+

--- a/components/org.wso2.carbon.identity.api.server.organization.connection.sharing.management/org.wso2.carbon.identity.api.server.organization.connection.sharing.management.v1/src/main/java/org/wso2/carbon/identity/api/server/organization/connection/sharing/management/v1/core/ConnectionsApiServiceCore.java
+++ b/components/org.wso2.carbon.identity.api.server.organization.connection.sharing.management/org.wso2.carbon.identity.api.server.organization.connection.sharing.management.v1/src/main/java/org/wso2/carbon/identity/api/server/organization/connection/sharing/management/v1/core/ConnectionsApiServiceCore.java
@@ -1,0 +1,611 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.organization.connection.sharing.management.v1.core;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.cxf.jaxrs.impl.UriInfoImpl;
+import org.apache.cxf.jaxrs.utils.JAXRSUtils;
+import org.apache.cxf.message.Message;
+import org.wso2.carbon.context.PrivilegedCarbonContext;
+import org.wso2.carbon.identity.api.server.organization.connection.sharing.management.common.constants.ConnectionSharingMgtConstants;
+import org.wso2.carbon.identity.api.server.organization.connection.sharing.management.v1.model.ConnectionCriteria;
+import org.wso2.carbon.identity.api.server.organization.connection.sharing.management.v1.model.ConnectionOrgShareConfig;
+import org.wso2.carbon.identity.api.server.organization.connection.sharing.management.v1.model.ConnectionShareSelectedRequestBody;
+import org.wso2.carbon.identity.api.server.organization.connection.sharing.management.v1.model.ConnectionShareWithAllRequestBody;
+import org.wso2.carbon.identity.api.server.organization.connection.sharing.management.v1.model.ConnectionSharedOrganization;
+import org.wso2.carbon.identity.api.server.organization.connection.sharing.management.v1.model.ConnectionSharedOrganizationsResponse;
+import org.wso2.carbon.identity.api.server.organization.connection.sharing.management.v1.model.ConnectionSharingMode;
+import org.wso2.carbon.identity.api.server.organization.connection.sharing.management.v1.model.ConnectionUnshareSelectedRequestBody;
+import org.wso2.carbon.identity.api.server.organization.connection.sharing.management.v1.model.ConnectionUnshareWithAllRequestBody;
+import org.wso2.carbon.identity.api.server.organization.connection.sharing.management.v1.model.Error;
+import org.wso2.carbon.identity.api.server.organization.connection.sharing.management.v1.model.Link;
+import org.wso2.carbon.identity.api.server.organization.connection.sharing.management.v1.model.ProcessSuccessResponse;
+import org.wso2.carbon.identity.organization.management.organization.connection.sharing.ConnectionSharingPolicyHandlerService;
+import org.wso2.carbon.identity.organization.management.organization.connection.sharing.dto.ConnectionSharingModeDTO;
+import org.wso2.carbon.identity.organization.management.organization.connection.sharing.dto.GeneralConnectionShareDTO;
+import org.wso2.carbon.identity.organization.management.organization.connection.sharing.dto.GeneralConnectionUnshareDTO;
+import org.wso2.carbon.identity.organization.management.organization.connection.sharing.dto.GetConnectionSharedOrgsDTO;
+import org.wso2.carbon.identity.organization.management.organization.connection.sharing.dto.ResponseConnectionOrgDetailsDTO;
+import org.wso2.carbon.identity.organization.management.organization.connection.sharing.dto.ResponseSharedConnectionOrgsDTO;
+import org.wso2.carbon.identity.organization.management.organization.connection.sharing.dto.SelectiveConnectionShareDTO;
+import org.wso2.carbon.identity.organization.management.organization.connection.sharing.dto.SelectiveConnectionShareOrgConfigDTO;
+import org.wso2.carbon.identity.organization.management.organization.connection.sharing.dto.SelectiveConnectionUnshareDTO;
+import org.wso2.carbon.identity.organization.management.organization.connection.sharing.exception.ConnectionSharingMgtClientException;
+import org.wso2.carbon.identity.organization.management.organization.connection.sharing.exception.ConnectionSharingMgtException;
+import org.wso2.carbon.identity.organization.management.organization.connection.sharing.models.connectioncriteria.ConnectionCriteriaType;
+import org.wso2.carbon.identity.organization.management.organization.connection.sharing.models.connectioncriteria.ConnectionIdList;
+import org.wso2.carbon.identity.organization.management.organization.connection.sharing.models.connectioncriteria.ConnectionNameList;
+import org.wso2.carbon.identity.organization.resource.sharing.policy.management.constant.PolicyEnum;
+
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriBuilder;
+import javax.ws.rs.core.UriInfo;
+
+import static org.wso2.carbon.identity.api.server.organization.connection.sharing.management.common.constants.ConnectionSharingMgtConstants.CONNECTION_IDS;
+import static org.wso2.carbon.identity.api.server.organization.connection.sharing.management.common.constants.ConnectionSharingMgtConstants.CONNECTION_NAMES;
+import static org.wso2.carbon.identity.api.server.organization.connection.sharing.management.common.constants.ConnectionSharingMgtConstants.ErrorMessage.ERROR_INVALID_CURSOR;
+import static org.wso2.carbon.identity.api.server.organization.connection.sharing.management.common.constants.ConnectionSharingMgtConstants.ErrorMessage.ERROR_INVALID_LIMIT;
+import static org.wso2.carbon.identity.api.server.organization.connection.sharing.management.common.constants.ConnectionSharingMgtConstants.ErrorMessage.ERROR_MISSING_CONNECTION_CRITERIA;
+import static org.wso2.carbon.identity.api.server.organization.connection.sharing.management.common.constants.ConnectionSharingMgtConstants.ErrorMessage.ERROR_UNSUPPORTED_CONNECTION_SHARE_POLICY;
+import static org.wso2.carbon.identity.api.server.organization.connection.sharing.management.common.constants.ConnectionSharingMgtConstants.ErrorMessage.INVALID_GENERAL_CONNECTION_SHARE_REQUEST_BODY;
+import static org.wso2.carbon.identity.api.server.organization.connection.sharing.management.common.constants.ConnectionSharingMgtConstants.ErrorMessage.INVALID_GENERAL_CONNECTION_UNSHARE_REQUEST_BODY;
+import static org.wso2.carbon.identity.api.server.organization.connection.sharing.management.common.constants.ConnectionSharingMgtConstants.ErrorMessage.INVALID_SELECTIVE_CONNECTION_SHARE_REQUEST_BODY;
+import static org.wso2.carbon.identity.api.server.organization.connection.sharing.management.common.constants.ConnectionSharingMgtConstants.ErrorMessage.INVALID_SELECTIVE_CONNECTION_UNSHARE_REQUEST_BODY;
+import static org.wso2.carbon.identity.api.server.organization.connection.sharing.management.common.constants.ConnectionSharingMgtConstants.ErrorMessage.INVALID_UUID_FORMAT;
+import static org.wso2.carbon.identity.api.server.organization.connection.sharing.management.common.constants.ConnectionSharingMgtConstants.RESPONSE_DETAIL_CONNECTION_SHARE;
+import static org.wso2.carbon.identity.api.server.organization.connection.sharing.management.common.constants.ConnectionSharingMgtConstants.RESPONSE_DETAIL_CONNECTION_UNSHARE;
+import static org.wso2.carbon.identity.api.server.organization.connection.sharing.management.common.constants.ConnectionSharingMgtConstants.RESPONSE_STATUS_PROCESSING;
+import static org.wso2.carbon.identity.organization.management.service.util.Utils.getOrganizationId;
+
+/**
+ * Core service class for handling connection sharing management APIs V1.
+ */
+public class ConnectionsApiServiceCore {
+
+    private static final Log LOG = LogFactory.getLog(ConnectionsApiServiceCore.class);
+    private final ConnectionSharingPolicyHandlerService connectionSharingPolicyHandlerService;
+
+    /**
+     * Creates the Connections API v1 core service with the required backend service dependency.
+     *
+     * @param connectionSharingPolicyHandlerService Backend service for connection sharing operations.
+     */
+    public ConnectionsApiServiceCore(ConnectionSharingPolicyHandlerService connectionSharingPolicyHandlerService) {
+
+        this.connectionSharingPolicyHandlerService = connectionSharingPolicyHandlerService;
+    }
+
+    // Public methods corresponding to the endpoints.
+
+    /**
+     * Shares connections with the organizations specified in the request.
+     *
+     * @param connectionShareSelectedRequestBody Request payload containing connection criteria and target
+     *                                           organizations.
+     * @return JAX-RS response.
+     */
+    public Response shareConnectionsWithSelectedOrgs(
+            ConnectionShareSelectedRequestBody connectionShareSelectedRequestBody) {
+
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Selective connection sharing API v1 invoked from tenantDomain: " +
+                    PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantDomain());
+        }
+        if (connectionShareSelectedRequestBody == null) {
+            return Response.status(Response.Status.BAD_REQUEST)
+                    .entity(buildErrorResponse(makeRequestError(INVALID_SELECTIVE_CONNECTION_SHARE_REQUEST_BODY)))
+                    .build();
+        }
+
+        try {
+            SelectiveConnectionShareDTO dto = buildSelectiveConnectionShareDTO(connectionShareSelectedRequestBody);
+            connectionSharingPolicyHandlerService.populateSelectiveConnectionShare(dto);
+            return Response.status(Response.Status.ACCEPTED)
+                    .entity(getProcessSuccessResponse(RESPONSE_DETAIL_CONNECTION_SHARE)).build();
+        } catch (ConnectionSharingMgtClientException e) {
+            return Response.status(Response.Status.BAD_REQUEST).entity(buildErrorResponse(e)).build();
+        } catch (ConnectionSharingMgtException e) {
+            LOG.error("Error occurred while sharing connections with specific organizations.", e);
+            return Response.status(Response.Status.INTERNAL_SERVER_ERROR).entity(buildErrorResponse(e)).build();
+        }
+    }
+
+    /**
+     * Shares connections with all child organizations according to the provided policy.
+     *
+     * @param connectionShareWithAllRequestBody Request payload containing connection criteria and global policy.
+     * @return JAX-RS response.
+     */
+    public Response shareConnectionsWithAllOrgs(ConnectionShareWithAllRequestBody connectionShareWithAllRequestBody) {
+
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("General connection sharing API v1 invoked from tenantDomain: " +
+                    PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantDomain());
+        }
+        if (connectionShareWithAllRequestBody == null) {
+            return Response.status(Response.Status.BAD_REQUEST)
+                    .entity(buildErrorResponse(makeRequestError(INVALID_GENERAL_CONNECTION_SHARE_REQUEST_BODY)))
+                    .build();
+        }
+
+        try {
+            GeneralConnectionShareDTO dto = buildGeneralConnectionShareDTO(connectionShareWithAllRequestBody);
+            connectionSharingPolicyHandlerService.populateGeneralConnectionShare(dto);
+            return Response.status(Response.Status.ACCEPTED)
+                    .entity(getProcessSuccessResponse(RESPONSE_DETAIL_CONNECTION_SHARE)).build();
+        } catch (ConnectionSharingMgtClientException e) {
+            return Response.status(Response.Status.BAD_REQUEST).entity(buildErrorResponse(e)).build();
+        } catch (ConnectionSharingMgtException e) {
+            LOG.error("Error occurred while sharing connections with all organizations.", e);
+            return Response.status(Response.Status.INTERNAL_SERVER_ERROR).entity(buildErrorResponse(e)).build();
+        }
+    }
+
+    /**
+     * Revokes connection sharing from the organizations specified in the request.
+     *
+     * @param connectionUnshareSelectedRequestBody Request payload containing connection criteria and organization IDs.
+     * @return JAX-RS response.
+     */
+    public Response unshareConnectionsFromSelectedOrgs(
+            ConnectionUnshareSelectedRequestBody connectionUnshareSelectedRequestBody) {
+
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Selective connection un-sharing API v1 invoked from tenantDomain: " +
+                    PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantDomain());
+        }
+        if (connectionUnshareSelectedRequestBody == null) {
+            return Response.status(Response.Status.BAD_REQUEST)
+                    .entity(buildErrorResponse(makeRequestError(INVALID_SELECTIVE_CONNECTION_UNSHARE_REQUEST_BODY)))
+                    .build();
+        }
+
+        try {
+            SelectiveConnectionUnshareDTO dto =
+                    buildSelectiveConnectionUnshareDTO(connectionUnshareSelectedRequestBody);
+            connectionSharingPolicyHandlerService.populateSelectiveConnectionUnshare(dto);
+            return Response.status(Response.Status.ACCEPTED)
+                    .entity(getProcessSuccessResponse(RESPONSE_DETAIL_CONNECTION_UNSHARE)).build();
+        } catch (ConnectionSharingMgtClientException e) {
+            return Response.status(Response.Status.BAD_REQUEST).entity(buildErrorResponse(e)).build();
+        } catch (ConnectionSharingMgtException e) {
+            LOG.error("Error occurred while unsharing connections from specific organizations.", e);
+            return Response.status(Response.Status.INTERNAL_SERVER_ERROR).entity(buildErrorResponse(e)).build();
+        }
+    }
+
+    /**
+     * Revokes all connection sharing associations for the connections identified by the given criteria.
+     *
+     * @param connectionUnshareWithAllRequestBody Request payload containing connection criteria.
+     * @return JAX-RS response.
+     */
+    public Response unshareConnectionsFromAllOrgs(
+            ConnectionUnshareWithAllRequestBody connectionUnshareWithAllRequestBody) {
+
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("General connection un-sharing API v1 invoked from tenantDomain: " +
+                    PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantDomain());
+        }
+        if (connectionUnshareWithAllRequestBody == null) {
+            return Response.status(Response.Status.BAD_REQUEST)
+                    .entity(buildErrorResponse(makeRequestError(INVALID_GENERAL_CONNECTION_UNSHARE_REQUEST_BODY)))
+                    .build();
+        }
+
+        try {
+            GeneralConnectionUnshareDTO dto = buildGeneralConnectionUnshareDTO(connectionUnshareWithAllRequestBody);
+            connectionSharingPolicyHandlerService.populateGeneralConnectionUnshare(dto);
+            return Response.status(Response.Status.ACCEPTED)
+                    .entity(getProcessSuccessResponse(RESPONSE_DETAIL_CONNECTION_UNSHARE)).build();
+        } catch (ConnectionSharingMgtClientException e) {
+            return Response.status(Response.Status.BAD_REQUEST).entity(buildErrorResponse(e)).build();
+        } catch (ConnectionSharingMgtException e) {
+            LOG.error("Error occurred while unsharing connections from all organizations.", e);
+            return Response.status(Response.Status.INTERNAL_SERVER_ERROR).entity(buildErrorResponse(e)).build();
+        }
+    }
+
+    /**
+     * Retrieves the list of organizations a specific connection has been shared with.
+     *
+     * @param connectionId ID of the connection whose shared organizations are to be retrieved.
+     * @param before       Cursor for pagination to get results before the specified cursor.
+     * @param after        Cursor for pagination to get results after the specified cursor.
+     * @param filter       Filter string to narrow down results.
+     * @param limit        Maximum number of results to return.
+     * @param recursive    Whether to include organizations shared recursively.
+     * @param attributes   Comma-separated list of additional attributes to include in the response.
+     * @return JAX-RS response containing the list of shared organizations.
+     */
+    public Response getConnectionSharedOrganizations(String connectionId, String before, String after, String filter,
+                                                     Integer limit, Boolean recursive, String attributes) {
+
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Get connection shared organizations API v1 invoked from tenantDomain: " +
+                    PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantDomain() +
+                    " for connection: " + connectionId);
+        }
+
+        try {
+            UUID.fromString(connectionId);
+        } catch (IllegalArgumentException e) {
+            return Response.status(Response.Status.BAD_REQUEST)
+                    .entity(buildErrorResponse(makeRequestError(INVALID_UUID_FORMAT))).build();
+        }
+
+        if (limit != null && limit < 0) {
+            return Response.status(Response.Status.BAD_REQUEST)
+                    .entity(buildErrorResponse(makeRequestError(ERROR_INVALID_LIMIT))).build();
+        }
+
+        final int resolvedLimit = (limit == null) ? 0 : limit;
+        final boolean recursiveFlag = (recursive == null) || recursive;
+
+        final int afterCursor;
+        final int beforeCursor;
+
+        try {
+            afterCursor = decodeCursor(after);
+            beforeCursor = decodeCursor(before);
+        } catch (IllegalArgumentException e) {
+            return Response.status(Response.Status.BAD_REQUEST)
+                    .entity(buildErrorResponse(makeRequestError(ERROR_INVALID_CURSOR))).build();
+        }
+
+        if (afterCursor < 0 || beforeCursor < 0) {
+            return Response.status(Response.Status.BAD_REQUEST)
+                    .entity(buildErrorResponse(makeRequestError(ERROR_INVALID_CURSOR))).build();
+        }
+
+        String organizationId = getOrganizationId();
+
+        try {
+            GetConnectionSharedOrgsDTO dto = new GetConnectionSharedOrgsDTO();
+            dto.setConnectionId(connectionId);
+            dto.setInitiatingOrgId(organizationId);
+            dto.setBefore(beforeCursor);
+            dto.setAfter(afterCursor);
+            dto.setFilter(filter);
+            dto.setLimit(resolvedLimit);
+            dto.setRecursive(recursiveFlag);
+            dto.setAttributes(splitAttributes(attributes));
+
+            ResponseSharedConnectionOrgsDTO result =
+                    connectionSharingPolicyHandlerService.getConnectionSharedOrganizations(dto);
+
+            ConnectionSharedOrganizationsResponse response =
+                    mapConnectionSharedOrganizationsResponse(result, connectionId, filter, limit, recursive,
+                            attributes);
+            return Response.ok().entity(response).build();
+        } catch (ConnectionSharingMgtClientException e) {
+            return Response.status(Response.Status.BAD_REQUEST).entity(buildErrorResponse(e)).build();
+        } catch (ConnectionSharingMgtException e) {
+            LOG.error("Error occurred while retrieving organizations for connection: " + connectionId, e);
+            return Response.status(Response.Status.INTERNAL_SERVER_ERROR).entity(buildErrorResponse(e)).build();
+        }
+    }
+
+    // Helper methods to build DTOs for the service layer.
+
+    private SelectiveConnectionShareDTO buildSelectiveConnectionShareDTO(
+            ConnectionShareSelectedRequestBody body) throws ConnectionSharingMgtClientException {
+
+        SelectiveConnectionShareDTO dto = new SelectiveConnectionShareDTO();
+        dto.setConnectionCriteria(buildConnectionCriteriaFromRequest(body.getConnectionCriteria()));
+
+        List<SelectiveConnectionShareOrgConfigDTO> orgs = new ArrayList<>();
+        if (body.getOrganizations() != null) {
+            for (ConnectionOrgShareConfig orgConfig : body.getOrganizations()) {
+                if (orgConfig != null) {
+                    SelectiveConnectionShareOrgConfigDTO orgDto = new SelectiveConnectionShareOrgConfigDTO();
+                    orgDto.setOrgId(orgConfig.getOrgId());
+                    if (orgConfig.getPolicy() != null) {
+                        orgDto.setPolicy(resolvePolicy(orgConfig.getPolicy().value()));
+                    }
+                    orgs.add(orgDto);
+                }
+            }
+        }
+        dto.setOrganizations(orgs);
+        return dto;
+    }
+
+    private GeneralConnectionShareDTO buildGeneralConnectionShareDTO(
+            ConnectionShareWithAllRequestBody body) throws ConnectionSharingMgtClientException {
+
+        GeneralConnectionShareDTO dto = new GeneralConnectionShareDTO();
+        dto.setConnectionCriteria(buildConnectionCriteriaFromRequest(body.getConnectionCriteria()));
+        if (body.getPolicy() != null) {
+            dto.setPolicy(resolvePolicy(body.getPolicy().value()));
+        }
+        return dto;
+    }
+
+    private SelectiveConnectionUnshareDTO buildSelectiveConnectionUnshareDTO(
+            ConnectionUnshareSelectedRequestBody body) throws ConnectionSharingMgtClientException {
+
+        SelectiveConnectionUnshareDTO dto = new SelectiveConnectionUnshareDTO();
+        dto.setConnectionCriteria(buildConnectionCriteriaFromRequest(body.getConnectionCriteria()));
+        dto.setOrgIds(body.getOrgIds());
+        return dto;
+    }
+
+    private GeneralConnectionUnshareDTO buildGeneralConnectionUnshareDTO(
+            ConnectionUnshareWithAllRequestBody body) throws ConnectionSharingMgtClientException {
+
+        GeneralConnectionUnshareDTO dto = new GeneralConnectionUnshareDTO();
+        dto.setConnectionCriteria(buildConnectionCriteriaFromRequest(body.getConnectionCriteria()));
+        return dto;
+    }
+
+    private Map<String, ConnectionCriteriaType> buildConnectionCriteriaFromRequest(
+            ConnectionCriteria connectionCriteria) throws ConnectionSharingMgtClientException {
+
+        if (connectionCriteria == null) {
+            throw makeRequestError(ERROR_MISSING_CONNECTION_CRITERIA);
+        }
+
+        Map<String, ConnectionCriteriaType> criteriaMap = new HashMap<>();
+
+        if (connectionCriteria.getConnectionIds() != null && !connectionCriteria.getConnectionIds().isEmpty()) {
+            criteriaMap.put(CONNECTION_IDS, new ConnectionIdList(connectionCriteria.getConnectionIds()));
+        }
+        if (connectionCriteria.getConnectionNames() != null && !connectionCriteria.getConnectionNames().isEmpty()) {
+            criteriaMap.put(CONNECTION_NAMES, new ConnectionNameList(connectionCriteria.getConnectionNames()));
+        }
+
+        if (criteriaMap.isEmpty()) {
+            throw makeRequestError(ERROR_MISSING_CONNECTION_CRITERIA);
+        }
+
+        return criteriaMap;
+    }
+
+    private PolicyEnum resolvePolicy(String policyValue) throws ConnectionSharingMgtClientException {
+
+        try {
+            return PolicyEnum.getPolicyByValue(policyValue);
+        } catch (IllegalArgumentException e) {
+            throw makeRequestError(ERROR_UNSUPPORTED_CONNECTION_SHARE_POLICY);
+        }
+    }
+
+    // Helper methods to map service layer responses to API layer responses.
+
+    private ConnectionSharedOrganizationsResponse mapConnectionSharedOrganizationsResponse(
+            ResponseSharedConnectionOrgsDTO result, String connectionId, String filter, Integer limit,
+            Boolean recursive, String attributes) {
+
+        ConnectionSharedOrganizationsResponse response = new ConnectionSharedOrganizationsResponse();
+
+        if (result.getSharingMode() != null) {
+            response.setSharingMode(toApiConnectionSharingMode(result.getSharingMode()));
+        }
+
+        List<ConnectionSharedOrganization> orgs = new ArrayList<>();
+        if (result.getSharedOrgs() != null) {
+            for (ResponseConnectionOrgDetailsDTO orgDTO : result.getSharedOrgs()) {
+                orgs.add(toApiConnectionSharedOrganization(orgDTO));
+            }
+        }
+        response.setOrganizations(orgs);
+
+        List<Link> links = buildPaginationLinks(result, connectionId, filter, limit, recursive, attributes);
+        response.setLinks(links);
+
+        return response;
+    }
+
+    private ConnectionSharedOrganization toApiConnectionSharedOrganization(ResponseConnectionOrgDetailsDTO orgDTO) {
+
+        ConnectionSharedOrganization org = new ConnectionSharedOrganization();
+        org.setOrgId(orgDTO.getOrgId());
+        org.setOrgName(orgDTO.getOrgName());
+        org.setOrgHandle(orgDTO.getOrgHandle());
+        org.setOrgStatus(orgDTO.getStatus());
+        org.setOrgRef(orgDTO.getOrgRef());
+        org.setHasChildren(orgDTO.getHasChildren());
+        org.setDepthFromRoot(orgDTO.getDepthFromRoot());
+        org.setParentOrgId(orgDTO.getParentOrgId());
+        org.setParentConnectionId(orgDTO.getParentConnectionId());
+        org.setSharedConnectionId(orgDTO.getSharedConnectionId());
+        if (orgDTO.getSharingMode() != null) {
+            org.setSharingMode(toApiConnectionSharingMode(orgDTO.getSharingMode()));
+        }
+        return org;
+    }
+
+    private ConnectionSharingMode toApiConnectionSharingMode(ConnectionSharingModeDTO modeDTO) {
+
+        ConnectionSharingMode apiMode = new ConnectionSharingMode();
+        if (modeDTO.getPolicy() != null) {
+            try {
+                apiMode.setPolicy(
+                        ConnectionSharingMode.PolicyEnum.fromValue(modeDTO.getPolicy().getValue()));
+            } catch (IllegalArgumentException e) {
+                LOG.warn("Unrecognised policy value in response: " + modeDTO.getPolicy().getValue());
+            }
+        }
+        return apiMode;
+    }
+
+    private List<Link> buildPaginationLinks(ResponseSharedConnectionOrgsDTO result, String connectionId, String filter,
+                                            Integer limit, Boolean recursive, String attributes) {
+
+        UriInfo uriInfo = getCurrentRequestUriInfo();
+        List<Link> links = new ArrayList<>();
+
+        int nextCursor = result.getNextPageCursor();
+        if (nextCursor > 0) {
+            links.add(new Link()
+                    .rel("next")
+                    .href(buildSharedOrgsPageLink(uriInfo, connectionId, filter, limit, recursive, attributes,
+                            encodeCursor(nextCursor), null)));
+        }
+
+        int prevCursor = result.getPreviousPageCursor();
+        if (prevCursor > 0) {
+            links.add(new Link()
+                    .rel("previous")
+                    .href(buildSharedOrgsPageLink(uriInfo, connectionId, filter, limit, recursive, attributes,
+                            null, encodeCursor(prevCursor))));
+        }
+
+        return links;
+    }
+
+    private String buildSharedOrgsPageLink(UriInfo uriInfo, String connectionId, String filter, Integer limit,
+                                           Boolean recursive, String attributes, String after, String before) {
+
+        if (uriInfo == null) {
+            return buildRelativeSharedOrgsPageLink(connectionId, filter, limit, recursive, attributes, after, before);
+        }
+
+        UriBuilder builder = uriInfo.getBaseUriBuilder()
+                .path("connections")
+                .path(connectionId)
+                .path("share");
+
+        if (limit != null) {
+            builder.queryParam("limit", limit);
+        }
+        if (filter != null && !filter.isEmpty()) {
+            builder.queryParam("filter", filter);
+        }
+        if (recursive != null) {
+            builder.queryParam("recursive", recursive);
+        }
+        if (attributes != null && !attributes.isEmpty()) {
+            builder.queryParam("attributes", attributes);
+        }
+        if (after != null && !after.isEmpty()) {
+            builder.queryParam("after", after);
+        } else if (before != null && !before.isEmpty()) {
+            builder.queryParam("before", before);
+        }
+
+        return builder.build().toString();
+    }
+
+    private String buildRelativeSharedOrgsPageLink(String connectionId, String filter, Integer limit,
+                                                   Boolean recursive, String attributes, String after, String before) {
+
+        String base = "/o/api/server/v1/connections/" + urlEncode(connectionId) + "/share";
+        List<String> qp = new ArrayList<>();
+
+        if (limit != null) {
+            qp.add("limit=" + limit);
+        }
+        if (filter != null && !filter.isEmpty()) {
+            qp.add("filter=" + urlEncode(filter));
+        }
+        if (recursive != null) {
+            qp.add("recursive=" + recursive);
+        }
+        if (attributes != null && !attributes.isEmpty()) {
+            qp.add("attributes=" + urlEncode(attributes));
+        }
+        if (after != null && !after.isEmpty()) {
+            qp.add("after=" + urlEncode(after));
+        } else if (before != null && !before.isEmpty()) {
+            qp.add("before=" + urlEncode(before));
+        }
+
+        return qp.isEmpty() ? base : base + "?" + String.join("&", qp);
+    }
+
+    private UriInfo getCurrentRequestUriInfo() {
+
+        Message message = JAXRSUtils.getCurrentMessage();
+        if (message == null) {
+            return null;
+        }
+        return new UriInfoImpl(message);
+    }
+
+    // Utility helpers.
+
+    private List<String> splitAttributes(String attributes) {
+
+        if (attributes == null || attributes.isEmpty()) {
+            return java.util.Collections.emptyList();
+        }
+        return java.util.Arrays.stream(attributes.split(","))
+                .map(String::trim)
+                .filter(s -> !s.isEmpty())
+                .distinct()
+                .collect(java.util.stream.Collectors.toList());
+    }
+
+    private int decodeCursor(String cursor) {
+
+        if (cursor == null) {
+            return 0;
+        }
+        String decoded = new String(Base64.getDecoder().decode(cursor), StandardCharsets.UTF_8);
+        return Integer.parseInt(decoded);
+    }
+
+    private String encodeCursor(int cursor) {
+
+        return Base64.getEncoder()
+                .encodeToString(String.valueOf(cursor).getBytes(StandardCharsets.UTF_8));
+    }
+
+    private String urlEncode(String value) {
+
+        try {
+            return java.net.URLEncoder.encode(value, "UTF-8");
+        } catch (java.io.UnsupportedEncodingException e) {
+            throw new IllegalStateException("UTF-8 encoding not supported", e);
+        }
+    }
+
+    // Response and error builders.
+
+    private ProcessSuccessResponse getProcessSuccessResponse(String details) {
+
+        ProcessSuccessResponse response = new ProcessSuccessResponse();
+        response.status(RESPONSE_STATUS_PROCESSING);
+        response.setDetails(details);
+        return response;
+    }
+
+    private ConnectionSharingMgtClientException makeRequestError(
+            ConnectionSharingMgtConstants.ErrorMessage error) {
+
+        return new ConnectionSharingMgtClientException(error.getCode(), error.getMessage(), error.getDescription());
+    }
+
+    private Error buildErrorResponse(ConnectionSharingMgtException e) {
+
+        return new Error().code(e.getErrorCode()).message(e.getMessage()).description(e.getDescription())
+                .traceId(UUID.randomUUID().toString());
+    }
+}

--- a/components/org.wso2.carbon.identity.api.server.organization.connection.sharing.management/org.wso2.carbon.identity.api.server.organization.connection.sharing.management.v1/src/main/java/org/wso2/carbon/identity/api/server/organization/connection/sharing/management/v1/factories/ConnectionsApiServiceCoreFactory.java
+++ b/components/org.wso2.carbon.identity.api.server.organization.connection.sharing.management/org.wso2.carbon.identity.api.server.organization.connection.sharing.management.v1/src/main/java/org/wso2/carbon/identity/api/server/organization/connection/sharing/management/v1/factories/ConnectionsApiServiceCoreFactory.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.organization.connection.sharing.management.v1.factories;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.identity.api.server.organization.connection.sharing.management.common.ConnectionSharingMgtServiceHolder;
+import org.wso2.carbon.identity.api.server.organization.connection.sharing.management.v1.core.ConnectionsApiServiceCore;
+import org.wso2.carbon.identity.organization.management.organization.connection.sharing.ConnectionSharingPolicyHandlerService;
+
+/**
+ * Factory class for ConnectionsApiService V1.
+ */
+public class ConnectionsApiServiceCoreFactory {
+
+    private static final Log LOG = LogFactory.getLog(ConnectionsApiServiceCoreFactory.class);
+    private static final ConnectionsApiServiceCore SERVICE;
+
+    static {
+        LOG.debug("Initializing ConnectionsApiServiceCoreFactory");
+        ConnectionSharingPolicyHandlerService connectionSharingPolicyHandlerService =
+                ConnectionSharingMgtServiceHolder.getConnectionSharingPolicyHandlerService();
+        if (connectionSharingPolicyHandlerService == null) {
+            LOG.error("Failed to initialize ConnectionsApiServiceCoreFactory: " +
+                    "ConnectionSharingPolicyHandlerService is not available from OSGi context");
+            throw new IllegalStateException(
+                    "ConnectionSharingPolicyHandlerService is not available from the OSGi context.");
+        }
+        SERVICE = new ConnectionsApiServiceCore(connectionSharingPolicyHandlerService);
+    }
+
+    /**
+     * Get ConnectionsApiServiceCore.
+     *
+     * @return ConnectionsApiServiceCore.
+     */
+    public static ConnectionsApiServiceCore getConnectionsApiServiceCore() {
+
+        return SERVICE;
+    }
+}

--- a/components/org.wso2.carbon.identity.api.server.organization.connection.sharing.management/org.wso2.carbon.identity.api.server.organization.connection.sharing.management.v1/src/main/java/org/wso2/carbon/identity/api/server/organization/connection/sharing/management/v1/impl/ConnectionsApiServiceImpl.java
+++ b/components/org.wso2.carbon.identity.api.server.organization.connection.sharing.management/org.wso2.carbon.identity.api.server.organization.connection.sharing.management.v1/src/main/java/org/wso2/carbon/identity/api/server/organization/connection/sharing/management/v1/impl/ConnectionsApiServiceImpl.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.organization.connection.sharing.management.v1.impl;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.identity.api.server.organization.connection.sharing.management.v1.ConnectionsApiService;
+import org.wso2.carbon.identity.api.server.organization.connection.sharing.management.v1.core.ConnectionsApiServiceCore;
+import org.wso2.carbon.identity.api.server.organization.connection.sharing.management.v1.factories.ConnectionsApiServiceCoreFactory;
+import org.wso2.carbon.identity.api.server.organization.connection.sharing.management.v1.model.ConnectionShareSelectedRequestBody;
+import org.wso2.carbon.identity.api.server.organization.connection.sharing.management.v1.model.ConnectionShareWithAllRequestBody;
+import org.wso2.carbon.identity.api.server.organization.connection.sharing.management.v1.model.ConnectionUnshareSelectedRequestBody;
+import org.wso2.carbon.identity.api.server.organization.connection.sharing.management.v1.model.ConnectionUnshareWithAllRequestBody;
+
+import javax.ws.rs.core.Response;
+
+import static org.wso2.carbon.identity.api.server.organization.connection.sharing.management.common.constants.ConnectionSharingMgtConstants.ErrorMessage.ERROR_INITIATING_CONNECTIONS_API_SERVICE;
+
+/**
+ * Implementation of the connection sharing management APIs V1.
+ */
+public class ConnectionsApiServiceImpl implements ConnectionsApiService {
+
+    private static final Log LOG = LogFactory.getLog(ConnectionsApiServiceImpl.class);
+    private final ConnectionsApiServiceCore connectionsApiServiceCore;
+
+    public ConnectionsApiServiceImpl() {
+
+        try {
+            this.connectionsApiServiceCore = ConnectionsApiServiceCoreFactory.getConnectionsApiServiceCore();
+            LOG.debug("ConnectionsApiServiceImpl V1 initialized successfully.");
+        } catch (IllegalStateException e) {
+            LOG.error("Failed to initialize ConnectionsApiServiceImpl.", e);
+            throw new RuntimeException(ERROR_INITIATING_CONNECTIONS_API_SERVICE.getMessage(), e);
+        }
+    }
+
+    @Override
+    public Response shareConnectionsWithSelected(
+            ConnectionShareSelectedRequestBody connectionShareSelectedRequestBody) {
+
+        return connectionsApiServiceCore.shareConnectionsWithSelectedOrgs(connectionShareSelectedRequestBody);
+    }
+
+    @Override
+    public Response shareConnectionsWithAll(ConnectionShareWithAllRequestBody connectionShareWithAllRequestBody) {
+
+        return connectionsApiServiceCore.shareConnectionsWithAllOrgs(connectionShareWithAllRequestBody);
+    }
+
+    @Override
+    public Response unshareConnectionsFromSelected(
+            ConnectionUnshareSelectedRequestBody connectionUnshareSelectedRequestBody) {
+
+        return connectionsApiServiceCore.unshareConnectionsFromSelectedOrgs(connectionUnshareSelectedRequestBody);
+    }
+
+    @Override
+    public Response unshareConnectionsFromAll(
+            ConnectionUnshareWithAllRequestBody connectionUnshareWithAllRequestBody) {
+
+        return connectionsApiServiceCore.unshareConnectionsFromAllOrgs(connectionUnshareWithAllRequestBody);
+    }
+
+    @Override
+    public Response getConnectionSharedOrganizations(String connectionId, String before, String after, String filter,
+                                                     Integer limit, Boolean recursive, String attributes) {
+
+        return connectionsApiServiceCore.getConnectionSharedOrganizations(connectionId, before, after, filter, limit,
+                recursive, attributes);
+    }
+}

--- a/components/org.wso2.carbon.identity.api.server.organization.connection.sharing.management/org.wso2.carbon.identity.api.server.organization.connection.sharing.management.v1/src/main/resources/connection-sharing-v1.yaml
+++ b/components/org.wso2.carbon.identity.api.server.organization.connection.sharing.management/org.wso2.carbon.identity.api.server.organization.connection.sharing.management.v1/src/main/resources/connection-sharing-v1.yaml
@@ -1,0 +1,818 @@
+openapi: 3.0.0
+info:
+  version: 1.0.0
+  title: "Connection Sharing API"
+  description: |-
+    This document defines the **Connection Sharing REST API** for organizations in **WSO2 Identity Server**.
+    It follows the same pattern as **User Sharing (v2)** and enables organization administrators to:
+    - Share federated identity provider connections with child organizations.
+    - Manage and revoke shared connection access.
+    - Retrieve the organizations a connection has been shared with.
+  contact:
+    name: WSO2
+    url: 'https://wso2.com/identity-platform/access-manager/'
+    email: iam-dev@wso2.org
+  license:
+    name: Apache 2.0
+    url: 'http://www.apache.org/licenses/LICENSE-2.0.html'
+servers:
+  - url: 'https://{server-url}/t/{tenant-domain}/api/server/v1'
+    variables:
+      tenant-domain:
+        default: "carbon.super"
+      server-url:
+        default: "localhost:9443"
+
+security:
+  - OAuth2: []
+  - BasicAuth: []
+
+paths:
+
+  /connections/share:
+    post:
+      tags:
+        - Connection Sharing
+      summary: Share connections with specific organizations
+      description: |-
+        Share one or more federated identity provider connections with a selected set of
+        child organizations.
+
+        Once shared, a shadow connection is created in each target sub-organization.
+        Sub-organization users can then add the shared connection to their application
+        login flows and authenticate through it.
+
+        This endpoint is treated as a **processing function**:
+        it triggers a sharing process and responds with `202 Accepted`.
+
+        **Scope required:** `internal_connection_share`
+      operationId: shareConnectionsWithSelected
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ConnectionShareSelectedRequestBody"
+            example:
+              connectionCriteria:
+                connectionIds:
+                  - "7a1b7d63-8cfc-4dc9-9332-3f84641b72d8"
+                  - "5d2a1c84-9f7a-43cd-b12e-6e52d7f87e16"
+                connectionNames:
+                  - "Google"
+                  - "Facebook"
+              organizations:
+                - orgId: "b028ca17-8f89-449c-ae27-fa955e66465d"
+                  policy: "SELECTED_ORG_ONLY"
+                - orgId: "a17b28ca-9f89-449c-ae27-fa955e66465f"
+                  policy: "SELECTED_ORG_WITH_ALL_EXISTING_AND_FUTURE_CHILDREN"
+      responses:
+        "202":
+          description: Connection sharing process triggered successfully.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ProcessSuccessResponse"
+              example:
+                status: "Processing"
+                details: "Connection sharing process triggered successfully."
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "500":
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+      x-codeSamples:
+        - lang: Curl
+          source: |
+            curl --location 'https://localhost:9443/t/carbon.super/api/server/v1/connections/share' \
+            -H 'Content-Type: application/json' \
+            -H 'Accept: application/json' \
+            -H 'Authorization: Bearer {bearer_token}' \
+            -d '{
+              "connectionCriteria": {
+                "connectionIds": [
+                  "7a1b7d63-8cfc-4dc9-9332-3f84641b72d8",
+                  "5d2a1c84-9f7a-43cd-b12e-6e52d7f87e16"
+                ],
+                "connectionNames": [
+                  "Google",
+                  "Facebook"
+                ]
+              },
+              "organizations": [
+                {
+                  "orgId": "b028ca17-8f89-449c-ae27-fa955e66465d",
+                  "policy": "SELECTED_ORG_ONLY"
+                },
+                {
+                  "orgId": "a17b28ca-9f89-449c-ae27-fa955e66465f",
+                  "policy": "SELECTED_ORG_WITH_ALL_EXISTING_AND_FUTURE_CHILDREN"
+                }
+              ]
+            }'
+
+  /connections/share-with-all:
+    post:
+      tags:
+        - Connection Sharing
+      summary: Share connections with all organizations
+      description: |-
+        Share one or more federated identity provider connections with **all child organizations**
+        according to the specified policy.
+
+        Once shared, a shadow connection is created in each matching sub-organization.
+        Sub-organization users can then add the shared connection to their application
+        login flows and authenticate through it.
+
+        This endpoint is treated as a **processing function** and responds with `202 Accepted`.
+
+        **Scope required:** `internal_connection_share`
+      operationId: shareConnectionsWithAll
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ConnectionShareWithAllRequestBody"
+            example:
+              connectionCriteria:
+                connectionIds:
+                  - "7a1b7d63-8cfc-4dc9-9332-3f84641b72d8"
+                  - "5d2a1c84-9f7a-43cd-b12e-6e52d7f87e16"
+                connectionNames:
+                  - "Google"
+                  - "Facebook"
+              policy: "ALL_EXISTING_AND_FUTURE_ORGS"
+      responses:
+        "202":
+          description: Connection share-with-all process triggered successfully.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ProcessSuccessResponse"
+              example:
+                status: "Processing"
+                details: "Connection share-with-all process triggered successfully."
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "500":
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+      x-codeSamples:
+        - lang: Curl
+          source: |
+            curl --location 'https://localhost:9443/t/carbon.super/api/server/v1/connections/share-with-all' \
+            -H 'Content-Type: application/json' \
+            -H 'Accept: application/json' \
+            -H 'Authorization: Bearer {bearer_token}' \
+            -d '{
+              "connectionCriteria": {
+                "connectionIds": [
+                  "7a1b7d63-8cfc-4dc9-9332-3f84641b72d8",
+                  "5d2a1c84-9f7a-43cd-b12e-6e52d7f87e16"
+                ],
+                "connectionNames": [
+                  "Google",
+                  "Facebook"
+                ]
+              },
+              "policy": "ALL_EXISTING_AND_FUTURE_ORGS"
+            }'
+
+  /connections/unshare:
+    post:
+      tags:
+        - Connection Sharing
+      summary: Unshare connections from specific organizations
+      description: |-
+        Unshare one or more federated identity provider connections from a selected set of
+        child organizations.
+
+        > **Note:**
+        > This only removes the shared connection from the specified organizations. If a connection
+        > was shared with a parent org and its children via a broader policy, you must explicitly
+        > include all relevant organization IDs when unsharing.
+
+        This endpoint is treated as a **processing function** and responds with `202 Accepted`.
+
+        **Scope required:** `internal_connection_unshare`
+      operationId: unshareConnectionsFromSelected
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ConnectionUnshareSelectedRequestBody"
+            example:
+              connectionCriteria:
+                connectionIds:
+                  - "7a1b7d63-8cfc-4dc9-9332-3f84641b72d8"
+                  - "5d2a1c84-9f7a-43cd-b12e-6e52d7f87e16"
+                connectionNames:
+                  - "Google"
+                  - "Facebook"
+              orgIds:
+                - "b028ca17-8f89-449c-ae27-fa955e66465d"
+                - "a17b28ca-9f89-449c-ae27-fa955e66465f"
+      responses:
+        "202":
+          description: Connection unsharing process triggered successfully.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ProcessSuccessResponse"
+              example:
+                status: "Processing"
+                details: "Connection unsharing process triggered successfully."
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "500":
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+      x-codeSamples:
+        - lang: Curl
+          source: |
+            curl --location 'https://localhost:9443/t/carbon.super/api/server/v1/connections/unshare' \
+            -H 'Content-Type: application/json' \
+            -H 'Accept: application/json' \
+            -H 'Authorization: Bearer {bearer_token}' \
+            -d '{
+              "connectionCriteria": {
+                "connectionIds": [
+                  "7a1b7d63-8cfc-4dc9-9332-3f84641b72d8",
+                  "5d2a1c84-9f7a-43cd-b12e-6e52d7f87e16"
+                ],
+                "connectionNames": [
+                  "Google",
+                  "Facebook"
+                ]
+              },
+              "orgIds": [
+                "b028ca17-8f89-449c-ae27-fa955e66465d",
+                "a17b28ca-9f89-449c-ae27-fa955e66465f"
+              ]
+            }'
+
+  /connections/unshare-with-all:
+    post:
+      tags:
+        - Connection Sharing
+      summary: Unshare connections from all organizations
+      description: |-
+        Completely remove shared access for one or more federated identity provider connections
+        from **all child organizations**.
+
+        This endpoint is treated as a **processing function** and responds with `202 Accepted`.
+
+        **Scope required:** `internal_connection_unshare`
+      operationId: unshareConnectionsFromAll
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ConnectionUnshareWithAllRequestBody"
+            example:
+              connectionCriteria:
+                connectionIds:
+                  - "7a1b7d63-8cfc-4dc9-9332-3f84641b72d8"
+                  - "5d2a1c84-9f7a-43cd-b12e-6e52d7f87e16"
+                connectionNames:
+                  - "Google"
+                  - "Facebook"
+      responses:
+        "202":
+          description: Connection unshare-with-all process triggered successfully.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ProcessSuccessResponse"
+              example:
+                status: "Processing"
+                details: "Connection unshare-with-all process triggered successfully."
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "500":
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+      x-codeSamples:
+        - lang: Curl
+          source: |
+            curl --location 'https://localhost:9443/t/carbon.super/api/server/v1/connections/unshare-with-all' \
+            -H 'Content-Type: application/json' \
+            -H 'Accept: application/json' \
+            -H 'Authorization: Bearer {bearer_token}' \
+            -d '{
+              "connectionCriteria": {
+                "connectionIds": [
+                  "7a1b7d63-8cfc-4dc9-9332-3f84641b72d8",
+                  "5d2a1c84-9f7a-43cd-b12e-6e52d7f87e16"
+                ],
+                "connectionNames": [
+                  "Google",
+                  "Facebook"
+                ]
+              }
+            }'
+
+  /connections/{connectionId}/share:
+    get:
+      tags:
+        - Connection Shared Organizations
+      summary: List organizations a connection has been shared with
+      description: |-
+        Retrieve the list of organizations that the specified connection has been shared with,
+        including per-organization sharing mode where applicable.
+
+        The response shape depends on how the connection was shared:
+        - If the connection was shared via **`ALL_EXISTING_AND_FUTURE_ORGS`** policy → a top-level
+          `sharingMode` is returned in the response (only when `attributes=sharingMode` is requested),
+          and no per-org `sharingMode` is present on each organization entry.
+        - If the connection was shared via **`SELECTED_ORG_WITH_ALL_EXISTING_AND_FUTURE_CHILDREN`**
+          policy → no top-level `sharingMode` is returned, and each matching organization entry
+          includes its own `sharingMode` (only when `attributes=sharingMode` is requested).
+        - If the connection was shared via **`SELECTED_ORG_ONLY`** policy → no `sharingMode` is
+          returned at either level, even if `attributes=sharingMode` is requested.
+
+        **Scope required:** `internal_connection_shared_access_view`
+      operationId: getConnectionSharedOrganizations
+      parameters:
+        - in: path
+          name: connectionId
+          required: true
+          schema:
+            type: string
+          description: The unique identifier (UUID) of the connection.
+        - in: query
+          name: before
+          required: false
+          schema:
+            type: string
+          example: "Ng=="
+          description: Base64 encoded cursor value for backward pagination.
+        - in: query
+          name: after
+          required: false
+          schema:
+            type: string
+          example: "Ng=="
+          description: Base64 encoded cursor value for forward pagination.
+        - in: query
+          name: filter
+          required: false
+          schema:
+            type: string
+          example: "orgId eq b028ca17-8f89-449c-ae27-fa955e66465d"
+          description: |-
+            Condition to filter the retrieval of records.
+            Supports `sw`, `co`, `ew`, and `eq` operations.
+        - in: query
+          name: limit
+          required: false
+          schema:
+            type: integer
+          example: 10
+          description: |-
+            Maximum number of records to return. If not specified, all shared organizations
+            are returned.
+        - in: query
+          name: recursive
+          required: false
+          schema:
+            type: boolean
+          description: |-
+            Determines whether a recursive search should happen.
+            If set to `true`, includes shared organizations at all levels of the hierarchy;
+            if set to `false`, includes only shared organizations at the next level of the hierarchy.
+        - in: query
+          name: attributes
+          required: false
+          schema:
+            type: string
+          example: "sharingMode"
+          description: |-
+            Specifies the additional parameters to include in the response.
+            Supported value: `sharingMode`.
+
+            When `sharingMode` is requested:
+            - For connections shared via `ALL_EXISTING_AND_FUTURE_ORGS`, a top-level `sharingMode`
+              is included in the response.
+            - For connections shared via `SELECTED_ORG_WITH_ALL_EXISTING_AND_FUTURE_CHILDREN`,
+              a `sharingMode` is included on each applicable organization entry.
+            - For connections shared via `SELECTED_ORG_ONLY`, no `sharingMode` is returned.
+      responses:
+        "200":
+          description: Successful response with the list of organizations the connection is shared with.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ConnectionSharedOrganizationsResponse"
+              examples:
+                sharedWithAll:
+                  summary: Connection shared with all organizations (attributes=sharingMode requested)
+                  value:
+                    links:
+                      - href: "/t/{tenant-domain}/api/server/v1/connections/7a1b7d63-8cfc-4dc9-9332-3f84641b72d8/share?limit=10&after=MTA="
+                        rel: "next"
+                    sharingMode:
+                      policy: "ALL_EXISTING_AND_FUTURE_ORGS"
+                    organizations:
+                      - orgId: "b028ca17-8f89-449c-ae27-fa955e66465d"
+                        orgName: "Child Org 1"
+                        orgHandle: "child-org-1"
+                        orgStatus: "ACTIVE"
+                        orgRef: "/t/wso2.com/api/server/v1/organizations/b028ca17-8f89-449c-ae27-fa955e66465d"
+                        hasChildren: true
+                        depthFromRoot: 1
+                        parentOrgId: "08f8c1d2-4b3e-4c5a-9f6b-7d8e9f0a1b2c"
+                        parentConnectionId: "7a1b7d63-8cfc-4dc9-9332-3f84641b72d8"
+                        sharedConnectionId: "550e8400-e29b-41d4-a716-446655440000"
+                sharedWithSelected:
+                  summary: Connection shared with selected organizations (attributes=sharingMode requested)
+                  value:
+                    links:
+                      - href: "/t/{tenant-domain}/api/server/v1/connections/7a1b7d63-8cfc-4dc9-9332-3f84641b72d8/share?limit=10&after=MTA="
+                        rel: "next"
+                    organizations:
+                      - orgId: "b028ca17-8f89-449c-ae27-fa955e66465d"
+                        orgName: "Child Org 1"
+                        orgHandle: "child-org-1"
+                        orgStatus: "ACTIVE"
+                        orgRef: "/t/wso2.com/api/server/v1/organizations/b028ca17-8f89-449c-ae27-fa955e66465d"
+                        hasChildren: true
+                        depthFromRoot: 1
+                        parentOrgId: "08f8c1d2-4b3e-4c5a-9f6b-7d8e9f0a1b2c"
+                        parentConnectionId: "7a1b7d63-8cfc-4dc9-9332-3f84641b72d8"
+                        sharedConnectionId: "550e8400-e29b-41d4-a716-446655440000"
+                        sharingMode:
+                          policy: "SELECTED_ORG_WITH_ALL_EXISTING_AND_FUTURE_CHILDREN"
+                      - orgId: "a17b28ca-9f89-449c-ae27-fa955e66465f"
+                        orgName: "Child Org 2"
+                        orgHandle: "child-org-2"
+                        orgStatus: "ACTIVE"
+                        orgRef: "/t/wso2.com/api/server/v1/organizations/a17b28ca-9f89-449c-ae27-fa955e66465f"
+                        hasChildren: false
+                        depthFromRoot: 1
+                        parentOrgId: "08f8c1d2-4b3e-4c5a-9f6b-7d8e9f0a1b2c"
+                        parentConnectionId: "7a1b7d63-8cfc-4dc9-9332-3f84641b72d8"
+                        sharedConnectionId: "3f2504e0-4f89-41d3-9a0c-0305e82c3301"
+                        sharingMode:
+                          policy: "SELECTED_ORG_WITH_ALL_EXISTING_AND_FUTURE_CHILDREN"
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "404":
+          description: Not Found — the specified connection does not exist.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "500":
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+      x-codeSamples:
+        - lang: Curl
+          label: Basic
+          source: |
+            curl --location 'https://localhost:9443/t/carbon.super/api/server/v1/connections/{connectionId}/share' \
+            -H 'Accept: application/json' \
+            -H 'Authorization: Bearer {bearer_token}'
+        - lang: Curl
+          label: With pagination and sharingMode
+          source: |
+            curl --location 'https://localhost:9443/t/carbon.super/api/server/v1/connections/{connectionId}/share?limit=10&after=Ng==&attributes=sharingMode&recursive=true' \
+            -H 'Accept: application/json' \
+            -H 'Authorization: Bearer {bearer_token}'
+        - lang: Curl
+          label: With filter
+          source: |
+            curl --location 'https://localhost:9443/t/carbon.super/api/server/v1/connections/{connectionId}/share?filter=orgId+eq+b028ca17-8f89-449c-ae27-fa955e66465d' \
+            -H 'Accept: application/json' \
+            -H 'Authorization: Bearer {bearer_token}'
+
+components:
+  securitySchemes:
+    BasicAuth:
+      type: http
+      scheme: basic
+    OAuth2:
+      type: oauth2
+      flows:
+        authorizationCode:
+          authorizationUrl: "https://localhost:9443/oauth2/authorize"
+          tokenUrl: "https://localhost:9443/oauth2/token"
+          scopes:
+            internal_connection_share: "Share connections with child organizations."
+            internal_connection_unshare: "Unshare connections from child organizations."
+            internal_connection_shared_access_view: "View organizations a connection has been shared with."
+
+  schemas:
+
+    # ===== Core request models =====
+
+    ConnectionCriteria:
+      type: object
+      description: |-
+        Criteria for selecting the connections to share or unshare.
+
+        At least one of `connectionIds` or `connectionNames` must be provided.
+        Both can be supplied simultaneously, in which case the union of matched
+        connections is used. Validation that at least one field is populated
+        is enforced at the service layer.
+      properties:
+        connectionIds:
+          type: array
+          description: List of connection UUIDs.
+          items:
+            type: string
+          example:
+            - "7a1b7d63-8cfc-4dc9-9332-3f84641b72d8"
+            - "5d2a1c84-9f7a-43cd-b12e-6e52d7f87e16"
+        connectionNames:
+          type: array
+          description: List of connection names.
+          items:
+            type: string
+          example:
+            - "Google"
+            - "Facebook"
+
+    ConnectionShareSelectedRequestBody:
+      type: object
+      description: |-
+        Request body for sharing connections with a **selected set of organizations**.
+      required:
+        - connectionCriteria
+        - organizations
+      properties:
+        connectionCriteria:
+          $ref: "#/components/schemas/ConnectionCriteria"
+        organizations:
+          type: array
+          description: |-
+            List of organizations to share the connections with, along with the
+            sharing policy for each organization.
+          items:
+            $ref: "#/components/schemas/ConnectionOrgShareConfig"
+
+    ConnectionOrgShareConfig:
+      type: object
+      description: Per-organization sharing configuration for selected organizations.
+      required:
+        - orgId
+        - policy
+      properties:
+        orgId:
+          type: string
+          description: The ID of the organization to share the connection with.
+          example: "b028ca17-8f89-449c-ae27-fa955e66465d"
+        policy:
+          type: string
+          description: |-
+            Sharing scope for this organization.
+
+            Possible values:
+            - `SELECTED_ORG_ONLY` — Share with only this specific organization. Sub-organizations
+              created under it will not automatically receive the shared connection.
+            - `SELECTED_ORG_WITH_ALL_EXISTING_AND_FUTURE_CHILDREN` — Share with this organization
+              and all of its child organizations, including those created in the future.
+          enum:
+            - SELECTED_ORG_ONLY
+            - SELECTED_ORG_WITH_ALL_EXISTING_AND_FUTURE_CHILDREN
+          example: "SELECTED_ORG_ONLY"
+
+    ConnectionShareWithAllRequestBody:
+      type: object
+      description: |-
+        Request body for sharing connections with **all child organizations**
+        controlled by the specified policy.
+      required:
+        - connectionCriteria
+        - policy
+      properties:
+        connectionCriteria:
+          $ref: "#/components/schemas/ConnectionCriteria"
+        policy:
+          type: string
+          description: |-
+            Global sharing policy.
+
+            Possible values:
+            - `ALL_EXISTING_AND_FUTURE_ORGS` — Share with all sub-organizations that currently
+              exist **and** any sub-organizations created in the future. This is the recommended
+              policy for connections intended to be used across the entire organization hierarchy.
+          enum:
+            - ALL_EXISTING_AND_FUTURE_ORGS
+          example: "ALL_EXISTING_AND_FUTURE_ORGS"
+
+    ConnectionUnshareSelectedRequestBody:
+      type: object
+      description: |-
+        Request body for unsharing connections from a selected set of organizations.
+      required:
+        - connectionCriteria
+        - orgIds
+      properties:
+        connectionCriteria:
+          $ref: "#/components/schemas/ConnectionCriteria"
+        orgIds:
+          type: array
+          description: List of organization IDs from which the connections should be unshared.
+          items:
+            type: string
+          example:
+            - "b028ca17-8f89-449c-ae27-fa955e66465d"
+            - "a17b28ca-9f89-449c-ae27-fa955e66465f"
+
+    ConnectionUnshareWithAllRequestBody:
+      type: object
+      description: |-
+        Request body for unsharing connections from **all child organizations**.
+      required:
+        - connectionCriteria
+      properties:
+        connectionCriteria:
+          $ref: "#/components/schemas/ConnectionCriteria"
+
+    # ===== Response models =====
+
+    ConnectionSharingMode:
+      type: object
+      description: |-
+        Represents the sharing policy under which a connection has been shared.
+        Only returned when `attributes=sharingMode` is explicitly requested in the GET call.
+
+        - When present at the **top level** of the response, the policy is always
+          `ALL_EXISTING_AND_FUTURE_ORGS`.
+        - When present **per organization**, the policy is always
+          `SELECTED_ORG_WITH_ALL_EXISTING_AND_FUTURE_CHILDREN`.
+        - Connections shared via `SELECTED_ORG_ONLY` will not have a `sharingMode`
+          returned at either level.
+      required:
+        - policy
+      properties:
+        policy:
+          type: string
+          description: |-
+            The sharing policy under which this connection was shared.
+
+            Possible values:
+            - `ALL_EXISTING_AND_FUTURE_ORGS`
+            - `SELECTED_ORG_WITH_ALL_EXISTING_AND_FUTURE_CHILDREN`
+          enum:
+            - ALL_EXISTING_AND_FUTURE_ORGS
+            - SELECTED_ORG_WITH_ALL_EXISTING_AND_FUTURE_CHILDREN
+          example: "ALL_EXISTING_AND_FUTURE_ORGS"
+
+    ConnectionSharedOrganization:
+      type: object
+      description: |-
+        Represents a single organization that a connection has been shared with,
+        including organization metadata and optionally the sharing mode.
+      properties:
+        orgId:
+          type: string
+          description: ID of the child organization.
+          example: "b028ca17-8f89-449c-ae27-fa955e66465d"
+        orgName:
+          type: string
+          description: Name of the child organization.
+          example: "Child Org 1"
+        orgHandle:
+          type: string
+          description: Unique, human-readable handle of the organization.
+          example: "child-org-1"
+        orgStatus:
+          type: string
+          description: Current status of the organization.
+          example: "ACTIVE"
+        orgRef:
+          type: string
+          description: API reference URL of the organization resource.
+          example: "/t/wso2.com/api/server/v1/organizations/b028ca17-8f89-449c-ae27-fa955e66465d"
+        hasChildren:
+          type: boolean
+          description: Indicates whether the organization has child organizations.
+          example: true
+        depthFromRoot:
+          type: integer
+          description: Depth of the organization in the hierarchy, where the root organization is 0.
+          example: 1
+        parentOrgId:
+          type: string
+          nullable: true
+          description: ID of the parent (sharing-initiated) organization.
+          example: "08f8c1d2-4b3e-4c5a-9f6b-7d8e9f0a1b2c"
+        parentConnectionId:
+          type: string
+          description: UUID of the original connection in the parent (sharing-initiated) organization.
+          example: "7a1b7d63-8cfc-4dc9-9332-3f84641b72d8"
+        sharedConnectionId:
+          type: string
+          description: UUID of the shadow connection created in this child organization.
+          example: "550e8400-e29b-41d4-a716-446655440000"
+        sharingMode:
+          $ref: "#/components/schemas/ConnectionSharingMode"
+
+    ConnectionSharedOrganizationsResponse:
+      type: object
+      description: |-
+        Response listing the organizations that a connection has been shared with.
+
+        - `sharingMode` at the top level is only present when the connection was shared
+          via `ALL_EXISTING_AND_FUTURE_ORGS` policy **and** `attributes=sharingMode`
+          was requested.
+        - `sharingMode` on each organization entry is only present when the connection
+          was shared via `SELECTED_ORG_WITH_ALL_EXISTING_AND_FUTURE_CHILDREN` policy
+          **and** `attributes=sharingMode` was requested.
+      properties:
+        links:
+          type: array
+          items:
+            $ref: "#/components/schemas/Link"
+        sharingMode:
+          $ref: "#/components/schemas/ConnectionSharingMode"
+        organizations:
+          type: array
+          items:
+            $ref: "#/components/schemas/ConnectionSharedOrganization"
+
+    # ===== Common models =====
+
+    Link:
+      type: object
+      properties:
+        href:
+          type: string
+          example: "/t/{tenant-domain}/api/server/v1/connections/7a1b7d63-8cfc-4dc9-9332-3f84641b72d8/share?limit=10&after=MTA="
+        rel:
+          type: string
+          example: "next"
+
+    ProcessSuccessResponse:
+      type: object
+      description: |-
+        Indicates that a sharing or unsharing process has been triggered successfully.
+      properties:
+        status:
+          type: string
+          example: "Processing"
+        details:
+          type: string
+          example: "Connection sharing process triggered successfully."
+
+    Error:
+      type: object
+      description: |-
+        Error response model with a code, message, description, and trace ID.
+      required:
+        - code
+        - message
+        - traceId
+      properties:
+        code:
+          type: string
+          example: "CSM-00000"
+        message:
+          type: string
+          example: "Some error message."
+        description:
+          type: string
+          example: "Some error description."
+        traceId:
+          type: string
+          example: "e0fbcfeb-7fc2-4b62-8b82-72d3c5fbcdeb"

--- a/components/org.wso2.carbon.identity.api.server.organization.connection.sharing.management/pom.xml
+++ b/components/org.wso2.carbon.identity.api.server.organization.connection.sharing.management/pom.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+  ~
+  ~ WSO2 LLC. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <groupId>org.wso2.carbon.identity.server.api</groupId>
+        <artifactId>identity-api-server</artifactId>
+        <version>1.6.8-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>org.wso2.carbon.identity.api.server.organization.connection.sharing.management</artifactId>
+    <packaging>pom</packaging>
+
+    <modules>
+        <module>org.wso2.carbon.identity.api.server.organization.connection.sharing.management.common</module>
+        <module>org.wso2.carbon.identity.api.server.organization.connection.sharing.management.v1</module>
+    </modules>
+
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -768,11 +768,28 @@
             </dependency>
             <dependency>
                 <groupId>org.wso2.carbon.identity.organization.management</groupId>
+                <artifactId>org.wso2.carbon.identity.organization.management.organization.connection.sharing</artifactId>
+                <version>${org.wso2.carbon.identity.organization.management.version}</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.wso2.carbon.identity.organization.management</groupId>
                 <artifactId>org.wso2.carbon.identity.organization.resource.sharing.policy.management</artifactId>
                 <version>${org.wso2.carbon.identity.organization.management.version}</version>
                 <scope>provided</scope>
             </dependency>
-
+            <dependency>
+                <groupId>org.wso2.carbon.identity.server.api</groupId>
+                <artifactId>org.wso2.carbon.identity.api.server.organization.connection.sharing.management.common</artifactId>
+                <version>${project.version}</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.wso2.carbon.identity.server.api</groupId>
+                <artifactId>org.wso2.carbon.identity.api.server.organization.connection.sharing.management.v1</artifactId>
+                <version>${project.version}</version>
+                <scope>provided</scope>
+            </dependency>
             <dependency>
                 <groupId>org.wso2.carbon.identity.server.api</groupId>
                 <artifactId>org.wso2.carbon.identity.api.server.organization.selfservice.common</artifactId>
@@ -1095,7 +1112,7 @@
         </org.wso2.carbon.identity.organization.management.core.version.range>
 
         <!-- Organization management service Version -->
-        <org.wso2.carbon.identity.organization.management.version>2.4.5
+        <org.wso2.carbon.identity.organization.management.version>2.5.3-SNAPSHOT
         </org.wso2.carbon.identity.organization.management.version>
 
         <org.wso2.carbon.identity.inbound.provisioning.scim2.version>3.4.146
@@ -1142,6 +1159,7 @@
         <module>components/org.wso2.carbon.identity.api.expired.password.identification</module>
         <module>components/org.wso2.carbon.identity.api.server.organization.user.invitation.management</module>
         <module>components/org.wso2.carbon.identity.api.server.organization.user.sharing.management</module>
+        <module>components/org.wso2.carbon.identity.api.server.organization.connection.sharing.management</module>
         <module>components/org.wso2.carbon.identity.api.server.api.resource</module>
         <module>components/org.wso2.carbon.identity.api.server.organization.configs</module>
         <module>components/org.wso2.carbon.identity.api.server.organization.selfservice</module>


### PR DESCRIPTION
### Purpose
Expose the connection sharing service layer as a REST API, enabling organization administrators to share, unshare, and query federated IDP connections across child organizations via HTTP.

### Goals
 - Implement the `Connection Sharing API v1` following the existing user sharing API patterns
 - Wire the OSGi-provided `ConnectionSharingPolicyHandlerService` into the API layer using the standard WSO2 CXF factory pattern
 - Register the new API component in the root POM dependency management

### Approach
 - Add a new two-module Maven component (`common` + `v1`) under `org.wso2.carbon.identity.api.server.organization.connection.sharing.management`
 - Define the OpenAPI spec at `connection-sharing-v1.yaml` with five endpoints: `POST /connections/share`, `POST /connections/share-with-all`, `POST /connections/unshare`, `POST /connections/unshare-with-all`, `GET /connections/{connectionId}/share`
 - Implement `ConnectionSharingMgtServiceHolder` using the OSGi static inner class lazy-lookup pattern (consistent with `UserSharingMgtServiceHolder`)
 - Implement `ConnectionsApiServiceCoreFactory` to fail fast at startup if the OSGi service is unavailable
 - Implement `ConnectionsApiServiceCore` with full request mapping, cursor-based pagination, and structured error responses
 - Add `org.wso2.carbon.identity.organization.management.organization.connection.sharing` to the root POM's `dependencyManagement` with version `${org.wso2.carbon.identity.organization.management.version}`

### Related Issue
 - issue