### PR TITLE
Change Moesif publisher update endpoint from PUT to PATCH

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.moesif.publisher/org.wso2.carbon.identity.api.server.moesif.publisher.v1/src/gen/java/org/wso2/carbon/identity/api/server/moesif/publisher/v1/MoesifPublishersApi.java
+++ b/components/org.wso2.carbon.identity.api.server.moesif.publisher/org.wso2.carbon.identity.api.server.moesif.publisher.v1/src/gen/java/org/wso2/carbon/identity/api/server/moesif/publisher/v1/MoesifPublishersApi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -25,6 +25,7 @@ import java.util.List;
 
 import org.wso2.carbon.identity.api.server.moesif.publisher.v1.model.Error;
 import org.wso2.carbon.identity.api.server.moesif.publisher.v1.model.MoesifPublisher;
+import org.wso2.carbon.identity.api.server.moesif.publisher.v1.model.MoesifPublisherPatchReq;
 import org.wso2.carbon.identity.api.server.moesif.publisher.v1.model.MoesifPublisherReq;
 import org.wso2.carbon.identity.api.server.moesif.publisher.v1.MoesifPublishersApiService;
 import org.wso2.carbon.identity.api.server.moesif.publisher.v1.factories.MoesifPublishersApiServiceFactory;
@@ -98,20 +99,20 @@ public class MoesifPublishersApi  {
     }
 
     @Valid
-    @PUT
-    
+    @PATCH
+
     @Consumes({ "application/json" })
     @Produces({ "application/json" })
