### PR TITLE
Add all the user claims to meta endpoint.

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.flow.management/org.wso2.carbon.identity.api.server.flow.management.v1/pom.xml
+++ b/components/org.wso2.carbon.identity.api.server.flow.management/org.wso2.carbon.identity.api.server.flow.management.v1/pom.xml
@@ -137,6 +137,14 @@
             <groupId>org.wso2.carbon.identity.server.api</groupId>
             <artifactId>org.wso2.carbon.identity.api.server.claim.management.common</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon</groupId>
+            <artifactId>org.wso2.carbon.user.core</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/components/org.wso2.carbon.identity.api.server.flow.management/org.wso2.carbon.identity.api.server.flow.management.v1/src/main/java/org/wso2/carbon/identity/api/server/flow/management/v1/response/handlers/AbstractMetaResponseHandler.java
+++ b/components/org.wso2.carbon.identity.api.server.flow.management/org.wso2.carbon.identity.api.server.flow.management.v1/src/main/java/org/wso2/carbon/identity/api/server/flow/management/v1/response/handlers/AbstractMetaResponseHandler.java
@@ -34,19 +34,23 @@ import org.wso2.carbon.identity.application.common.model.IdentityProvider;
 import org.wso2.carbon.identity.claim.metadata.mgt.ClaimMetadataManagementService;
 import org.wso2.carbon.identity.claim.metadata.mgt.exception.ClaimMetadataException;
 import org.wso2.carbon.identity.claim.metadata.mgt.model.LocalClaim;
+import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.flow.extension.model.FlowExtensionAction;
 import org.wso2.carbon.identity.flow.mgt.exception.FlowMgtClientException;
 import org.wso2.carbon.identity.multi.attribute.login.constants.MultiAttributeLoginConstants;
 import org.wso2.carbon.idp.mgt.IdentityProviderManagementException;
 import org.wso2.carbon.idp.mgt.IdpManager;
 import org.wso2.carbon.idp.mgt.model.IdpSearchResult;
+import org.wso2.carbon.user.core.UserCoreConstants;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import static org.wso2.carbon.identity.api.server.claim.management.common.Constant.PROP_DISPLAY_NAME;
 import static org.wso2.carbon.identity.api.server.claim.management.common.Constant.PROP_READ_ONLY;
@@ -66,8 +70,6 @@ import static org.wso2.carbon.identity.api.server.flow.management.v1.constants.F
 import static org.wso2.carbon.identity.api.server.flow.management.v1.constants.FlowEndpointConstants.Executors.USER_PROVISIONING_EXECUTOR;
 import static org.wso2.carbon.identity.api.server.flow.management.v1.constants.FlowEndpointConstants.IDP_TEMPLATE_ID;
 import static org.wso2.carbon.identity.api.server.flow.management.v1.constants.FlowEndpointConstants.MICROSOFT_IDP_TEMPLATE_ID;
-import static org.wso2.carbon.identity.api.server.flow.management.v1.constants.FlowEndpointConstants.USER_IDENTIFIER;
-import static org.wso2.carbon.identity.api.server.flow.management.v1.constants.FlowEndpointConstants.USER_IDENTIFIER_NAME;
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.GROUPS_CLAIM;
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.ROLES_CLAIM;
 
