### PR TITLE
[refactor] Centralize attribute handling in ActionResponse

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.action.management/org.wso2.carbon.identity.api.server.action.management.v1/src/extend/java/org/wso2/carbon/identity/api/server/action/management/v1/PreUpdatePasswordActionResponse.java
+++ b/components/org.wso2.carbon.identity.api.server.action.management/org.wso2.carbon.identity.api.server.action.management.v1/src/extend/java/org/wso2/carbon/identity/api/server/action/management/v1/PreUpdatePasswordActionResponse.java
@@ -45,6 +45,7 @@ public class PreUpdatePasswordActionResponse extends ActionResponse {
         setCreatedAt(actionResponse.getCreatedAt());
         setUpdatedAt(actionResponse.getUpdatedAt());
         setEndpoint(actionResponse.getEndpoint());
+        setAttributes(actionResponse.getAttributes());
         setRule(actionResponse.getRule());
     }
 
@@ -71,19 +72,6 @@ public class PreUpdatePasswordActionResponse extends ActionResponse {
 
         this.attributes = attributes;
         return this;
-    }
-
-    @ApiModelProperty()
-    @JsonProperty("attributes")
-    @Valid
-    public List<String> getAttributes() {
-
-        return attributes;
-    }
-
-    public void setAttributes(List<String> attributes) {
-
-        this.attributes = attributes;
     }
 
     @Override

--- a/components/org.wso2.carbon.identity.api.server.action.management/org.wso2.carbon.identity.api.server.action.management.v1/src/extend/java/org/wso2/carbon/identity/api/server/action/management/v1/PreUpdateProfileActionResponse.java
+++ b/components/org.wso2.carbon.identity.api.server.action.management/org.wso2.carbon.identity.api.server.action.management.v1/src/extend/java/org/wso2/carbon/identity/api/server/action/management/v1/PreUpdateProfileActionResponse.java
@@ -18,13 +18,8 @@
 
 package org.wso2.carbon.identity.api.server.action.management.v1;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-import io.swagger.annotations.ApiModelProperty;
-
 import java.util.List;
 import java.util.Objects;
