### PR TITLE
[identity-api-server] Bump Jackson to 2.21.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1098,11 +1098,11 @@
         <!--Maven Plugin Version-->
         <maven.compiler.plugin.version>3.10.1</maven.compiler.plugin.version>
         <maven.bundle.plugin.version>2.4.0</maven.bundle.plugin.version>
-        <jackson-jaxrs-json-provider.version>2.16.1</jackson-jaxrs-json-provider.version>
-        <jackson-databind.version>2.16.1</jackson-databind.version>
+        <jackson-jaxrs-json-provider.version>2.21.2</jackson-jaxrs-json-provider.version>
+        <jackson-databind.version>2.21.2</jackson-databind.version>
         <cxf-bundle.version>3.5.9</cxf-bundle.version>
         <cxf.extensions.search.version>3.5.9</cxf.extensions.search.version>
-        <jackson.version>2.16.1</jackson.version>
+        <jackson.version>2.21.2</jackson.version>
         <swagger-jaxrs.version>1.6.2</swagger-jaxrs.version>
         <javax.ws.rs-api.version>2.1.1</javax.ws.rs-api.version>
         <version.org.wso2.orbit.javax.xml.bind>2.3.1.wso2v1</version.org.wso2.orbit.javax.xml.bind>


### PR DESCRIPTION
## Purpose
Upgrade Jackson Databind and related libraries to the latest stable 2.21.x release.

## Goals
- Align all Jackson artifacts to a consistent 2.21.x baseline across the IS dependency tree
- Replace the 2.16.x versions that are no longer receiving upstream fixes

## Approach
Version property bumps only — no code or logic changes. The following properties were updated in the root `pom.xml`:
- `jackson.version` → `2.21.2`
- `jackson-databind.version` → `2.21.2`
- `jackson-jaxrs-json-provider.version` → `2.21.2`