### PR TITLE
Add admin APIs to consent management API

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.branding.preference.management/org.wso2.carbon.identity.api.server.branding.preference.management.common/src/main/java/org/wso2/carbon/identity/api/server/branding/preference/management/common/BrandingPreferenceManagementConstants.java
+++ b/components/org.wso2.carbon.identity.api.server.branding.preference.management/org.wso2.carbon.identity.api.server.branding.preference.management.common/src/main/java/org/wso2/carbon/identity/api/server/branding/preference/management/common/BrandingPreferenceManagementConstants.java
@@ -41,6 +41,9 @@ public class BrandingPreferenceManagementConstants {
     public static final String CUSTOM_TEXT_PREFERENCE_NOT_EXISTS_ERROR_CODE = "BRANDINGM_00023";
     public static final String CUSTOM_TEXT_PREFERENCE_ALREADY_EXISTS_ERROR_CODE = "BRANDINGM_00024";
 
+    // Operation scope constants.
+    public static final String UPDATE_POLICY_URL_OPERATION = "updatePolicyUrl";
+
     // AI Constants.
     public static final String AI_RESPONSE_DATA_KEY = "data";
     public static final String AI_RESPONSE_STATUS_KEY = "status";

--- a/components/org.wso2.carbon.identity.api.server.branding.preference.management/org.wso2.carbon.identity.api.server.branding.preference.management.v1/src/main/java/org/wso2/carbon/identity/api/server/branding/preference/management/v1/core/BrandingPreferenceManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.branding.preference.management/org.wso2.carbon.identity.api.server.branding.preference.management.v1/src/main/java/org/wso2/carbon/identity/api/server/branding/preference/management/v1/core/BrandingPreferenceManagementService.java
@@ -34,14 +34,15 @@ import org.wso2.carbon.identity.api.server.branding.preference.management.v1.mod
 import org.wso2.carbon.identity.api.server.branding.preference.management.v1.model.ResolvedCustomTextModal;
 import org.wso2.carbon.identity.api.server.common.error.APIError;
 import org.wso2.carbon.identity.api.server.common.error.ErrorResponse;
-import org.wso2.carbon.identity.authorization.common.AuthorizationUtil;
-import org.wso2.carbon.identity.authorization.common.exception.ForbiddenException;
 import org.wso2.carbon.identity.branding.preference.management.core.BrandingPreferenceManager;
 import org.wso2.carbon.identity.branding.preference.management.core.exception.BrandingPreferenceMgtClientException;
 import org.wso2.carbon.identity.branding.preference.management.core.exception.BrandingPreferenceMgtException;
 import org.wso2.carbon.identity.branding.preference.management.core.exception.BrandingPreferenceMgtServerException;
 import org.wso2.carbon.identity.branding.preference.management.core.model.BrandingPreference;
 import org.wso2.carbon.identity.branding.preference.management.core.model.CustomText;
+
+import java.util.List;
+import java.util.Map;
 
 import javax.ws.rs.core.Response;
 
@@ -70,6 +71,7 @@ import static org.wso2.carbon.identity.api.server.branding.preference.management
 import static org.wso2.carbon.identity.api.server.branding.preference.management.common.BrandingPreferenceManagementConstants.ErrorMessage.ERROR_CODE_INVALID_CUSTOM_TEXT_PREFERENCE;
 import static org.wso2.carbon.identity.api.server.branding.preference.management.common.BrandingPreferenceManagementConstants.ErrorMessage.ERROR_CODE_NOT_ALLOWED_BRANDING_PREFERENCE_CONFIGURATIONS;
 import static org.wso2.carbon.identity.api.server.branding.preference.management.common.BrandingPreferenceManagementConstants.ORGANIZATION_TYPE;
+import static org.wso2.carbon.identity.api.server.branding.preference.management.common.BrandingPreferenceManagementConstants.UPDATE_POLICY_URL_OPERATION;
 import static org.wso2.carbon.identity.api.server.common.ContextLoader.getTenantDomainFromContext;
 
 /**
@@ -77,7 +79,6 @@ import static org.wso2.carbon.identity.api.server.common.ContextLoader.getTenant
  */
 public class BrandingPreferenceManagementService {
 
-    private static final String UPDATE_POLICY_URL_OPERATION = "updatePolicyUrl";
     private static final String ATTR_URLS = "urls";
 
     private final BrandingPreferenceManager brandingPreferenceManager;
@@ -259,16 +260,7 @@ public class BrandingPreferenceManagementService {
      */
     public BrandingPreferenceModel updateBrandingPreference(BrandingPreferenceModel brandingPreferenceModel) {
 
-        try {
-            AuthorizationUtil.validateOperationScopes(UPDATE_POLICY_URL_OPERATION);
-        } catch (ForbiddenException e) {
-            throw handleExceptionWithMessage(Response.Status.FORBIDDEN,
-                    ERROR_CODE_NOT_ALLOWED_BRANDING_PREFERENCE_CONFIGURATIONS, e.getMessage());
-        }
-
-        OperationScopeValidationContext operationScopeCtx =
-                PrivilegedCarbonContext.getThreadLocalCarbonContext().getOperationScopeValidationContext();
-        boolean restrictToUrls = operationScopeCtx != null && operationScopeCtx.isValidationRequired();
+        boolean restrictToUrls = isRestrictedToUrlUpdate();
 
         String tenantDomain = getTenantDomainFromContext();
 
@@ -483,6 +475,24 @@ public class BrandingPreferenceManagementService {
                     tenantDomain);
         }
         return buildCustomTextResponseFromResponseDTO(responseDTO);
+    }
+
+    private boolean isRestrictedToUrlUpdate() {
+
+        OperationScopeValidationContext operationScopeValidationContext =
+                PrivilegedCarbonContext.getThreadLocalCarbonContext().getOperationScopeValidationContext();
+        if (operationScopeValidationContext != null) {
+            List<String> allowedScopes = operationScopeValidationContext.getValidatedScopes();
+            Map<String, String> operationScopeMap = operationScopeValidationContext.getOperationScopeSet().
+                    getOperationScopeMap();
+            String operationScope = operationScopeMap.get(UPDATE_POLICY_URL_OPERATION);
+            if (!allowedScopes.contains(operationScope)) {
+                log.debug("Operation is not permitted. You do not have permissions to make this request.");
+                return false;
+            }
+            return true;
+        }
+        return false;
     }
 
     private void mergeUrlsIntoExistingPreference(BrandingPreferenceModel brandingPreferenceModel,

--- a/components/org.wso2.carbon.identity.api.server.branding.preference.management/org.wso2.carbon.identity.api.server.branding.preference.management.v1/src/main/java/org/wso2/carbon/identity/api/server/branding/preference/management/v1/core/BrandingPreferenceManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.branding.preference.management/org.wso2.carbon.identity.api.server.branding.preference.management.v1/src/main/java/org/wso2/carbon/identity/api/server/branding/preference/management/v1/core/BrandingPreferenceManagementService.java
@@ -34,15 +34,14 @@ import org.wso2.carbon.identity.api.server.branding.preference.management.v1.mod
 import org.wso2.carbon.identity.api.server.branding.preference.management.v1.model.ResolvedCustomTextModal;
 import org.wso2.carbon.identity.api.server.common.error.APIError;
 import org.wso2.carbon.identity.api.server.common.error.ErrorResponse;
+import org.wso2.carbon.identity.authorization.common.AuthorizationUtil;
+import org.wso2.carbon.identity.authorization.common.exception.ForbiddenException;
 import org.wso2.carbon.identity.branding.preference.management.core.BrandingPreferenceManager;
 import org.wso2.carbon.identity.branding.preference.management.core.exception.BrandingPreferenceMgtClientException;
 import org.wso2.carbon.identity.branding.preference.management.core.exception.BrandingPreferenceMgtException;
 import org.wso2.carbon.identity.branding.preference.management.core.exception.BrandingPreferenceMgtServerException;
 import org.wso2.carbon.identity.branding.preference.management.core.model.BrandingPreference;
 import org.wso2.carbon.identity.branding.preference.management.core.model.CustomText;
-
-import java.util.List;
-import java.util.Map;
 
 import javax.ws.rs.core.Response;
 
@@ -260,7 +259,16 @@ public class BrandingPreferenceManagementService {
      */
     public BrandingPreferenceModel updateBrandingPreference(BrandingPreferenceModel brandingPreferenceModel) {
 
-        boolean restrictToUrls = isRestrictedToUrlUpdate();
+        try {
+            AuthorizationUtil.validateOperationScopes(UPDATE_POLICY_URL_OPERATION);
+        } catch (ForbiddenException e) {
+            throw handleExceptionWithMessage(Response.Status.FORBIDDEN,
+                    ERROR_CODE_NOT_ALLOWED_BRANDING_PREFERENCE_CONFIGURATIONS, e.getMessage());
+        }
+
+        OperationScopeValidationContext operationScopeCtx =
+                PrivilegedCarbonContext.getThreadLocalCarbonContext().getOperationScopeValidationContext();
+        boolean restrictToUrls = operationScopeCtx != null && operationScopeCtx.isValidationRequired();
 
         String tenantDomain = getTenantDomainFromContext();
 
@@ -475,24 +483,6 @@ public class BrandingPreferenceManagementService {
                     tenantDomain);
         }
         return buildCustomTextResponseFromResponseDTO(responseDTO);
-    }
-
-    private boolean isRestrictedToUrlUpdate() {
-
-        OperationScopeValidationContext operationScopeValidationContext =
-                PrivilegedCarbonContext.getThreadLocalCarbonContext().getOperationScopeValidationContext();
-        if (operationScopeValidationContext != null) {
-            List<String> allowedScopes = operationScopeValidationContext.getValidatedScopes();
-            Map<String, String> operationScopeMap = operationScopeValidationContext.getOperationScopeSet().
-                    getOperationScopeMap();
-            String operationScope = operationScopeMap.get(UPDATE_POLICY_URL_OPERATION);
-            if (!allowedScopes.contains(operationScope)) {
-                log.debug("Operation is not permitted. You do not have permissions to make this request.");
-                return false;
-            }
-            return true;
-        }
-        return false;
     }
 
     private void mergeUrlsIntoExistingPreference(BrandingPreferenceModel brandingPreferenceModel,

--- a/components/org.wso2.carbon.identity.api.server.consent.management/org.wso2.carbon.identity.api.server.consent.management.common/src/main/java/org/wso2/carbon/identity/api/server/consent/management/common/ConsentManagementConstants.java
+++ b/components/org.wso2.carbon.identity.api.server.consent.management/org.wso2.carbon.identity.api.server.consent.management.common/src/main/java/org/wso2/carbon/identity/api/server/consent/management/common/ConsentManagementConstants.java
@@ -43,8 +43,4 @@ public class ConsentManagementConstants {
     // Pagination Link Relations
     public static final String LINK_REL_PREVIOUS = "previous";
     public static final String LINK_REL_NEXT = "next";
-
-    // Operation scope names for admin-level consent operations
-    public static final String CONSENT_ADMIN_CREATE_OPERATION = "createConsent";
-    public static final String CONSENT_ADMIN_LIST_OPERATION = "viewConsent";
 }

--- a/components/org.wso2.carbon.identity.api.server.consent.management/org.wso2.carbon.identity.api.server.consent.management.common/src/main/java/org/wso2/carbon/identity/api/server/consent/management/common/ConsentManagementConstants.java
+++ b/components/org.wso2.carbon.identity.api.server.consent.management/org.wso2.carbon.identity.api.server.consent.management.common/src/main/java/org/wso2/carbon/identity/api/server/consent/management/common/ConsentManagementConstants.java
@@ -43,4 +43,8 @@ public class ConsentManagementConstants {
     // Pagination Link Relations
     public static final String LINK_REL_PREVIOUS = "previous";
     public static final String LINK_REL_NEXT = "next";
+
+    // Operation scope names for admin-level consent operations
+    public static final String CONSENT_ADMIN_CREATE_OPERATION = "createConsent";
+    public static final String CONSENT_ADMIN_LIST_OPERATION = "viewConsent";
 }

--- a/components/org.wso2.carbon.identity.api.server.consent.management/org.wso2.carbon.identity.api.server.consent.management.v2/pom.xml
+++ b/components/org.wso2.carbon.identity.api.server.consent.management/org.wso2.carbon.identity.api.server.consent.management.v2/pom.xml
@@ -159,6 +159,11 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.authorization.common</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>org.wso2.carbon.identity.server.api</groupId>
             <artifactId>org.wso2.carbon.identity.api.server.consent.management.common</artifactId>
             <version>${project.version}</version>

--- a/components/org.wso2.carbon.identity.api.server.consent.management/org.wso2.carbon.identity.api.server.consent.management.v2/src/gen/java/org/wso2/carbon/identity/api/server/consent/management/v2/ConsentsApi.java
+++ b/components/org.wso2.carbon.identity.api.server.consent.management/org.wso2.carbon.identity.api.server.consent.management.v2/src/gen/java/org/wso2/carbon/identity/api/server/consent/management/v2/ConsentsApi.java
@@ -19,8 +19,6 @@
 package org.wso2.carbon.identity.api.server.consent.management.v2;
 
 import org.wso2.carbon.identity.api.server.consent.management.v2.factories.ConsentsApiServiceFactory;
-import org.wso2.carbon.identity.api.server.consent.management.v2.model.AuthorizationCreateRequest;
-import org.wso2.carbon.identity.api.server.consent.management.v2.model.AuthorizationDTO;
 import org.wso2.carbon.identity.api.server.consent.management.v2.model.ConsentCreateRequest;
 import org.wso2.carbon.identity.api.server.consent.management.v2.model.ConsentDTO;
 import org.wso2.carbon.identity.api.server.consent.management.v2.model.ConsentListResponse;
@@ -50,35 +48,10 @@ public class ConsentsApi  {
 
     @Valid
     @POST
-    @Path("/{consentId}/authorize")
-    @Consumes({ "application/json" })
-    @Produces({ "application/json" })
-    @ApiOperation(value = "Authorize a consent", notes = "Authorizes a PENDING consent. The authenticated user must be in the consent's authorization list, returns 403 otherwise. When all required users have approved, the consent transitions to ACTIVE state. If any user rejects, the consent transitions to REJECTED state. ", response = AuthorizationDTO.class, authorizations = {
-        @Authorization(value = "BasicAuth"),
-        @Authorization(value = "OAuth2", scopes = {
-            
-        })
-    }, tags={ "Consents", })
-    @ApiResponses(value = { 
-        @ApiResponse(code = 200, message = "Consent authorized successfully", response = AuthorizationDTO.class),
-        @ApiResponse(code = 400, message = "Bad Request", response = ErrorDTO.class),
-        @ApiResponse(code = 401, message = "Unauthorized", response = ErrorDTO.class),
-        @ApiResponse(code = 403, message = "Forbidden", response = ErrorDTO.class),
-        @ApiResponse(code = 404, message = "Not Found", response = ErrorDTO.class),
-        @ApiResponse(code = 409, message = "Conflict", response = ErrorDTO.class),
-        @ApiResponse(code = 500, message = "Server Error", response = ErrorDTO.class)
-    })
-    public Response consentsAuthorize( @Size(min=1,max=255)@ApiParam(value = "ID of the consent.",required=true) @PathParam("consentId") String consentId, @ApiParam(value = "" ,required=true) @Valid AuthorizationCreateRequest authorizationCreateRequest) {
-
-        return delegate.consentsAuthorize(consentId,  authorizationCreateRequest );
-    }
-
-    @Valid
-    @POST
     
     @Consumes({ "application/json" })
     @Produces({ "application/json" })
-    @ApiOperation(value = "Create a consent record", notes = "Record consent for specified purposes and elements.  Without a scope, the authenticated user creates and gives consent simultaneously. The consent is immediately recorded as `ACTIVE`. The `subjectId` field is ignored — the calling user is always the consent subject. Providing `authorizations` returns 400.  <b>Scope(Permission) required:</b> `internal_consent_mgt_consent_create` — Creates a consent record on behalf of a subject user without giving consent. The consent is created in `PENDING` state and requires the subject user to authorize via `POST /consents/{consentId}/authorize`. The `subjectId` field is required. The `authorizations` field may be provided to pre-declare which users must authorize the pending consent. ", response = ConsentResponseDTO.class, authorizations = {
+    @ApiOperation(value = "Create a consent record", notes = "Record a consent on behalf of a subject user.<br> <b>Scope(Permission) required:</b> `internal_consent_mgt_consent_create` ", response = ConsentResponseDTO.class, authorizations = {
         @Authorization(value = "BasicAuth"),
         @Authorization(value = "OAuth2", scopes = {
             
@@ -102,7 +75,7 @@ public class ConsentsApi  {
     @Path("/{consentId}")
     
     @Produces({ "application/json" })
-    @ApiOperation(value = "Get a consent record", notes = "Retrieve a specific consent record by consent ID.  Without a scope, only the consent subject may retrieve the record. Returns 403 if the authenticated user is not the consent subject.  <b>Scope(Permission) required:</b> `internal_consent_mgt_consent_view` — Any consent record can be retrieved regardless of who the subject is. ", response = ConsentDTO.class, authorizations = {
+    @ApiOperation(value = "Get a consent record", notes = "Retrieve a specific consent record by consent ID.<br> <b>Scope(Permission) required:</b> `internal_consent_mgt_consent_view` ", response = ConsentDTO.class, authorizations = {
         @Authorization(value = "BasicAuth"),
         @Authorization(value = "OAuth2", scopes = {
             
@@ -126,7 +99,7 @@ public class ConsentsApi  {
     
     
     @Produces({ "application/json" })
-    @ApiOperation(value = "List consent records", notes = "Retrieve consent records with optional filtering.  Without a scope, returns only the authenticated user's own consents. The `subjectId` query parameter is ignored.  <b>Scope(Permission) required:</b> `internal_consent_mgt_consent_view` — Returns consents for any user. The `subjectId` parameter is applied as a filter. ", response = ConsentListResponse.class, authorizations = {
+    @ApiOperation(value = "List consent records", notes = "Retrieve consent records with optional filtering.<br> <b>Scope(Permission) required:</b> `internal_consent_mgt_consent_view` ", response = ConsentListResponse.class, authorizations = {
         @Authorization(value = "BasicAuth"),
         @Authorization(value = "OAuth2", scopes = {
             
@@ -148,7 +121,7 @@ public class ConsentsApi  {
     @Path("/{consentId}/revoke")
     
     @Produces({ "application/json" })
-    @ApiOperation(value = "Revoke a consent", notes = "Revokes the consent. The authenticated user must be the consent subject, returns 403 otherwise. Idempotent — if the consent is already revoked, returns 204 with no error. ", response = Void.class, authorizations = {
+    @ApiOperation(value = "Revoke a consent", notes = "Revokes the consent. Idempotent — if the consent is already revoked, returns 204 with no error.<br> <b>Scope(Permission) required:</b> `internal_consent_mgt_consent_update` ", response = Void.class, authorizations = {
         @Authorization(value = "BasicAuth"),
         @Authorization(value = "OAuth2", scopes = {
             
@@ -172,7 +145,7 @@ public class ConsentsApi  {
     @Path("/{consentId}")
     @Consumes({ "application/json" })
     @Produces({ "application/json" })
-    @ApiOperation(value = "Update a consent record", notes = "Update an existing consent record's expiry time, properties, and authorizations. All fields in the request body are optional; omit a field to leave that aspect of the consent unchanged. `expiryTime` sets or clears the expiry, `properties` replaces the full property map, and `authorizations` upserts the listed users — adding them as authorizers if absent or overriding their state if present.  <b>Scope(Permission) required:</b> `internal_consent_mgt_consent_update` — Updates any consent record regardless of who the subject is. ", response = ConsentDTO.class, authorizations = {
+    @ApiOperation(value = "Update a consent record", notes = "Update an existing consent record's expiry time, properties, and authorizations. All fields in the request body are optional; omit a field to leave that aspect of the consent unchanged. `expiryTime` sets or clears the expiry, `properties` replaces the full property map, and `authorizations` upserts the listed users — adding them as authorizers if absent or overriding their state if present.<br> <b>Scope(Permission) required:</b> `internal_consent_mgt_consent_update` ", response = ConsentDTO.class, authorizations = {
         @Authorization(value = "BasicAuth"),
         @Authorization(value = "OAuth2", scopes = {
             
@@ -196,7 +169,7 @@ public class ConsentsApi  {
     @Path("/{consentId}/validate")
     
     @Produces({ "application/json" })
-    @ApiOperation(value = "Get the current state of a consent object", notes = "Returns the current state of a consent record, performing a lazy expiry check. The authenticated user must be the consent subject, returns 403 otherwise. ", response = ConsentValidateResponse.class, authorizations = {
+    @ApiOperation(value = "Get the current state of a consent object", notes = "Returns the current state of a consent record, performing a lazy expiry check.<br> <b>Scope(Permission) required:</b> `internal_consent_mgt_consent_view` ", response = ConsentValidateResponse.class, authorizations = {
         @Authorization(value = "BasicAuth"),
         @Authorization(value = "OAuth2", scopes = {
             

--- a/components/org.wso2.carbon.identity.api.server.consent.management/org.wso2.carbon.identity.api.server.consent.management.v2/src/gen/java/org/wso2/carbon/identity/api/server/consent/management/v2/ConsentsApi.java
+++ b/components/org.wso2.carbon.identity.api.server.consent.management/org.wso2.carbon.identity.api.server.consent.management.v2/src/gen/java/org/wso2/carbon/identity/api/server/consent/management/v2/ConsentsApi.java
@@ -25,6 +25,7 @@ import org.wso2.carbon.identity.api.server.consent.management.v2.model.ConsentCr
 import org.wso2.carbon.identity.api.server.consent.management.v2.model.ConsentDTO;
 import org.wso2.carbon.identity.api.server.consent.management.v2.model.ConsentListResponse;
 import org.wso2.carbon.identity.api.server.consent.management.v2.model.ConsentResponseDTO;
+import org.wso2.carbon.identity.api.server.consent.management.v2.model.ConsentUpdateRequest;
 import org.wso2.carbon.identity.api.server.consent.management.v2.model.ConsentValidateResponse;
 import org.wso2.carbon.identity.api.server.consent.management.v2.model.ErrorDTO;
 
@@ -52,7 +53,7 @@ public class ConsentsApi  {
     @Path("/{consentId}/authorize")
     @Consumes({ "application/json" })
     @Produces({ "application/json" })
-    @ApiOperation(value = "Authorize a consent", notes = "Authorizes a PENDING consent. The authenticated user must be in the consent's authorization list. When all required users have approved, the consent transitions to ACTIVE state. If any user rejects, the consent transitions to REJECTED state. Returns 403 if the calling user is not in the authorization list. ", response = AuthorizationDTO.class, authorizations = {
+    @ApiOperation(value = "Authorize a consent", notes = "Authorizes a PENDING consent. The authenticated user must be in the consent's authorization list, returns 403 otherwise. When all required users have approved, the consent transitions to ACTIVE state. If any user rejects, the consent transitions to REJECTED state. ", response = AuthorizationDTO.class, authorizations = {
         @Authorization(value = "BasicAuth"),
         @Authorization(value = "OAuth2", scopes = {
             
@@ -77,7 +78,7 @@ public class ConsentsApi  {
     
     @Consumes({ "application/json" })
     @Produces({ "application/json" })
-    @ApiOperation(value = "Create a consent record", notes = "Record user consent for specified purposes and elements. ", response = ConsentResponseDTO.class, authorizations = {
+    @ApiOperation(value = "Create a consent record", notes = "Record consent for specified purposes and elements.  Without a scope, the authenticated user creates and gives consent simultaneously. The consent is immediately recorded as `ACTIVE`. The `subjectId` field is ignored — the calling user is always the consent subject. Providing `authorizations` returns 400.  <b>Scope(Permission) required:</b> `internal_consent_mgt_consent_create` — Creates a consent record on behalf of a subject user without giving consent. The consent is created in `PENDING` state and requires the subject user to authorize via `POST /consents/{consentId}/authorize`. The `subjectId` field is required. The `authorizations` field may be provided to pre-declare which users must authorize the pending consent. ", response = ConsentResponseDTO.class, authorizations = {
         @Authorization(value = "BasicAuth"),
         @Authorization(value = "OAuth2", scopes = {
             
@@ -101,7 +102,7 @@ public class ConsentsApi  {
     @Path("/{consentId}")
     
     @Produces({ "application/json" })
-    @ApiOperation(value = "Get a consent record", notes = "Retrieve a specific consent record by consent ID. ", response = ConsentDTO.class, authorizations = {
+    @ApiOperation(value = "Get a consent record", notes = "Retrieve a specific consent record by consent ID.  Without a scope, only the consent subject may retrieve the record. Returns 403 if the authenticated user is not the consent subject.  <b>Scope(Permission) required:</b> `internal_consent_mgt_consent_view` — Any consent record can be retrieved regardless of who the subject is. ", response = ConsentDTO.class, authorizations = {
         @Authorization(value = "BasicAuth"),
         @Authorization(value = "OAuth2", scopes = {
             
@@ -111,6 +112,7 @@ public class ConsentsApi  {
         @ApiResponse(code = 200, message = "Consent record details", response = ConsentDTO.class),
         @ApiResponse(code = 400, message = "Bad Request", response = ErrorDTO.class),
         @ApiResponse(code = 401, message = "Unauthorized", response = ErrorDTO.class),
+        @ApiResponse(code = 403, message = "Forbidden", response = ErrorDTO.class),
         @ApiResponse(code = 404, message = "Not Found", response = ErrorDTO.class),
         @ApiResponse(code = 500, message = "Server Error", response = ErrorDTO.class)
     })
@@ -124,7 +126,7 @@ public class ConsentsApi  {
     
     
     @Produces({ "application/json" })
-    @ApiOperation(value = "List consent records", notes = "Retrieve consent records with optional filtering. ", response = ConsentListResponse.class, authorizations = {
+    @ApiOperation(value = "List consent records", notes = "Retrieve consent records with optional filtering.  Without a scope, returns only the authenticated user's own consents. The `subjectId` query parameter is ignored.  <b>Scope(Permission) required:</b> `internal_consent_mgt_consent_view` — Returns consents for any user. The `subjectId` parameter is applied as a filter. ", response = ConsentListResponse.class, authorizations = {
         @Authorization(value = "BasicAuth"),
         @Authorization(value = "OAuth2", scopes = {
             
@@ -136,9 +138,9 @@ public class ConsentsApi  {
         @ApiResponse(code = 401, message = "Unauthorized", response = ErrorDTO.class),
         @ApiResponse(code = 500, message = "Server Error", response = ErrorDTO.class)
     })
-    public Response consentsList(    @Valid @Size(max=255)@ApiParam(value = "Filter by subject username.")  @QueryParam("subjectId") String subjectId,     @Valid @Size(max=255)@ApiParam(value = "Filter by service ID.")  @QueryParam("serviceId") String serviceId,     @Valid@ApiParam(value = "Filter consents by state.", allowableValues="PENDING, ACTIVE, REJECTED, REVOKED, EXPIRED")  @QueryParam("state") String state,     @Valid@ApiParam(value = "Filter consents by purpose ID.")  @QueryParam("purposeId") String purposeId,     @Valid@ApiParam(value = "Filter consents by specific purpose version ID.")  @QueryParam("purposeVersionId") String purposeVersionId,     @Valid @Min(1)@ApiParam(value = "Maximum number of records to return.", defaultValue="10") @DefaultValue("10")  @QueryParam("limit") Integer limit,     @Valid@ApiParam(value = "Cursor for forward pagination. Pass the base64-encoded UUID of the last item received from the previous page to retrieve the next page of results. ")  @QueryParam("after") String after,     @Valid@ApiParam(value = "Cursor for backward pagination. Pass the base64-encoded UUID of the first item received from the current page to retrieve the previous page of results. ")  @QueryParam("before") String before) {
+    public Response consentsList(    @Valid @Size(max=255)@ApiParam(value = "Filter by subject username.")  @QueryParam("subjectId") String subjectId,     @Valid @Size(max=255)@ApiParam(value = "Filter by service ID.")  @QueryParam("serviceId") String serviceId,     @Valid@ApiParam(value = "Filter consents by state.", allowableValues="PENDING, ACTIVE, REJECTED, REVOKED, EXPIRED")  @QueryParam("state") String state,     @Valid@ApiParam(value = "Filter consents by purpose ID.")  @QueryParam("purposeId") String purposeId,     @Valid@ApiParam(value = "Filter consents by specific purpose version ID.")  @QueryParam("purposeVersionId") String purposeVersionId,     @Valid@ApiParam(value = "Filter consents by custom properties using dot notation `properties.<key>`. Supports 'sw' (starts with), 'co' (contains), 'ew' (ends with), and 'eq' (equals) operations. Combine multiple conditions with 'and', 'or' logical operators. Examples: - filter=properties.dataCategory eq personal - filter=properties.region eq EU - filter=properties.region eq EU and properties.dataCategory eq personal ")  @QueryParam("filter") String filter,     @Valid @Min(1)@ApiParam(value = "Maximum number of records to return.", defaultValue="10") @DefaultValue("10")  @QueryParam("limit") Integer limit,     @Valid@ApiParam(value = "Cursor for forward pagination. Pass the base64-encoded UUID of the last item received from the previous page to retrieve the next page of results. ")  @QueryParam("after") String after,     @Valid@ApiParam(value = "Cursor for backward pagination. Pass the base64-encoded UUID of the first item received from the current page to retrieve the previous page of results. ")  @QueryParam("before") String before) {
 
-        return delegate.consentsList(subjectId,  serviceId,  state,  purposeId,  purposeVersionId,  limit,  after,  before );
+        return delegate.consentsList(subjectId,  serviceId,  state,  purposeId,  purposeVersionId,  filter,  limit,  after,  before );
     }
 
     @Valid
@@ -146,7 +148,7 @@ public class ConsentsApi  {
     @Path("/{consentId}/revoke")
     
     @Produces({ "application/json" })
-    @ApiOperation(value = "Revoke a consent", notes = "Revokes the consent. Idempotent — if the consent is already revoked, returns 204 with no error. For consents with an authorization list, only users in that list may revoke (returns 403 otherwise). ", response = Void.class, authorizations = {
+    @ApiOperation(value = "Revoke a consent", notes = "Revokes the consent. The authenticated user must be the consent subject, returns 403 otherwise. Idempotent — if the consent is already revoked, returns 204 with no error. ", response = Void.class, authorizations = {
         @Authorization(value = "BasicAuth"),
         @Authorization(value = "OAuth2", scopes = {
             
@@ -166,11 +168,35 @@ public class ConsentsApi  {
     }
 
     @Valid
+    @PATCH
+    @Path("/{consentId}")
+    @Consumes({ "application/json" })
+    @Produces({ "application/json" })
+    @ApiOperation(value = "Update a consent record", notes = "Update an existing consent record's expiry time, properties, and authorizations. All fields in the request body are optional; omit a field to leave that aspect of the consent unchanged. `expiryTime` sets or clears the expiry, `properties` replaces the full property map, and `authorizations` upserts the listed users — adding them as authorizers if absent or overriding their state if present.  <b>Scope(Permission) required:</b> `internal_consent_mgt_consent_update` — Updates any consent record regardless of who the subject is. ", response = ConsentDTO.class, authorizations = {
+        @Authorization(value = "BasicAuth"),
+        @Authorization(value = "OAuth2", scopes = {
+            
+        })
+    }, tags={ "Consents", })
+    @ApiResponses(value = { 
+        @ApiResponse(code = 200, message = "Consent updated successfully", response = ConsentDTO.class),
+        @ApiResponse(code = 400, message = "Bad Request", response = ErrorDTO.class),
+        @ApiResponse(code = 401, message = "Unauthorized", response = ErrorDTO.class),
+        @ApiResponse(code = 403, message = "Forbidden", response = ErrorDTO.class),
+        @ApiResponse(code = 404, message = "Not Found", response = ErrorDTO.class),
+        @ApiResponse(code = 500, message = "Server Error", response = ErrorDTO.class)
+    })
+    public Response consentsUpdate( @Size(min=1,max=255)@ApiParam(value = "ID of the consent.",required=true) @PathParam("consentId") String consentId, @ApiParam(value = "" ,required=true) @Valid ConsentUpdateRequest consentUpdateRequest) {
+
+        return delegate.consentsUpdate(consentId,  consentUpdateRequest );
+    }
+
+    @Valid
     @GET
     @Path("/{consentId}/validate")
     
     @Produces({ "application/json" })
-    @ApiOperation(value = "Get the current state of a consent object", notes = "", response = ConsentValidateResponse.class, authorizations = {
+    @ApiOperation(value = "Get the current state of a consent object", notes = "Returns the current state of a consent record, performing a lazy expiry check. The authenticated user must be the consent subject, returns 403 otherwise. ", response = ConsentValidateResponse.class, authorizations = {
         @Authorization(value = "BasicAuth"),
         @Authorization(value = "OAuth2", scopes = {
             
@@ -180,6 +206,7 @@ public class ConsentsApi  {
         @ApiResponse(code = 200, message = "Validation result", response = ConsentValidateResponse.class),
         @ApiResponse(code = 400, message = "Bad Request", response = ErrorDTO.class),
         @ApiResponse(code = 401, message = "Unauthorized", response = ErrorDTO.class),
+        @ApiResponse(code = 403, message = "Forbidden", response = ErrorDTO.class),
         @ApiResponse(code = 404, message = "Not Found", response = ErrorDTO.class),
         @ApiResponse(code = 500, message = "Server Error", response = ErrorDTO.class)
     })

--- a/components/org.wso2.carbon.identity.api.server.consent.management/org.wso2.carbon.identity.api.server.consent.management.v2/src/gen/java/org/wso2/carbon/identity/api/server/consent/management/v2/ConsentsApiService.java
+++ b/components/org.wso2.carbon.identity.api.server.consent.management/org.wso2.carbon.identity.api.server.consent.management.v2/src/gen/java/org/wso2/carbon/identity/api/server/consent/management/v2/ConsentsApiService.java
@@ -24,8 +24,6 @@ import org.apache.cxf.jaxrs.ext.multipart.Attachment;
 import org.apache.cxf.jaxrs.ext.multipart.Multipart;
 import java.io.InputStream;
 import java.util.List;
-import org.wso2.carbon.identity.api.server.consent.management.v2.model.AuthorizationCreateRequest;
-import org.wso2.carbon.identity.api.server.consent.management.v2.model.AuthorizationDTO;
 import org.wso2.carbon.identity.api.server.consent.management.v2.model.ConsentCreateRequest;
 import org.wso2.carbon.identity.api.server.consent.management.v2.model.ConsentDTO;
 import org.wso2.carbon.identity.api.server.consent.management.v2.model.ConsentListResponse;
@@ -37,8 +35,6 @@ import javax.ws.rs.core.Response;
 
 
 public interface ConsentsApiService {
-
-      public Response consentsAuthorize(String consentId, AuthorizationCreateRequest authorizationCreateRequest);
 
       public Response consentsCreate(ConsentCreateRequest consentCreateRequest);
 

--- a/components/org.wso2.carbon.identity.api.server.consent.management/org.wso2.carbon.identity.api.server.consent.management.v2/src/gen/java/org/wso2/carbon/identity/api/server/consent/management/v2/ConsentsApiService.java
+++ b/components/org.wso2.carbon.identity.api.server.consent.management/org.wso2.carbon.identity.api.server.consent.management.v2/src/gen/java/org/wso2/carbon/identity/api/server/consent/management/v2/ConsentsApiService.java
@@ -30,6 +30,7 @@ import org.wso2.carbon.identity.api.server.consent.management.v2.model.ConsentCr
 import org.wso2.carbon.identity.api.server.consent.management.v2.model.ConsentDTO;
 import org.wso2.carbon.identity.api.server.consent.management.v2.model.ConsentListResponse;
 import org.wso2.carbon.identity.api.server.consent.management.v2.model.ConsentResponseDTO;
+import org.wso2.carbon.identity.api.server.consent.management.v2.model.ConsentUpdateRequest;
 import org.wso2.carbon.identity.api.server.consent.management.v2.model.ConsentValidateResponse;
 import org.wso2.carbon.identity.api.server.consent.management.v2.model.ErrorDTO;
 import javax.ws.rs.core.Response;
@@ -43,9 +44,11 @@ public interface ConsentsApiService {
 
       public Response consentsGet(String consentId);
 
-      public Response consentsList(String subjectId, String serviceId, String state, String purposeId, String purposeVersionId, Integer limit, String after, String before);
+      public Response consentsList(String subjectId, String serviceId, String state, String purposeId, String purposeVersionId, String filter, Integer limit, String after, String before);
 
       public Response consentsRevoke(String consentId);
+
+      public Response consentsUpdate(String consentId, ConsentUpdateRequest consentUpdateRequest);
 
       public Response consentsValidate(String consentId);
 }

--- a/components/org.wso2.carbon.identity.api.server.consent.management/org.wso2.carbon.identity.api.server.consent.management.v2/src/gen/java/org/wso2/carbon/identity/api/server/consent/management/v2/model/AuthorizationUpdateEntry.java
+++ b/components/org.wso2.carbon.identity.api.server.consent.management/org.wso2.carbon.identity.api.server.consent.management.v2/src/gen/java/org/wso2/carbon/identity/api/server/consent/management/v2/model/AuthorizationUpdateEntry.java
@@ -30,21 +30,55 @@ import java.util.Objects;
 import javax.validation.Valid;
 import javax.xml.bind.annotation.*;
 
-public class AuthorizationEntry  {
+public class AuthorizationUpdateEntry  {
   
     private String userId;
-    private String type;
+    private String type = "USER";
+
+@XmlType(name="StateEnum")
+@XmlEnum(String.class)
+public enum StateEnum {
+
+    @XmlEnumValue("APPROVED") APPROVED(String.valueOf("APPROVED")), @XmlEnumValue("REJECTED") REJECTED(String.valueOf("REJECTED")), @XmlEnumValue("REVOKED") REVOKED(String.valueOf("REVOKED"));
+
+
+    private String value;
+
+    StateEnum(String v) {
+        value = v;
+    }
+
+    public String value() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    public static StateEnum fromValue(String value) {
+        for (StateEnum b : StateEnum.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
+}
+
+    private StateEnum state;
 
     /**
-    * Username of the user expected to authorize this consent
+    * Username of the authorizer to add or update
     **/
-    public AuthorizationEntry userId(String userId) {
+    public AuthorizationUpdateEntry userId(String userId) {
 
         this.userId = userId;
         return this;
     }
     
-    @ApiModelProperty(example = "alice@wso2.com", required = true, value = "Username of the user expected to authorize this consent")
+    @ApiModelProperty(example = "alice@wso2.com", required = true, value = "Username of the authorizer to add or update")
     @JsonProperty("userId")
     @Valid
     @NotNull(message = "Property userId cannot be null.")
@@ -57,15 +91,15 @@ public class AuthorizationEntry  {
     }
 
     /**
-    * Type of the authorization principal
+    * Type of the authorization principal. Used when adding a new authorizer.
     **/
-    public AuthorizationEntry type(String type) {
+    public AuthorizationUpdateEntry type(String type) {
 
         this.type = type;
         return this;
     }
     
-    @ApiModelProperty(example = "USER", value = "Type of the authorization principal")
+    @ApiModelProperty(example = "USER", value = "Type of the authorization principal. Used when adding a new authorizer.")
     @JsonProperty("type")
     @Valid
     public String getType() {
@@ -73,6 +107,25 @@ public class AuthorizationEntry  {
     }
     public void setType(String type) {
         this.type = type;
+    }
+
+    /**
+    * Authorization state to set. Required when overriding an existing authorizer; for a newly added authorizer, omit to leave it pending. 
+    **/
+    public AuthorizationUpdateEntry state(StateEnum state) {
+
+        this.state = state;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "REVOKED", value = "Authorization state to set. Required when overriding an existing authorizer; for a newly added authorizer, omit to leave it pending. ")
+    @JsonProperty("state")
+    @Valid
+    public StateEnum getState() {
+        return state;
+    }
+    public void setState(StateEnum state) {
+        this.state = state;
     }
 
 
@@ -86,24 +139,26 @@ public class AuthorizationEntry  {
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        AuthorizationEntry authorizationEntry = (AuthorizationEntry) o;
-        return Objects.equals(this.userId, authorizationEntry.userId) &&
-            Objects.equals(this.type, authorizationEntry.type);
+        AuthorizationUpdateEntry authorizationUpdateEntry = (AuthorizationUpdateEntry) o;
+        return Objects.equals(this.userId, authorizationUpdateEntry.userId) &&
+            Objects.equals(this.type, authorizationUpdateEntry.type) &&
+            Objects.equals(this.state, authorizationUpdateEntry.state);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(userId, type);
+        return Objects.hash(userId, type, state);
     }
 
     @Override
     public String toString() {
 
         StringBuilder sb = new StringBuilder();
-        sb.append("class AuthorizationEntry {\n");
+        sb.append("class AuthorizationUpdateEntry {\n");
         
         sb.append("    userId: ").append(toIndentedString(userId)).append("\n");
         sb.append("    type: ").append(toIndentedString(type)).append("\n");
+        sb.append("    state: ").append(toIndentedString(state)).append("\n");
         sb.append("}");
         return sb.toString();
     }

--- a/components/org.wso2.carbon.identity.api.server.consent.management/org.wso2.carbon.identity.api.server.consent.management.v2/src/gen/java/org/wso2/carbon/identity/api/server/consent/management/v2/model/AuthorizationUpdateEntry.java
+++ b/components/org.wso2.carbon.identity.api.server.consent.management/org.wso2.carbon.identity.api.server.consent.management.v2/src/gen/java/org/wso2/carbon/identity/api/server/consent/management/v2/model/AuthorizationUpdateEntry.java
@@ -33,7 +33,7 @@ import javax.xml.bind.annotation.*;
 public class AuthorizationUpdateEntry  {
   
     private String userId;
-    private String type = "USER";
+    private String type;
 
 @XmlType(name="StateEnum")
 @XmlEnum(String.class)

--- a/components/org.wso2.carbon.identity.api.server.consent.management/org.wso2.carbon.identity.api.server.consent.management.v2/src/gen/java/org/wso2/carbon/identity/api/server/consent/management/v2/model/ConsentCreateRequest.java
+++ b/components/org.wso2.carbon.identity.api.server.consent.management/org.wso2.carbon.identity.api.server.consent.management.v2/src/gen/java/org/wso2/carbon/identity/api/server/consent/management/v2/model/ConsentCreateRequest.java
@@ -215,7 +215,7 @@ public enum StateEnum {
         return this;
     }
     
-    @ApiModelProperty(example = "[{\"id\":\"alice@wso2.com\"},{\"id\":\"bob@wso2.com\"}]", value = "Optional list of users who are expected to authorize this consent. Each user will use the /authorize endpoint to give their actual consent.")
+    @ApiModelProperty(example = "[{\"userId\":\"alice@wso2.com\",\"type\":\"USER\"},{\"userId\":\"bob@wso2.com\",\"type\":\"USER\"}]", value = "Optional list of users who are expected to authorize this consent. Each user will use the /authorize endpoint to give their actual consent.")
     @JsonProperty("authorizations")
     @Valid
     public List<AuthorizationEntry> getAuthorizations() {

--- a/components/org.wso2.carbon.identity.api.server.consent.management/org.wso2.carbon.identity.api.server.consent.management.v2/src/gen/java/org/wso2/carbon/identity/api/server/consent/management/v2/model/ConsentCreateRequest.java
+++ b/components/org.wso2.carbon.identity.api.server.consent.management/org.wso2.carbon.identity.api.server.consent.management.v2/src/gen/java/org/wso2/carbon/identity/api/server/consent/management/v2/model/ConsentCreateRequest.java
@@ -84,7 +84,7 @@ public enum StateEnum {
 
 
     /**
-    * Username of the user giving consent. If omitted, defaults to the authenticated caller. Required when the subject differs from the caller (delegated consent). 
+    * Username of the user giving consent.
     **/
     public ConsentCreateRequest subjectId(String subjectId) {
 
@@ -92,9 +92,11 @@ public enum StateEnum {
         return this;
     }
     
-    @ApiModelProperty(example = "alice@wso2.com", value = "Username of the user giving consent. If omitted, defaults to the authenticated caller. Required when the subject differs from the caller (delegated consent). ")
+    @ApiModelProperty(example = "alice@wso2.com", required = true, value = "Username of the user giving consent.")
     @JsonProperty("subjectId")
-    @Valid @Size(min=1,max=255)
+    @Valid
+    @NotNull(message = "Property subjectId cannot be null.")
+ @Size(min=1,max=255)
     public String getSubjectId() {
         return subjectId;
     }
@@ -207,7 +209,7 @@ public enum StateEnum {
     }
 
     /**
-    * Optional list of users who are expected to authorize this consent. Each user will use the /authorize endpoint to give their actual consent.
+    * Optional list of users who are expected to authorize this consent.
     **/
     public ConsentCreateRequest authorizations(List<AuthorizationEntry> authorizations) {
 
@@ -215,7 +217,7 @@ public enum StateEnum {
         return this;
     }
     
-    @ApiModelProperty(example = "[{\"userId\":\"alice@wso2.com\",\"type\":\"USER\"},{\"userId\":\"bob@wso2.com\",\"type\":\"USER\"}]", value = "Optional list of users who are expected to authorize this consent. Each user will use the /authorize endpoint to give their actual consent.")
+    @ApiModelProperty(example = "[{\"userId\":\"alice@wso2.com\",\"type\":\"USER\"},{\"userId\":\"bob@wso2.com\",\"type\":\"USER\"}]", value = "Optional list of users who are expected to authorize this consent.")
     @JsonProperty("authorizations")
     @Valid
     public List<AuthorizationEntry> getAuthorizations() {

--- a/components/org.wso2.carbon.identity.api.server.consent.management/org.wso2.carbon.identity.api.server.consent.management.v2/src/gen/java/org/wso2/carbon/identity/api/server/consent/management/v2/model/ConsentResponseDTO.java
+++ b/components/org.wso2.carbon.identity.api.server.consent.management/org.wso2.carbon.identity.api.server.consent.management.v2/src/gen/java/org/wso2/carbon/identity/api/server/consent/management/v2/model/ConsentResponseDTO.java
@@ -40,40 +40,6 @@ public class ConsentResponseDTO  {
     private String subjectId;
     private String tenantDomain;
 
-@XmlType(name="StateEnum")
-@XmlEnum(String.class)
-public enum StateEnum {
-
-    @XmlEnumValue("PENDING") PENDING(String.valueOf("PENDING")), @XmlEnumValue("ACTIVE") ACTIVE(String.valueOf("ACTIVE")), @XmlEnumValue("REJECTED") REJECTED(String.valueOf("REJECTED")), @XmlEnumValue("REVOKED") REVOKED(String.valueOf("REVOKED")), @XmlEnumValue("EXPIRED") EXPIRED(String.valueOf("EXPIRED"));
-
-
-    private String value;
-
-    StateEnum(String v) {
-        value = v;
-    }
-
-    public String value() {
-        return value;
-    }
-
-    @Override
-    public String toString() {
-        return String.valueOf(value);
-    }
-
-    public static StateEnum fromValue(String value) {
-        for (StateEnum b : StateEnum.values()) {
-            if (b.value.equals(value)) {
-                return b;
-            }
-        }
-        throw new IllegalArgumentException("Unexpected value '" + value + "'");
-    }
-}
-
-    private StateEnum state;
-
     /**
     * Unique identifier for this consent
     **/
@@ -150,25 +116,6 @@ public enum StateEnum {
         this.tenantDomain = tenantDomain;
     }
 
-    /**
-    * PENDING if awaiting approvals, ACTIVE if all accepted, REJECTED if any rejected before activation, REVOKED if any user revoked after activation, EXPIRED if expiryTime has passed.
-    **/
-    public ConsentResponseDTO state(StateEnum state) {
-
-        this.state = state;
-        return this;
-    }
-    
-    @ApiModelProperty(example = "ACTIVE", value = "PENDING if awaiting approvals, ACTIVE if all accepted, REJECTED if any rejected before activation, REVOKED if any user revoked after activation, EXPIRED if expiryTime has passed.")
-    @JsonProperty("state")
-    @Valid
-    public StateEnum getState() {
-        return state;
-    }
-    public void setState(StateEnum state) {
-        this.state = state;
-    }
-
 
 
     @Override
@@ -184,13 +131,12 @@ public enum StateEnum {
         return Objects.equals(this.id, consentResponseDTO.id) &&
             Objects.equals(this.language, consentResponseDTO.language) &&
             Objects.equals(this.subjectId, consentResponseDTO.subjectId) &&
-            Objects.equals(this.tenantDomain, consentResponseDTO.tenantDomain) &&
-            Objects.equals(this.state, consentResponseDTO.state);
+            Objects.equals(this.tenantDomain, consentResponseDTO.tenantDomain);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, language, subjectId, tenantDomain, state);
+        return Objects.hash(id, language, subjectId, tenantDomain);
     }
 
     @Override
@@ -203,7 +149,6 @@ public enum StateEnum {
         sb.append("    language: ").append(toIndentedString(language)).append("\n");
         sb.append("    subjectId: ").append(toIndentedString(subjectId)).append("\n");
         sb.append("    tenantDomain: ").append(toIndentedString(tenantDomain)).append("\n");
-        sb.append("    state: ").append(toIndentedString(state)).append("\n");
         sb.append("}");
         return sb.toString();
     }

--- a/components/org.wso2.carbon.identity.api.server.consent.management/org.wso2.carbon.identity.api.server.consent.management.v2/src/gen/java/org/wso2/carbon/identity/api/server/consent/management/v2/model/ConsentUpdateRequest.java
+++ b/components/org.wso2.carbon.identity.api.server.consent.management/org.wso2.carbon.identity.api.server.consent.management.v2/src/gen/java/org/wso2/carbon/identity/api/server/consent/management/v2/model/ConsentUpdateRequest.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.consent.management.v2.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.wso2.carbon.identity.api.server.consent.management.v2.model.AuthorizationUpdateEntry;
+import javax.validation.constraints.*;
+
+/**
+ * Admin update of an existing consent. All fields are optional; omit a field to leave that aspect of the consent unchanged. 
+ **/
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+import javax.validation.Valid;
+import javax.xml.bind.annotation.*;
+@ApiModel(description = "Admin update of an existing consent. All fields are optional; omit a field to leave that aspect of the consent unchanged. ")
+public class ConsentUpdateRequest  {
+  
+    private Long expiryTime;
+    private Map<String, String> properties = null;
+
+    private List<AuthorizationUpdateEntry> authorizations = null;
+
+
+    /**
+    * When present, sets or extends the consent&#39;s expiry time to the given milliseconds-since-epoch timestamp. Omit to leave the existing expiry unchanged. Pass any negative value (e.g. &#x60;-1&#x60;) to remove the expiry entirely (the consent no longer expires).
+    **/
+    public ConsentUpdateRequest expiryTime(Long expiryTime) {
+
+        this.expiryTime = expiryTime;
+        return this;
+    }
+
+    @ApiModelProperty(example = "1766383796000", value = "When present, sets or extends the consent's expiry time to the given milliseconds-since-epoch timestamp. Omit to leave the existing expiry unchanged. Pass any negative value (e.g. `-1`) to remove the expiry entirely (the consent no longer expires). ")
+    @JsonProperty("expiryTime")
+    @Valid
+    public Long getExpiryTime() {
+        return expiryTime;
+    }
+    public void setExpiryTime(Long expiryTime) {
+        this.expiryTime = expiryTime;
+    }
+
+    /**
+    * When present, replaces the consent&#39;s full property map. Omit to leave existing properties unchanged. 
+    **/
+    public ConsentUpdateRequest properties(Map<String, String> properties) {
+
+        this.properties = properties;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "{\"dataCategory\":\"personal\",\"region\":\"EU\"}", value = "When present, replaces the consent's full property map. Omit to leave existing properties unchanged. ")
+    @JsonProperty("properties")
+    @Valid
+    public Map<String, String> getProperties() {
+        return properties;
+    }
+    public void setProperties(Map<String, String> properties) {
+        this.properties = properties;
+    }
+
+
+    public ConsentUpdateRequest putPropertiesItem(String key, String propertiesItem) {
+        if (this.properties == null) {
+            this.properties = new HashMap<>();
+        }
+        this.properties.put(key, propertiesItem);
+        return this;
+    }
+
+        /**
+    * When present, upserts each listed user&#39;s authorization — adds the user as an authorizer if absent, or overrides the existing authorization state if present. Users not listed are left untouched. 
+    **/
+    public ConsentUpdateRequest authorizations(List<AuthorizationUpdateEntry> authorizations) {
+
+        this.authorizations = authorizations;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "[{\"userId\":\"alice@wso2.com\",\"state\":\"REVOKED\"},{\"userId\":\"carol@wso2.com\",\"type\":\"USER\",\"state\":\"APPROVED\"}]", value = "When present, upserts each listed user's authorization — adds the user as an authorizer if absent, or overrides the existing authorization state if present. Users not listed are left untouched. ")
+    @JsonProperty("authorizations")
+    @Valid
+    public List<AuthorizationUpdateEntry> getAuthorizations() {
+        return authorizations;
+    }
+    public void setAuthorizations(List<AuthorizationUpdateEntry> authorizations) {
+        this.authorizations = authorizations;
+    }
+
+    public ConsentUpdateRequest addAuthorizationsItem(AuthorizationUpdateEntry authorizationsItem) {
+        if (this.authorizations == null) {
+            this.authorizations = new ArrayList<>();
+        }
+        this.authorizations.add(authorizationsItem);
+        return this;
+    }
+
+    
+
+    @Override
+    public boolean equals(java.lang.Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ConsentUpdateRequest consentUpdateRequest = (ConsentUpdateRequest) o;
+        return Objects.equals(this.expiryTime, consentUpdateRequest.expiryTime) &&
+            Objects.equals(this.properties, consentUpdateRequest.properties) &&
+            Objects.equals(this.authorizations, consentUpdateRequest.authorizations);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(expiryTime, properties, authorizations);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class ConsentUpdateRequest {\n");
+        
+        sb.append("    expiryTime: ").append(toIndentedString(expiryTime)).append("\n");
+        sb.append("    properties: ").append(toIndentedString(properties)).append("\n");
+        sb.append("    authorizations: ").append(toIndentedString(authorizations)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+    * Convert the given object to string with each line indented by 4 spaces
+    * (except the first line).
+    */
+    private String toIndentedString(java.lang.Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}
+

--- a/components/org.wso2.carbon.identity.api.server.consent.management/org.wso2.carbon.identity.api.server.consent.management.v2/src/gen/java/org/wso2/carbon/identity/api/server/consent/management/v2/model/ConsentUpdateRequest.java
+++ b/components/org.wso2.carbon.identity.api.server.consent.management/org.wso2.carbon.identity.api.server.consent.management.v2/src/gen/java/org/wso2/carbon/identity/api/server/consent/management/v2/model/ConsentUpdateRequest.java
@@ -47,14 +47,14 @@ public class ConsentUpdateRequest  {
 
 
     /**
-    * When present, sets or extends the consent&#39;s expiry time to the given milliseconds-since-epoch timestamp. Omit to leave the existing expiry unchanged. Pass any negative value (e.g. &#x60;-1&#x60;) to remove the expiry entirely (the consent no longer expires).
+    * When present, sets or extends the consent&#39;s expiry time to the given milliseconds-since-epoch timestamp. Omit to leave the existing expiry unchanged. Pass any negative value (e.g. &#x60;-1&#x60;) to remove the expiry entirely (the consent no longer expires). 
     **/
     public ConsentUpdateRequest expiryTime(Long expiryTime) {
 
         this.expiryTime = expiryTime;
         return this;
     }
-
+    
     @ApiModelProperty(example = "1766383796000", value = "When present, sets or extends the consent's expiry time to the given milliseconds-since-epoch timestamp. Omit to leave the existing expiry unchanged. Pass any negative value (e.g. `-1`) to remove the expiry entirely (the consent no longer expires). ")
     @JsonProperty("expiryTime")
     @Valid

--- a/components/org.wso2.carbon.identity.api.server.consent.management/org.wso2.carbon.identity.api.server.consent.management.v2/src/gen/java/org/wso2/carbon/identity/api/server/consent/management/v2/model/ConsentedElementDTO.java
+++ b/components/org.wso2.carbon.identity.api.server.consent.management/org.wso2.carbon.identity.api.server.consent.management.v2/src/gen/java/org/wso2/carbon/identity/api/server/consent/management/v2/model/ConsentedElementDTO.java
@@ -47,9 +47,11 @@ public class ConsentedElementDTO  {
         return this;
     }
     
-    @ApiModelProperty(example = "f83aa1a3-5d4d-4c0e-84db-c3a4f1e6c8b2", value = "")
+    @ApiModelProperty(example = "f83aa1a3-5d4d-4c0e-84db-c3a4f1e6c8b2", required = true, value = "")
     @JsonProperty("id")
     @Valid
+    @NotNull(message = "Property id cannot be null.")
+
     public String getId() {
         return id;
     }
@@ -65,9 +67,11 @@ public class ConsentedElementDTO  {
         return this;
     }
     
-    @ApiModelProperty(example = "email_address", value = "")
+    @ApiModelProperty(example = "email_address", required = true, value = "")
     @JsonProperty("name")
     @Valid
+    @NotNull(message = "Property name cannot be null.")
+
     public String getName() {
         return name;
     }

--- a/components/org.wso2.carbon.identity.api.server.consent.management/org.wso2.carbon.identity.api.server.consent.management.v2/src/gen/java/org/wso2/carbon/identity/api/server/consent/management/v2/model/ElementCreateRequest.java
+++ b/components/org.wso2.carbon.identity.api.server.consent.management/org.wso2.carbon.identity.api.server.consent.management.v2/src/gen/java/org/wso2/carbon/identity/api/server/consent/management/v2/model/ElementCreateRequest.java
@@ -22,6 +22,9 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import javax.validation.constraints.*;
 
 
@@ -35,6 +38,8 @@ public class ElementCreateRequest  {
     private String name;
     private String displayName;
     private String description;
+    private Map<String, String> properties = null;
+
 
     /**
     * Identifier/name of the consent element
@@ -95,7 +100,35 @@ public class ElementCreateRequest  {
         this.description = description;
     }
 
+    /**
+    * Free-form key-value properties for this element.
+    **/
+    public ElementCreateRequest properties(Map<String, String> properties) {
 
+        this.properties = properties;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "{\"dataCategory\":\"personal\",\"retentionPeriod\":\"365\"}", value = "Free-form key-value properties for this element.")
+    @JsonProperty("properties")
+    @Valid
+    public Map<String, String> getProperties() {
+        return properties;
+    }
+    public void setProperties(Map<String, String> properties) {
+        this.properties = properties;
+    }
+
+
+    public ElementCreateRequest putPropertiesItem(String key, String propertiesItem) {
+        if (this.properties == null) {
+            this.properties = new HashMap<>();
+        }
+        this.properties.put(key, propertiesItem);
+        return this;
+    }
+
+    
 
     @Override
     public boolean equals(java.lang.Object o) {
@@ -109,12 +142,13 @@ public class ElementCreateRequest  {
         ElementCreateRequest elementCreateRequest = (ElementCreateRequest) o;
         return Objects.equals(this.name, elementCreateRequest.name) &&
             Objects.equals(this.displayName, elementCreateRequest.displayName) &&
-            Objects.equals(this.description, elementCreateRequest.description);
+            Objects.equals(this.description, elementCreateRequest.description) &&
+            Objects.equals(this.properties, elementCreateRequest.properties);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(name, displayName, description);
+        return Objects.hash(name, displayName, description, properties);
     }
 
     @Override
@@ -126,6 +160,7 @@ public class ElementCreateRequest  {
         sb.append("    name: ").append(toIndentedString(name)).append("\n");
         sb.append("    displayName: ").append(toIndentedString(displayName)).append("\n");
         sb.append("    description: ").append(toIndentedString(description)).append("\n");
+        sb.append("    properties: ").append(toIndentedString(properties)).append("\n");
         sb.append("}");
         return sb.toString();
     }

--- a/components/org.wso2.carbon.identity.api.server.consent.management/org.wso2.carbon.identity.api.server.consent.management.v2/src/gen/java/org/wso2/carbon/identity/api/server/consent/management/v2/model/ElementDTO.java
+++ b/components/org.wso2.carbon.identity.api.server.consent.management/org.wso2.carbon.identity.api.server.consent.management.v2/src/gen/java/org/wso2/carbon/identity/api/server/consent/management/v2/model/ElementDTO.java
@@ -22,6 +22,9 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import javax.validation.constraints.*;
 
 
@@ -36,6 +39,8 @@ public class ElementDTO  {
     private String name;
     private String displayName;
     private String description;
+    private Map<String, String> properties = null;
+
     private String tenantDomain;
 
     /**
@@ -66,9 +71,11 @@ public class ElementDTO  {
         return this;
     }
     
-    @ApiModelProperty(example = "email_address", value = "Name/identifier of the element")
+    @ApiModelProperty(example = "email_address", required = true, value = "Name/identifier of the element")
     @JsonProperty("name")
     @Valid
+    @NotNull(message = "Property name cannot be null.")
+
     public String getName() {
         return name;
     }
@@ -115,6 +122,34 @@ public class ElementDTO  {
     }
 
     /**
+    * Free-form key-value properties for this element.
+    **/
+    public ElementDTO properties(Map<String, String> properties) {
+
+        this.properties = properties;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "{\"dataCategory\":\"personal\",\"retentionPeriod\":\"365\"}", value = "Free-form key-value properties for this element.")
+    @JsonProperty("properties")
+    @Valid
+    public Map<String, String> getProperties() {
+        return properties;
+    }
+    public void setProperties(Map<String, String> properties) {
+        this.properties = properties;
+    }
+
+
+    public ElementDTO putPropertiesItem(String key, String propertiesItem) {
+        if (this.properties == null) {
+            this.properties = new HashMap<>();
+        }
+        this.properties.put(key, propertiesItem);
+        return this;
+    }
+
+        /**
     * Tenant domain that owns this element
     **/
     public ElementDTO tenantDomain(String tenantDomain) {
@@ -149,12 +184,13 @@ public class ElementDTO  {
             Objects.equals(this.name, elementDTO.name) &&
             Objects.equals(this.displayName, elementDTO.displayName) &&
             Objects.equals(this.description, elementDTO.description) &&
+            Objects.equals(this.properties, elementDTO.properties) &&
             Objects.equals(this.tenantDomain, elementDTO.tenantDomain);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, name, displayName, description, tenantDomain);
+        return Objects.hash(id, name, displayName, description, properties, tenantDomain);
     }
 
     @Override
@@ -167,6 +203,7 @@ public class ElementDTO  {
         sb.append("    name: ").append(toIndentedString(name)).append("\n");
         sb.append("    displayName: ").append(toIndentedString(displayName)).append("\n");
         sb.append("    description: ").append(toIndentedString(description)).append("\n");
+        sb.append("    properties: ").append(toIndentedString(properties)).append("\n");
         sb.append("    tenantDomain: ").append(toIndentedString(tenantDomain)).append("\n");
         sb.append("}");
         return sb.toString();

--- a/components/org.wso2.carbon.identity.api.server.consent.management/org.wso2.carbon.identity.api.server.consent.management.v2/src/gen/java/org/wso2/carbon/identity/api/server/consent/management/v2/model/PurposeElementDTO.java
+++ b/components/org.wso2.carbon.identity.api.server.consent.management/org.wso2.carbon.identity.api.server.consent.management.v2/src/gen/java/org/wso2/carbon/identity/api/server/consent/management/v2/model/PurposeElementDTO.java
@@ -66,9 +66,11 @@ public class PurposeElementDTO  {
         return this;
     }
     
-    @ApiModelProperty(example = "email_address", value = "Name/identifier of the element")
+    @ApiModelProperty(example = "email_address", required = true, value = "Name/identifier of the element")
     @JsonProperty("name")
     @Valid
+    @NotNull(message = "Property name cannot be null.")
+
     public String getName() {
         return name;
     }
@@ -123,9 +125,11 @@ public class PurposeElementDTO  {
         return this;
     }
     
-    @ApiModelProperty(example = "true", value = "Whether this element is mandatory")
+    @ApiModelProperty(example = "true", required = true, value = "Whether this element is mandatory")
     @JsonProperty("mandatory")
     @Valid
+    @NotNull(message = "Property mandatory cannot be null.")
+
     public Boolean getMandatory() {
         return mandatory;
     }

--- a/components/org.wso2.carbon.identity.api.server.consent.management/org.wso2.carbon.identity.api.server.consent.management.v2/src/main/java/org/wso2/carbon/identity/api/server/consent/management/v2/core/ConsentManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.consent.management/org.wso2.carbon.identity.api.server.consent.management.v2/src/main/java/org/wso2/carbon/identity/api/server/consent/management/v2/core/ConsentManagementService.java
@@ -189,9 +189,10 @@ public class ConsentManagementService {
                 throw handleClientException(ERROR_CODE_INVALID_FILTER_EXPRESSION,
                         "Only 'properties.<key>' attributes are supported in consent filter. Got: " + attr);
             }
-            if (!"eq".equalsIgnoreCase(node.getOperation())) {
+            String op = node.getOperation() != null ? node.getOperation().toLowerCase() : "";
+            if (!("eq".equals(op) || "sw".equals(op) || "co".equals(op) || "ew".equals(op))) {
                 throw handleClientException(ERROR_CODE_INVALID_FILTER_EXPRESSION,
-                        "Only 'eq' operation is supported for consent property filter.");
+                        "Only 'eq', 'sw', 'co', and 'ew' operations are supported for consent property filter.");
             }
         }
 

--- a/components/org.wso2.carbon.identity.api.server.consent.management/org.wso2.carbon.identity.api.server.consent.management.v2/src/main/java/org/wso2/carbon/identity/api/server/consent/management/v2/core/ConsentManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.consent.management/org.wso2.carbon.identity.api.server.consent.management.v2/src/main/java/org/wso2/carbon/identity/api/server/consent/management/v2/core/ConsentManagementService.java
@@ -64,7 +64,6 @@ import java.util.ArrayList;
 import java.util.Base64;
 import java.util.Collections;
 import java.util.List;
-import static org.wso2.carbon.consent.mgt.core.constant.ConsentConstants.ACTIVE_STATE;
 import static org.wso2.carbon.consent.mgt.core.constant.ConsentConstants.DEFAULT_LIMIT;
 import static org.wso2.carbon.consent.mgt.core.constant.ConsentConstants.ErrorMessages.ERROR_CODE_CONSENT_REJECTED_WITH_AUTHORIZATIONS;
 import static org.wso2.carbon.consent.mgt.core.constant.ConsentConstants.ErrorMessages.ERROR_CODE_ELEMENT_UUID_NOT_FOUND;
@@ -123,14 +122,6 @@ public class ConsentManagementService {
         responseDTO.setLanguage(addReceiptResponse.getLanguage());
         responseDTO.setSubjectId(addReceiptResponse.getPiiPrincipalId());
         responseDTO.setTenantDomain(addReceiptResponse.getTenantDomain());
-        boolean hasPendingAuth = request.getAuthorizations() != null && !request.getAuthorizations().isEmpty();
-        if (hasPendingAuth) {
-            responseDTO.setState(ConsentResponseDTO.StateEnum.PENDING);
-        } else if (ConsentCreateRequest.StateEnum.REJECTED.equals(request.getState())) {
-            responseDTO.setState(ConsentResponseDTO.StateEnum.REJECTED);
-        } else {
-            responseDTO.setState(ConsentResponseDTO.StateEnum.ACTIVE);
-        }
         return responseDTO;
     }
 
@@ -280,10 +271,6 @@ public class ConsentManagementService {
 
         try {
             Receipt receipt = consentManager.getReceiptWithExtendedSchema(receiptId);
-            String currentState = StringUtils.isNotBlank(receipt.getState()) ? receipt.getState() : ACTIVE_STATE;
-            if (REVOKE_STATE.equals(currentState)) {
-                return;
-            }
             consentManager.authorizeConsent(receiptId, receipt.getPiiPrincipalId(), REVOKE_STATE);
         } catch (ConsentManagementException e) {
             throw ConsentMgtEndpointUtil.handleConsentManagementException(e);
@@ -389,8 +376,7 @@ public class ConsentManagementService {
         dto.setTimestamp(receipt.getConsentTimestamp());
         dto.setLanguage(receipt.getLanguage());
         dto.setSubjectId(receipt.getPiiPrincipalId());
-        String state = StringUtils.isNotBlank(receipt.getState()) ? receipt.getState() : ACTIVE_STATE;
-        dto.setState(ConsentDTO.StateEnum.fromValue(state));
+        dto.setState(ConsentDTO.StateEnum.fromValue(receipt.getState()));
         dto.setExpiryTime(receipt.getExpiryTime() != null ? receipt.getExpiryTime().getTime() : null);
 
         // Extract service name and purposes from the first service entry (V2 is single-service).
@@ -444,7 +430,6 @@ public class ConsentManagementService {
         ConsentedPurposeDTO dto = new ConsentedPurposeDTO();
         dto.setName(consentPurpose.getPurpose());
 
-        // Resolve purpose int ID to UUID, and populate version label using the fetched purpose.
         String versionUuid = consentPurpose.getPurposeVersionId();
         try {
             Purpose purpose = consentManager.getPurposeByUuid(consentPurpose.getUuid());
@@ -476,7 +461,7 @@ public class ConsentManagementService {
             }
         } catch (ConsentManagementException e) {
             if (LOG.isDebugEnabled()) {
-                LOG.debug("Could not resolve purpose UUID for purposeId: " + consentPurpose.getPurposeId(), e);
+                LOG.debug("Could not resolve purpose UUID: " + consentPurpose.getUuid(), e);
             }
         }
 
@@ -486,21 +471,20 @@ public class ConsentManagementService {
                 ConsentedElementDTO elementDTO = new ConsentedElementDTO();
                 elementDTO.setName(piiCategoryValidity.getName());
                 elementDTO.setDisplayName(piiCategoryValidity.getDisplayName());
-                // Resolve element int ID to UUID.
                 try {
-                    PIICategory element = consentManager.getPIICategoryByUuid(piiCategoryValidity.getUuid());
-                    if (element == null) {
+                    PIICategory piiCategory = consentManager.getPIICategoryByUuid(piiCategoryValidity.getUuid());
+                    if (piiCategory == null) {
                         if (LOG.isDebugEnabled()) {
                             LOG.debug("Could not resolve element UUID for elementId: " + piiCategoryValidity.getUuid());
                         }
                     } else {
-                        if (StringUtils.isNotBlank(element.getUuid())) {
-                            elementDTO.setId(element.getUuid());
+                        if (StringUtils.isNotBlank(piiCategory.getUuid())) {
+                            elementDTO.setId(piiCategory.getUuid());
                         }
                     }
                 } catch (ConsentManagementException e) {
                     if (LOG.isDebugEnabled()) {
-                        LOG.debug("Could not resolve element UUID for elementId: " + piiCategoryValidity.getId(), e);
+                        LOG.debug("Could not resolve element UUID: " + piiCategoryValidity.getUuid(), e);
                     }
                 }
                 elementDTOs.add(elementDTO);
@@ -538,8 +522,7 @@ public class ConsentManagementService {
         ConsentSummaryDTO dto = new ConsentSummaryDTO();
         dto.setId(receipt.getConsentReceiptId());
         dto.setSubjectId(receipt.getPiiPrincipalId());
-        String state = StringUtils.isNotBlank(receipt.getState()) ? receipt.getState() : ACTIVE_STATE;
-        dto.setState(ConsentSummaryDTO.StateEnum.fromValue(state));
+        dto.setState(ConsentSummaryDTO.StateEnum.fromValue(receipt.getState()));
         dto.setTimestamp(receipt.getConsentTimestamp());
         dto.setExpiryTime(receipt.getExpiryTime() != null ? receipt.getExpiryTime().getTime() : null);
         if (receipt.getServices() != null && !receipt.getServices().isEmpty()) {

--- a/components/org.wso2.carbon.identity.api.server.consent.management/org.wso2.carbon.identity.api.server.consent.management.v2/src/main/java/org/wso2/carbon/identity/api/server/consent/management/v2/core/ConsentManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.consent.management/org.wso2.carbon.identity.api.server.consent.management.v2/src/main/java/org/wso2/carbon/identity/api/server/consent/management/v2/core/ConsentManagementService.java
@@ -229,7 +229,7 @@ public class ConsentManagementService {
             if (FilterConstants.FILTER_ATTR_AFTER.equals(attr) || FilterConstants.FILTER_ATTR_BEFORE.equals(attr)) {
                 continue;
             }
-            if (attr == null || !attr.startsWith("properties.")) {
+            if (attr == null || !attr.startsWith("properties.") || attr.length() <= "properties.".length()) {
                 throw handleClientException(ERROR_CODE_INVALID_FILTER_EXPRESSION,
                         "Only 'properties.<key>' attributes are supported in consent filter. Got: " + attr);
             }

--- a/components/org.wso2.carbon.identity.api.server.consent.management/org.wso2.carbon.identity.api.server.consent.management.v2/src/main/java/org/wso2/carbon/identity/api/server/consent/management/v2/core/ConsentManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.consent.management/org.wso2.carbon.identity.api.server.consent.management.v2/src/main/java/org/wso2/carbon/identity/api/server/consent/management/v2/core/ConsentManagementService.java
@@ -56,6 +56,7 @@ import org.wso2.carbon.identity.api.server.consent.management.v2.model.ElementTe
 import org.wso2.carbon.identity.api.server.consent.management.v2.model.PaginationLink;
 import org.wso2.carbon.identity.api.server.consent.management.v2.util.ConsentMgtEndpointUtil;
 import org.wso2.carbon.identity.core.model.ExpressionNode;
+import org.wso2.carbon.identity.core.util.IdentityUtil;
 
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
@@ -537,6 +538,14 @@ public class ConsentManagementService {
         limit = limit == null ? DEFAULT_LIMIT : limit;
         if (limit <= 0) {
             throw handleClientException(ERROR_CODE_INVALID_QUERY_PARAM, limit.toString());
+        }
+        int maximumItemPerPage = IdentityUtil.getMaximumItemPerPage();
+        if (limit > maximumItemPerPage) {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Given limit exceeds the maximum limit. Therefore the configured maximum limit: "
+                        + maximumItemPerPage + " is set as the limit.");
+            }
+            return maximumItemPerPage;
         }
         return limit;
     }

--- a/components/org.wso2.carbon.identity.api.server.consent.management/org.wso2.carbon.identity.api.server.consent.management.v2/src/main/java/org/wso2/carbon/identity/api/server/consent/management/v2/core/ConsentManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.consent.management/org.wso2.carbon.identity.api.server.consent.management.v2/src/main/java/org/wso2/carbon/identity/api/server/consent/management/v2/core/ConsentManagementService.java
@@ -39,7 +39,6 @@ import org.wso2.carbon.consent.mgt.core.util.ConsentReceiptUtils;
 import org.wso2.carbon.consent.mgt.core.util.FilterQueriesUtil;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.identity.api.server.consent.management.common.ConsentManagementConstants;
-import org.wso2.carbon.identity.api.server.consent.management.v2.model.AuthorizationCreateRequest;
 import org.wso2.carbon.identity.api.server.consent.management.v2.model.AuthorizationDTO;
 import org.wso2.carbon.identity.api.server.consent.management.v2.model.AuthorizationEntry;
 import org.wso2.carbon.identity.api.server.consent.management.v2.model.AuthorizationUpdateEntry;
@@ -56,8 +55,6 @@ import org.wso2.carbon.identity.api.server.consent.management.v2.model.Consented
 import org.wso2.carbon.identity.api.server.consent.management.v2.model.ElementTerminationInfo;
 import org.wso2.carbon.identity.api.server.consent.management.v2.model.PaginationLink;
 import org.wso2.carbon.identity.api.server.consent.management.v2.util.ConsentMgtEndpointUtil;
-import org.wso2.carbon.identity.authorization.common.AuthorizationUtil;
-import org.wso2.carbon.identity.authorization.common.exception.ForbiddenException;
 import org.wso2.carbon.identity.core.model.ExpressionNode;
 
 import java.net.URLEncoder;
@@ -69,18 +66,14 @@ import java.util.Collections;
 import java.util.List;
 import static org.wso2.carbon.consent.mgt.core.constant.ConsentConstants.ACTIVE_STATE;
 import static org.wso2.carbon.consent.mgt.core.constant.ConsentConstants.DEFAULT_LIMIT;
-import static org.wso2.carbon.consent.mgt.core.constant.ConsentConstants.ErrorMessages.ERROR_CODE_CONSENT_INVALID_STATE_FOR_AUTHORIZE;
 import static org.wso2.carbon.consent.mgt.core.constant.ConsentConstants.ErrorMessages.ERROR_CODE_CONSENT_REJECTED_WITH_AUTHORIZATIONS;
 import static org.wso2.carbon.consent.mgt.core.constant.ConsentConstants.ErrorMessages.ERROR_CODE_ELEMENT_UUID_NOT_FOUND;
 import static org.wso2.carbon.consent.mgt.core.constant.ConsentConstants.ErrorMessages.ERROR_CODE_INVALID_FILTER_EXPRESSION;
 import static org.wso2.carbon.consent.mgt.core.constant.ConsentConstants.ErrorMessages.ERROR_CODE_INVALID_QUERY_PARAM;
-import static org.wso2.carbon.consent.mgt.core.constant.ConsentConstants.ErrorMessages.ERROR_CODE_USER_NOT_AUTHORIZED;
 import static org.wso2.carbon.consent.mgt.core.constant.ConsentConstants.FilterConstants;
 import static org.wso2.carbon.consent.mgt.core.constant.ConsentConstants.PENDING_STATE;
 import static org.wso2.carbon.consent.mgt.core.constant.ConsentConstants.REVOKE_STATE;
 import static org.wso2.carbon.consent.mgt.core.util.ConsentUtils.handleClientException;
-import static org.wso2.carbon.identity.api.server.consent.management.common.ConsentManagementConstants.CONSENT_ADMIN_CREATE_OPERATION;
-import static org.wso2.carbon.identity.api.server.consent.management.common.ConsentManagementConstants.CONSENT_ADMIN_LIST_OPERATION;
 
 /**
  * Service class for consent (receipt) operations in the V2 Consent Management API.
@@ -115,18 +108,7 @@ public class ConsentManagementService {
 
     private ConsentResponseDTO createConsentInternal(ConsentCreateRequest request) throws ConsentManagementException {
 
-        PrivilegedCarbonContext carbonContext = PrivilegedCarbonContext.getThreadLocalCarbonContext();
-        String currentUser = carbonContext.getUsername();
-        String subjectId;
-        try {
-            AuthorizationUtil.validateOperationScopes(CONSENT_ADMIN_CREATE_OPERATION);
-            subjectId = StringUtils.isNotBlank(request.getSubjectId()) ? request.getSubjectId() : currentUser;
-        } catch (ForbiddenException e) {
-            subjectId = currentUser;
-            if (request.getAuthorizations() != null && !request.getAuthorizations().isEmpty()) {
-                throw handleClientException(ERROR_CODE_USER_NOT_AUTHORIZED, currentUser);
-            }
-        }
+        String subjectId = request.getSubjectId();
         boolean hasAuthorizations = request.getAuthorizations() != null && !request.getAuthorizations().isEmpty();
         boolean rejected = ConsentCreateRequest.StateEnum.REJECTED.equals(request.getState());
         if (rejected && hasAuthorizations) {
@@ -163,16 +145,6 @@ public class ConsentManagementService {
 
         try {
             Receipt receipt = consentManager.getReceiptWithExtendedSchema(receiptId);
-            // Need operation scopes to list consents of other users.
-            try {
-                AuthorizationUtil.validateOperationScopes(CONSENT_ADMIN_LIST_OPERATION);
-            } catch (ForbiddenException e) {
-                String currentUser = PrivilegedCarbonContext.getThreadLocalCarbonContext().getUsername();
-                if (!currentUser.equalsIgnoreCase(receipt.getPiiPrincipalId())) {
-                    throw handleClientException(ERROR_CODE_USER_NOT_AUTHORIZED, currentUser);
-                }
-            }
-            // The effective state (including expiry) is already resolved by getReceiptWithExtendedSchema.
             return toConsentDTO(receipt);
         } catch (ConsentManagementException e) {
             throw ConsentMgtEndpointUtil.handleConsentManagementException(e);
@@ -210,13 +182,6 @@ public class ConsentManagementService {
             throws ConsentManagementException {
 
         limit = validatedLimit(limit);
-
-        // Need operation scopes to list consents of other users.
-        try {
-            AuthorizationUtil.validateOperationScopes(CONSENT_ADMIN_LIST_OPERATION);
-        } catch (ForbiddenException e) {
-            subjectId = PrivilegedCarbonContext.getThreadLocalCarbonContext().getUsername();
-        }
 
         if (StringUtils.isNotBlank(before) && StringUtils.isNotBlank(after)) {
             throw handleClientException(ERROR_CODE_INVALID_QUERY_PARAM,
@@ -314,14 +279,12 @@ public class ConsentManagementService {
     public void revokeConsent(String receiptId) {
 
         try {
-            String callingUser = PrivilegedCarbonContext.getThreadLocalCarbonContext().getUsername();
             Receipt receipt = consentManager.getReceiptWithExtendedSchema(receiptId);
             String currentState = StringUtils.isNotBlank(receipt.getState()) ? receipt.getState() : ACTIVE_STATE;
             if (REVOKE_STATE.equals(currentState)) {
                 return;
             }
-            validateConsentAccess(receiptId, callingUser, receipt);
-            consentManager.authorizeConsent(receiptId, callingUser, REVOKE_STATE);
+            consentManager.authorizeConsent(receiptId, receipt.getPiiPrincipalId(), REVOKE_STATE);
         } catch (ConsentManagementException e) {
             throw ConsentMgtEndpointUtil.handleConsentManagementException(e);
         }
@@ -548,47 +511,6 @@ public class ConsentManagementService {
     }
 
     /**
-     * Authorizes (approves/rejects) a consent receipt.
-     *
-     * @param consentId Consent receipt ID.
-     * @param request   Authorization create request.
-     * @return Response with AuthorizationDTO.
-     * @throws ConsentManagementException if authorization fails.
-     */
-    public AuthorizationDTO authorizeConsent(String consentId, AuthorizationCreateRequest request) {
-
-        try {
-            Receipt receipt = consentManager.getReceiptWithExtendedSchema(consentId);
-            String currentState = StringUtils.isNotBlank(receipt.getState()) ? receipt.getState() : ACTIVE_STATE;
-            if (!PENDING_STATE.equals(currentState)) {
-                throw handleClientException(ERROR_CODE_CONSENT_INVALID_STATE_FOR_AUTHORIZE, consentId);
-            }
-
-            String callingUser = PrivilegedCarbonContext.getThreadLocalCarbonContext().getUsername();
-            String authStatus = request.getState() != null ? request.getState().toString() : "APPROVED";
-
-            validateConsentAccess(consentId, callingUser, receipt);
-            consentManager.authorizeConsent(consentId, callingUser, authStatus);
-
-            List<ConsentAuthorization> all = consentManager.getConsentAuthorizations(consentId);
-            ConsentAuthorization updated = all.stream()
-                    .filter(a -> callingUser.equalsIgnoreCase(a.getUserId()))
-                    .findFirst()
-                    .orElse(null);
-
-            AuthorizationDTO dto = new AuthorizationDTO();
-            dto.setUserId(callingUser);
-            if (updated != null) {
-                dto.setState(AuthorizationDTO.StateEnum.fromValue(updated.getStatus().name()));
-                dto.setUpdatedTime(updated.getUpdatedTime());
-            }
-            return dto;
-        } catch (ConsentManagementException e) {
-            throw ConsentMgtEndpointUtil.handleConsentManagementException(e);
-        }
-    }
-
-    /**
      * Validates the current status of a consent receipt.
      *
      * @param consentId Consent receipt ID.
@@ -598,9 +520,7 @@ public class ConsentManagementService {
     public ConsentValidateResponse validateConsent(String consentId) {
 
         try {
-            String callingUser = PrivilegedCarbonContext.getThreadLocalCarbonContext().getUsername();
             Receipt receipt = consentManager.getReceiptWithExtendedSchema(consentId);
-            validateConsentAccess(consentId, callingUser, receipt);
             String status = consentManager.validateConsentStatus(consentId);
 
             ConsentValidateResponse validateResponse = new ConsentValidateResponse();
@@ -610,22 +530,6 @@ public class ConsentManagementService {
             return validateResponse;
         } catch (ConsentManagementException e) {
             throw ConsentMgtEndpointUtil.handleConsentManagementException(e);
-        }
-    }
-
-    private void validateConsentAccess(String consentId, String callingUser, Receipt receipt)
-            throws ConsentManagementException {
-
-        List<ConsentAuthorization> authorizations = consentManager.getConsentAuthorizations(consentId);
-        if (authorizations == null || authorizations.isEmpty()) {
-            if (receipt == null || !callingUser.equalsIgnoreCase(receipt.getPiiPrincipalId())) {
-                throw handleClientException(ERROR_CODE_USER_NOT_AUTHORIZED, callingUser);
-            }
-        } else {
-            boolean inList = authorizations.stream().anyMatch(a -> callingUser.equalsIgnoreCase(a.getUserId()));
-            if (!inList) {
-                throw handleClientException(ERROR_CODE_USER_NOT_AUTHORIZED, callingUser);
-            }
         }
     }
 

--- a/components/org.wso2.carbon.identity.api.server.consent.management/org.wso2.carbon.identity.api.server.consent.management.v2/src/main/java/org/wso2/carbon/identity/api/server/consent/management/v2/core/ConsentManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.consent.management/org.wso2.carbon.identity.api.server.consent.management.v2/src/main/java/org/wso2/carbon/identity/api/server/consent/management/v2/core/ConsentManagementService.java
@@ -302,12 +302,7 @@ public class ConsentManagementService {
         updateInput.setConsentReceiptId(consentId);
 
         if (request.getExpiryTime() != null) {
-            if (request.getExpiryTime() < 0) {
-                // A negative expiryTime is the sentinel for removing the expiry entirely.
-                updateInput.setClearExpiry(true);
-            } else {
-                updateInput.setExpiryTime(new Timestamp(request.getExpiryTime()));
-            }
+            updateInput.setExpiryTime(new Timestamp(request.getExpiryTime()));
         }
 
         updateInput.setProperties(request.getProperties());

--- a/components/org.wso2.carbon.identity.api.server.consent.management/org.wso2.carbon.identity.api.server.consent.management.v2/src/main/java/org/wso2/carbon/identity/api/server/consent/management/v2/core/ConsentManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.consent.management/org.wso2.carbon.identity.api.server.consent.management.v2/src/main/java/org/wso2/carbon/identity/api/server/consent/management/v2/core/ConsentManagementService.java
@@ -34,26 +34,32 @@ import org.wso2.carbon.consent.mgt.core.model.PurposeVersion;
 import org.wso2.carbon.consent.mgt.core.model.Receipt;
 import org.wso2.carbon.consent.mgt.core.model.ReceiptInput;
 import org.wso2.carbon.consent.mgt.core.model.ReceiptService;
+import org.wso2.carbon.consent.mgt.core.model.ReceiptUpdateInput;
 import org.wso2.carbon.consent.mgt.core.util.ConsentReceiptUtils;
+import org.wso2.carbon.consent.mgt.core.util.FilterQueriesUtil;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.identity.api.server.consent.management.common.ConsentManagementConstants;
 import org.wso2.carbon.identity.api.server.consent.management.v2.model.AuthorizationCreateRequest;
 import org.wso2.carbon.identity.api.server.consent.management.v2.model.AuthorizationDTO;
 import org.wso2.carbon.identity.api.server.consent.management.v2.model.AuthorizationEntry;
+import org.wso2.carbon.identity.api.server.consent.management.v2.model.AuthorizationUpdateEntry;
 import org.wso2.carbon.identity.api.server.consent.management.v2.model.ConsentCreateRequest;
 import org.wso2.carbon.identity.api.server.consent.management.v2.model.ConsentDTO;
 import org.wso2.carbon.identity.api.server.consent.management.v2.model.ConsentListResponse;
 import org.wso2.carbon.identity.api.server.consent.management.v2.model.ConsentPurposeBinding;
 import org.wso2.carbon.identity.api.server.consent.management.v2.model.ConsentResponseDTO;
 import org.wso2.carbon.identity.api.server.consent.management.v2.model.ConsentSummaryDTO;
+import org.wso2.carbon.identity.api.server.consent.management.v2.model.ConsentUpdateRequest;
 import org.wso2.carbon.identity.api.server.consent.management.v2.model.ConsentValidateResponse;
 import org.wso2.carbon.identity.api.server.consent.management.v2.model.ConsentedElementDTO;
 import org.wso2.carbon.identity.api.server.consent.management.v2.model.ConsentedPurposeDTO;
 import org.wso2.carbon.identity.api.server.consent.management.v2.model.ElementTerminationInfo;
 import org.wso2.carbon.identity.api.server.consent.management.v2.model.PaginationLink;
 import org.wso2.carbon.identity.api.server.consent.management.v2.util.ConsentMgtEndpointUtil;
+import org.wso2.carbon.identity.authorization.common.AuthorizationUtil;
+import org.wso2.carbon.identity.authorization.common.exception.ForbiddenException;
+import org.wso2.carbon.identity.core.model.ExpressionNode;
 
-import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.sql.Timestamp;
@@ -61,18 +67,20 @@ import java.util.ArrayList;
 import java.util.Base64;
 import java.util.Collections;
 import java.util.List;
-
 import static org.wso2.carbon.consent.mgt.core.constant.ConsentConstants.ACTIVE_STATE;
 import static org.wso2.carbon.consent.mgt.core.constant.ConsentConstants.DEFAULT_LIMIT;
 import static org.wso2.carbon.consent.mgt.core.constant.ConsentConstants.ErrorMessages.ERROR_CODE_CONSENT_INVALID_STATE_FOR_AUTHORIZE;
 import static org.wso2.carbon.consent.mgt.core.constant.ConsentConstants.ErrorMessages.ERROR_CODE_CONSENT_REJECTED_WITH_AUTHORIZATIONS;
-import static org.wso2.carbon.consent.mgt.core.constant.ConsentConstants.ErrorMessages.ERROR_CODE_CONSENT_USER_NOT_IN_AUTHORIZATION_LIST;
 import static org.wso2.carbon.consent.mgt.core.constant.ConsentConstants.ErrorMessages.ERROR_CODE_ELEMENT_UUID_NOT_FOUND;
+import static org.wso2.carbon.consent.mgt.core.constant.ConsentConstants.ErrorMessages.ERROR_CODE_INVALID_FILTER_EXPRESSION;
 import static org.wso2.carbon.consent.mgt.core.constant.ConsentConstants.ErrorMessages.ERROR_CODE_INVALID_QUERY_PARAM;
+import static org.wso2.carbon.consent.mgt.core.constant.ConsentConstants.ErrorMessages.ERROR_CODE_USER_NOT_AUTHORIZED;
 import static org.wso2.carbon.consent.mgt.core.constant.ConsentConstants.FilterConstants;
 import static org.wso2.carbon.consent.mgt.core.constant.ConsentConstants.PENDING_STATE;
 import static org.wso2.carbon.consent.mgt.core.constant.ConsentConstants.REVOKE_STATE;
 import static org.wso2.carbon.consent.mgt.core.util.ConsentUtils.handleClientException;
+import static org.wso2.carbon.identity.api.server.consent.management.common.ConsentManagementConstants.CONSENT_ADMIN_CREATE_OPERATION;
+import static org.wso2.carbon.identity.api.server.consent.management.common.ConsentManagementConstants.CONSENT_ADMIN_LIST_OPERATION;
 
 /**
  * Service class for consent (receipt) operations in the V2 Consent Management API.
@@ -109,7 +117,16 @@ public class ConsentManagementService {
 
         PrivilegedCarbonContext carbonContext = PrivilegedCarbonContext.getThreadLocalCarbonContext();
         String currentUser = carbonContext.getUsername();
-        String subjectId = StringUtils.isNotBlank(request.getSubjectId()) ? request.getSubjectId() : currentUser;
+        String subjectId;
+        try {
+            AuthorizationUtil.validateOperationScopes(CONSENT_ADMIN_CREATE_OPERATION);
+            subjectId = StringUtils.isNotBlank(request.getSubjectId()) ? request.getSubjectId() : currentUser;
+        } catch (ForbiddenException e) {
+            subjectId = currentUser;
+            if (request.getAuthorizations() != null && !request.getAuthorizations().isEmpty()) {
+                throw handleClientException(ERROR_CODE_USER_NOT_AUTHORIZED, currentUser);
+            }
+        }
         boolean hasAuthorizations = request.getAuthorizations() != null && !request.getAuthorizations().isEmpty();
         boolean rejected = ConsentCreateRequest.StateEnum.REJECTED.equals(request.getState());
         if (rejected && hasAuthorizations) {
@@ -146,11 +163,16 @@ public class ConsentManagementService {
 
         try {
             Receipt receipt = consentManager.getReceiptWithExtendedSchema(receiptId);
-            // Lazy expiry on GET — validate status and re-fetch if state changed
-            String latestState = consentManager.validateConsentStatus(receiptId);
-            if (!latestState.equals(receipt.getState())) {
-                receipt = consentManager.getReceiptWithExtendedSchema(receiptId);
+            // Need operation scopes to list consents of other users.
+            try {
+                AuthorizationUtil.validateOperationScopes(CONSENT_ADMIN_LIST_OPERATION);
+            } catch (ForbiddenException e) {
+                String currentUser = PrivilegedCarbonContext.getThreadLocalCarbonContext().getUsername();
+                if (!currentUser.equalsIgnoreCase(receipt.getPiiPrincipalId())) {
+                    throw handleClientException(ERROR_CODE_USER_NOT_AUTHORIZED, currentUser);
+                }
             }
+            // The effective state (including expiry) is already resolved by getReceiptWithExtendedSchema.
             return toConsentDTO(receipt);
         } catch (ConsentManagementException e) {
             throw ConsentMgtEndpointUtil.handleConsentManagementException(e);
@@ -169,37 +191,56 @@ public class ConsentManagementService {
      * @param after            Cursor for pagination (results after this cursor).
      * @param before           Cursor for pagination (results before this cursor).
      * @return Response with list of ConsentSummaryDTOs.
-     * @throws ConsentManagementException if listing fails.
      */
     public ConsentListResponse listConsents(String subjectId, String serviceId, String state, String purposeId,
-                                            String purposeVersionId, Integer limit, String after, String before) {
+                                            String purposeVersionId, String filter, Integer limit,
+                                            String after, String before) {
 
         try {
-            return listConsentsInternal(subjectId, serviceId, state, purposeId, purposeVersionId, limit, after, before);
+            return listConsentsInternal(subjectId, serviceId, state, purposeId, purposeVersionId, filter, limit,
+                    after, before);
         } catch (ConsentManagementException e) {
             throw ConsentMgtEndpointUtil.handleConsentManagementException(e);
         }
     }
 
     private ConsentListResponse listConsentsInternal(String subjectId, String serviceId, String state,
-                                                     String purposeId, String purposeVersionId, Integer limit,
-                                                     String after, String before)
+                                                     String purposeId, String purposeVersionId, String filter,
+                                                     Integer limit, String after, String before)
             throws ConsentManagementException {
 
         limit = validatedLimit(limit);
+
+        // Need operation scopes to list consents of other users.
+        try {
+            AuthorizationUtil.validateOperationScopes(CONSENT_ADMIN_LIST_OPERATION);
+        } catch (ForbiddenException e) {
+            subjectId = PrivilegedCarbonContext.getThreadLocalCarbonContext().getUsername();
+        }
 
         if (StringUtils.isNotBlank(before) && StringUtils.isNotBlank(after)) {
             throw handleClientException(ERROR_CODE_INVALID_QUERY_PARAM,
                     "Both 'before' and 'after' parameters are provided.");
         }
 
+        List<ExpressionNode> expressionNodes = FilterQueriesUtil.getExpressionNodes(filter, after, before);
+        for (ExpressionNode node : expressionNodes) {
+            String attr = node.getAttributeValue();
+            if (FilterConstants.FILTER_ATTR_AFTER.equals(attr) || FilterConstants.FILTER_ATTR_BEFORE.equals(attr)) {
+                continue;
+            }
+            if (attr == null || !attr.startsWith("properties.")) {
+                throw handleClientException(ERROR_CODE_INVALID_FILTER_EXPRESSION,
+                        "Only 'properties.<key>' attributes are supported in consent filter. Got: " + attr);
+            }
+            if (!"eq".equalsIgnoreCase(node.getOperation())) {
+                throw handleClientException(ERROR_CODE_INVALID_FILTER_EXPRESSION,
+                        "Only 'eq' operation is supported for consent property filter.");
+            }
+        }
+
         List<Receipt> receipts = consentManager.listReceipts(
-                subjectId,
-                serviceId,
-                state,
-                purposeId != null ? purposeId.toString() : null,
-                purposeVersionId != null ? purposeVersionId.toString() : null,
-                after, before, limit + 1);
+                subjectId, serviceId, state, purposeId, purposeVersionId, expressionNodes, limit + 1);
 
         ConsentListResponse result = new ConsentListResponse();
         List<PaginationLink> links = new ArrayList<>();
@@ -212,24 +253,23 @@ public class ConsentManagementService {
             boolean isLastPage = !hasMoreItems && (StringUtils.isNotBlank(after) || StringUtils.isBlank(before));
 
             String url = "?limit=" + limit;
-            try {
-                if (StringUtils.isNotBlank(subjectId)) {
-                    url += "&subjectId=" + URLEncoder.encode(subjectId, StandardCharsets.UTF_8.name());
-                }
-                if (StringUtils.isNotBlank(serviceId)) {
-                    url += "&serviceId=" + URLEncoder.encode(serviceId, StandardCharsets.UTF_8.name());
-                }
-                if (StringUtils.isNotBlank(state)) {
-                    url += "&state=" + URLEncoder.encode(state, StandardCharsets.UTF_8.name());
-                }
-            } catch (UnsupportedEncodingException e) {
-                LOG.debug("Server encountered an error while building pagination URL for the response.", e);
+            if (StringUtils.isNotBlank(subjectId)) {
+                url += "&subjectId=" + URLEncoder.encode(subjectId, StandardCharsets.UTF_8);
+            }
+            if (StringUtils.isNotBlank(serviceId)) {
+                url += "&serviceId=" + URLEncoder.encode(serviceId, StandardCharsets.UTF_8);
+            }
+            if (StringUtils.isNotBlank(state)) {
+                url += "&state=" + URLEncoder.encode(state, StandardCharsets.UTF_8);
             }
             if (purposeId != null) {
                 url += "&purposeId=" + purposeId;
             }
             if (purposeVersionId != null) {
                 url += "&purposeVersionId=" + purposeVersionId;
+            }
+            if (StringUtils.isNotBlank(filter)) {
+                url += "&filter=" + URLEncoder.encode(filter, StandardCharsets.UTF_8);
             }
 
             if (hasMoreItems) {
@@ -274,16 +314,68 @@ public class ConsentManagementService {
     public void revokeConsent(String receiptId) {
 
         try {
+            String callingUser = PrivilegedCarbonContext.getThreadLocalCarbonContext().getUsername();
             Receipt receipt = consentManager.getReceiptWithExtendedSchema(receiptId);
             String currentState = StringUtils.isNotBlank(receipt.getState()) ? receipt.getState() : ACTIVE_STATE;
             if (REVOKE_STATE.equals(currentState)) {
                 return;
             }
-            String callingUser = PrivilegedCarbonContext.getThreadLocalCarbonContext().getUsername();
+            validateConsentAccess(receiptId, callingUser, receipt);
             consentManager.authorizeConsent(receiptId, callingUser, REVOKE_STATE);
         } catch (ConsentManagementException e) {
             throw ConsentMgtEndpointUtil.handleConsentManagementException(e);
         }
+    }
+
+    /**
+     * Admin update of an existing consent's expiryTime, properties, and/or authorizations.
+     *
+     * @param consentId Consent receipt ID.
+     * @param request   Update request (all fields optional).
+     * @return Updated ConsentDTO.
+     */
+    public ConsentDTO updateConsent(String consentId, ConsentUpdateRequest request) {
+
+        try {
+            return updateConsentInternal(consentId, request);
+        } catch (ConsentManagementException e) {
+            throw ConsentMgtEndpointUtil.handleConsentManagementException(e);
+        }
+    }
+
+    private ConsentDTO updateConsentInternal(String consentId, ConsentUpdateRequest request)
+            throws ConsentManagementException {
+
+        ReceiptUpdateInput updateInput = new ReceiptUpdateInput();
+        updateInput.setConsentReceiptId(consentId);
+
+        if (request.getExpiryTime() != null) {
+            if (request.getExpiryTime() < 0) {
+                // A negative expiryTime is the sentinel for removing the expiry entirely.
+                updateInput.setClearExpiry(true);
+            } else {
+                updateInput.setExpiryTime(new Timestamp(request.getExpiryTime()));
+            }
+        }
+
+        updateInput.setProperties(request.getProperties());
+
+        if (request.getAuthorizations() != null) {
+            List<ConsentAuthorization> authorizations = new ArrayList<>();
+            for (AuthorizationUpdateEntry entry : request.getAuthorizations()) {
+                ConsentAuthorization auth = new ConsentAuthorization();
+                auth.setUserId(entry.getUserId());
+                auth.setType(entry.getType());
+                if (entry.getState() != null) {
+                    auth.setStatus(ConsentAuthorization.AuthorizationStatus.valueOf(entry.getState().toString()));
+                }
+                authorizations.add(auth);
+            }
+            updateInput.setAuthorizations(authorizations);
+        }
+
+        consentManager.updateConsent(updateInput);
+        return toConsentDTO(consentManager.getReceiptWithExtendedSchema(consentId));
     }
 
     private ReceiptInput buildReceiptInput(ConsentCreateRequest request, String subjectId)
@@ -312,15 +404,18 @@ public class ConsentManagementService {
         String tenantDomain = PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantDomain();
         Long expiryMillis = request.getExpiryTime();
         Timestamp expiryTime = expiryMillis != null ? new Timestamp(expiryMillis) : null;
-        List<String> authorizationUserIds = null;
+        List<ConsentAuthorization> authorizations = null;
         if (request.getAuthorizations() != null) {
-            authorizationUserIds = new ArrayList<>();
+            authorizations = new ArrayList<>();
             for (AuthorizationEntry entry : request.getAuthorizations()) {
-                authorizationUserIds.add(entry.getId());
+                ConsentAuthorization auth = new ConsentAuthorization();
+                auth.setUserId(entry.getUserId());
+                auth.setType(entry.getType());
+                authorizations.add(auth);
             }
         }
-        return ConsentReceiptUtils.buildReceiptInput(request.getLanguage(), subjectId, tenantDomain,
-                expiryTime, rejected, authorizationUserIds, request.getProperties(),
+        return ConsentReceiptUtils.buildReceiptInput(request.getLanguage(), subjectId,
+                tenantDomain, expiryTime, rejected, authorizations, request.getProperties(),
                 request.getServiceId(), purposeBindings, consentManager);
     }
 
@@ -469,21 +564,15 @@ public class ConsentManagementService {
                 throw handleClientException(ERROR_CODE_CONSENT_INVALID_STATE_FOR_AUTHORIZE, consentId);
             }
 
-            PrivilegedCarbonContext carbonContext = PrivilegedCarbonContext.getThreadLocalCarbonContext();
-            String callingUser = carbonContext.getUsername();
+            String callingUser = PrivilegedCarbonContext.getThreadLocalCarbonContext().getUsername();
             String authStatus = request.getState() != null ? request.getState().toString() : "APPROVED";
 
-            List<ConsentAuthorization> existing = consentManager.getConsentAuthorizations(consentId);
-            boolean callingUserInList = existing.stream().anyMatch(a -> callingUser.equals(a.getUserId()));
-            if (!callingUserInList) {
-                throw handleClientException(ERROR_CODE_CONSENT_USER_NOT_IN_AUTHORIZATION_LIST, callingUser);
-            }
-
+            validateConsentAccess(consentId, callingUser, receipt);
             consentManager.authorizeConsent(consentId, callingUser, authStatus);
 
             List<ConsentAuthorization> all = consentManager.getConsentAuthorizations(consentId);
             ConsentAuthorization updated = all.stream()
-                    .filter(a -> callingUser.equals(a.getUserId()))
+                    .filter(a -> callingUser.equalsIgnoreCase(a.getUserId()))
                     .findFirst()
                     .orElse(null);
 
@@ -509,19 +598,34 @@ public class ConsentManagementService {
     public ConsentValidateResponse validateConsent(String consentId) {
 
         try {
+            String callingUser = PrivilegedCarbonContext.getThreadLocalCarbonContext().getUsername();
+            Receipt receipt = consentManager.getReceiptWithExtendedSchema(consentId);
+            validateConsentAccess(consentId, callingUser, receipt);
             String status = consentManager.validateConsentStatus(consentId);
 
             ConsentValidateResponse validateResponse = new ConsentValidateResponse();
             validateResponse.setState(ConsentValidateResponse.StateEnum.fromValue(status));
-
-            Receipt receipt = consentManager.getReceiptWithExtendedSchema(consentId);
-            if (receipt != null) {
-                validateResponse.setExpiryTime(
-                        receipt.getExpiryTime() != null ? receipt.getExpiryTime().getTime() : null);
-            }
+            validateResponse.setExpiryTime(
+                    receipt.getExpiryTime() != null ? receipt.getExpiryTime().getTime() : null);
             return validateResponse;
         } catch (ConsentManagementException e) {
             throw ConsentMgtEndpointUtil.handleConsentManagementException(e);
+        }
+    }
+
+    private void validateConsentAccess(String consentId, String callingUser, Receipt receipt)
+            throws ConsentManagementException {
+
+        List<ConsentAuthorization> authorizations = consentManager.getConsentAuthorizations(consentId);
+        if (authorizations == null || authorizations.isEmpty()) {
+            if (receipt == null || !callingUser.equalsIgnoreCase(receipt.getPiiPrincipalId())) {
+                throw handleClientException(ERROR_CODE_USER_NOT_AUTHORIZED, callingUser);
+            }
+        } else {
+            boolean inList = authorizations.stream().anyMatch(a -> callingUser.equalsIgnoreCase(a.getUserId()));
+            if (!inList) {
+                throw handleClientException(ERROR_CODE_USER_NOT_AUTHORIZED, callingUser);
+            }
         }
     }
 
@@ -556,4 +660,5 @@ public class ConsentManagementService {
                         ConsentManagementConstants.CONSENTS_PATH + url).toString())
                 .rel(rel);
     }
+
 }

--- a/components/org.wso2.carbon.identity.api.server.consent.management/org.wso2.carbon.identity.api.server.consent.management.v2/src/main/java/org/wso2/carbon/identity/api/server/consent/management/v2/core/ElementManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.consent.management/org.wso2.carbon.identity.api.server.consent.management.v2/src/main/java/org/wso2/carbon/identity/api/server/consent/management/v2/core/ElementManagementService.java
@@ -84,6 +84,9 @@ public class ElementManagementService {
                     : request.getName();
             PIICategory piiCategory = new PIICategory(request.getName(), request.getDescription(), false, displayName);
             piiCategory.setTenantId(ConsentUtils.getTenantIdFromCarbonContext());
+            if (request.getProperties() != null) {
+                piiCategory.setProperties(request.getProperties());
+            }
             PIICategory created = consentManager.addPIICategoryWithUuid(piiCategory);
             return toElementDTO(created);
         } catch (ConsentManagementException e) {
@@ -231,6 +234,7 @@ public class ElementManagementService {
         dto.setName(cat.getName());
         dto.setDisplayName(cat.getDisplayName());
         dto.setDescription(cat.getDescription());
+        dto.setProperties(cat.getProperties());
         dto.setTenantDomain(cat.getTenantDomain());
         return dto;
     }

--- a/components/org.wso2.carbon.identity.api.server.consent.management/org.wso2.carbon.identity.api.server.consent.management.v2/src/main/java/org/wso2/carbon/identity/api/server/consent/management/v2/core/ElementManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.consent.management/org.wso2.carbon.identity.api.server.consent.management.v2/src/main/java/org/wso2/carbon/identity/api/server/consent/management/v2/core/ElementManagementService.java
@@ -37,6 +37,7 @@ import org.wso2.carbon.identity.base.IdentityException;
 import org.wso2.carbon.identity.core.model.ExpressionNode;
 import org.wso2.carbon.identity.core.model.FilterTreeBuilder;
 import org.wso2.carbon.identity.core.model.Node;
+import org.wso2.carbon.identity.core.util.IdentityUtil;
 
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
@@ -244,6 +245,14 @@ public class ElementManagementService {
         limit = limit == null ? DEFAULT_LIMIT : limit;
         if (limit <= 0) {
             throw handleClientException(ERROR_CODE_INVALID_QUERY_PARAM, limit.toString());
+        }
+        int maximumItemPerPage = IdentityUtil.getMaximumItemPerPage();
+        if (limit > maximumItemPerPage) {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Given limit exceeds the maximum limit. Therefore the configured maximum limit: "
+                        + maximumItemPerPage + " is set as the limit.");
+            }
+            return maximumItemPerPage;
         }
         return limit;
     }

--- a/components/org.wso2.carbon.identity.api.server.consent.management/org.wso2.carbon.identity.api.server.consent.management.v2/src/main/java/org/wso2/carbon/identity/api/server/consent/management/v2/core/PurposeManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.consent.management/org.wso2.carbon.identity.api.server.consent.management.v2/src/main/java/org/wso2/carbon/identity/api/server/consent/management/v2/core/PurposeManagementService.java
@@ -49,6 +49,7 @@ import org.wso2.carbon.identity.base.IdentityException;
 import org.wso2.carbon.identity.core.model.ExpressionNode;
 import org.wso2.carbon.identity.core.model.FilterTreeBuilder;
 import org.wso2.carbon.identity.core.model.Node;
+import org.wso2.carbon.identity.core.util.IdentityUtil;
 
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
@@ -553,6 +554,14 @@ public class PurposeManagementService {
         limit = limit == null ? DEFAULT_LIMIT : limit;
         if (limit <= 0) {
             throw handleClientException(ERROR_CODE_INVALID_QUERY_PARAM, limit.toString());
+        }
+        int maximumItemPerPage = IdentityUtil.getMaximumItemPerPage();
+        if (limit > maximumItemPerPage) {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Given limit exceeds the maximum limit. Therefore the configured maximum limit: "
+                        + maximumItemPerPage + " is set as the limit.");
+            }
+            return maximumItemPerPage;
         }
         return limit;
     }

--- a/components/org.wso2.carbon.identity.api.server.consent.management/org.wso2.carbon.identity.api.server.consent.management.v2/src/main/java/org/wso2/carbon/identity/api/server/consent/management/v2/impl/ConsentsApiServiceImpl.java
+++ b/components/org.wso2.carbon.identity.api.server.consent.management/org.wso2.carbon.identity.api.server.consent.management.v2/src/main/java/org/wso2/carbon/identity/api/server/consent/management/v2/impl/ConsentsApiServiceImpl.java
@@ -22,7 +22,6 @@ import org.wso2.carbon.identity.api.server.common.ContextLoader;
 import org.wso2.carbon.identity.api.server.consent.management.v2.ConsentsApiService;
 import org.wso2.carbon.identity.api.server.consent.management.v2.core.ConsentManagementService;
 import org.wso2.carbon.identity.api.server.consent.management.v2.factories.ConsentManagementServiceFactory;
-import org.wso2.carbon.identity.api.server.consent.management.v2.model.AuthorizationCreateRequest;
 import org.wso2.carbon.identity.api.server.consent.management.v2.model.ConsentCreateRequest;
 import org.wso2.carbon.identity.api.server.consent.management.v2.model.ConsentResponseDTO;
 import org.wso2.carbon.identity.api.server.consent.management.v2.model.ConsentUpdateRequest;
@@ -47,12 +46,6 @@ public class ConsentsApiServiceImpl implements ConsentsApiService {
         } catch (IllegalStateException e) {
             throw new RuntimeException("Error occurred while initiating consent management service.", e);
         }
-    }
-
-    @Override
-    public Response consentsAuthorize(String consentId, AuthorizationCreateRequest authorizationCreateRequest) {
-
-        return Response.ok().entity(consentService.authorizeConsent(consentId, authorizationCreateRequest)).build();
     }
 
     @Override

--- a/components/org.wso2.carbon.identity.api.server.consent.management/org.wso2.carbon.identity.api.server.consent.management.v2/src/main/java/org/wso2/carbon/identity/api/server/consent/management/v2/impl/ConsentsApiServiceImpl.java
+++ b/components/org.wso2.carbon.identity.api.server.consent.management/org.wso2.carbon.identity.api.server.consent.management.v2/src/main/java/org/wso2/carbon/identity/api/server/consent/management/v2/impl/ConsentsApiServiceImpl.java
@@ -25,6 +25,7 @@ import org.wso2.carbon.identity.api.server.consent.management.v2.factories.Conse
 import org.wso2.carbon.identity.api.server.consent.management.v2.model.AuthorizationCreateRequest;
 import org.wso2.carbon.identity.api.server.consent.management.v2.model.ConsentCreateRequest;
 import org.wso2.carbon.identity.api.server.consent.management.v2.model.ConsentResponseDTO;
+import org.wso2.carbon.identity.api.server.consent.management.v2.model.ConsentUpdateRequest;
 
 import java.net.URI;
 
@@ -70,11 +71,11 @@ public class ConsentsApiServiceImpl implements ConsentsApiService {
 
     @Override
     public Response consentsList(String subjectId, String serviceId, String state, String purposeId,
-                                     String purposeVersionId, Integer limit, String after, String before) {
+                                 String purposeVersionId, String filter, Integer limit, String after, String before) {
 
         return Response.ok().entity(
-                consentService.listConsents(subjectId, serviceId, state, purposeId, purposeVersionId, limit, after,
-                        before)).build();
+                consentService.listConsents(subjectId, serviceId, state, purposeId, purposeVersionId, filter, limit,
+                        after, before)).build();
     }
 
     @Override
@@ -82,6 +83,12 @@ public class ConsentsApiServiceImpl implements ConsentsApiService {
 
         consentService.revokeConsent(consentId);
         return Response.noContent().build();
+    }
+
+    @Override
+    public Response consentsUpdate(String consentId, ConsentUpdateRequest consentUpdateRequest) {
+
+        return Response.ok().entity(consentService.updateConsent(consentId, consentUpdateRequest)).build();
     }
 
     @Override

--- a/components/org.wso2.carbon.identity.api.server.consent.management/org.wso2.carbon.identity.api.server.consent.management.v2/src/main/resources/consent-management-v2.yaml
+++ b/components/org.wso2.carbon.identity.api.server.consent.management/org.wso2.carbon.identity.api.server.consent.management.v2/src/main/resources/consent-management-v2.yaml
@@ -1473,11 +1473,6 @@ components:
           type: string
           description: Tenant domain
           example: "carbon.super"
-        state:
-          type: string
-          enum: [PENDING, ACTIVE, REJECTED, REVOKED, EXPIRED]
-          description: PENDING if awaiting approvals, ACTIVE if all accepted, REJECTED if any rejected before activation, REVOKED if any user revoked after activation, EXPIRED if expiryTime has passed.
-          example: "ACTIVE"
 
     ConsentListResponse:
       type: object

--- a/components/org.wso2.carbon.identity.api.server.consent.management/org.wso2.carbon.identity.api.server.consent.management.v2/src/main/resources/consent-management-v2.yaml
+++ b/components/org.wso2.carbon.identity.api.server.consent.management/org.wso2.carbon.identity.api.server.consent.management.v2/src/main/resources/consent-management-v2.yaml
@@ -42,7 +42,8 @@ paths:
         - Purposes
       summary: Create a new purpose
       description: |
-        Create a new consent purpose (e.g., "Privacy Policy", "Marketing").
+        Create a new consent purpose (e.g., "Privacy Policy", "Marketing").<br>
+        <b>Scope(Permission) required:</b> `internal_consent_mgt_purpose_create`
       operationId: purposesCreate
       requestBody:
         required: true
@@ -78,7 +79,8 @@ paths:
         - Purposes
       summary: List all purposes
       description: |
-        Retrieve all purposes with optional filtering.
+        Retrieve all purposes with optional filtering.<br>
+        <b>Scope(Permission) required:</b> `internal_consent_mgt_purpose_view`
       operationId: purposesList
       parameters:
         - $ref: '#/components/parameters/filterPurposes'
@@ -105,7 +107,8 @@ paths:
         - Purposes
       summary: Get a purpose
       description: |
-        Retrieve a specific purpose by ID.
+        Retrieve a specific purpose by ID.<br>
+        <b>Scope(Permission) required:</b> `internal_consent_mgt_purpose_view`
       operationId: purposesGet
       parameters:
         - $ref: '#/components/parameters/purposeId'
@@ -130,7 +133,8 @@ paths:
         - Purposes
       summary: Delete a purpose
       description: |
-        Delete a purpose by ID.
+        Delete a purpose by ID.<br>
+        <b>Scope(Permission) required:</b> `internal_consent_mgt_purpose_delete`
       operationId: purposesDelete
       parameters:
         - $ref: '#/components/parameters/purposeId'
@@ -156,7 +160,8 @@ paths:
         - Purposes
       summary: List purpose versions
       description: |
-        Retrieve all versions of a specific purpose with pagination support.
+        Retrieve all versions of a specific purpose with pagination support.<br>
+        <b>Scope(Permission) required:</b> `internal_consent_mgt_purpose_view`
       operationId: purposesVersionsList
       parameters:
         - $ref: '#/components/parameters/purposeId'
@@ -184,7 +189,8 @@ paths:
         - Purposes
       summary: Create a new purpose version
       description: |
-        Add a new version to an existing purpose.
+        Add a new version to an existing purpose.<br>
+        <b>Scope(Permission) required:</b> `internal_consent_mgt_purpose_update`
       operationId: purposesVersionsCreate
       parameters:
         - $ref: '#/components/parameters/purposeId'
@@ -221,7 +227,8 @@ paths:
       summary: Set the latest version of a purpose
       description: |
         Designate a specific version as the "latest" version of a purpose. The latest version
-        is returned in GET /purposes/{purposeId} and used when creating new consents.
+        is returned in GET /purposes/{purposeId} and used when creating new consents.<br>
+        <b>Scope(Permission) required:</b> `internal_consent_mgt_purpose_update`
       operationId: purposesSetLatestVersion
       parameters:
         - $ref: '#/components/parameters/purposeId'
@@ -251,7 +258,8 @@ paths:
         - Purposes
       summary: Get a purpose version
       description: |
-        Retrieve a specific version of a purpose.
+        Retrieve a specific version of a purpose.<br>
+        <b>Scope(Permission) required:</b> `internal_consent_mgt_purpose_view`
       operationId: purposesVersionsGet
       parameters:
         - $ref: '#/components/parameters/purposeId'
@@ -277,7 +285,8 @@ paths:
         - Purposes
       summary: Delete a purpose version
       description: |
-        Delete a specific version of a purpose.
+        Delete a specific version of a purpose.<br>
+        <b>Scope(Permission) required:</b> `internal_consent_mgt_purpose_delete`
       operationId: purposesVersionsDelete
       parameters:
         - $ref: '#/components/parameters/purposeId'
@@ -304,7 +313,8 @@ paths:
         - Elements
       summary: Create a consent element
       description: |
-        Create a new consent element (e.g., "email_address", "phone_number").
+        Create a new consent element (e.g., "email_address", "phone_number").<br>
+        <b>Scope(Permission) required:</b> `internal_consent_mgt_element_create`
       operationId: elementsCreate
       requestBody:
         required: true
@@ -340,7 +350,8 @@ paths:
         - Elements
       summary: List consent elements
       description: |
-        Retrieve all consent elements with optional filtering.
+        Retrieve all consent elements with optional filtering.<br>
+        <b>Scope(Permission) required:</b> `internal_consent_mgt_element_view`
       operationId: elementsList
       parameters:
         - $ref: '#/components/parameters/filterElements'
@@ -367,7 +378,8 @@ paths:
         - Elements
       summary: Get a consent element
       description: |
-        Retrieve a specific consent element by ID.
+        Retrieve a specific consent element by ID.<br>
+        <b>Scope(Permission) required:</b> `internal_consent_mgt_element_view`
       operationId: elementsGet
       parameters:
         - $ref: '#/components/parameters/elementId'
@@ -392,7 +404,8 @@ paths:
         - Elements
       summary: Delete a consent element
       description: |
-        Delete a consent element by ID.
+        Delete a consent element by ID.<br>
+        <b>Scope(Permission) required:</b> `internal_consent_mgt_element_delete`
       operationId: elementsDelete
       parameters:
         - $ref: '#/components/parameters/elementId'
@@ -418,7 +431,17 @@ paths:
         - Consents
       summary: Create a consent record
       description: |
-        Record user consent for specified purposes and elements.
+        Record consent for specified purposes and elements.
+
+        Without a scope, the authenticated user creates and gives consent simultaneously. The consent is
+        immediately recorded as `ACTIVE`. The `subjectId` field is ignored — the calling user is always
+        the consent subject. Providing `authorizations` returns 400.
+
+        <b>Scope(Permission) required:</b> `internal_consent_mgt_consent_create` — Creates a consent
+        record on behalf of a subject user without giving consent. The consent is created in `PENDING`
+        state and requires the subject user to authorize via `POST /consents/{consentId}/authorize`.
+        The `subjectId` field is required. The `authorizations` field may be provided to pre-declare
+        which users must authorize the pending consent.
       operationId: consentsCreate
       requestBody:
         required: true
@@ -455,6 +478,12 @@ paths:
       summary: List consent records
       description: |
         Retrieve consent records with optional filtering.
+
+        Without a scope, returns only the authenticated user's own consents. The `subjectId` query
+        parameter is ignored.
+
+        <b>Scope(Permission) required:</b> `internal_consent_mgt_consent_view` — Returns consents for
+        any user. The `subjectId` parameter is applied as a filter.
       operationId: consentsList
       parameters:
         - $ref: '#/components/parameters/subjectId'
@@ -462,6 +491,7 @@ paths:
         - $ref: '#/components/parameters/consentState'
         - $ref: '#/components/parameters/purposeIdQuery'
         - $ref: '#/components/parameters/purposeVersionIdQuery'
+        - $ref: '#/components/parameters/filterConsents'
         - $ref: '#/components/parameters/limit'
         - $ref: '#/components/parameters/after'
         - $ref: '#/components/parameters/before'
@@ -486,6 +516,12 @@ paths:
       summary: Get a consent record
       description: |
         Retrieve a specific consent record by consent ID.
+
+        Without a scope, only the consent subject may retrieve the record. Returns 403 if the
+        authenticated user is not the consent subject.
+
+        <b>Scope(Permission) required:</b> `internal_consent_mgt_consent_view` — Any consent record
+        can be retrieved regardless of who the subject is.
       operationId: consentsGet
       parameters:
         - $ref: '#/components/parameters/consentId'
@@ -500,6 +536,48 @@ paths:
           $ref: '#/components/responses/BadRequest'
         '401':
           $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/ServerError'
+
+    patch:
+      tags:
+        - Consents
+      summary: Update a consent record
+      description: |
+        Update an existing consent record's expiry time, properties, and authorizations.
+        All fields in the request body are optional; omit a field to leave that aspect of
+        the consent unchanged. `expiryTime` sets or clears the expiry, `properties`
+        replaces the full property map, and `authorizations` upserts the listed users —
+        adding them as authorizers if absent or overriding their state if present.
+
+        <b>Scope(Permission) required:</b> `internal_consent_mgt_consent_update` — Updates
+        any consent record regardless of who the subject is.
+      operationId: consentsUpdate
+      parameters:
+        - $ref: '#/components/parameters/consentId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ConsentUpdateRequest'
+      responses:
+        '200':
+          description: Consent updated successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ConsentDTO'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
         '404':
           $ref: '#/components/responses/NotFound'
         '500':
@@ -511,8 +589,8 @@ paths:
         - Consents
       summary: Revoke a consent
       description: |
-        Revokes the consent. Idempotent — if the consent is already revoked, returns 204 with no error.
-        For consents with an authorization list, only users in that list may revoke (returns 403 otherwise).
+        Revokes the consent. The authenticated user must be the consent subject, returns 403 otherwise.
+        Idempotent — if the consent is already revoked, returns 204 with no error.
       operationId: consentsRevoke
       parameters:
         - $ref: '#/components/parameters/consentId'
@@ -536,10 +614,10 @@ paths:
         - Consents
       summary: Authorize a consent
       description: |
-        Authorizes a PENDING consent. The authenticated user must be in the consent's authorization list.
+        Authorizes a PENDING consent. The authenticated user must be in the consent's authorization
+        list, returns 403 otherwise.
         When all required users have approved, the consent transitions to ACTIVE state.
         If any user rejects, the consent transitions to REJECTED state.
-        Returns 403 if the calling user is not in the authorization list.
       operationId: consentsAuthorize
       parameters:
         - $ref: '#/components/parameters/consentId'
@@ -574,6 +652,9 @@ paths:
       tags:
         - Consents
       summary: Get the current state of a consent object
+      description: |
+        Returns the current state of a consent record, performing a lazy expiry check.
+        The authenticated user must be the consent subject, returns 403 otherwise.
       operationId: consentsValidate
       parameters:
         - $ref: '#/components/parameters/consentId'
@@ -588,6 +669,8 @@ paths:
           $ref: '#/components/responses/BadRequest'
         '401':
           $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
         '404':
           $ref: '#/components/responses/NotFound'
         '500':
@@ -802,6 +885,21 @@ components:
         maxLength: 255
       description: Filter purposes by name (partial match, case-insensitive).
 
+    filterConsents:
+      in: query
+      name: filter
+      required: false
+      description: |
+        Filter consents by custom properties using dot notation `properties.<key>`.
+        Supports 'sw' (starts with), 'co' (contains), 'ew' (ends with), and 'eq' (equals) operations.
+        Combine multiple conditions with 'and', 'or' logical operators.
+        Examples:
+        - filter=properties.dataCategory eq personal
+        - filter=properties.region eq EU
+        - filter=properties.region eq EU and properties.dataCategory eq personal
+      schema:
+        type: string
+
   schemas:
     # ============================================================================
     # REQUEST SCHEMAS
@@ -937,6 +1035,14 @@ components:
           maxLength: 1024
           description: Detailed description of the element
           example: "User email address used for account notifications and communications"
+        properties:
+          type: object
+          description: Free-form key-value properties for this element.
+          additionalProperties:
+            type: string
+          example:
+            dataCategory: "personal"
+            retentionPeriod: "365"
 
     ConsentCreateRequest:
       type: object
@@ -995,8 +1101,10 @@ components:
           items:
             $ref: '#/components/schemas/AuthorizationEntry'
           example:
-            - id: "alice@wso2.com"
-            - id: "bob@wso2.com"
+            - userId: "alice@wso2.com"
+              type: "USER"
+            - userId: "bob@wso2.com"
+              type: "USER"
         properties:
           type: object
           description: Optional properties as key-value pairs
@@ -1031,6 +1139,69 @@ components:
 
           description: ID of the consent element
           example: "f83aa1a3-5d4d-4c0e-84db-c3a4f1e6c8b2"
+
+    ConsentUpdateRequest:
+      type: object
+      description: >
+        Admin update of an existing consent. All fields are optional; omit a field to
+        leave that aspect of the consent unchanged.
+      properties:
+        expiryTime:
+          type: integer
+          format: int64
+          description: >
+            When present, sets or extends the consent's expiry time to the given
+            milliseconds-since-epoch timestamp. Omit to leave the existing expiry unchanged.
+            Pass any negative value (e.g. `-1`) to remove the expiry entirely (the consent
+            no longer expires).
+          example: 1766383796000
+        properties:
+          type: object
+          nullable: true
+          description: >
+            When present, replaces the consent's full property map. Omit to leave existing
+            properties unchanged.
+          additionalProperties:
+            type: string
+          example:
+            dataCategory: "personal"
+            region: "EU"
+        authorizations:
+          type: array
+          nullable: true
+          description: >
+            When present, upserts each listed user's authorization — adds the user as an
+            authorizer if absent, or overrides the existing authorization state if present.
+            Users not listed are left untouched.
+          items:
+            $ref: '#/components/schemas/AuthorizationUpdateEntry'
+          example:
+            - userId: "alice@wso2.com"
+              state: "REVOKED"
+            - userId: "carol@wso2.com"
+              type: "USER"
+              state: "APPROVED"
+
+    AuthorizationUpdateEntry:
+      type: object
+      required:
+        - userId
+      properties:
+        userId:
+          type: string
+          description: Username of the authorizer to add or update
+          example: "alice@wso2.com"
+        type:
+          type: string
+          description: Type of the authorization principal. Used when adding a new authorizer.
+          example: "USER"
+        state:
+          type: string
+          enum: [APPROVED, REJECTED, REVOKED]
+          description: >
+            Authorization state to set. Required when overriding an existing authorizer;
+            for a newly added authorizer, omit to leave it pending.
+          example: "REVOKED"
 
     # ============================================================================
     # RESPONSE SCHEMAS
@@ -1168,6 +1339,9 @@ components:
 
     PurposeElementDTO:
       type: object
+      required:
+        - name
+        - mandatory
       properties:
         id:
           type: string
@@ -1273,6 +1447,8 @@ components:
 
     ElementDTO:
       type: object
+      required:
+        - name
       properties:
         id:
           type: string
@@ -1294,6 +1470,15 @@ components:
           nullable: true
           description: Detailed description
           example: "User email address used for account notifications and communications"
+        properties:
+          type: object
+          nullable: true
+          description: Free-form key-value properties for this element.
+          additionalProperties:
+            type: string
+          example:
+            dataCategory: "personal"
+            retentionPeriod: "365"
         tenantDomain:
           type: string
           nullable: true
@@ -1510,6 +1695,9 @@ components:
     ConsentedElementDTO:
       type: object
       description: Element information within a consented purpose
+      required:
+        - id
+        - name
       properties:
         id:
           type: string
@@ -1539,12 +1727,16 @@ components:
     AuthorizationEntry:
       type: object
       required:
-        - id
+        - userId
       properties:
-        id:
+        userId:
           type: string
           description: Username of the user expected to authorize this consent
           example: "alice@wso2.com"
+        type:
+          type: string
+          description: Type of the authorization principal
+          example: "USER"
 
     AuthorizationDTO:
       type: object

--- a/components/org.wso2.carbon.identity.api.server.consent.management/org.wso2.carbon.identity.api.server.consent.management.v2/src/main/resources/consent-management-v2.yaml
+++ b/components/org.wso2.carbon.identity.api.server.consent.management/org.wso2.carbon.identity.api.server.consent.management.v2/src/main/resources/consent-management-v2.yaml
@@ -431,17 +431,8 @@ paths:
         - Consents
       summary: Create a consent record
       description: |
-        Record consent for specified purposes and elements.
-
-        Without a scope, the authenticated user creates and gives consent simultaneously. The consent is
-        immediately recorded as `ACTIVE`. The `subjectId` field is ignored — the calling user is always
-        the consent subject. Providing `authorizations` returns 400.
-
-        <b>Scope(Permission) required:</b> `internal_consent_mgt_consent_create` — Creates a consent
-        record on behalf of a subject user without giving consent. The consent is created in `PENDING`
-        state and requires the subject user to authorize via `POST /consents/{consentId}/authorize`.
-        The `subjectId` field is required. The `authorizations` field may be provided to pre-declare
-        which users must authorize the pending consent.
+        Record a consent on behalf of a subject user.<br>
+        <b>Scope(Permission) required:</b> `internal_consent_mgt_consent_create`
       operationId: consentsCreate
       requestBody:
         required: true
@@ -477,13 +468,8 @@ paths:
         - Consents
       summary: List consent records
       description: |
-        Retrieve consent records with optional filtering.
-
-        Without a scope, returns only the authenticated user's own consents. The `subjectId` query
-        parameter is ignored.
-
-        <b>Scope(Permission) required:</b> `internal_consent_mgt_consent_view` — Returns consents for
-        any user. The `subjectId` parameter is applied as a filter.
+        Retrieve consent records with optional filtering.<br>
+        <b>Scope(Permission) required:</b> `internal_consent_mgt_consent_view`
       operationId: consentsList
       parameters:
         - $ref: '#/components/parameters/subjectId'
@@ -515,13 +501,8 @@ paths:
         - Consents
       summary: Get a consent record
       description: |
-        Retrieve a specific consent record by consent ID.
-
-        Without a scope, only the consent subject may retrieve the record. Returns 403 if the
-        authenticated user is not the consent subject.
-
-        <b>Scope(Permission) required:</b> `internal_consent_mgt_consent_view` — Any consent record
-        can be retrieved regardless of who the subject is.
+        Retrieve a specific consent record by consent ID.<br>
+        <b>Scope(Permission) required:</b> `internal_consent_mgt_consent_view`
       operationId: consentsGet
       parameters:
         - $ref: '#/components/parameters/consentId'
@@ -552,10 +533,8 @@ paths:
         All fields in the request body are optional; omit a field to leave that aspect of
         the consent unchanged. `expiryTime` sets or clears the expiry, `properties`
         replaces the full property map, and `authorizations` upserts the listed users —
-        adding them as authorizers if absent or overriding their state if present.
-
-        <b>Scope(Permission) required:</b> `internal_consent_mgt_consent_update` — Updates
-        any consent record regardless of who the subject is.
+        adding them as authorizers if absent or overriding their state if present.<br>
+        <b>Scope(Permission) required:</b> `internal_consent_mgt_consent_update`
       operationId: consentsUpdate
       parameters:
         - $ref: '#/components/parameters/consentId'
@@ -589,8 +568,8 @@ paths:
         - Consents
       summary: Revoke a consent
       description: |
-        Revokes the consent. The authenticated user must be the consent subject, returns 403 otherwise.
-        Idempotent — if the consent is already revoked, returns 204 with no error.
+        Revokes the consent. Idempotent — if the consent is already revoked, returns 204 with no error.<br>
+        <b>Scope(Permission) required:</b> `internal_consent_mgt_consent_update`
       operationId: consentsRevoke
       parameters:
         - $ref: '#/components/parameters/consentId'
@@ -608,53 +587,14 @@ paths:
         '500':
           $ref: '#/components/responses/ServerError'
 
-  /consents/{consentId}/authorize:
-    post:
-      tags:
-        - Consents
-      summary: Authorize a consent
-      description: |
-        Authorizes a PENDING consent. The authenticated user must be in the consent's authorization
-        list, returns 403 otherwise.
-        When all required users have approved, the consent transitions to ACTIVE state.
-        If any user rejects, the consent transitions to REJECTED state.
-      operationId: consentsAuthorize
-      parameters:
-        - $ref: '#/components/parameters/consentId'
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/AuthorizationCreateRequest'
-      responses:
-        '200':
-          description: Consent authorized successfully
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/AuthorizationDTO'
-        '400':
-          $ref: '#/components/responses/BadRequest'
-        '401':
-          $ref: '#/components/responses/Unauthorized'
-        '403':
-          $ref: '#/components/responses/Forbidden'
-        '404':
-          $ref: '#/components/responses/NotFound'
-        '409':
-          $ref: '#/components/responses/Conflict'
-        '500':
-          $ref: '#/components/responses/ServerError'
-
   /consents/{consentId}/validate:
     get:
       tags:
         - Consents
       summary: Get the current state of a consent object
       description: |
-        Returns the current state of a consent record, performing a lazy expiry check.
-        The authenticated user must be the consent subject, returns 403 otherwise.
+        Returns the current state of a consent record, performing a lazy expiry check.<br>
+        <b>Scope(Permission) required:</b> `internal_consent_mgt_consent_view`
       operationId: consentsValidate
       parameters:
         - $ref: '#/components/parameters/consentId'
@@ -1047,6 +987,7 @@ components:
     ConsentCreateRequest:
       type: object
       required:
+        - subjectId
         - serviceId
         - purposes
       properties:
@@ -1054,9 +995,7 @@ components:
           type: string
           minLength: 1
           maxLength: 255
-          description: >
-            Username of the user giving consent. If omitted, defaults to the authenticated
-            caller. Required when the subject differs from the caller (delegated consent).
+          description: Username of the user giving consent.
           example: "alice@wso2.com"
         serviceId:
           type: string
@@ -1097,7 +1036,7 @@ components:
           example: 1766383796000
         authorizations:
           type: array
-          description: Optional list of users who are expected to authorize this consent. Each user will use the /authorize endpoint to give their actual consent.
+          description: Optional list of users who are expected to authorize this consent.
           items:
             $ref: '#/components/schemas/AuthorizationEntry'
           example:

--- a/components/org.wso2.carbon.identity.api.server.consent.management/org.wso2.carbon.identity.api.server.consent.management.v2/src/main/resources/consent-management-v2.yaml
+++ b/components/org.wso2.carbon.identity.api.server.consent.management/org.wso2.carbon.identity.api.server.consent.management.v2/src/main/resources/consent-management-v2.yaml
@@ -1031,6 +1031,7 @@ components:
         expiryTime:
           type: integer
           format: int64
+          minimum: 0
           nullable: true
           description: Milliseconds since epoch until which the consent is valid. If omitted, the consent does not expire.
           example: 1766383796000
@@ -1088,11 +1089,10 @@ components:
         expiryTime:
           type: integer
           format: int64
+          minimum: 0
           description: >
             When present, sets or extends the consent's expiry time to the given
             milliseconds-since-epoch timestamp. Omit to leave the existing expiry unchanged.
-            Pass any negative value (e.g. `-1`) to remove the expiry entirely (the consent
-            no longer expires).
           example: 1766383796000
         properties:
           type: object

--- a/pom.xml
+++ b/pom.xml
@@ -1133,7 +1133,7 @@
         <apache.felix.scr.ds.annotations.version>1.2.4</apache.felix.scr.ds.annotations.version>
         <workflow.imple.bps.version>5.5.21</workflow.imple.bps.version>
         <carbon.workflow.engine.version>1.0.18</carbon.workflow.engine.version>
-        <carbon.consent.mgt.version>2.9.9</carbon.consent.mgt.version>
+        <carbon.consent.mgt.version>2.9.10</carbon.consent.mgt.version>
 
         <!--<maven.checkstyleplugin.excludes>**/gen/**/*</maven.checkstyleplugin.excludes>-->
 

--- a/pom.xml
+++ b/pom.xml
@@ -1133,7 +1133,7 @@
         <apache.felix.scr.ds.annotations.version>1.2.4</apache.felix.scr.ds.annotations.version>
         <workflow.imple.bps.version>5.5.21</workflow.imple.bps.version>
         <carbon.workflow.engine.version>1.0.18</carbon.workflow.engine.version>
-        <carbon.consent.mgt.version>2.9.4</carbon.consent.mgt.version>
+        <carbon.consent.mgt.version>2.9.9</carbon.consent.mgt.version>
 
         <!--<maven.checkstyleplugin.excludes>**/gen/**/*</maven.checkstyleplugin.excludes>-->
 


### PR DESCRIPTION
## Summary

Add admin APIs for DPDP compliant consent management.

This PR introduces:
1. Admin-only consent management REST APIs (v2) — create, list, get, update, revoke consents on behalf of users.
2. Admin APIs for managing purpose-application mappings under the configs API.
3. Removal of self-service consent endpoints (authorize-by-user flow) that were part of an earlier draft.

Related issue https://github.com/wso2/product-is/issues/26859

## Approach

### Consent Management API (v2)

- Replaced `POST /consents/{consentId}/revoke` endpoint with a unified `PATCH /consents/{consentId}` that handles updates (expiry, properties, authorizations) and revocation via state change.
- Added `ConsentUpdateRequest` and `AuthorizationUpdateEntry` models.
- Removed the `POST /consents/{consentId}/authorize` self-service endpoint (end-user authorization flow).
- Removed the self-service `GET /consents/{consentId}/validate` lazy-expiry re-fetch from the GET path.
- Added `filter` query parameter to `GET /consents` backed by `FilterQueriesUtil`, restricting filter attributes to `properties.<key>` with `eq` operation only.
- Made `subjectId` in `ConsentCreateRequest` required (no implicit fallback to the current user).
- Added OAuth2 scope annotations (`internal_consent_mgt_*`) to all endpoints in the YAML spec.