-
-import javax.validation.Valid;
 
 /**
  * Pre Update Profile Action Response.
@@ -44,26 +39,8 @@ public class PreUpdateProfileActionResponse extends ActionResponse {
         setCreatedAt(actionResponse.getCreatedAt());
         setUpdatedAt(actionResponse.getUpdatedAt());
         setEndpoint(actionResponse.getEndpoint());
+        setAttributes(actionResponse.getAttributes());
         setRule(actionResponse.getRule());
-    }
-
-    public PreUpdateProfileActionResponse attributes(List<String> attributes) {
-
-        this.attributes = attributes;
-        return this;
-    }
-
-    @ApiModelProperty()
-    @JsonProperty("attributes")
-    @Valid
-    public List<String> getAttributes() {
-
-        return attributes;
-    }
-
-    public void setAttributes(List<String> attributes) {
-
-        this.attributes = attributes;
     }
 
     @Override

--- a/components/org.wso2.carbon.identity.api.server.action.management/org.wso2.carbon.identity.api.server.action.management.v1/src/main/java/org/wso2/carbon/identity/api/server/action/management/v1/mapper/PreUpdatePasswordActionMapper.java
+++ b/components/org.wso2.carbon.identity.api.server.action.management/org.wso2.carbon.identity.api.server.action.management.v1/src/main/java/org/wso2/carbon/identity/api/server/action/management/v1/mapper/PreUpdatePasswordActionMapper.java
@@ -62,9 +62,7 @@ public class PreUpdatePasswordActionMapper implements ActionMapper {
                 actionModel.getEndpoint().getAllowedParameters());
         Action basicAction = ActionMapperUtil.buildActionRequest(getSupportedActionType(), actionModel);
         return new PreUpdatePasswordAction.RequestBuilder(basicAction)
-                .passwordSharing(buildPasswordSharingRequest((PreUpdatePasswordActionModel) actionModel))
-                .attributes(((PreUpdatePasswordActionModel) actionModel).getAttributes())
-                .build();
+                .passwordSharing(buildPasswordSharingRequest((PreUpdatePasswordActionModel) actionModel)).build();
     }
 
     @Override
@@ -84,7 +82,6 @@ public class PreUpdatePasswordActionMapper implements ActionMapper {
         return new PreUpdatePasswordAction.RequestBuilder(basicUpdatingAction)
                 .passwordSharing(
                         buildPasswordSharingUpdateRequest((PreUpdatePasswordActionUpdateModel) actionUpdateModel))
-                .attributes(((PreUpdatePasswordActionUpdateModel) actionUpdateModel).getAttributes())
                 .build();
     }
 
@@ -98,8 +95,7 @@ public class PreUpdatePasswordActionMapper implements ActionMapper {
 
         ActionResponse actionResponse = ActionMapperUtil.buildActionResponse(action);
         return new PreUpdatePasswordActionResponse(actionResponse)
-                .passwordSharing(buildPasswordSharingResponse((PreUpdatePasswordAction) action))
-                .attributes(((PreUpdatePasswordAction) action).getAttributes());
+                .passwordSharing(buildPasswordSharingResponse((PreUpdatePasswordAction) action));
 
     }
 

--- a/components/org.wso2.carbon.identity.api.server.action.management/org.wso2.carbon.identity.api.server.action.management.v1/src/main/java/org/wso2/carbon/identity/api/server/action/management/v1/mapper/PreUpdateProfileActionMapper.java
+++ b/components/org.wso2.carbon.identity.api.server.action.management/org.wso2.carbon.identity.api.server.action.management.v1/src/main/java/org/wso2/carbon/identity/api/server/action/management/v1/mapper/PreUpdateProfileActionMapper.java
@@ -59,9 +59,7 @@ public class PreUpdateProfileActionMapper implements ActionMapper {
         validateAllowedHeadersAndParameters(actionModel.getEndpoint().getAllowedHeaders(),
                 actionModel.getEndpoint().getAllowedParameters());
         Action basicAction = ActionMapperUtil.buildActionRequest(getSupportedActionType(), actionModel);
-        return new PreUpdateProfileAction.RequestBuilder(basicAction)
-                .attributes(((PreUpdateProfileActionModel) actionModel).getAttributes())
-                .build();
+        return new PreUpdateProfileAction.RequestBuilder(basicAction).build();
     }
 
     @Override
@@ -78,9 +76,7 @@ public class PreUpdateProfileActionMapper implements ActionMapper {
         }
         Action basicUpdatingAction = ActionMapperUtil.buildUpdatingActionRequest(getSupportedActionType(),
                 actionUpdateModel);
-        return new PreUpdateProfileAction.RequestBuilder(basicUpdatingAction)
-                .attributes(((PreUpdateProfileActionUpdateModel) actionUpdateModel).getAttributes())
-                .build();
+        return new PreUpdateProfileAction.RequestBuilder(basicUpdatingAction).build();
     }
 
     @Override
@@ -92,8 +88,7 @@ public class PreUpdateProfileActionMapper implements ActionMapper {
         }
 
         ActionResponse actionResponse = ActionMapperUtil.buildActionResponse(action);
-        return new PreUpdateProfileActionResponse(actionResponse)
-                .attributes(((PreUpdateProfileAction) action).getAttributes());
+        return new PreUpdateProfileActionResponse(actionResponse);
     }
 
     private void validateAllowedHeadersAndParameters(List<String> allowedHeaders, List<String> allowedParams) {


### PR DESCRIPTION
This pull request refactors how the `attributes` field is handled in the `PreUpdatePasswordActionResponse` and `PreUpdateProfileActionResponse` classes and their associated mappers. The main goal is to simplify the response and mapper logic by removing redundant getter, setter, and builder methods for `attributes`, and instead setting it directly from the base `ActionResponse`.

**Related Issue**
- https://github.com/wso2/product-is/issues/27830