### PR TITLE
Add properties for get consent endpoint

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.consent.management/org.wso2.carbon.identity.api.server.consent.management.v2/src/gen/java/org/wso2/carbon/identity/api/server/consent/management/v2/model/ConsentedPurposeDTO.java
+++ b/components/org.wso2.carbon.identity.api.server.consent.management/org.wso2.carbon.identity.api.server.consent.management.v2/src/gen/java/org/wso2/carbon/identity/api/server/consent/management/v2/model/ConsentedPurposeDTO.java
@@ -42,6 +42,7 @@ public class ConsentedPurposeDTO  {
   
     private String name;
     private String id;
+    private String type;
     private String versionId;
     private String version;
     private List<ConsentedElementDTO> elements = null;
@@ -81,7 +82,29 @@ public class ConsentedPurposeDTO  {
         return id;
     }
     public void setId(String id) {
+
         this.id = id;
+    }
+
+    /**
+    * Purpose type classification
+    **/
+    public ConsentedPurposeDTO type(String type) {
+
+        this.type = type;
+        return this;
+    }
+
+    @ApiModelProperty(example = "Policy", value = "Purpose type classification")
+    @JsonProperty("type")
+    @Valid
+    public String getType() {
+
+        return type;
+    }
+    public void setType(String type) {
+
+        this.type = type;
     }
 
     /**
@@ -193,6 +216,7 @@ public class ConsentedPurposeDTO  {
         ConsentedPurposeDTO consentedPurposeDTO = (ConsentedPurposeDTO) o;
         return Objects.equals(this.name, consentedPurposeDTO.name) &&
             Objects.equals(this.id, consentedPurposeDTO.id) &&
+            Objects.equals(this.type, consentedPurposeDTO.type) &&
             Objects.equals(this.versionId, consentedPurposeDTO.versionId) &&
             Objects.equals(this.version, consentedPurposeDTO.version) &&
             Objects.equals(this.elements, consentedPurposeDTO.elements) &&
@@ -201,7 +225,7 @@ public class ConsentedPurposeDTO  {
 
     @Override
     public int hashCode() {
-        return Objects.hash(name, id, versionId, version, elements, properties);
+        return Objects.hash(name, id, type, versionId, version, elements, properties);
     }
 
     @Override
@@ -212,6 +236,7 @@ public class ConsentedPurposeDTO  {
 
         sb.append("    name: ").append(toIndentedString(name)).append("\n");
         sb.append("    id: ").append(toIndentedString(id)).append("\n");
+        sb.append("    type: ").append(toIndentedString(type)).append("\n");
         sb.append("    versionId: ").append(toIndentedString(versionId)).append("\n");
         sb.append("    version: ").append(toIndentedString(version)).append("\n");
         sb.append("    elements: ").append(toIndentedString(elements)).append("\n");

--- a/components/org.wso2.carbon.identity.api.server.consent.management/org.wso2.carbon.identity.api.server.consent.management.v2/src/gen/java/org/wso2/carbon/identity/api/server/consent/management/v2/model/ConsentedPurposeDTO.java
+++ b/components/org.wso2.carbon.identity.api.server.consent.management/org.wso2.carbon.identity.api.server.consent.management.v2/src/gen/java/org/wso2/carbon/identity/api/server/consent/management/v2/model/ConsentedPurposeDTO.java
@@ -23,7 +23,9 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import org.wso2.carbon.identity.api.server.consent.management.v2.model.ConsentedElementDTO;
 import javax.validation.constraints.*;
 
@@ -43,6 +45,7 @@ public class ConsentedPurposeDTO  {
     private String versionId;
     private String version;
     private List<ConsentedElementDTO> elements = null;
+    private Map<String, String> properties = null;
 
 
     /**
@@ -146,7 +149,37 @@ public class ConsentedPurposeDTO  {
         return this;
     }
 
-    
+    /**
+    * Key-value properties from the consented purpose version
+    **/
+    public ConsentedPurposeDTO properties(Map<String, String> properties) {
+
+        this.properties = properties;
+        return this;
+    }
+
+    @ApiModelProperty(value = "Key-value properties from the consented purpose version")
+    @JsonProperty("properties")
+    @Valid
+    public Map<String, String> getProperties() {
+
+        return properties;
+    }
+    public void setProperties(Map<String, String> properties) {
+
+        this.properties = properties;
+    }
+
+    public ConsentedPurposeDTO putPropertiesItem(String key, String propertiesItem) {
+
+        if (this.properties == null) {
+            this.properties = new HashMap<>();
+        }
+        this.properties.put(key, propertiesItem);
+        return this;
+    }
+
+
 
     @Override
     public boolean equals(java.lang.Object o) {
@@ -162,12 +195,13 @@ public class ConsentedPurposeDTO  {
             Objects.equals(this.id, consentedPurposeDTO.id) &&
             Objects.equals(this.versionId, consentedPurposeDTO.versionId) &&
             Objects.equals(this.version, consentedPurposeDTO.version) &&
-            Objects.equals(this.elements, consentedPurposeDTO.elements);
+            Objects.equals(this.elements, consentedPurposeDTO.elements) &&
+            Objects.equals(this.properties, consentedPurposeDTO.properties);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(name, id, versionId, version, elements);
+        return Objects.hash(name, id, versionId, version, elements, properties);
     }
 
     @Override
@@ -175,12 +209,13 @@ public class ConsentedPurposeDTO  {
 
         StringBuilder sb = new StringBuilder();
         sb.append("class ConsentedPurposeDTO {\n");
-        
+
         sb.append("    name: ").append(toIndentedString(name)).append("\n");
         sb.append("    id: ").append(toIndentedString(id)).append("\n");
         sb.append("    versionId: ").append(toIndentedString(versionId)).append("\n");
         sb.append("    version: ").append(toIndentedString(version)).append("\n");
         sb.append("    elements: ").append(toIndentedString(elements)).append("\n");
+        sb.append("    properties: ").append(toIndentedString(properties)).append("\n");
         sb.append("}");
         return sb.toString();
     }

--- a/components/org.wso2.carbon.identity.api.server.consent.management/org.wso2.carbon.identity.api.server.consent.management.v2/src/main/java/org/wso2/carbon/identity/api/server/consent/management/v2/core/ConsentManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.consent.management/org.wso2.carbon.identity.api.server.consent.management.v2/src/main/java/org/wso2/carbon/identity/api/server/consent/management/v2/core/ConsentManagementService.java
@@ -395,10 +395,12 @@ public class ConsentManagementService {
                     PurposeVersion latestVersion = purpose.getLatestVersion();
                     if (latestVersion != null && versionUuid.equals(latestVersion.getUuid())) {
                         dto.setVersion(latestVersion.getVersion());
+                        dto.setProperties(latestVersion.getProperties());
                     } else if (dto.getId() != null) {
                         PurposeVersion pv = consentManager.getPurposeVersion(dto.getId(), versionUuid);
                         if (pv != null) {
                             dto.setVersion(pv.getVersion());
+                            dto.setProperties(pv.getProperties());
                         }
                     }
                 }

--- a/components/org.wso2.carbon.identity.api.server.consent.management/org.wso2.carbon.identity.api.server.consent.management.v2/src/main/java/org/wso2/carbon/identity/api/server/consent/management/v2/core/ConsentManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.consent.management/org.wso2.carbon.identity.api.server.consent.management.v2/src/main/java/org/wso2/carbon/identity/api/server/consent/management/v2/core/ConsentManagementService.java
@@ -390,6 +390,9 @@ public class ConsentManagementService {
                 if (StringUtils.isNotBlank(purpose.getUuid())) {
                     dto.setId(purpose.getUuid());
                 }
+                if (StringUtils.isNotBlank(purpose.getGroupType())) {
+                    dto.setType(purpose.getGroupType());
+                }
                 if (StringUtils.isNotBlank(versionUuid)) {
                     dto.setVersionId(versionUuid);
                     PurposeVersion latestVersion = purpose.getLatestVersion();

--- a/components/org.wso2.carbon.identity.api.server.consent.management/org.wso2.carbon.identity.api.server.consent.management.v2/src/main/resources/consent-management-v2.yaml
+++ b/components/org.wso2.carbon.identity.api.server.consent.management/org.wso2.carbon.identity.api.server.consent.management.v2/src/main/resources/consent-management-v2.yaml
@@ -1475,6 +1475,11 @@ components:
           description: Consented elements for this purpose
           items:
             $ref: '#/components/schemas/ConsentedElementDTO'
+        properties:
+          type: object
+          description: Key-value properties from the consented purpose version
+          additionalProperties:
+            type: string
 
     ConsentedElementDTO:
       type: object

--- a/components/org.wso2.carbon.identity.api.server.consent.management/org.wso2.carbon.identity.api.server.consent.management.v2/src/main/resources/consent-management-v2.yaml
+++ b/components/org.wso2.carbon.identity.api.server.consent.management/org.wso2.carbon.identity.api.server.consent.management.v2/src/main/resources/consent-management-v2.yaml
@@ -1460,6 +1460,10 @@ components:
           type: string
 
           example: "f83aa1a3-5d4d-4c0e-84db-c3a4f1e6c8b2"
+        type:
+          type: string
+          description: Purpose type classification
+          example: "Policy"
         versionId:
           type: string
 
@@ -1477,6 +1481,7 @@ components:
             $ref: '#/components/schemas/ConsentedElementDTO'
         properties:
           type: object
+          nullable: true
           description: Key-value properties from the consented purpose version
           additionalProperties:
             type: string


### PR DESCRIPTION
## Purpose
This pull request enhances the consent management API by adding support for key-value properties associated with each consented purpose version. The main changes introduce a new `properties` field to the `ConsentedPurposeDTO` model, update its serialization and equality logic, and ensure these properties are populated and documented throughout the service and API specification.

**Model enhancements:**

* Added a `properties` field of type `Map<String, String>` to the `ConsentedPurposeDTO` class, along with corresponding getter, setter, and helper methods. This allows storing additional key-value metadata for each consented purpose version. [[1]](diffhunk://#diff-2406f6627693bd7ce7da2ca05e2e7be1803e2bc2aba328dafe77e95f10118e28R48) [[2]](diffhunk://#diff-2406f6627693bd7ce7da2ca05e2e7be1803e2bc2aba328dafe77e95f10118e28R152-R181)
* Updated the `equals`, `hashCode`, and `toString` methods of `ConsentedPurposeDTO` to include the new `properties` field, ensuring correct object comparison and representation. [[1]](diffhunk://#diff-2406f6627693bd7ce7da2ca05e2e7be1803e2bc2aba328dafe77e95f10118e28L165-R204) [[2]](diffhunk://#diff-2406f6627693bd7ce7da2ca05e2e7be1803e2bc2aba328dafe77e95f10118e28R218)

**Service and API updates:**

* Modified the `ConsentManagementService` to set the `properties` field on `ConsentedPurposeDTO` objects when populating them from purpose versions.
* Updated the OpenAPI specification (`consent-management-v2.yaml`) to document the new `properties` field in the `ConsentedPurposeDTO` schema, describing it as an object of string key-value pairs.

## Related issue
- https://github.com/wso2/product-is/issues/26859