### PR TITLE
Improve Custom Authenticator related APIs for provide OAuth2 Client Credential and Password Credential based Authentication Support

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.authenticators/org.wso2.carbon.identity.api.server.authenticators.v1/src/gen/java/org/wso2/carbon/identity/api/server/authenticators/v1/model/AuthenticationType.java
+++ b/components/org.wso2.carbon.identity.api.server.authenticators/org.wso2.carbon.identity.api.server.authenticators.v1/src/gen/java/org/wso2/carbon/identity/api/server/authenticators/v1/model/AuthenticationType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2024-2026, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -40,7 +40,7 @@ public class AuthenticationType  {
 @XmlEnum(String.class)
 public enum TypeEnum {
 
-    @XmlEnumValue("NONE") NONE(String.valueOf("NONE")), @XmlEnumValue("BEARER") BEARER(String.valueOf("BEARER")), @XmlEnumValue("API_KEY") API_KEY(String.valueOf("API_KEY")), @XmlEnumValue("BASIC") BASIC(String.valueOf("BASIC"));
+    @XmlEnumValue("NONE") NONE(String.valueOf("NONE")), @XmlEnumValue("BEARER") BEARER(String.valueOf("BEARER")), @XmlEnumValue("API_KEY") API_KEY(String.valueOf("API_KEY")), @XmlEnumValue("BASIC") BASIC(String.valueOf("BASIC")), @XmlEnumValue("CLIENT_CREDENTIAL") CLIENT_CREDENTIAL(String.valueOf("CLIENT_CREDENTIAL")), @XmlEnumValue("PASSWORD_CREDENTIAL") PASSWORD_CREDENTIAL(String.valueOf("PASSWORD_CREDENTIAL"));
 
 
     private String value;

--- a/components/org.wso2.carbon.identity.api.server.authenticators/org.wso2.carbon.identity.api.server.authenticators.v1/src/main/resources/authenticators.yaml
+++ b/components/org.wso2.carbon.identity.api.server.authenticators/org.wso2.carbon.identity.api.server.authenticators.v1/src/main/resources/authenticators.yaml
@@ -451,6 +451,8 @@ components:
             - BEARER
             - API_KEY
             - BASIC
+            - CLIENT_CREDENTIAL
+            - PASSWORD_CREDENTIAL
           example: BASIC
         properties:
           type: object

--- a/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/gen/java/org/wso2/carbon/identity/api/server/configs/v1/model/AuthenticationType.java
+++ b/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/gen/java/org/wso2/carbon/identity/api/server/configs/v1/model/AuthenticationType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2024-2026, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -40,7 +40,7 @@ public class AuthenticationType  {
 @XmlEnum(String.class)
 public enum TypeEnum {
 
-    @XmlEnumValue("NONE") NONE(String.valueOf("NONE")), @XmlEnumValue("BEARER") BEARER(String.valueOf("BEARER")), @XmlEnumValue("API_KEY") API_KEY(String.valueOf("API_KEY")), @XmlEnumValue("BASIC") BASIC(String.valueOf("BASIC"));
+    @XmlEnumValue("NONE") NONE(String.valueOf("NONE")), @XmlEnumValue("BEARER") BEARER(String.valueOf("BEARER")), @XmlEnumValue("API_KEY") API_KEY(String.valueOf("API_KEY")), @XmlEnumValue("BASIC") BASIC(String.valueOf("BASIC")), @XmlEnumValue("CLIENT_CREDENTIAL") CLIENT_CREDENTIAL(String.valueOf("CLIENT_CREDENTIAL")), @XmlEnumValue("PASSWORD_CREDENTIAL") PASSWORD_CREDENTIAL(String.valueOf("PASSWORD_CREDENTIAL"));
 
 
     private String value;

--- a/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/main/java/org/wso2/carbon/identity/api/server/configs/v1/core/ServerConfigManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/main/java/org/wso2/carbon/identity/api/server/configs/v1/core/ServerConfigManagementService.java
@@ -976,15 +976,12 @@ public class ServerConfigManagementService {
     private void resolveEndpointConfigurationForAuthenticatorFromConfig(
             Authenticator authenticator, UserDefinedLocalAuthenticatorConfig config) {
 
-        /* Only the endpoint URI of the endpoint configurations of the user-defined authenticator is set to the
-        authenticator. The authentication properties in the config are aliases for secrets and must not be included
-         in the response body.*/
         UserDefinedAuthenticatorEndpointConfig endpointConfig = config.getEndpointConfig();
 
         AuthenticationType authenticationType = new AuthenticationType();
         authenticationType.setType(AuthenticationType.TypeEnum.fromValue(
                 endpointConfig.getAuthenticatorEndpointAuthenticationType()));
-        authenticationType.setProperties(null);
+        authenticationType.setProperties(endpointConfig.getResolvedEndpointAuthenticationProperties());
 
         Endpoint endpoint = new Endpoint();
         endpoint.setUri(endpointConfig.getAuthenticatorEndpointUri());

--- a/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/main/resources/configs.yaml
+++ b/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/main/resources/configs.yaml
@@ -1770,6 +1770,8 @@ components:
             - BEARER
             - API_KEY
             - BASIC
+            - CLIENT_CREDENTIAL
+            - PASSWORD_CREDENTIAL
           example: BASIC
         properties:
           type: object

--- a/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/gen/java/org/wso2/carbon/identity/api/server/idp/v1/model/AuthenticationType.java
+++ b/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/gen/java/org/wso2/carbon/identity/api/server/idp/v1/model/AuthenticationType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2024-2026, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -40,7 +40,7 @@ public class AuthenticationType  {
 @XmlEnum(String.class)
 public enum TypeEnum {
 
-    @XmlEnumValue("NONE") NONE(String.valueOf("NONE")), @XmlEnumValue("BEARER") BEARER(String.valueOf("BEARER")), @XmlEnumValue("API_KEY") API_KEY(String.valueOf("API_KEY")), @XmlEnumValue("BASIC") BASIC(String.valueOf("BASIC"));
+    @XmlEnumValue("NONE") NONE(String.valueOf("NONE")), @XmlEnumValue("BEARER") BEARER(String.valueOf("BEARER")), @XmlEnumValue("API_KEY") API_KEY(String.valueOf("API_KEY")), @XmlEnumValue("BASIC") BASIC(String.valueOf("BASIC")), @XmlEnumValue("CLIENT_CREDENTIAL") CLIENT_CREDENTIAL(String.valueOf("CLIENT_CREDENTIAL")), @XmlEnumValue("PASSWORD_CREDENTIAL") PASSWORD_CREDENTIAL(String.valueOf("PASSWORD_CREDENTIAL"));
 
 
     private String value;

--- a/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/main/java/org/wso2/carbon/identity/api/server/idp/v1/impl/FederatedAuthenticatorConfigBuilderFactory.java
+++ b/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/main/java/org/wso2/carbon/identity/api/server/idp/v1/impl/FederatedAuthenticatorConfigBuilderFactory.java
@@ -462,7 +462,7 @@ public class FederatedAuthenticatorConfigBuilderFactory {
             AuthenticationType authenticationType = new AuthenticationType();
             authenticationType.setType(AuthenticationType.TypeEnum.fromValue(endpointConfig.getEndpointConfig()
                     .getAuthentication().getType().toString()));
-            authenticationType.setProperties(null);
+            authenticationType.setProperties(endpointConfig.getResolvedEndpointAuthenticationProperties());
 
             Endpoint endpoint = new Endpoint();
             endpoint.setUri(endpointConfig.getEndpointConfig().getUri());

--- a/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/main/resources/idp.yaml
+++ b/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/main/resources/idp.yaml
@@ -2919,6 +2919,8 @@ components:
             - BEARER
             - API_KEY
             - BASIC
+            - CLIENT_CREDENTIAL
+            - PASSWORD_CREDENTIAL
           example: BASIC
         properties:
           type: object

--- a/pom.xml
+++ b/pom.xml
@@ -800,24 +800,6 @@
                 <version>${org.wso2.carbon.identity.organization.management.version}</version>
                 <scope>provided</scope>
             </dependency>
-            <dependency>
-                <groupId>org.wso2.carbon.identity.organization.management</groupId>
-                <artifactId>org.wso2.carbon.identity.organization.management.capability.governance</artifactId>
-                <version>${org.wso2.carbon.identity.organization.management.version}</version>
-                <scope>provided</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.wso2.carbon.identity.server.api</groupId>
-                <artifactId>org.wso2.carbon.identity.api.server.organization.capability.governance.common</artifactId>
-                <version>${project.version}</version>
-                <scope>provided</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.wso2.carbon.identity.server.api</groupId>
-                <artifactId>org.wso2.carbon.identity.api.server.organization.capability.governance.v1</artifactId>
-                <version>${project.version}</version>
-                <scope>provided</scope>
-            </dependency>
 
             <dependency>
                 <groupId>org.wso2.carbon.identity.server.api</groupId>
@@ -1103,7 +1085,7 @@
         <maven.buildnumber.plugin.version>1.4</maven.buildnumber.plugin.version>
         <org.apache.felix.annotations.version>1.2.4</org.apache.felix.annotations.version>
         <identity.governance.version>1.11.103</identity.governance.version>
-        <carbon.identity.framework.version>7.11.86</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.11.74</carbon.identity.framework.version>
         <maven.findbugsplugin.version>3.0.5</maven.findbugsplugin.version>
         <spotbugs.maven.plugin.version>4.9.8.2</spotbugs.maven.plugin.version>
         <spotbugs.annotations.version>4.9.8</spotbugs.annotations.version>
@@ -1145,7 +1127,7 @@
         <org.wso2.carbon.identity.moesif.version>1.0.0</org.wso2.carbon.identity.moesif.version>
 
         <!-- Organization management service Version -->
-        <org.wso2.carbon.identity.organization.management.version>2.5.10
+        <org.wso2.carbon.identity.organization.management.version>2.5.5
         </org.wso2.carbon.identity.organization.management.version>
 
         <org.wso2.carbon.identity.inbound.provisioning.scim2.version>3.4.146
@@ -1194,7 +1176,6 @@
         <module>components/org.wso2.carbon.identity.api.server.organization.user.invitation.management</module>
         <module>components/org.wso2.carbon.identity.api.server.organization.agent.sharing.management</module>
         <module>components/org.wso2.carbon.identity.api.server.organization.user.sharing.management</module>
-        <module>components/org.wso2.carbon.identity.api.server.organization.capability.governance</module>
         <module>components/org.wso2.carbon.identity.api.server.api.resource</module>
         <module>components/org.wso2.carbon.identity.api.server.organization.configs</module>
         <module>components/org.wso2.carbon.identity.api.server.organization.selfservice</module>


### PR DESCRIPTION
## Purpose
- Improve Custom Authenticator related APIs for provide OAuth2 Client Credential and Password Credential based Authentication Support

## Related Issue
- Improve Custom Authenticator related APIs for provide OAuth2 Client Credential and Password Credential based Authentication Support

## Summary
This pull request adds support for two new authentication types, `CLIENT_CREDENTIAL` and `PASSWORD_CREDENTIAL`, across the authenticators, configs, and identity provider (IDP) APIs. It also ensures that endpoint authentication properties are properly set in API responses, and updates the copyright years and framework dependency.

**Authentication Type Enhancements:**

* Added `CLIENT_CREDENTIAL` and `PASSWORD_CREDENTIAL` as new options to the `TypeEnum` in `AuthenticationType` models for authenticators, configs, and IDP APIs, enabling broader authentication support. [[1]](diffhunk://#diff-2726c967c874e5ed36d7b58b51c898cea08fd5c6b67d764d825f552116a3ea4aL43-R43) [[2]](diffhunk://#diff-c32bc384abe2ad1fccf4ba8e56be9225bfcad9469ceb8547814c7ccdf3fb43d4L43-R43) [[3]](diffhunk://#diff-b8713ba735f2a15f10ddc00f3d0cb556ca26afcfc7fccfbd20152e4e9a44a0c6L43-R43)
* Updated the corresponding OpenAPI YAML files (`authenticators.yaml`, `configs.yaml`, `idp.yaml`) to document these new authentication types in the API specification. [[1]](diffhunk://#diff-34235ea69a0b84b4f729cd77f6a9cca397beb94aece588ed353efed6a4a47e7bR454-R455) [[2]](diffhunk://#diff-7ed2c12b47588ef4166a3507aa38c809122f66e1b7bcc892752f4874b4dab73bR1773-R1774) [[3]](diffhunk://#diff-45468b460d5050a3f6ed28ac2aa6f342bb2d89469a677777cf03bc6262afc0d1R2922-R2923)

**API Response Improvements:**

* Modified logic in `ServerConfigManagementService.java` and `FederatedAuthenticatorConfigBuilderFactory.java` to set endpoint authentication properties in the API response, instead of always returning `null`. This ensures clients receive the correct authentication properties for endpoints. [[1]](diffhunk://#diff-795c8a71a78557b8ee61df48cd95fc7ce1b63a5272acaddef7385eccce84f14dL979-R984) [[2]](diffhunk://#diff-9aa850f951b9e5520bbbee5a2271cbf6ba9ce93c6cee97d05d90485da124d894L465-R465)

**Dependency and Metadata Updates:**

* Bumped the `carbon.identity.framework.version` dependency to `7.11.86-SNAPSHOT` in `pom.xml` for compatibility with the new features.
* Updated copyright years to include 2026 in affected files. [[1]](diffhunk://#diff-2726c967c874e5ed36d7b58b51c898cea08fd5c6b67d764d825f552116a3ea4aL2-R2) [[2]](diffhunk://#diff-c32bc384abe2ad1fccf4ba8e56be9225bfcad9469ceb8547814c7ccdf3fb43d4L2-R2) [[3]](diffhunk://#diff-b8713ba735f2a15f10ddc00f3d0cb556ca26afcfc7fccfbd20152e4e9a44a0c6L2-R2)