-    @ApiOperation(value = "Update the Moesif event publisher configuration", notes = "", response = MoesifPublisher.class, tags={ "Moesif Publishers" })
-    @ApiResponses(value = { 
+    @ApiOperation(value = "Partially update the Moesif event publisher configuration", notes = "", response = MoesifPublisher.class, tags={ "Moesif Publishers" })
+    @ApiResponses(value = {
         @ApiResponse(code = 200, message = "Successfully updated", response = MoesifPublisher.class),
         @ApiResponse(code = 400, message = "Bad Request", response = Error.class),
         @ApiResponse(code = 404, message = "Not Found", response = Error.class),
         @ApiResponse(code = 500, message = "Internal Server Error", response = Error.class)
     })
-    public Response updateMoesifPublisher(@ApiParam(value = "" ,required=true) @Valid MoesifPublisherReq moesifPublisherReq) {
+    public Response patchMoesifPublisher(@ApiParam(value = "" ,required=true) @Valid MoesifPublisherPatchReq moesifPublisherPatchReq) {
 
-        return delegate.updateMoesifPublisher(moesifPublisherReq );
+        return delegate.patchMoesifPublisher(moesifPublisherPatchReq );
     }
 
 }

--- a/components/org.wso2.carbon.identity.api.server.moesif.publisher/org.wso2.carbon.identity.api.server.moesif.publisher.v1/src/gen/java/org/wso2/carbon/identity/api/server/moesif/publisher/v1/MoesifPublishersApiService.java
+++ b/components/org.wso2.carbon.identity.api.server.moesif.publisher/org.wso2.carbon.identity.api.server.moesif.publisher.v1/src/gen/java/org/wso2/carbon/identity/api/server/moesif/publisher/v1/MoesifPublishersApiService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -26,6 +26,7 @@ import java.io.InputStream;
 import java.util.List;
 import org.wso2.carbon.identity.api.server.moesif.publisher.v1.model.Error;
 import org.wso2.carbon.identity.api.server.moesif.publisher.v1.model.MoesifPublisher;
+import org.wso2.carbon.identity.api.server.moesif.publisher.v1.model.MoesifPublisherPatchReq;
 import org.wso2.carbon.identity.api.server.moesif.publisher.v1.model.MoesifPublisherReq;
 import javax.ws.rs.core.Response;
 
@@ -38,5 +39,5 @@ public interface MoesifPublishersApiService {
 
       public Response getMoesifPublisher();
 
-      public Response updateMoesifPublisher(MoesifPublisherReq moesifPublisherReq);
+      public Response patchMoesifPublisher(MoesifPublisherPatchReq moesifPublisherPatchReq);
 }

--- a/components/org.wso2.carbon.identity.api.server.moesif.publisher/org.wso2.carbon.identity.api.server.moesif.publisher.v1/src/gen/java/org/wso2/carbon/identity/api/server/moesif/publisher/v1/factories/MoesifPublishersApiServiceFactory.java
+++ b/components/org.wso2.carbon.identity.api.server.moesif.publisher/org.wso2.carbon.identity.api.server.moesif.publisher.v1/src/gen/java/org/wso2/carbon/identity/api/server/moesif/publisher/v1/factories/MoesifPublishersApiServiceFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except

--- a/components/org.wso2.carbon.identity.api.server.moesif.publisher/org.wso2.carbon.identity.api.server.moesif.publisher.v1/src/gen/java/org/wso2/carbon/identity/api/server/moesif/publisher/v1/model/Error.java
+++ b/components/org.wso2.carbon.identity.api.server.moesif.publisher/org.wso2.carbon.identity.api.server.moesif.publisher.v1/src/gen/java/org/wso2/carbon/identity/api/server/moesif/publisher/v1/model/Error.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except

--- a/components/org.wso2.carbon.identity.api.server.moesif.publisher/org.wso2.carbon.identity.api.server.moesif.publisher.v1/src/gen/java/org/wso2/carbon/identity/api/server/moesif/publisher/v1/model/MoesifPublisher.java
+++ b/components/org.wso2.carbon.identity.api.server.moesif.publisher/org.wso2.carbon.identity.api.server.moesif.publisher.v1/src/gen/java/org/wso2/carbon/identity/api/server/moesif/publisher/v1/model/MoesifPublisher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except

--- a/components/org.wso2.carbon.identity.api.server.moesif.publisher/org.wso2.carbon.identity.api.server.moesif.publisher.v1/src/gen/java/org/wso2/carbon/identity/api/server/moesif/publisher/v1/model/MoesifPublisherPatchReq.java
+++ b/components/org.wso2.carbon.identity.api.server.moesif.publisher/org.wso2.carbon.identity.api.server.moesif.publisher.v1/src/gen/java/org/wso2/carbon/identity/api/server/moesif/publisher/v1/model/MoesifPublisherPatchReq.java
@@ -33,26 +33,24 @@ import java.util.Objects;
 import javax.validation.Valid;
 import javax.xml.bind.annotation.*;
 
-public class MoesifPublisherReq  {
-  
+public class MoesifPublisherPatchReq  {
+
     private String apiKeyValue;
     private Map<String, Boolean> eventPublisherEnablement = null;
 
 
     /**
-    * Moesif collector API key value.
+    * Moesif collector API key value. If omitted or null, the existing API key is retained.
     **/
-    public MoesifPublisherReq apiKeyValue(String apiKeyValue) {
+    public MoesifPublisherPatchReq apiKeyValue(String apiKeyValue) {
 
         this.apiKeyValue = apiKeyValue;
         return this;
     }
-    
-    @ApiModelProperty(example = "mzf_live_1234567890abcdef", required = true, value = "Moesif collector API key value.")
+
+    @ApiModelProperty(example = "mzf_live_1234567890abcdef", value = "Moesif collector API key value. If omitted or null, the existing API key is retained.")
     @JsonProperty("apiKeyValue")
     @Valid
-    @NotNull(message = "Property apiKeyValue cannot be null.")
-
     public String getApiKeyValue() {
         return apiKeyValue;
     }
@@ -61,17 +59,20 @@ public class MoesifPublisherReq  {
     }
 
     /**
-    * Map of event publisher key to enabled flag (e.g. {\&quot;moesif-authentication-publisher\&quot;: true, \&quot;moesif-registration-publisher\&quot;: false, \&quot;flow\&quot;: true, \&quot;moesif-oauth2-token-publisher\&quot;: true}). Keys absent from the map default to false (replace-all semantics). Known keys: \&quot;moesif-authentication-publisher\&quot;, \&quot;moesif-registration-publisher\&quot;, \&quot;moesif-flow-publisher\&quot;, \&quot;moesif-oauth2-token-publisher\&quot;. 
+    * Map of event publisher key to enabled flag. Keys absent from the map default to false
+    * (replace-all semantics). Known keys: "moesif-authentication-publisher",
+    * "moesif-registration-publisher", "moesif-flow-publisher", "moesif-oauth2-token-publisher".
     **/
-    public MoesifPublisherReq eventPublisherEnablement(Map<String, Boolean> eventPublisherEnablement) {
+    public MoesifPublisherPatchReq eventPublisherEnablement(Map<String, Boolean> eventPublisherEnablement) {
 
         this.eventPublisherEnablement = eventPublisherEnablement;
         return this;
     }
-    
-    @ApiModelProperty(example = "{\"authentication\":true,\"registration\":false,\"flow\":true,\"oauthToken\":true}", value = "Map of event publisher key to enabled flag (e.g. {\"moesif-authentication-publisher\": true, \"moesif-registration-publisher\": false, \"flow\": true, \"moesif-oauth2-token-publisher\": true}). Keys absent from the map default to false (replace-all semantics). Known keys: \"moesif-authentication-publisher\", \"moesif-registration-publisher\", \"moesif-flow-publisher\", \"moesif-oauth2-token-publisher\". ")
+
+    @ApiModelProperty(example = "{\"moesif-authentication-publisher\":true,\"moesif-registration-publisher\":false,\"moesif-flow-publisher\":true,\"moesif-oauth2-token-publisher\":true}", required = true, value = "Map of event publisher key to enabled flag.")
     @JsonProperty("eventPublisherEnablement")
     @Valid
+    @NotNull(message = "Property eventPublisherEnablement cannot be null.")
     public Map<String, Boolean> getEventPublisherEnablement() {
         return eventPublisherEnablement;
     }
@@ -80,7 +81,7 @@ public class MoesifPublisherReq  {
     }
 
 
-    public MoesifPublisherReq putEventPublisherEnablementItem(String key, Boolean eventPublisherEnablementItem) {
+    public MoesifPublisherPatchReq putEventPublisherEnablementItem(String key, Boolean eventPublisherEnablementItem) {
         if (this.eventPublisherEnablement == null) {
             this.eventPublisherEnablement = new HashMap<>();
         }
@@ -88,7 +89,7 @@ public class MoesifPublisherReq  {
         return this;
     }
 
-    
+
 
     @Override
     public boolean equals(java.lang.Object o) {
@@ -99,9 +100,9 @@ public class MoesifPublisherReq  {
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        MoesifPublisherReq moesifPublisherReq = (MoesifPublisherReq) o;
-        return Objects.equals(this.apiKeyValue, moesifPublisherReq.apiKeyValue) &&
-            Objects.equals(this.eventPublisherEnablement, moesifPublisherReq.eventPublisherEnablement);
+        MoesifPublisherPatchReq moesifPublisherPatchReq = (MoesifPublisherPatchReq) o;
+        return Objects.equals(this.apiKeyValue, moesifPublisherPatchReq.apiKeyValue) &&
+            Objects.equals(this.eventPublisherEnablement, moesifPublisherPatchReq.eventPublisherEnablement);
     }
 
     @Override
@@ -113,8 +114,8 @@ public class MoesifPublisherReq  {
     public String toString() {
 
         StringBuilder sb = new StringBuilder();
-        sb.append("class MoesifPublisherReq {\n");
-        
+        sb.append("class MoesifPublisherPatchReq {\n");
+
         sb.append("    apiKeyValue: ").append(toIndentedString(apiKeyValue)).append("\n");
         sb.append("    eventPublisherEnablement: ").append(toIndentedString(eventPublisherEnablement)).append("\n");
         sb.append("}");
@@ -133,4 +134,3 @@ public class MoesifPublisherReq  {
         return o.toString().replace("\n", "\n");
     }
 }
-

--- a/components/org.wso2.carbon.identity.api.server.moesif.publisher/org.wso2.carbon.identity.api.server.moesif.publisher.v1/src/main/java/org/wso2/carbon/identity/api/server/moesif/publisher/v1/impl/MoesifPublishersApiServiceImpl.java
+++ b/components/org.wso2.carbon.identity.api.server.moesif.publisher/org.wso2.carbon.identity.api.server.moesif.publisher.v1/src/main/java/org/wso2/carbon/identity/api/server/moesif/publisher/v1/impl/MoesifPublishersApiServiceImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -22,6 +22,7 @@ import org.wso2.carbon.identity.api.server.moesif.publisher.v1.MoesifPublishersA
 import org.wso2.carbon.identity.api.server.moesif.publisher.v1.core.MoesifPublisherManagementService;
 import org.wso2.carbon.identity.api.server.moesif.publisher.v1.factories.MoesifPublisherManagementServiceFactory;
 import org.wso2.carbon.identity.api.server.moesif.publisher.v1.model.MoesifPublisher;
+import org.wso2.carbon.identity.api.server.moesif.publisher.v1.model.MoesifPublisherPatchReq;
 import org.wso2.carbon.identity.api.server.moesif.publisher.v1.model.MoesifPublisherReq;
 
 import java.net.URI;
@@ -68,11 +69,11 @@ public class MoesifPublishersApiServiceImpl implements MoesifPublishersApiServic
     }
 
     @Override
-    public Response updateMoesifPublisher(MoesifPublisherReq moesifPublisherReq) {
+    public Response patchMoesifPublisher(MoesifPublisherPatchReq moesifPublisherPatchReq) {
 
         MoesifPublisher updated = moesifPublisherManagementService.updateMoesifPublisher(
-                moesifPublisherReq.getApiKeyValue(),
-                moesifPublisherReq.getEventPublisherEnablement());
+                moesifPublisherPatchReq.getApiKeyValue(),
+                moesifPublisherPatchReq.getEventPublisherEnablement());
         return Response.ok().entity(updated).build();
     }
 

--- a/components/org.wso2.carbon.identity.api.server.moesif.publisher/org.wso2.carbon.identity.api.server.moesif.publisher.v1/src/main/resources/moesif-publisher.yaml
+++ b/components/org.wso2.carbon.identity.api.server.moesif.publisher/org.wso2.carbon.identity.api.server.moesif.publisher.v1/src/main/resources/moesif-publisher.yaml
@@ -55,16 +55,16 @@ paths:
           $ref: '#/components/responses/NotFound'
         '500':
           $ref: '#/components/responses/ServerError'
-    put:
+    patch:
       tags:
         - Moesif Publishers
-      summary: Update the Moesif event publisher configuration
-      operationId: updateMoesifPublisher
+      summary: Partially update the Moesif event publisher configuration
+      operationId: patchMoesifPublisher
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/MoesifPublisherReq'
+              $ref: '#/components/schemas/MoesifPublisherPatchReq'
         required: true
       responses:
         '200':
@@ -112,6 +112,31 @@ components:
             (e.g. {"moesif-authentication-publisher": true, "moesif-registration-publisher": false, "flow": true, "moesif-oauth2-token-publisher": true}).
             Keys absent from the map default to false (replace-all semantics).
             Known keys: "moesif-authentication-publisher", "moesif-registration-publisher", "moesif-flow-publisher", "moesif-oauth2-token-publisher".
+          example:
+            moesif-authentication-publisher: true
+            moesif-registration-publisher: false
+            moesif-flow-publisher: true
+            moesif-oauth2-token-publisher: true
+    MoesifPublisherPatchReq:
+      type: object
+      required:
+        - eventPublisherEnablement
+      properties:
+        apiKeyValue:
+          type: string
+          nullable: true
+          description: >
+            Moesif collector API key value. If omitted or null, the existing API key is retained.
+          example: mzf_live_1234567890abcdef
+        eventPublisherEnablement:
+          type: object
+          additionalProperties:
+            type: boolean
+          description: >
+            Map of event publisher key to enabled flag. Keys absent from the map default to false
+            (replace-all semantics).
+            Known keys: "moesif-authentication-publisher", "moesif-registration-publisher",
+            "moesif-flow-publisher", "moesif-oauth2-token-publisher".
           example:
             moesif-authentication-publisher: true
             moesif-registration-publisher: false


### PR DESCRIPTION
## Summary

- Replaces `PUT /moesif-publishers` with `PATCH /moesif-publishers` to support partial updates
- Adds new `MoesifPublisherPatchReq` model where `eventPublisherEnablement` is required and `apiKeyValue` is optional (nullable)
- When `apiKeyValue` is omitted/null, the existing API key is retained; when provided, it is updated
- Updates the OpenAPI/Swagger spec, JAX-RS resource class, service interface, and service implementation

## Changed files

- `moesif-publisher.yaml` — PATCH verb, new `MoesifPublisherPatchReq` schema
- `MoesifPublisherPatchReq.java` — new model class (generated)
- `MoesifPublishersApi.java` — `@PATCH` annotation, `patchMoesifPublisher` method
- `MoesifPublishersApiService.java` — updated interface method
- `MoesifPublishersApiServiceImpl.java` — delegates to `updateMoesifPublisher` with nullable apiKeyValue

## Related

Backend changes: https://github.com/wso2-extensions/identity-moesif-integration (branch `patch-moesif-publisher-update` on fork)

## Test plan

- [ ] `PATCH /moesif-publishers` with both `eventPublisherEnablement` and `apiKeyValue` → updates both
- [ ] `PATCH /moesif-publishers` with only `eventPublisherEnablement` (no `apiKeyValue`) → updates enablement, retains existing key
- [ ] `PATCH /moesif-publishers` with blank `apiKeyValue` → 400 Bad Request
- [ ] `PATCH /moesif-publishers` when publisher does not exist → 404 Not Found

🤖 Generated with [Claude Code](https://claude.com/claude-code)