### PR TITLE
Return tenant domain in consent response

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.consent.management/org.wso2.carbon.identity.api.server.consent.management.v2/src/gen/java/org/wso2/carbon/identity/api/server/consent/management/v2/model/ElementDTO.java
+++ b/components/org.wso2.carbon.identity.api.server.consent.management/org.wso2.carbon.identity.api.server.consent.management.v2/src/gen/java/org/wso2/carbon/identity/api/server/consent/management/v2/model/ElementDTO.java
@@ -36,6 +36,7 @@ public class ElementDTO  {
     private String name;
     private String displayName;
     private String description;
+    private String tenantDomain;
 
     /**
     * ID of the element
@@ -113,6 +114,25 @@ public class ElementDTO  {
         this.description = description;
     }
 
+    /**
+    * Tenant domain that owns this element
+    **/
+    public ElementDTO tenantDomain(String tenantDomain) {
+
+        this.tenantDomain = tenantDomain;
+        return this;
+    }
+
+    @ApiModelProperty(example = "wso2.com", value = "Tenant domain that owns this element")
+    @JsonProperty("tenantDomain")
+    @Valid
+    public String getTenantDomain() {
+        return tenantDomain;
+    }
+    public void setTenantDomain(String tenantDomain) {
+        this.tenantDomain = tenantDomain;
+    }
+
 
 
     @Override
@@ -128,12 +148,13 @@ public class ElementDTO  {
         return Objects.equals(this.id, elementDTO.id) &&
             Objects.equals(this.name, elementDTO.name) &&
             Objects.equals(this.displayName, elementDTO.displayName) &&
-            Objects.equals(this.description, elementDTO.description);
+            Objects.equals(this.description, elementDTO.description) &&
+            Objects.equals(this.tenantDomain, elementDTO.tenantDomain);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, name, displayName, description);
+        return Objects.hash(id, name, displayName, description, tenantDomain);
     }
 
     @Override
@@ -146,6 +167,7 @@ public class ElementDTO  {
         sb.append("    name: ").append(toIndentedString(name)).append("\n");
         sb.append("    displayName: ").append(toIndentedString(displayName)).append("\n");
         sb.append("    description: ").append(toIndentedString(description)).append("\n");
+        sb.append("    tenantDomain: ").append(toIndentedString(tenantDomain)).append("\n");
         sb.append("}");
         return sb.toString();
     }

