### PR TITLE
Fix pagination links of consent mgt API

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.consent.management/org.wso2.carbon.identity.api.server.consent.management.common/src/main/java/org/wso2/carbon/identity/api/server/consent/management/common/ConsentManagementConstants.java
+++ b/components/org.wso2.carbon.identity.api.server.consent.management/org.wso2.carbon.identity.api.server.consent.management.common/src/main/java/org/wso2/carbon/identity/api/server/consent/management/common/ConsentManagementConstants.java
@@ -26,6 +26,7 @@ public class ConsentManagementConstants {
     }
 
     // API Path Components
+    public static final String IDENTITY_API_PATH_COMPONENT = "/api/identity";
     public static final String V2_API_PATH_COMPONENT = "/consent-mgt/v2.0";
 
     // Resource Paths

--- a/components/org.wso2.carbon.identity.api.server.consent.management/org.wso2.carbon.identity.api.server.consent.management.v2/src/gen/java/org/wso2/carbon/identity/api/server/consent/management/v2/model/ConsentCreateRequest.java
+++ b/components/org.wso2.carbon.identity.api.server.consent.management/org.wso2.carbon.identity.api.server.consent.management.v2/src/gen/java/org/wso2/carbon/identity/api/server/consent/management/v2/model/ConsentCreateRequest.java
@@ -76,7 +76,7 @@ public enum StateEnum {
 }
 
     private StateEnum state = StateEnum.ACTIVE;
-    private Long validityTime;
+    private Long expiryTime;
     private List<String> authorizations = null;
 
     private Map<String, String> properties = null;