@@ -79,6 +81,7 @@ import static org.wso2.carbon.identity.application.authentication.framework.util
 public abstract class AbstractMetaResponseHandler {
 
     private static final Log log = LogFactory.getLog(AbstractMetaResponseHandler.class);
+    private static final String HIDDEN_CLAIMS_IDENTITY_CONFIG = "HiddenClaims.HiddenClaim";
     private static final String MULTI_ATTRIBUTE_LOGIN_ENABLED = "multiAttributeLoginEnabled";
 
     /**
@@ -154,7 +157,7 @@ public abstract class AbstractMetaResponseHandler {
         response.setFlowType(getFlowType());
         response.setAttributeProfile(getAttributeProfile());
         response.setWorkflowEnabled(getWorkflowEnabled());
-        response.setAttributeMetadata(getSupportedClaims(getAttributeProfile()));
+        response.setAttributeMetadata(getSupportedClaims());
         response.setSupportedExecutors(getSupportedExecutors());
         response.setConnectorConfigs(getConnectorConfigs());
         response.setExecutorConnections(getExecutorConnections());
@@ -168,15 +171,15 @@ public abstract class AbstractMetaResponseHandler {
         return Utils.getSupportedFlowCompletionConfig(getFlowType());
     }
 
-    private List<AttributeMetadata> getSupportedClaims(String attributeProfile) {
+    protected List<AttributeMetadata> getSupportedClaims() {
 
         String tenantDomain = PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantDomain();
         List<AttributeMetadata> claimProperties = new ArrayList<>();
         try {
             ClaimMetadataManagementService claimService = (ClaimMetadataManagementService) PrivilegedCarbonContext
                     .getThreadLocalCarbonContext().getOSGiService(ClaimMetadataManagementService.class, null);
-            List<LocalClaim> attributeList =
-                    claimService.getSupportedLocalClaimsForProfile(tenantDomain, attributeProfile);
+            List<LocalClaim> attributeList = claimService.getLocalClaims(tenantDomain);
+            attributeList = filterClaims(attributeList);
 
             for (LocalClaim claim : attributeList) {
                 Map<String, String> claimProps = claim.getClaimProperties();
@@ -196,12 +199,9 @@ public abstract class AbstractMetaResponseHandler {
                 }
             }
 
-            // Add user identifier claim if multi-attribute login is enabled.
-            if (Utils.getGovernanceConfig(
-                    PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantDomain(),
-                    MultiAttributeLoginConstants.MULTI_ATTRIBUTE_LOGIN_PROPERTY)) {
-                claimProperties.add(createUserIdentifierMeta());
-            }
+            // Sort claims alphabetically by display name.
+            claimProperties.sort(Comparator.comparing(AttributeMetadata::getName,
+                    Comparator.nullsLast(String.CASE_INSENSITIVE_ORDER)));
         } catch (ClaimMetadataException e) {
             throw Utils.handleFlowMgtException(new FlowMgtClientException(
                     FlowEndpointConstants.ErrorMessages.ERROR_CODE_GET_SUPPORTED_CLAIMS.getCode(),
@@ -209,6 +209,21 @@ public abstract class AbstractMetaResponseHandler {
                     FlowEndpointConstants.ErrorMessages.ERROR_CODE_GET_SUPPORTED_CLAIMS.getDescription(), e));
         }
         return claimProperties;
+    }
+
+    /**
+     * Filter out identity claims and hidden claims from the list of local claims.
+     * @param claims List of local claims to filter.
+     * @return Filtered list of local claims.
+     */
+    private static List<LocalClaim> filterClaims(List<LocalClaim> claims) {
+
+        List<String> hiddenClaims = IdentityUtil.getPropertyAsList(HIDDEN_CLAIMS_IDENTITY_CONFIG);
+        return claims.stream()
+                .filter(claim ->
+                        !claim.getClaimURI().startsWith(UserCoreConstants.ClaimTypeURIs.IDENTITY_CLAIM_URI))
+                .filter(claim -> !hiddenClaims.contains(claim.getClaimURI()))
+                .collect(Collectors.toList());
     }
 
     /**
@@ -345,15 +360,5 @@ public abstract class AbstractMetaResponseHandler {
             offset += pageSize;
         } while (offset < totalCount);
         return identityProviders;
-    }
-
-    private AttributeMetadata createUserIdentifierMeta() {
-
-        AttributeMetadata meta = new AttributeMetadata();
-        meta.setName(USER_IDENTIFIER_NAME);
-        meta.claimURI(USER_IDENTIFIER);
-        meta.setRequired(true);
-        meta.setReadOnly(true);
-        return meta;
     }
 }

--- a/components/org.wso2.carbon.identity.api.server.flow.management/org.wso2.carbon.identity.api.server.flow.management.v1/src/main/java/org/wso2/carbon/identity/api/server/flow/management/v1/response/handlers/PasswordRecoveryFlowMetaHandler.java
+++ b/components/org.wso2.carbon.identity.api.server.flow.management/org.wso2.carbon.identity.api.server.flow.management.v1/src/main/java/org/wso2/carbon/identity/api/server/flow/management/v1/response/handlers/PasswordRecoveryFlowMetaHandler.java
@@ -19,8 +19,10 @@
 package org.wso2.carbon.identity.api.server.flow.management.v1.response.handlers;
 
 import org.wso2.carbon.context.PrivilegedCarbonContext;
+import org.wso2.carbon.identity.api.server.flow.management.v1.AttributeMetadata;
 import org.wso2.carbon.identity.api.server.flow.management.v1.utils.Utils;
 import org.wso2.carbon.identity.flow.mgt.Constants;
+import org.wso2.carbon.identity.multi.attribute.login.constants.MultiAttributeLoginConstants;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -28,6 +30,8 @@ import java.util.Map;
 
 import static org.wso2.carbon.identity.api.server.flow.management.v1.constants.FlowEndpointConstants.END_USER_ATTRIBUTE_PROFILE;
 import static org.wso2.carbon.identity.api.server.flow.management.v1.constants.FlowEndpointConstants.Executors.USER_RESOLVE_EXECUTOR;
+import static org.wso2.carbon.identity.api.server.flow.management.v1.constants.FlowEndpointConstants.USER_IDENTIFIER;
+import static org.wso2.carbon.identity.api.server.flow.management.v1.constants.FlowEndpointConstants.USER_IDENTIFIER_NAME;
 
 /**
  * Handler for managing the password recovery flow meta information.
@@ -81,5 +85,28 @@ public class PasswordRecoveryFlowMetaHandler extends AbstractMetaResponseHandler
         List<String> supportedExecutors = new ArrayList<>(super.getSupportedExecutors());
         supportedExecutors.add(USER_RESOLVE_EXECUTOR);
         return supportedExecutors;
+    }
+
+    @Override
+    protected List<AttributeMetadata> getSupportedClaims() {
+
+        List<AttributeMetadata> supportedClaims = new ArrayList<>(super.getSupportedClaims());
+        // Add user identifier claim if multi-attribute login is enabled.
+        if (Utils.getGovernanceConfig(
+                PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantDomain(),
+                MultiAttributeLoginConstants.MULTI_ATTRIBUTE_LOGIN_PROPERTY)) {
+            supportedClaims.add(createUserIdentifierMeta());
+        }
+        return supportedClaims;
+    }
+
+    private AttributeMetadata createUserIdentifierMeta() {
+
+        AttributeMetadata meta = new AttributeMetadata();
+        meta.setName(USER_IDENTIFIER_NAME);
+        meta.setClaimURI(USER_IDENTIFIER);
+        meta.setRequired(true);
+        meta.setReadOnly(true);
+        return meta;
     }
 }


### PR DESCRIPTION
Related Issues

- [x] https://github.com/wso2/product-is/issues/27804

This pull request refactors and enhances how supported claims are determined and presented in the flow management API, with a focus on filtering out unnecessary claims and improving extensibility for specific flows like password recovery. The changes centralize claim filtering logic, add new dependencies, and move the logic for including the user identifier claim to a more appropriate location.

**Claim filtering and metadata improvements:**

* The logic for retrieving supported claims was updated to fetch all local claims, then filter out identity claims and hidden claims using a new `filterClaims` method. Claims are now sorted alphabetically by display name for consistency. [[1]](diffhunk://#diff-e3271f71f78b5744eae16bd62e474d2c569143516caf75fcbb6e0c1c61d9c506L157-R160) [[2]](diffhunk://#diff-e3271f71f78b5744eae16bd62e474d2c569143516caf75fcbb6e0c1c61d9c506L171-R182) [[3]](diffhunk://#diff-e3271f71f78b5744eae16bd62e474d2c569143516caf75fcbb6e0c1c61d9c506L199-R204) [[4]](diffhunk://#diff-e3271f71f78b5744eae16bd62e474d2c569143516caf75fcbb6e0c1c61d9c506R214-R228) [[5]](diffhunk://#diff-e3271f71f78b5744eae16bd62e474d2c569143516caf75fcbb6e0c1c61d9c506R84)
* The method for getting supported claims was changed from `private` to `protected` to allow subclasses to extend or override claim selection logic.

**Password recovery flow-specific logic:**

* In the `PasswordRecoveryFlowMetaHandler`, the logic for adding the user identifier claim (when multi-attribute login is enabled) was moved from the abstract handler to this subclass, ensuring it's only included for relevant flows.

**Dependency updates:**

* Added dependencies on `org.wso2.carbon.identity.core` and `org.wso2.carbon.user.core` in the module's `pom.xml` to support the new filtering logic.

**Code cleanup:**

* Removed unused imports and the now-unnecessary `createUserIdentifierMeta` method from the abstract handler, as this logic is now handled in the subclass. [[1]](diffhunk://#diff-e3271f71f78b5744eae16bd62e474d2c569143516caf75fcbb6e0c1c61d9c506L69-L70) [[2]](diffhunk://#diff-e3271f71f78b5744eae16bd62e474d2c569143516caf75fcbb6e0c1c61d9c506L349-L358)

These changes improve maintainability, ensure claims are filtered and presented appropriately, and make it easier to customize claim metadata for specific flows.