### PR TITLE
Address review comments.

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/main/java/org/wso2/carbon/identity/api/server/configs/v1/core/ServerConfigManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/main/java/org/wso2/carbon/identity/api/server/configs/v1/core/ServerConfigManagementService.java
@@ -2516,8 +2516,8 @@ public class ServerConfigManagementService {
             CompatibilitySetting setting = compatibilitySettingsService.getCompatibilitySettings(tenantDomain);
             return CompatibilitySettingUtil.toCompatibilitySettings(setting);
         } catch (CompatibilitySettingException e) {
-            throw handleCompatibilitySettingsError(e, Constants.ErrorMessage.ERROR_CODE_COMPATIBILITY_SETTINGS_RETRIEVE,
-                    null);
+            throw CompatibilitySettingUtil.handleCompatibilitySettingsException(e,
+                    Constants.ErrorMessage.ERROR_CODE_COMPATIBILITY_SETTINGS_RETRIEVE, null);
         }
     }
 
@@ -2536,8 +2536,8 @@ public class ServerConfigManagementService {
                     compatibilitySettingsService.updateCompatibilitySettings(tenantDomain, setting);
             return CompatibilitySettingUtil.toCompatibilitySettings(updatedSetting);
         } catch (CompatibilitySettingException e) {
-            throw handleCompatibilitySettingsError(e, Constants.ErrorMessage.ERROR_CODE_COMPATIBILITY_SETTINGS_UPDATE,
-                    null);
+            throw CompatibilitySettingUtil.handleCompatibilitySettingsException(e,
+                    Constants.ErrorMessage.ERROR_CODE_COMPATIBILITY_SETTINGS_UPDATE, null);
         }
     }
 
@@ -2550,11 +2550,10 @@ public class ServerConfigManagementService {
     public CompatibilitySettingsGroup getCompatibilitySettingsByGroup(String settingGroup) {
 
         if (!CompatibilitySettingUtil.isValidSettingGroupName(settingGroup)) {
-            throw handleCompatibilitySettingsError(
-                    new IllegalArgumentException("Invalid setting group name: " + settingGroup),
+            throw CompatibilitySettingUtil.handleCompatibilitySettingsException(
+                    Response.Status.BAD_REQUEST,
                     Constants.ErrorMessage.ERROR_CODE_INVALID_INPUT,
-                    settingGroup
-            );
+                    settingGroup);
         }
 
         try {
@@ -2563,30 +2562,16 @@ public class ServerConfigManagementService {
                     compatibilitySettingsService.getCompatibilitySettingsByGroup(tenantDomain, settingGroup);
 
             if (!CompatibilitySettingUtil.hasSettingGroup(setting, settingGroup)) {
-                throw handleCompatibilitySettingsError(
-                        new IllegalArgumentException("Setting group not found: " + settingGroup),
+                throw CompatibilitySettingUtil.handleCompatibilitySettingsException(
+                        Response.Status.NOT_FOUND,
                         Constants.ErrorMessage.ERROR_CODE_SETTING_GROUP_NOT_FOUND,
-                        settingGroup
-                );
+                        settingGroup);
             }
 
             return CompatibilitySettingUtil.toCompatibilitySettingsGroup(setting, settingGroup);
         } catch (CompatibilitySettingException e) {
-            throw handleCompatibilitySettingsError(e, Constants.ErrorMessage.ERROR_CODE_COMPATIBILITY_SETTINGS_RETRIEVE,
-                    settingGroup);
+            throw CompatibilitySettingUtil.handleCompatibilitySettingsException(e,
+                    Constants.ErrorMessage.ERROR_CODE_COMPATIBILITY_SETTINGS_RETRIEVE, settingGroup);
         }
-    }
-
-    /**
-     * Handle compatibility settings errors.
-     *
-     * @param e         Exception.
-     * @param errorEnum Error enum.
-     * @param data      Additional data.
-     * @return APIError.
-     */
-    private APIError handleCompatibilitySettingsError(Exception e, Constants.ErrorMessage errorEnum, String data) {
-
-        return CompatibilitySettingUtil.handleCompatibilitySettingsException(e, errorEnum, data);
     }
 }

--- a/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/main/java/org/wso2/carbon/identity/api/server/configs/v1/function/CompatibilitySettingUtil.java
+++ b/components/org.wso2.carbon.identity.api.server.configs/org.wso2.carbon.identity.api.server.configs.v1/src/main/java/org/wso2/carbon/identity/api/server/configs/v1/function/CompatibilitySettingUtil.java
@@ -200,6 +200,24 @@ public class CompatibilitySettingUtil {
     }
 
     /**
+     * Build an APIError for compatibility settings flows where the HTTP status is known up-front
+     * (e.g., NOT_FOUND for a missing setting group or BAD_REQUEST for invalid input) and there is no
+     * underlying exception to extract details from.
+     *
+     * @param status    HTTP response status.
+     * @param errorEnum Error Message enum.
+     * @param data      Extra data.
+     * @return APIError.
+     */
+    public static APIError handleCompatibilitySettingsException(Response.Status status,
+                                                                Constants.ErrorMessage errorEnum,
+                                                                String data) {
+
+        ErrorResponse errorResponse = getErrorBuilder(errorEnum, data).build(LOG, errorEnum.description());
+        return new APIError(status, errorResponse);
+    }
+
+    /**
      * Return error builder with given error message enum and data.
      *
      * @param errorEnum Error Message enum.
@@ -223,12 +241,6 @@ public class CompatibilitySettingUtil {
      */
     private static String includeData(Constants.ErrorMessage error, String data) {
 
-        String message;
-        if (StringUtils.isNotBlank(data)) {
-            message = String.format(error.description(), data);
-        } else {
-            message = error.description();
-        }
-        return message;
+        return StringUtils.isNotBlank(data) ? String.format(error.description(), data) : error.description();
     }
 }


