### PR TITLE
Improve Custom Authenticator related APIs for provide OAuth2 client Credential and Password Credential based Authentication Support

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.authenticators/org.wso2.carbon.identity.api.server.authenticators.v1/src/gen/java/org/wso2/carbon/identity/api/server/authenticators/v1/model/AuthenticationType.java
+++ b/components/org.wso2.carbon.identity.api.server.authenticators/org.wso2.carbon.identity.api.server.authenticators.v1/src/gen/java/org/wso2/carbon/identity/api/server/authenticators/v1/model/AuthenticationType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2024-2026, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -40,7 +40,7 @@ public class AuthenticationType  {
 @XmlEnum(String.class)
 public enum TypeEnum {
 
-    @XmlEnumValue("NONE") NONE(String.valueOf("NONE")), @XmlEnumValue("BEARER") BEARER(String.valueOf("BEARER")), @XmlEnumValue("API_KEY") API_KEY(String.valueOf("API_KEY")), @XmlEnumValue("BASIC") BASIC(String.valueOf("BASIC"));
+    @XmlEnumValue("NONE") NONE(String.valueOf("NONE")), @XmlEnumValue("BEARER") BEARER(String.valueOf("BEARER")), @XmlEnumValue("API_KEY") API_KEY(String.valueOf("API_KEY")), @XmlEnumValue("BASIC") BASIC(String.valueOf("BASIC")), @XmlEnumValue("CLIENT_CREDENTIAL") CLIENT_CREDENTIAL(String.valueOf("CLIENT_CREDENTIAL")), @XmlEnumValue("PASSWORD_CREDENTIAL") PASSWORD_CREDENTIAL(String.valueOf("PASSWORD_CREDENTIAL"));
 
 
     private String value;

--- a/components/org.wso2.carbon.identity.api.server.authenticators/org.wso2.carbon.identity.api.server.authenticators.v1/src/main/resources/authenticators.yaml
+++ b/components/org.wso2.carbon.identity.api.server.authenticators/org.wso2.carbon.identity.api.server.authenticators.v1/src/main/resources/authenticators.yaml
@@ -451,6 +451,8 @@ components:
             - BEARER
             - API_KEY
             - BASIC
+            - CLIENT_CREDENTIAL
+            - PASSWORD_CREDENTIAL
           example: BASIC
         properties:
           type: object

--- a/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/gen/java/org/wso2/carbon/identity/api/server/configs/v1/model/AuthenticationType.java
+++ b/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/gen/java/org/wso2/carbon/identity/api/server/configs/v1/model/AuthenticationType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2024-2026, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -40,7 +40,7 @@ public class AuthenticationType  {
 @XmlEnum(String.class)
 public enum TypeEnum {
 
-    @XmlEnumValue("NONE") NONE(String.valueOf("NONE")), @XmlEnumValue("BEARER") BEARER(String.valueOf("BEARER")), @XmlEnumValue("API_KEY") API_KEY(String.valueOf("API_KEY")), @XmlEnumValue("BASIC") BASIC(String.valueOf("BASIC"));
+    @XmlEnumValue("NONE") NONE(String.valueOf("NONE")), @XmlEnumValue("BEARER") BEARER(String.valueOf("BEARER")), @XmlEnumValue("API_KEY") API_KEY(String.valueOf("API_KEY")), @XmlEnumValue("BASIC") BASIC(String.valueOf("BASIC")), @XmlEnumValue("CLIENT_CREDENTIAL") CLIENT_CREDENTIAL(String.valueOf("CLIENT_CREDENTIAL")), @XmlEnumValue("PASSWORD_CREDENTIAL") PASSWORD_CREDENTIAL(String.valueOf("PASSWORD_CREDENTIAL"));
 
 
     private String value;

--- a/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/main/java/org/wso2/carbon/identity/api/server/configs/v1/core/ServerConfigManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/main/java/org/wso2/carbon/identity/api/server/configs/v1/core/ServerConfigManagementService.java
@@ -976,15 +976,12 @@ public class ServerConfigManagementService {
     private void resolveEndpointConfigurationForAuthenticatorFromConfig(
             Authenticator authenticator, UserDefinedLocalAuthenticatorConfig config) {
 
-        /* Only the endpoint URI of the endpoint configurations of the user-defined authenticator is set to the
-        authenticator. The authentication properties in the config are aliases for secrets and must not be included
-         in the response body.*/
         UserDefinedAuthenticatorEndpointConfig endpointConfig = config.getEndpointConfig();
 
         AuthenticationType authenticationType = new AuthenticationType();
         authenticationType.setType(AuthenticationType.TypeEnum.fromValue(
                 endpointConfig.getAuthenticatorEndpointAuthenticationType()));
-        authenticationType.setProperties(null);
+        authenticationType.setProperties(endpointConfig.getResolvedEndpointAuthenticationProperties());
 
         Endpoint endpoint = new Endpoint();
         endpoint.setUri(endpointConfig.getAuthenticatorEndpointUri());

--- a/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/main/resources/configs.yaml
+++ b/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/main/resources/configs.yaml
@@ -1770,6 +1770,8 @@ components:
             - BEARER
             - API_KEY
             - BASIC
+            - CLIENT_CREDENTIAL
+            - PASSWORD_CREDENTIAL
           example: BASIC
         properties:
           type: object

--- a/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/gen/java/org/wso2/carbon/identity/api/server/idp/v1/model/AuthenticationType.java
+++ b/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/gen/java/org/wso2/carbon/identity/api/server/idp/v1/model/AuthenticationType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2024-2026, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -40,7 +40,7 @@ public class AuthenticationType  {
 @XmlEnum(String.class)
 public enum TypeEnum {
 
-    @XmlEnumValue("NONE") NONE(String.valueOf("NONE")), @XmlEnumValue("BEARER") BEARER(String.valueOf("BEARER")), @XmlEnumValue("API_KEY") API_KEY(String.valueOf("API_KEY")), @XmlEnumValue("BASIC") BASIC(String.valueOf("BASIC"));
+    @XmlEnumValue("NONE") NONE(String.valueOf("NONE")), @XmlEnumValue("BEARER") BEARER(String.valueOf("BEARER")), @XmlEnumValue("API_KEY") API_KEY(String.valueOf("API_KEY")), @XmlEnumValue("BASIC") BASIC(String.valueOf("BASIC")), @XmlEnumValue("CLIENT_CREDENTIAL") CLIENT_CREDENTIAL(String.valueOf("CLIENT_CREDENTIAL")), @XmlEnumValue("PASSWORD_CREDENTIAL") PASSWORD_CREDENTIAL(String.valueOf("PASSWORD_CREDENTIAL"));
 
 
     private String value;

--- a/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/main/java/org/wso2/carbon/identity/api/server/idp/v1/impl/FederatedAuthenticatorConfigBuilderFactory.java
+++ b/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/main/java/org/wso2/carbon/identity/api/server/idp/v1/impl/FederatedAuthenticatorConfigBuilderFactory.java
@@ -462,7 +462,7 @@ public class FederatedAuthenticatorConfigBuilderFactory {
             AuthenticationType authenticationType = new AuthenticationType();
             authenticationType.setType(AuthenticationType.TypeEnum.fromValue(endpointConfig.getEndpointConfig()
                     .getAuthentication().getType().toString()));
-            authenticationType.setProperties(null);
+            authenticationType.setProperties(endpointConfig.getResolvedEndpointAuthenticationProperties());
 
             Endpoint endpoint = new Endpoint();
             endpoint.setUri(endpointConfig.getEndpointConfig().getUri());

--- a/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/main/resources/idp.yaml
+++ b/components/org.wso2.carbon.identity.api.server.idp/org.wso2.carbon.identity.api.server.idp.v1/src/main/resources/idp.yaml
@@ -2919,6 +2919,8 @@ components:
             - BEARER
             - API_KEY
             - BASIC
+            - CLIENT_CREDENTIAL
+            - PASSWORD_CREDENTIAL
           example: BASIC
         properties:
           type: object

--- a/pom.xml
+++ b/pom.xml
@@ -1103,7 +1103,7 @@
         <maven.buildnumber.plugin.version>1.4</maven.buildnumber.plugin.version>
         <org.apache.felix.annotations.version>1.2.4</org.apache.felix.annotations.version>
         <identity.governance.version>1.11.103</identity.governance.version>
-        <carbon.identity.framework.version>7.11.86</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.11.95</carbon.identity.framework.version>
         <maven.findbugsplugin.version>3.0.5</maven.findbugsplugin.version>
         <spotbugs.maven.plugin.version>4.9.8.2</spotbugs.maven.plugin.version>
         <spotbugs.annotations.version>4.9.8</spotbugs.annotations.version>


### PR DESCRIPTION
## Purpose
- Improve Custom Authenticator related APIs for provide OAuth2 client Credential and Password Credential based Authentication Support

## Related Issue
- https://github.com/wso2/product-is/issues/27832

## ToDo

- [ ] Bump Framework Version

## Summary
This pull request extends support for authentication types across the Identity Server's API models and configuration files. It introduces two new authentication types, `CLIENT_CREDENTIAL` and `PASSWORD_CREDENTIAL`, updates the related OpenAPI YAML definitions, and ensures that authentication properties are correctly set in API responses. Additionally, copyright years have been updated.

**Authentication Type Enhancements:**

* Added `CLIENT_CREDENTIAL` and `PASSWORD_CREDENTIAL` as new options in the `TypeEnum` of the `AuthenticationType` model in the following modules: authenticators, configs, and idp. [[1]](diffhunk://#diff-2726c967c874e5ed36d7b58b51c898cea08fd5c6b67d764d825f552116a3ea4aL43-R43) [[2]](diffhunk://#diff-c32bc384abe2ad1fccf4ba8e56be9225bfcad9469ceb8547814c7ccdf3fb43d4L43-R43) [[3]](diffhunk://#diff-b8713ba735f2a15f10ddc00f3d0cb556ca26afcfc7fccfbd20152e4e9a44a0c6L43-R43)
* Updated the OpenAPI YAML files (`authenticators.yaml`, `configs.yaml`, `idp.yaml`) to include the new authentication types in the allowed enum values. [[1]](diffhunk://#diff-34235ea69a0b84b4f729cd77f6a9cca397beb94aece588ed353efed6a4a47e7bR454-R455) [[2]](diffhunk://#diff-7ed2c12b47588ef4166a3507aa38c809122f66e1b7bcc892752f4874b4dab73bR1773-R1774) [[3]](diffhunk://#diff-45468b460d5050a3f6ed28ac2aa6f342bb2d89469a677777cf03bc6262afc0d1R2922-R2923)

**API Response Improvements:**

* Modified Java service logic to set the resolved authentication properties for endpoints, instead of leaving them as null, in both user-defined local authenticators and federated authenticators. [[1]](diffhunk://#diff-795c8a71a78557b8ee61df48cd95fc7ce1b63a5272acaddef7385eccce84f14dL979-R984) [[2]](diffhunk://#diff-9aa850f951b9e5520bbbee5a2271cbf6ba9ce93c6cee97d05d90485da124d894L465-R465)

**Other Updates:**

* Updated copyright years in the `AuthenticationType.java` files across all relevant modules. [[1]](diffhunk://#diff-2726c967c874e5ed36d7b58b51c898cea08fd5c6b67d764d825f552116a3ea4aL2-R2) [[2]](diffhunk://#diff-c32bc384abe2ad1fccf4ba8e56be9225bfcad9469ceb8547814c7ccdf3fb43d4L2-R2) [[3]](diffhunk://#diff-b8713ba735f2a15f10ddc00f3d0cb556ca26afcfc7fccfbd20152e4e9a44a0c6L2-R2)