--- a/components/org.wso2.carbon.identity.api.server.consent.management/org.wso2.carbon.identity.api.server.consent.management.v2/src/gen/java/org/wso2/carbon/identity/api/server/consent/management/v2/model/PurposeDTO.java
+++ b/components/org.wso2.carbon.identity.api.server.consent.management/org.wso2.carbon.identity.api.server.consent.management.v2/src/gen/java/org/wso2/carbon/identity/api/server/consent/management/v2/model/PurposeDTO.java
@@ -44,8 +44,8 @@ public class PurposeDTO  {
     private String type;
     private PurposeDTOLatestVersion latestVersion;
     private List<PurposeElementDTO> elements = null;
-
     private Map<String, String> properties = null;
+    private String tenantDomain;
 
 
     /**
@@ -197,7 +197,26 @@ public class PurposeDTO  {
         return this;
     }
 
-    
+    /**
+    * Tenant domain that owns this purpose
+    **/
+    public PurposeDTO tenantDomain(String tenantDomain) {
+
+        this.tenantDomain = tenantDomain;
+        return this;
+    }
+
+    @ApiModelProperty(example = "wso2.com", value = "Tenant domain that owns this purpose")
+    @JsonProperty("tenantDomain")
+    @Valid
+    public String getTenantDomain() {
+        return tenantDomain;
+    }
+    public void setTenantDomain(String tenantDomain) {
+        this.tenantDomain = tenantDomain;
+    }
+
+
 
     @Override
     public boolean equals(java.lang.Object o) {
@@ -215,12 +234,13 @@ public class PurposeDTO  {
             Objects.equals(this.type, purposeDTO.type) &&
             Objects.equals(this.latestVersion, purposeDTO.latestVersion) &&
             Objects.equals(this.elements, purposeDTO.elements) &&
-            Objects.equals(this.properties, purposeDTO.properties);
+            Objects.equals(this.properties, purposeDTO.properties) &&
+            Objects.equals(this.tenantDomain, purposeDTO.tenantDomain);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, name, description, type, latestVersion, elements, properties);
+        return Objects.hash(id, name, description, type, latestVersion, elements, properties, tenantDomain);
     }
 
     @Override
@@ -236,6 +256,7 @@ public class PurposeDTO  {
         sb.append("    latestVersion: ").append(toIndentedString(latestVersion)).append("\n");
         sb.append("    elements: ").append(toIndentedString(elements)).append("\n");
         sb.append("    properties: ").append(toIndentedString(properties)).append("\n");
+        sb.append("    tenantDomain: ").append(toIndentedString(tenantDomain)).append("\n");
         sb.append("}");
         return sb.toString();
     }

--- a/components/org.wso2.carbon.identity.api.server.consent.management/org.wso2.carbon.identity.api.server.consent.management.v2/src/gen/java/org/wso2/carbon/identity/api/server/consent/management/v2/model/PurposeSummaryDTO.java
+++ b/components/org.wso2.carbon.identity.api.server.consent.management/org.wso2.carbon.identity.api.server.consent.management.v2/src/gen/java/org/wso2/carbon/identity/api/server/consent/management/v2/model/PurposeSummaryDTO.java
@@ -41,6 +41,7 @@ public class PurposeSummaryDTO  {
     private String description;
     private String type;
     private PurposeDTOLatestVersion latestVersion;
+    private String tenantDomain;
 
     /**
     **/
@@ -132,6 +133,25 @@ public class PurposeSummaryDTO  {
         this.latestVersion = latestVersion;
     }
 
+    /**
+    * Tenant domain that owns this purpose
+    **/
+    public PurposeSummaryDTO tenantDomain(String tenantDomain) {
+
+        this.tenantDomain = tenantDomain;
+        return this;
+    }
+
+    @ApiModelProperty(example = "wso2.com", value = "Tenant domain that owns this purpose")
+    @JsonProperty("tenantDomain")
+    @Valid
+    public String getTenantDomain() {
+        return tenantDomain;
+    }
+    public void setTenantDomain(String tenantDomain) {
+        this.tenantDomain = tenantDomain;
+    }
+
 
 
     @Override
@@ -148,12 +168,13 @@ public class PurposeSummaryDTO  {
             Objects.equals(this.name, purposeSummaryDTO.name) &&
             Objects.equals(this.description, purposeSummaryDTO.description) &&
             Objects.equals(this.type, purposeSummaryDTO.type) &&
-            Objects.equals(this.latestVersion, purposeSummaryDTO.latestVersion);
+            Objects.equals(this.latestVersion, purposeSummaryDTO.latestVersion) &&
+            Objects.equals(this.tenantDomain, purposeSummaryDTO.tenantDomain);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, name, description, type, latestVersion);
+        return Objects.hash(id, name, description, type, latestVersion, tenantDomain);
     }
 
     @Override
@@ -167,6 +188,7 @@ public class PurposeSummaryDTO  {
         sb.append("    description: ").append(toIndentedString(description)).append("\n");
         sb.append("    type: ").append(toIndentedString(type)).append("\n");
         sb.append("    latestVersion: ").append(toIndentedString(latestVersion)).append("\n");
+        sb.append("    tenantDomain: ").append(toIndentedString(tenantDomain)).append("\n");
         sb.append("}");
         return sb.toString();
     }

--- a/components/org.wso2.carbon.identity.api.server.consent.management/org.wso2.carbon.identity.api.server.consent.management.v2/src/main/java/org/wso2/carbon/identity/api/server/consent/management/v2/core/ElementManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.consent.management/org.wso2.carbon.identity.api.server.consent.management.v2/src/main/java/org/wso2/carbon/identity/api/server/consent/management/v2/core/ElementManagementService.java
@@ -37,6 +37,7 @@ import org.wso2.carbon.identity.base.IdentityException;
 import org.wso2.carbon.identity.core.model.ExpressionNode;
 import org.wso2.carbon.identity.core.model.FilterTreeBuilder;
 import org.wso2.carbon.identity.core.model.Node;
+import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
@@ -231,6 +232,7 @@ public class ElementManagementService {
         dto.setName(cat.getName());
         dto.setDisplayName(cat.getDisplayName());
         dto.setDescription(cat.getDescription());
+        dto.setTenantDomain(IdentityTenantUtil.getTenantDomain(cat.getTenantId()));
         return dto;
     }
 

--- a/components/org.wso2.carbon.identity.api.server.consent.management/org.wso2.carbon.identity.api.server.consent.management.v2/src/main/java/org/wso2/carbon/identity/api/server/consent/management/v2/core/PurposeManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.consent.management/org.wso2.carbon.identity.api.server.consent.management.v2/src/main/java/org/wso2/carbon/identity/api/server/consent/management/v2/core/PurposeManagementService.java
@@ -49,6 +49,7 @@ import org.wso2.carbon.identity.base.IdentityException;
 import org.wso2.carbon.identity.core.model.ExpressionNode;
 import org.wso2.carbon.identity.core.model.FilterTreeBuilder;
 import org.wso2.carbon.identity.core.model.Node;
+import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
@@ -457,6 +458,7 @@ public class PurposeManagementService {
         dto.setName(purpose.getName());
         dto.setDescription(purpose.getDescription());
         dto.setType(purpose.getGroupType());
+        dto.setTenantDomain(IdentityTenantUtil.getTenantDomain(purpose.getTenantId()));
         PurposeVersion latestVersion = purpose.getLatestVersion();
         if (latestVersion != null) {
             PurposeDTOLatestVersion lv = new PurposeDTOLatestVersion();
@@ -476,6 +478,7 @@ public class PurposeManagementService {
         dto.setName(purpose.getName());
         dto.setDescription(purpose.getDescription());
         dto.setType(purpose.getGroupType());
+        dto.setTenantDomain(IdentityTenantUtil.getTenantDomain(purpose.getTenantId()));
 
         PurposeVersion latestVersion = purpose.getLatestVersion();
         if (latestVersion != null) {

--- a/components/org.wso2.carbon.identity.api.server.consent.management/org.wso2.carbon.identity.api.server.consent.management.v2/src/main/resources/consent-management-v2.yaml
+++ b/components/org.wso2.carbon.identity.api.server.consent.management/org.wso2.carbon.identity.api.server.consent.management.v2/src/main/resources/consent-management-v2.yaml
@@ -1084,6 +1084,11 @@ components:
           example:
             policy_url: "https://example.com/privacy-policy"
             retentionPeriod: "365"
+        tenantDomain:
+          type: string
+          nullable: true
+          description: Tenant domain that owns this purpose
+          example: "wso2.com"
 
     PurposeListResponse:
       type: object
@@ -1105,6 +1110,7 @@ components:
               name: "Privacy Policy"
               description: "Collection of user data for privacy policy compliance and consent management"
               type: "Policy"
+              tenantDomain: "wso2.com"
               latestVersion:
                 id: "a1b2c3d4-1234-5678-abcd-ef1234567890"
                 version: "v1.0"
@@ -1112,6 +1118,7 @@ components:
               name: "DEFAULT"
               description: "For core functionalities of the product"
               type: "SP"
+              tenantDomain: "subsidiaryA.com"
               latestVersion:
                 id: "b2c3d4e5-2345-6789-bcde-f01234567892"
                 version: "v1.0"
@@ -1144,13 +1151,18 @@ components:
           properties:
             id:
               type: string
-    
+
               description: ID of the latest version
               example: "a1b2c3d4-1234-5678-abcd-ef1234567890"
             version:
               type: string
               description: Version label
               example: "v1"
+        tenantDomain:
+          type: string
+          nullable: true
+          description: Tenant domain that owns this purpose
+          example: "wso2.com"
 
     PurposeElementDTO:
       type: object
@@ -1280,6 +1292,11 @@ components:
           nullable: true
           description: Detailed description
           example: "User email address used for account notifications and communications"
+        tenantDomain:
+          type: string
+          nullable: true
+          description: Tenant domain that owns this element
+          example: "wso2.com"
 
     ElementListResponse:
       type: object
@@ -1301,10 +1318,12 @@ components:
               name: "email_address"
               displayName: "Email Address"
               description: "User email address used for account notifications and communications"
+              tenantDomain: "wso2.com"
             - id: "c2d3e4f5-2345-6789-bcde-f01234567891"
               name: "phone_number"
               displayName: "Phone Number"
               description: "User phone number used for SMS notifications and two-factor authentication"
+              tenantDomain: "subsidiaryA.com"
           items:
             $ref: '#/components/schemas/ElementDTO'
 


### PR DESCRIPTION
## Purpose
Since we enable org hierarchy for consent mgt feature we need to return the tenant domain for consents and elements in consent-mgt API 

## Related issue
- https://github.com/wso2/product-is/issues/26859

## Related PR
- https://github.com/wso2/carbon-consent-management/pull/275