@@ -189,20 +189,20 @@ public enum StateEnum {
     /**
     * Milliseconds since epoch until which the consent is valid. If omitted, the consent does not expire.
     **/
-    public ConsentCreateRequest validityTime(Long validityTime) {
+    public ConsentCreateRequest expiryTime(Long expiryTime) {
 
-        this.validityTime = validityTime;
+        this.expiryTime = expiryTime;
         return this;
     }
     
     @ApiModelProperty(example = "1766383796000", value = "Milliseconds since epoch until which the consent is valid. If omitted, the consent does not expire.")
-    @JsonProperty("validityTime")
+    @JsonProperty("expiryTime")
     @Valid
-    public Long getValidityTime() {
-        return validityTime;
+    public Long getExpiryTime() {
+        return expiryTime;
     }
-    public void setValidityTime(Long validityTime) {
-        this.validityTime = validityTime;
+    public void setExpiryTime(Long expiryTime) {
+        this.expiryTime = expiryTime;
     }
 
     /**
@@ -277,14 +277,14 @@ public enum StateEnum {
             Objects.equals(this.language, consentCreateRequest.language) &&
             Objects.equals(this.purposes, consentCreateRequest.purposes) &&
             Objects.equals(this.state, consentCreateRequest.state) &&
-            Objects.equals(this.validityTime, consentCreateRequest.validityTime) &&
+            Objects.equals(this.expiryTime, consentCreateRequest.expiryTime) &&
             Objects.equals(this.authorizations, consentCreateRequest.authorizations) &&
             Objects.equals(this.properties, consentCreateRequest.properties);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(subjectId, serviceId, language, purposes, state, validityTime, authorizations, properties);
+        return Objects.hash(subjectId, serviceId, language, purposes, state, expiryTime, authorizations, properties);
     }
 
     @Override
@@ -298,7 +298,7 @@ public enum StateEnum {
         sb.append("    language: ").append(toIndentedString(language)).append("\n");
         sb.append("    purposes: ").append(toIndentedString(purposes)).append("\n");
         sb.append("    state: ").append(toIndentedString(state)).append("\n");
-        sb.append("    validityTime: ").append(toIndentedString(validityTime)).append("\n");
+        sb.append("    expiryTime: ").append(toIndentedString(expiryTime)).append("\n");
         sb.append("    authorizations: ").append(toIndentedString(authorizations)).append("\n");
         sb.append("    properties: ").append(toIndentedString(properties)).append("\n");
         sb.append("}");

--- a/components/org.wso2.carbon.identity.api.server.consent.management/org.wso2.carbon.identity.api.server.consent.management.v2/src/gen/java/org/wso2/carbon/identity/api/server/consent/management/v2/model/ConsentDTO.java
+++ b/components/org.wso2.carbon.identity.api.server.consent.management/org.wso2.carbon.identity.api.server.consent.management.v2/src/gen/java/org/wso2/carbon/identity/api/server/consent/management/v2/model/ConsentDTO.java
@@ -80,7 +80,7 @@ public enum StateEnum {
 }
 
     private StateEnum state;
-    private Long validityTime;
+    private Long expiryTime;
     private List<ConsentedPurposeDTO> purposes = null;
 
     private List<AuthorizationDTO> authorizations = null;
@@ -184,7 +184,7 @@ public enum StateEnum {
     }
 
     /**
-    * PENDING if awaiting approvals, ACTIVE if all accepted, REJECTED if any rejected before activation, REVOKED if any user revoked after activation, EXPIRED if validityTime has passed.
+    * PENDING if awaiting approvals, ACTIVE if all accepted, REJECTED if any rejected before activation, REVOKED if any user revoked after activation, EXPIRED if expiryTime has passed.
     **/
     public ConsentDTO state(StateEnum state) {
 
@@ -192,7 +192,7 @@ public enum StateEnum {
         return this;
     }
     
-    @ApiModelProperty(example = "ACTIVE", value = "PENDING if awaiting approvals, ACTIVE if all accepted, REJECTED if any rejected before activation, REVOKED if any user revoked after activation, EXPIRED if validityTime has passed.")
+    @ApiModelProperty(example = "ACTIVE", value = "PENDING if awaiting approvals, ACTIVE if all accepted, REJECTED if any rejected before activation, REVOKED if any user revoked after activation, EXPIRED if expiryTime has passed.")
     @JsonProperty("state")
     @Valid
     public StateEnum getState() {
@@ -205,20 +205,20 @@ public enum StateEnum {
     /**
     * Milliseconds since epoch until which the consent is valid. Null if no expiry.
     **/
-    public ConsentDTO validityTime(Long validityTime) {
+    public ConsentDTO expiryTime(Long expiryTime) {
 
-        this.validityTime = validityTime;
+        this.expiryTime = expiryTime;
         return this;
     }
     
     @ApiModelProperty(example = "1766383796000", value = "Milliseconds since epoch until which the consent is valid. Null if no expiry.")
-    @JsonProperty("validityTime")
+    @JsonProperty("expiryTime")
     @Valid
-    public Long getValidityTime() {
-        return validityTime;
+    public Long getExpiryTime() {
+        return expiryTime;
     }
-    public void setValidityTime(Long validityTime) {
-        this.validityTime = validityTime;
+    public void setExpiryTime(Long expiryTime) {
+        this.expiryTime = expiryTime;
     }
 
     /**
@@ -321,7 +321,7 @@ public enum StateEnum {
             Objects.equals(this.subjectId, consentDTO.subjectId) &&
             Objects.equals(this.serviceId, consentDTO.serviceId) &&
             Objects.equals(this.state, consentDTO.state) &&
-            Objects.equals(this.validityTime, consentDTO.validityTime) &&
+            Objects.equals(this.expiryTime, consentDTO.expiryTime) &&
             Objects.equals(this.purposes, consentDTO.purposes) &&
             Objects.equals(this.authorizations, consentDTO.authorizations) &&
             Objects.equals(this.properties, consentDTO.properties);
@@ -329,7 +329,7 @@ public enum StateEnum {
 
     @Override
     public int hashCode() {
-        return Objects.hash(timestamp, id, language, subjectId, serviceId, state, validityTime, purposes, authorizations, properties);
+        return Objects.hash(timestamp, id, language, subjectId, serviceId, state, expiryTime, purposes, authorizations, properties);
     }
 
     @Override
@@ -344,7 +344,7 @@ public enum StateEnum {
         sb.append("    subjectId: ").append(toIndentedString(subjectId)).append("\n");
         sb.append("    serviceId: ").append(toIndentedString(serviceId)).append("\n");
         sb.append("    state: ").append(toIndentedString(state)).append("\n");
-        sb.append("    validityTime: ").append(toIndentedString(validityTime)).append("\n");
+        sb.append("    expiryTime: ").append(toIndentedString(expiryTime)).append("\n");
         sb.append("    purposes: ").append(toIndentedString(purposes)).append("\n");
         sb.append("    authorizations: ").append(toIndentedString(authorizations)).append("\n");
         sb.append("    properties: ").append(toIndentedString(properties)).append("\n");

--- a/components/org.wso2.carbon.identity.api.server.consent.management/org.wso2.carbon.identity.api.server.consent.management.v2/src/gen/java/org/wso2/carbon/identity/api/server/consent/management/v2/model/ConsentListResponse.java
+++ b/components/org.wso2.carbon.identity.api.server.consent.management/org.wso2.carbon.identity.api.server.consent.management.v2/src/gen/java/org/wso2/carbon/identity/api/server/consent/management/v2/model/ConsentListResponse.java
@@ -97,7 +97,7 @@ public class ConsentListResponse  {
         return this;
     }
     
-    @ApiModelProperty(example = "[{\"id\":\"f83aa1a3-5d4d-4c0e-84db-c3a4f1e6c8b2\",\"subjectId\":\"alice@wso2.com\",\"serviceId\":\"admin-dashboard\",\"state\":\"ACTIVE\",\"timestamp\":1744000000000,\"validityTime\":1766383796000},{\"id\":\"c2d3e4f5-2345-6789-bcde-f01234567891\",\"subjectId\":\"bob@wso2.com\",\"serviceId\":\"mobile-app\",\"state\":\"PENDING\",\"timestamp\":1744000100000,\"validityTime\":null}]", value = "List of consent records")
+    @ApiModelProperty(example = "[{\"id\":\"f83aa1a3-5d4d-4c0e-84db-c3a4f1e6c8b2\",\"subjectId\":\"alice@wso2.com\",\"serviceId\":\"admin-dashboard\",\"state\":\"ACTIVE\",\"timestamp\":1744000000000,\"expiryTime\":1766383796000},{\"id\":\"c2d3e4f5-2345-6789-bcde-f01234567891\",\"subjectId\":\"bob@wso2.com\",\"serviceId\":\"mobile-app\",\"state\":\"PENDING\",\"timestamp\":1744000100000,\"expiryTime\":null}]", value = "List of consent records")
     @JsonProperty("Consents")
     @Valid
     public List<ConsentSummaryDTO> getConsents() {

--- a/components/org.wso2.carbon.identity.api.server.consent.management/org.wso2.carbon.identity.api.server.consent.management.v2/src/gen/java/org/wso2/carbon/identity/api/server/consent/management/v2/model/ConsentResponseDTO.java
+++ b/components/org.wso2.carbon.identity.api.server.consent.management/org.wso2.carbon.identity.api.server.consent.management.v2/src/gen/java/org/wso2/carbon/identity/api/server/consent/management/v2/model/ConsentResponseDTO.java
@@ -151,7 +151,7 @@ public enum StateEnum {
     }
 
     /**
-    * PENDING if awaiting approvals, ACTIVE if all accepted, REJECTED if any rejected before activation, REVOKED if any user revoked after activation, EXPIRED if validityTime has passed.
+    * PENDING if awaiting approvals, ACTIVE if all accepted, REJECTED if any rejected before activation, REVOKED if any user revoked after activation, EXPIRED if expiryTime has passed.
     **/
     public ConsentResponseDTO state(StateEnum state) {
 
@@ -159,7 +159,7 @@ public enum StateEnum {
         return this;
     }
     
-    @ApiModelProperty(example = "ACTIVE", value = "PENDING if awaiting approvals, ACTIVE if all accepted, REJECTED if any rejected before activation, REVOKED if any user revoked after activation, EXPIRED if validityTime has passed.")
+    @ApiModelProperty(example = "ACTIVE", value = "PENDING if awaiting approvals, ACTIVE if all accepted, REJECTED if any rejected before activation, REVOKED if any user revoked after activation, EXPIRED if expiryTime has passed.")
     @JsonProperty("state")
     @Valid
     public StateEnum getState() {

--- a/components/org.wso2.carbon.identity.api.server.consent.management/org.wso2.carbon.identity.api.server.consent.management.v2/src/gen/java/org/wso2/carbon/identity/api/server/consent/management/v2/model/ConsentSummaryDTO.java
+++ b/components/org.wso2.carbon.identity.api.server.consent.management/org.wso2.carbon.identity.api.server.consent.management.v2/src/gen/java/org/wso2/carbon/identity/api/server/consent/management/v2/model/ConsentSummaryDTO.java
@@ -73,7 +73,7 @@ public enum StateEnum {
 
     private StateEnum state;
     private Long timestamp;
-    private Long validityTime;
+    private Long expiryTime;
 
     /**
     * Unique identifier for the consent
@@ -171,20 +171,20 @@ public enum StateEnum {
     /**
     * Milliseconds since epoch until which the consent is valid. Null if no expiry.
     **/
-    public ConsentSummaryDTO validityTime(Long validityTime) {
+    public ConsentSummaryDTO expiryTime(Long expiryTime) {
 
-        this.validityTime = validityTime;
+        this.expiryTime = expiryTime;
         return this;
     }
     
     @ApiModelProperty(example = "1766383796000", value = "Milliseconds since epoch until which the consent is valid. Null if no expiry.")
-    @JsonProperty("validityTime")
+    @JsonProperty("expiryTime")
     @Valid
-    public Long getValidityTime() {
-        return validityTime;
+    public Long getExpiryTime() {
+        return expiryTime;
     }
-    public void setValidityTime(Long validityTime) {
-        this.validityTime = validityTime;
+    public void setExpiryTime(Long expiryTime) {
+        this.expiryTime = expiryTime;
     }
 
 
@@ -204,12 +204,12 @@ public enum StateEnum {
             Objects.equals(this.serviceId, consentSummaryDTO.serviceId) &&
             Objects.equals(this.state, consentSummaryDTO.state) &&
             Objects.equals(this.timestamp, consentSummaryDTO.timestamp) &&
-            Objects.equals(this.validityTime, consentSummaryDTO.validityTime);
+            Objects.equals(this.expiryTime, consentSummaryDTO.expiryTime);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, subjectId, serviceId, state, timestamp, validityTime);
+        return Objects.hash(id, subjectId, serviceId, state, timestamp, expiryTime);
     }
 
     @Override
@@ -223,7 +223,7 @@ public enum StateEnum {
         sb.append("    serviceId: ").append(toIndentedString(serviceId)).append("\n");
         sb.append("    state: ").append(toIndentedString(state)).append("\n");
         sb.append("    timestamp: ").append(toIndentedString(timestamp)).append("\n");
-        sb.append("    validityTime: ").append(toIndentedString(validityTime)).append("\n");
+        sb.append("    expiryTime: ").append(toIndentedString(expiryTime)).append("\n");
         sb.append("}");
         return sb.toString();
     }

--- a/components/org.wso2.carbon.identity.api.server.consent.management/org.wso2.carbon.identity.api.server.consent.management.v2/src/gen/java/org/wso2/carbon/identity/api/server/consent/management/v2/model/ConsentValidateResponse.java
+++ b/components/org.wso2.carbon.identity.api.server.consent.management/org.wso2.carbon.identity.api.server.consent.management.v2/src/gen/java/org/wso2/carbon/identity/api/server/consent/management/v2/model/ConsentValidateResponse.java
@@ -66,7 +66,7 @@ public enum StateEnum {
 }
 
     private StateEnum state;
-    private Long validityTime;
+    private Long expiryTime;
 
     /**
     * Current state of the consent object.
@@ -90,20 +90,20 @@ public enum StateEnum {
     /**
     * Milliseconds since epoch until which the consent is valid. Null if no expiry.
     **/
-    public ConsentValidateResponse validityTime(Long validityTime) {
+    public ConsentValidateResponse expiryTime(Long expiryTime) {
 
-        this.validityTime = validityTime;
+        this.expiryTime = expiryTime;
         return this;
     }
     
     @ApiModelProperty(example = "1766383796000", value = "Milliseconds since epoch until which the consent is valid. Null if no expiry.")
-    @JsonProperty("validityTime")
+    @JsonProperty("expiryTime")
     @Valid
-    public Long getValidityTime() {
-        return validityTime;
+    public Long getExpiryTime() {
+        return expiryTime;
     }
-    public void setValidityTime(Long validityTime) {
-        this.validityTime = validityTime;
+    public void setExpiryTime(Long expiryTime) {
+        this.expiryTime = expiryTime;
     }
 
 
@@ -119,12 +119,12 @@ public enum StateEnum {
         }
         ConsentValidateResponse consentValidateResponse = (ConsentValidateResponse) o;
         return Objects.equals(this.state, consentValidateResponse.state) &&
-            Objects.equals(this.validityTime, consentValidateResponse.validityTime);
+            Objects.equals(this.expiryTime, consentValidateResponse.expiryTime);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(state, validityTime);
+        return Objects.hash(state, expiryTime);
     }
 
     @Override
@@ -134,7 +134,7 @@ public enum StateEnum {
         sb.append("class ConsentValidateResponse {\n");
         
         sb.append("    state: ").append(toIndentedString(state)).append("\n");
-        sb.append("    validityTime: ").append(toIndentedString(validityTime)).append("\n");
+        sb.append("    expiryTime: ").append(toIndentedString(expiryTime)).append("\n");
         sb.append("}");
         return sb.toString();
     }

--- a/components/org.wso2.carbon.identity.api.server.consent.management/org.wso2.carbon.identity.api.server.consent.management.v2/src/main/java/org/wso2/carbon/identity/api/server/consent/management/v2/core/ConsentManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.consent.management/org.wso2.carbon.identity.api.server.consent.management.v2/src/main/java/org/wso2/carbon/identity/api/server/consent/management/v2/core/ConsentManagementService.java
@@ -36,7 +36,6 @@ import org.wso2.carbon.consent.mgt.core.model.ReceiptInput;
 import org.wso2.carbon.consent.mgt.core.model.ReceiptService;
 import org.wso2.carbon.consent.mgt.core.util.ConsentReceiptUtils;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
-import org.wso2.carbon.identity.api.server.common.ContextLoader;
 import org.wso2.carbon.identity.api.server.consent.management.common.ConsentManagementConstants;
 import org.wso2.carbon.identity.api.server.consent.management.v2.model.AuthorizationCreateRequest;
 import org.wso2.carbon.identity.api.server.consent.management.v2.model.AuthorizationDTO;
@@ -243,13 +242,14 @@ public class ConsentManagementService {
             }
             if (!isFirstPage) {
                 String encodedString = Base64.getEncoder().encodeToString(
-                        receipts.get(0).getConsentReceiptId().getBytes(StandardCharsets.UTF_8));
+                        String.valueOf(receipts.get(0).getConsentTimestamp()).getBytes(StandardCharsets.UTF_8));
                 links.add(buildPaginationLink(url + "&" + FilterConstants.FILTER_ATTR_BEFORE + "=" + encodedString,
                         ConsentManagementConstants.LINK_REL_PREVIOUS));
             }
             if (!isLastPage) {
                 String encodedString = Base64.getEncoder().encodeToString(
-                        receipts.get(receipts.size() - 1).getConsentReceiptId().getBytes(StandardCharsets.UTF_8));
+                        String.valueOf(receipts.get(receipts.size() - 1).getConsentTimestamp())
+                                .getBytes(StandardCharsets.UTF_8));
                 links.add(buildPaginationLink(url + "&" + FilterConstants.FILTER_ATTR_AFTER + "=" + encodedString,
                         ConsentManagementConstants.LINK_REL_NEXT));
             }
@@ -547,7 +547,7 @@ public class ConsentManagementService {
     private PaginationLink buildPaginationLink(String url, String rel) {
 
         return new PaginationLink()
-                .href(ContextLoader.buildURIForHeader(ConsentManagementConstants.V2_API_PATH_COMPONENT +
+                .href(ConsentMgtEndpointUtil.buildURIForHeader(ConsentManagementConstants.V2_API_PATH_COMPONENT +
                         ConsentManagementConstants.CONSENTS_PATH + url).toString())
                 .rel(rel);
     }

--- a/components/org.wso2.carbon.identity.api.server.consent.management/org.wso2.carbon.identity.api.server.consent.management.v2/src/main/java/org/wso2/carbon/identity/api/server/consent/management/v2/core/ConsentManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.consent.management/org.wso2.carbon.identity.api.server.consent.management.v2/src/main/java/org/wso2/carbon/identity/api/server/consent/management/v2/core/ConsentManagementService.java
@@ -55,6 +55,7 @@ import org.wso2.carbon.identity.api.server.consent.management.v2.util.ConsentMgt
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
+import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.Base64;
 import java.util.Collections;
@@ -308,8 +309,10 @@ public class ConsentManagementService {
 
         boolean rejected = ConsentCreateRequest.StateEnum.REJECTED.equals(request.getState());
         String tenantDomain = PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantDomain();
+        Long expiryMillis = request.getExpiryTime();
+        Timestamp expiryTime = expiryMillis != null ? new Timestamp(expiryMillis) : null;
         return ConsentReceiptUtils.buildReceiptInput(request.getLanguage(), subjectId, tenantDomain,
-                request.getValidityTime(), rejected, request.getAuthorizations(), request.getProperties(),
+                expiryTime, rejected, request.getAuthorizations(), request.getProperties(),
                 request.getServiceId(), purposeBindings, consentManager);
     }
 
@@ -322,7 +325,7 @@ public class ConsentManagementService {
         dto.setSubjectId(receipt.getPiiPrincipalId());
         String state = StringUtils.isNotBlank(receipt.getState()) ? receipt.getState() : ACTIVE_STATE;
         dto.setState(ConsentDTO.StateEnum.fromValue(state));
-        dto.setValidityTime(receipt.getValidityTime());
+        dto.setExpiryTime(receipt.getExpiryTime() != null ? receipt.getExpiryTime().getTime() : null);
 
         // Extract service name and purposes from the first service entry (V2 is single-service).
         List<ConsentedPurposeDTO> purposeDTOs = new ArrayList<>();
@@ -500,7 +503,8 @@ public class ConsentManagementService {
 
             Receipt receipt = consentManager.getReceiptWithExtendedSchema(consentId);
             if (receipt != null) {
-                validateResponse.setValidityTime(receipt.getValidityTime());
+                validateResponse.setExpiryTime(
+                        receipt.getExpiryTime() != null ? receipt.getExpiryTime().getTime() : null);
             }
             return validateResponse;
         } catch (ConsentManagementException e) {
@@ -516,7 +520,7 @@ public class ConsentManagementService {
         String state = StringUtils.isNotBlank(receipt.getState()) ? receipt.getState() : ACTIVE_STATE;
         dto.setState(ConsentSummaryDTO.StateEnum.fromValue(state));
         dto.setTimestamp(receipt.getConsentTimestamp());
-        dto.setValidityTime(receipt.getValidityTime());
+        dto.setExpiryTime(receipt.getExpiryTime() != null ? receipt.getExpiryTime().getTime() : null);
         if (receipt.getServices() != null && !receipt.getServices().isEmpty()) {
             dto.setServiceId(receipt.getServices().get(0).getService());
         }

--- a/components/org.wso2.carbon.identity.api.server.consent.management/org.wso2.carbon.identity.api.server.consent.management.v2/src/main/java/org/wso2/carbon/identity/api/server/consent/management/v2/core/ConsentManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.consent.management/org.wso2.carbon.identity.api.server.consent.management.v2/src/main/java/org/wso2/carbon/identity/api/server/consent/management/v2/core/ConsentManagementService.java
@@ -238,14 +238,13 @@ public class ConsentManagementService {
             }
             if (!isFirstPage) {
                 String encodedString = Base64.getEncoder().encodeToString(
-                        String.valueOf(receipts.get(0).getConsentTimestamp()).getBytes(StandardCharsets.UTF_8));
+                        receipts.get(0).getCursor().getBytes(StandardCharsets.UTF_8));
                 links.add(buildPaginationLink(url + "&" + FilterConstants.FILTER_ATTR_BEFORE + "=" + encodedString,
                         ConsentManagementConstants.LINK_REL_PREVIOUS));
             }
             if (!isLastPage) {
                 String encodedString = Base64.getEncoder().encodeToString(
-                        String.valueOf(receipts.get(receipts.size() - 1).getConsentTimestamp())
-                                .getBytes(StandardCharsets.UTF_8));
+                        receipts.get(receipts.size() - 1).getCursor().getBytes(StandardCharsets.UTF_8));
                 links.add(buildPaginationLink(url + "&" + FilterConstants.FILTER_ATTR_AFTER + "=" + encodedString,
                         ConsentManagementConstants.LINK_REL_NEXT));
             }

--- a/components/org.wso2.carbon.identity.api.server.consent.management/org.wso2.carbon.identity.api.server.consent.management.v2/src/main/java/org/wso2/carbon/identity/api/server/consent/management/v2/core/ConsentManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.consent.management/org.wso2.carbon.identity.api.server.consent.management.v2/src/main/java/org/wso2/carbon/identity/api/server/consent/management/v2/core/ConsentManagementService.java
@@ -64,7 +64,6 @@ import static org.wso2.carbon.consent.mgt.core.constant.ConsentConstants.ACTIVE_
 import static org.wso2.carbon.consent.mgt.core.constant.ConsentConstants.DEFAULT_LIMIT;
 import static org.wso2.carbon.consent.mgt.core.constant.ConsentConstants.ErrorMessages.ERROR_CODE_CONSENT_INVALID_STATE_FOR_AUTHORIZE;
 import static org.wso2.carbon.consent.mgt.core.constant.ConsentConstants.ErrorMessages.ERROR_CODE_CONSENT_REJECTED_WITH_AUTHORIZATIONS;
-import static org.wso2.carbon.consent.mgt.core.constant.ConsentConstants.ErrorMessages.ERROR_CODE_CONSENT_SUBJECT_MISMATCH;
 import static org.wso2.carbon.consent.mgt.core.constant.ConsentConstants.ErrorMessages.ERROR_CODE_CONSENT_USER_NOT_IN_AUTHORIZATION_LIST;
 import static org.wso2.carbon.consent.mgt.core.constant.ConsentConstants.ErrorMessages.ERROR_CODE_ELEMENT_UUID_NOT_FOUND;
 import static org.wso2.carbon.consent.mgt.core.constant.ConsentConstants.ErrorMessages.ERROR_CODE_INVALID_QUERY_PARAM;
@@ -113,9 +112,6 @@ public class ConsentManagementService {
         boolean rejected = ConsentCreateRequest.StateEnum.REJECTED.equals(request.getState());
         if (rejected && hasAuthorizations) {
             throw handleClientException(ERROR_CODE_CONSENT_REJECTED_WITH_AUTHORIZATIONS, null);
-        }
-        if (!subjectId.equals(currentUser) && !hasAuthorizations) {
-            throw handleClientException(ERROR_CODE_CONSENT_SUBJECT_MISMATCH, subjectId);
         }
 
         ReceiptInput receiptInput = buildReceiptInput(request, subjectId);
@@ -283,13 +279,6 @@ public class ConsentManagementService {
                 return;
             }
             String callingUser = PrivilegedCarbonContext.getThreadLocalCarbonContext().getUsername();
-            List<ConsentAuthorization> auths = consentManager.getConsentAuthorizations(receiptId);
-            if (auths != null && !auths.isEmpty()) {
-                boolean callingUserInList = auths.stream().anyMatch(a -> callingUser.equals(a.getUserId()));
-                if (!callingUserInList) {
-                    throw handleClientException(ERROR_CODE_CONSENT_USER_NOT_IN_AUTHORIZATION_LIST, callingUser);
-                }
-            }
             consentManager.authorizeConsent(receiptId, callingUser, REVOKE_STATE);
         } catch (ConsentManagementException e) {
             throw ConsentMgtEndpointUtil.handleConsentManagementException(e);

--- a/components/org.wso2.carbon.identity.api.server.consent.management/org.wso2.carbon.identity.api.server.consent.management.v2/src/main/java/org/wso2/carbon/identity/api/server/consent/management/v2/core/ElementManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.consent.management/org.wso2.carbon.identity.api.server.consent.management.v2/src/main/java/org/wso2/carbon/identity/api/server/consent/management/v2/core/ElementManagementService.java
@@ -26,7 +26,6 @@ import org.wso2.carbon.consent.mgt.core.exception.ConsentManagementException;
 import org.wso2.carbon.consent.mgt.core.model.PIICategory;
 import org.wso2.carbon.consent.mgt.core.util.ConsentUtils;
 import org.wso2.carbon.consent.mgt.core.util.FilterQueriesUtil;
-import org.wso2.carbon.identity.api.server.common.ContextLoader;
 import org.wso2.carbon.identity.api.server.consent.management.common.ConsentManagementConstants;
 import org.wso2.carbon.identity.api.server.consent.management.v2.model.ElementCreateRequest;
 import org.wso2.carbon.identity.api.server.consent.management.v2.model.ElementDTO;
@@ -177,14 +176,15 @@ public class ElementManagementService {
                 }
                 if (!isFirstPage) {
                     String prevCursor = Base64.getEncoder().encodeToString(
-                            categories.get(0).getUuid().getBytes(StandardCharsets.UTF_8));
+                            String.valueOf(categories.get(0).getId()).getBytes(StandardCharsets.UTF_8));
                     links.add(buildPaginationLink(
                             url + "&" + FilterConstants.FILTER_ATTR_BEFORE + "=" + prevCursor,
                             ConsentManagementConstants.LINK_REL_PREVIOUS));
                 }
                 if (!isLastPage) {
                     String nextCursor = Base64.getEncoder().encodeToString(
-                            categories.get(categories.size() - 1).getUuid().getBytes(StandardCharsets.UTF_8));
+                            String.valueOf(categories.get(categories.size() - 1).getId())
+                                    .getBytes(StandardCharsets.UTF_8));
                     links.add(buildPaginationLink(
                             url + "&" + FilterConstants.FILTER_ATTR_AFTER + "=" + nextCursor,
                             ConsentManagementConstants.LINK_REL_NEXT));
@@ -246,7 +246,7 @@ public class ElementManagementService {
     private PaginationLink buildPaginationLink(String url, String rel) {
 
         return new PaginationLink()
-                .href(ContextLoader.buildURIForHeader(ConsentManagementConstants.V2_API_PATH_COMPONENT +
+                .href(ConsentMgtEndpointUtil.buildURIForHeader(ConsentManagementConstants.V2_API_PATH_COMPONENT +
                         ConsentManagementConstants.ELEMENTS_PATH + url).toString())
                 .rel(rel);
     }

--- a/components/org.wso2.carbon.identity.api.server.consent.management/org.wso2.carbon.identity.api.server.consent.management.v2/src/main/java/org/wso2/carbon/identity/api/server/consent/management/v2/core/PurposeManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.consent.management/org.wso2.carbon.identity.api.server.consent.management.v2/src/main/java/org/wso2/carbon/identity/api/server/consent/management/v2/core/PurposeManagementService.java
@@ -29,7 +29,6 @@ import org.wso2.carbon.consent.mgt.core.model.PurposePIICategory;
 import org.wso2.carbon.consent.mgt.core.model.PurposeVersion;
 import org.wso2.carbon.consent.mgt.core.util.ConsentUtils;
 import org.wso2.carbon.consent.mgt.core.util.FilterQueriesUtil;
-import org.wso2.carbon.identity.api.server.common.ContextLoader;
 import org.wso2.carbon.identity.api.server.consent.management.common.ConsentManagementConstants;
 import org.wso2.carbon.identity.api.server.consent.management.v2.model.PaginationLink;
 import org.wso2.carbon.identity.api.server.consent.management.v2.model.PurposeCreateRequest;
@@ -198,14 +197,14 @@ public class PurposeManagementService {
                 }
                 if (!isFirstPage) {
                     String prevCursor = Base64.getEncoder().encodeToString(
-                            purposes.get(0).getUuid().getBytes(StandardCharsets.UTF_8));
+                            String.valueOf(purposes.get(0).getId()).getBytes(StandardCharsets.UTF_8));
                     links.add(buildPaginationLink(ConsentManagementConstants.PURPOSES_PATH,
                             url + "&" + FilterConstants.FILTER_ATTR_BEFORE + "=" + prevCursor,
                             ConsentManagementConstants.LINK_REL_PREVIOUS));
                 }
                 if (!isLastPage) {
                     String nextCursor = Base64.getEncoder().encodeToString(
-                            purposes.get(purposes.size() - 1).getUuid().getBytes(StandardCharsets.UTF_8));
+                            String.valueOf(purposes.get(purposes.size() - 1).getId()).getBytes(StandardCharsets.UTF_8));
                     links.add(buildPaginationLink(ConsentManagementConstants.PURPOSES_PATH,
                             url + "&" + FilterConstants.FILTER_ATTR_AFTER + "=" + nextCursor,
                             ConsentManagementConstants.LINK_REL_NEXT));
@@ -215,9 +214,6 @@ public class PurposeManagementService {
             List<PurposeSummaryDTO> items = new ArrayList<>();
             if (purposes != null) {
                 for (Purpose p : purposes) {
-                    if (StringUtils.isBlank(p.getUuid())) {
-                        continue;
-                    }
                     items.add(toPurposeSummaryDTO(p));
                 }
             }
@@ -562,7 +558,7 @@ public class PurposeManagementService {
     private PaginationLink buildPaginationLink(String resourcePath, String url, String rel) {
 
         return new PaginationLink()
-                .href(ContextLoader.buildURIForHeader(ConsentManagementConstants.V2_API_PATH_COMPONENT +
+                .href(ConsentMgtEndpointUtil.buildURIForHeader(ConsentManagementConstants.V2_API_PATH_COMPONENT +
                         resourcePath + url).toString())
                 .rel(rel);
     }

--- a/components/org.wso2.carbon.identity.api.server.consent.management/org.wso2.carbon.identity.api.server.consent.management.v2/src/main/java/org/wso2/carbon/identity/api/server/consent/management/v2/util/ConsentMgtEndpointUtil.java
+++ b/components/org.wso2.carbon.identity.api.server.consent.management/org.wso2.carbon.identity.api.server.consent.management.v2/src/main/java/org/wso2/carbon/identity/api/server/consent/management/v2/util/ConsentMgtEndpointUtil.java
@@ -24,7 +24,10 @@ import org.wso2.carbon.consent.mgt.core.exception.ConsentManagementClientExcepti
 import org.wso2.carbon.consent.mgt.core.exception.ConsentManagementException;
 import org.wso2.carbon.identity.api.server.common.error.APIError;
 import org.wso2.carbon.identity.api.server.common.error.ErrorResponse;
+import org.wso2.carbon.identity.core.ServiceURLBuilder;
+import org.wso2.carbon.identity.core.URLBuilderException;
 
+import java.net.URI;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
@@ -57,6 +60,7 @@ import static org.wso2.carbon.consent.mgt.core.constant.ConsentConstants.ErrorMe
 import static org.wso2.carbon.consent.mgt.core.constant.ConsentConstants.STATUS_BAD_REQUEST_MESSAGE_DEFAULT;
 import static org.wso2.carbon.consent.mgt.core.constant.ConsentConstants.STATUS_INTERNAL_SERVER_ERROR_DESCRIPTION_DEFAULT;
 import static org.wso2.carbon.consent.mgt.core.constant.ConsentConstants.STATUS_INTERNAL_SERVER_ERROR_MESSAGE_DEFAULT;
+import static org.wso2.carbon.identity.api.server.consent.management.common.ConsentManagementConstants.IDENTITY_API_PATH_COMPONENT;
 import static org.wso2.carbon.identity.api.server.consent.management.common.ConsentManagementConstants.STATUS_CONFLICT_MESSAGE_DEFAULT;
 import static org.wso2.carbon.identity.api.server.consent.management.common.ConsentManagementConstants.STATUS_FORBIDDEN_MESSAGE_DEFAULT;
 import static org.wso2.carbon.identity.api.server.consent.management.common.ConsentManagementConstants.STATUS_NOT_FOUND_MESSAGE_DEFAULT;
@@ -106,6 +110,21 @@ public class ConsentMgtEndpointUtil {
 
     private ConsentMgtEndpointUtil() {
 
+    }
+
+    public static URI buildURIForHeader(String endpoint) {
+
+        try {
+            String url = ServiceURLBuilder.create().addPath(IDENTITY_API_PATH_COMPONENT + endpoint)
+                    .build().getAbsolutePublicURL();
+            return URI.create(url);
+        } catch (URLBuilderException e) {
+            ErrorResponse errorResponse = new ErrorResponse.Builder()
+                    .withMessage("Error while building response.")
+                    .withDescription("Server encountered an error while building URL for response header.")
+                    .build(LOG, e, e.getMessage());
+            throw new APIError(Response.Status.INTERNAL_SERVER_ERROR, errorResponse);
+        }
     }
 
     public static APIError handleConsentManagementException(ConsentManagementException e) {

--- a/components/org.wso2.carbon.identity.api.server.consent.management/org.wso2.carbon.identity.api.server.consent.management.v2/src/main/resources/consent-management-v2.yaml
+++ b/components/org.wso2.carbon.identity.api.server.consent.management/org.wso2.carbon.identity.api.server.consent.management.v2/src/main/resources/consent-management-v2.yaml
@@ -983,7 +983,7 @@ components:
             version is published. PENDING is set automatically when authorizations are
             provided and cannot be specified here.
           example: "ACTIVE"
-        validityTime:
+        expiryTime:
           type: integer
           format: int64
           nullable: true
@@ -1331,7 +1331,7 @@ components:
         state:
           type: string
           enum: [PENDING, ACTIVE, REJECTED, REVOKED, EXPIRED]
-          description: PENDING if awaiting approvals, ACTIVE if all accepted, REJECTED if any rejected before activation, REVOKED if any user revoked after activation, EXPIRED if validityTime has passed.
+          description: PENDING if awaiting approvals, ACTIVE if all accepted, REJECTED if any rejected before activation, REVOKED if any user revoked after activation, EXPIRED if expiryTime has passed.
           example: "ACTIVE"
 
     ConsentListResponse:
@@ -1355,13 +1355,13 @@ components:
               serviceId: "admin-dashboard"
               state: "ACTIVE"
               timestamp: 1744000000000
-              validityTime: 1766383796000
+              expiryTime: 1766383796000
             - id: "c2d3e4f5-2345-6789-bcde-f01234567891"
               subjectId: "bob@wso2.com"
               serviceId: "mobile-app"
               state: "PENDING"
               timestamp: 1744000100000
-              validityTime: null
+              expiryTime: null
           items:
             $ref: '#/components/schemas/ConsentSummaryDTO'
 
@@ -1389,7 +1389,7 @@ components:
           format: int64
           description: Milliseconds since epoch when the consent was created.
           example: 1744000000000
-        validityTime:
+        expiryTime:
           type: integer
           format: int64
           nullable: true
@@ -1424,9 +1424,9 @@ components:
         state:
           type: string
           enum: [PENDING, ACTIVE, REJECTED, REVOKED, EXPIRED]
-          description: PENDING if awaiting approvals, ACTIVE if all accepted, REJECTED if any rejected before activation, REVOKED if any user revoked after activation, EXPIRED if validityTime has passed.
+          description: PENDING if awaiting approvals, ACTIVE if all accepted, REJECTED if any rejected before activation, REVOKED if any user revoked after activation, EXPIRED if expiryTime has passed.
           example: "ACTIVE"
-        validityTime:
+        expiryTime:
           type: integer
           format: int64
           nullable: true
@@ -1536,7 +1536,7 @@ components:
           enum: [PENDING, ACTIVE, REJECTED, REVOKED, EXPIRED]
           description: Current state of the consent object.
           example: "ACTIVE"
-        validityTime:
+        expiryTime:
           type: integer
           format: int64
           nullable: true

--- a/pom.xml
+++ b/pom.xml
@@ -1109,7 +1109,7 @@
         <apache.felix.scr.ds.annotations.version>1.2.4</apache.felix.scr.ds.annotations.version>
         <workflow.imple.bps.version>5.5.21</workflow.imple.bps.version>
         <carbon.workflow.engine.version>1.0.18</carbon.workflow.engine.version>
-        <carbon.consent.mgt.version>2.9.4-SNAPSHOT</carbon.consent.mgt.version>
+        <carbon.consent.mgt.version>2.9.4</carbon.consent.mgt.version>
 
         <!--<maven.checkstyleplugin.excludes>**/gen/**/*</maven.checkstyleplugin.excludes>-->
 

--- a/pom.xml
+++ b/pom.xml
@@ -1109,7 +1109,7 @@
         <apache.felix.scr.ds.annotations.version>1.2.4</apache.felix.scr.ds.annotations.version>
         <workflow.imple.bps.version>5.5.21</workflow.imple.bps.version>
         <carbon.workflow.engine.version>1.0.18</carbon.workflow.engine.version>
-        <carbon.consent.mgt.version>2.9.1</carbon.consent.mgt.version>
+        <carbon.consent.mgt.version>2.9.4-SNAPSHOT</carbon.consent.mgt.version>
 
         <!--<maven.checkstyleplugin.excludes>**/gen/**/*</maven.checkstyleplugin.excludes>-->
 


### PR DESCRIPTION
## Purpose
This pull request refactors and improves the pagination and endpoint URL construction logic in the consent management API. The main changes involve switching pagination cursors from UUIDs to numeric IDs or timestamps, centralizing endpoint URL building, and cleaning up unused code. These updates aim to make pagination more robust and standardize how API URLs are generated.

**Pagination improvements:**
- Changed pagination cursors in consent, element, and purpose listings from using UUIDs to using numeric IDs (for elements and purposes) or timestamps (for consents), ensuring more reliable and consistent pagination behavior. [[1]](diffhunk://#diff-3c4454d12e892db2d833f01f6310dd95f00141c62a459b2940ca1ef3d68465a0L246-R252) [[2]](diffhunk://#diff-e7da176097a1a69aacc7892193f7378dc21bd9631465afca6e3b4d376ac701a9L180-R187) [[3]](diffhunk://#diff-9a15b9e3e140b48f04bb55f59cc5ab11f76797d360db52460691b93b0ff813b7L201-R207)
- Removed filtering out of purposes with blank UUIDs, as IDs are now used for pagination and summary creation.

**Endpoint URL construction:**
- Centralized endpoint URL construction by introducing the `ConsentMgtEndpointUtil.buildURIForHeader` method, replacing previous direct calls to `ContextLoader.buildURIForHeader`. This method uses `ServiceURLBuilder` and handles errors more gracefully. [[1]](diffhunk://#diff-fe0f075eb38276e122d1eeb56c9e20f6d5ddbdf964b00fa5923d7189ba6afa42R115-R129) [[2]](diffhunk://#diff-3c4454d12e892db2d833f01f6310dd95f00141c62a459b2940ca1ef3d68465a0L550-R550) [[3]](diffhunk://#diff-e7da176097a1a69aacc7892193f7378dc21bd9631465afca6e3b4d376ac701a9L249-R249) [[4]](diffhunk://#diff-9a15b9e3e140b48f04bb55f59cc5ab11f76797d360db52460691b93b0ff813b7L565-R561)
- Added a new constant `IDENTITY_API_PATH_COMPONENT` to `ConsentManagementConstants` for consistent API path construction. [[1]](diffhunk://#diff-a1251baacc5181f7c2965932a13c7bcdaf30f9382bf90a75991340d1d8535d17R29) [[2]](diffhunk://#diff-fe0f075eb38276e122d1eeb56c9e20f6d5ddbdf964b00fa5923d7189ba6afa42R63)

**Code cleanup:**
- Removed unused imports of `ContextLoader` from several service classes, reflecting the switch to the new endpoint utility. [[1]](diffhunk://#diff-3c4454d12e892db2d833f01f6310dd95f00141c62a459b2940ca1ef3d68465a0L39) [[2]](diffhunk://#diff-e7da176097a1a69aacc7892193f7378dc21bd9631465afca6e3b4d376ac701a9L29) [[3]](diffhunk://#diff-9a15b9e3e140b48f04bb55f59cc5ab11f76797d360db52460691b93b0ff813b7L32)
- Added necessary imports for `ServiceURLBuilder`, `URLBuilderException`, and `URI` in the new utility.

These changes make the pagination mechanism more robust and the codebase cleaner and more maintainable.

## Related issue
- https://github.com/wso2/product-is/issues/26859