### PR DESCRIPTION
This PR addresses review comments on:

- [ ] https://github.com/wso2/identity-api-server/pull/1078

This pull request refactors how API errors are handled in the `ServerConfigManagementService` for compatibility settings. Instead of using a private error handler, it now consistently uses static utility methods from `CompatibilitySettingUtil`, which improves code clarity and allows for more precise HTTP status codes in error responses. Additionally, a new utility method is introduced for building API errors when the HTTP status is known up front.

**Error handling improvements:**

* Replaced calls to the private `handleCompatibilitySettingsError` method with the static `handleCompatibilitySettingsException` methods from `CompatibilitySettingUtil`, ensuring consistent error handling throughout `ServerConfigManagementService`. [[1]](diffhunk://#diff-795c8a71a78557b8ee61df48cd95fc7ce1b63a5272acaddef7385eccce84f14dL2519-R2520) [[2]](diffhunk://#diff-795c8a71a78557b8ee61df48cd95fc7ce1b63a5272acaddef7385eccce84f14dL2539-R2540) [[3]](diffhunk://#diff-795c8a71a78557b8ee61df48cd95fc7ce1b63a5272acaddef7385eccce84f14dL2553-R2556) [[4]](diffhunk://#diff-795c8a71a78557b8ee61df48cd95fc7ce1b63a5272acaddef7385eccce84f14dL2566-L2590)
* Enhanced error responses for invalid input and missing setting groups by specifying HTTP status codes (`BAD_REQUEST`, `NOT_FOUND`) directly in the new utility method. [[1]](diffhunk://#diff-795c8a71a78557b8ee61df48cd95fc7ce1b63a5272acaddef7385eccce84f14dL2553-R2556) [[2]](diffhunk://#diff-795c8a71a78557b8ee61df48cd95fc7ce1b63a5272acaddef7385eccce84f14dL2566-L2590)

**Utility method additions and improvements:**

* Added a new overloaded `handleCompatibilitySettingsException` method in `CompatibilitySettingUtil` to support error handling when the HTTP status is known up front and there is no underlying exception.
* Simplified the `includeData` method in `CompatibilitySettingUtil` for more concise error message formatting.

These changes improve maintainability and make error handling more robust and expressive.