### PR TITLE
Add enableAllPublishers flag to Moesif publisher API

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.moesif.publisher/org.wso2.carbon.identity.api.server.moesif.publisher.v1/src/gen/java/org/wso2/carbon/identity/api/server/moesif/publisher/v1/model/MoesifPublisher.java
+++ b/components/org.wso2.carbon.identity.api.server.moesif.publisher/org.wso2.carbon.identity.api.server.moesif.publisher.v1/src/gen/java/org/wso2/carbon/identity/api/server/moesif/publisher/v1/model/MoesifPublisher.java
@@ -37,6 +37,7 @@ public class MoesifPublisher  {
   
     private String name;
     private Map<String, Boolean> eventPublisherEnablement = null;
+    private Boolean enableAllPublishers;
 
 
     /**
@@ -86,6 +87,26 @@ public class MoesifPublisher  {
     }
 
     
+
+    /**
+    * When true, all supported publishers are enabled regardless of eventPublisherEnablement.
+    **/
+    public MoesifPublisher enableAllPublishers(Boolean enableAllPublishers) {
+
+        this.enableAllPublishers = enableAllPublishers;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "false", value = "When true, all supported publishers are enabled regardless of eventPublisherEnablement.")
+    @JsonProperty("enableAllPublishers")
+    @Valid
+    public Boolean getEnableAllPublishers() {
+        return enableAllPublishers;
+    }
+    public void setEnableAllPublishers(Boolean enableAllPublishers) {
+        this.enableAllPublishers = enableAllPublishers;
+    }
+
 
     @Override
     public boolean equals(java.lang.Object o) {

--- a/components/org.wso2.carbon.identity.api.server.moesif.publisher/org.wso2.carbon.identity.api.server.moesif.publisher.v1/src/gen/java/org/wso2/carbon/identity/api/server/moesif/publisher/v1/model/MoesifPublisherPatchReq.java
+++ b/components/org.wso2.carbon.identity.api.server.moesif.publisher/org.wso2.carbon.identity.api.server.moesif.publisher.v1/src/gen/java/org/wso2/carbon/identity/api/server/moesif/publisher/v1/model/MoesifPublisherPatchReq.java
@@ -37,6 +37,7 @@ public class MoesifPublisherPatchReq  {
 
     private String apiKeyValue;
     private Map<String, Boolean> eventPublisherEnablement = null;
+    private Boolean enableAllPublishers;
 
 
     /**
@@ -89,6 +90,26 @@ public class MoesifPublisherPatchReq  {
         return this;
     }
 
+
+
+    /**
+    * When true, all supported publishers are enabled regardless of eventPublisherEnablement.
+    **/
+    public MoesifPublisherPatchReq enableAllPublishers(Boolean enableAllPublishers) {
+
+        this.enableAllPublishers = enableAllPublishers;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "false", value = "When true, all supported publishers are enabled regardless of eventPublisherEnablement.")
+    @JsonProperty("enableAllPublishers")
+    @Valid
+    public Boolean getEnableAllPublishers() {
+        return enableAllPublishers;
+    }
+    public void setEnableAllPublishers(Boolean enableAllPublishers) {
+        this.enableAllPublishers = enableAllPublishers;
+    }
 
 
     @Override

--- a/components/org.wso2.carbon.identity.api.server.moesif.publisher/org.wso2.carbon.identity.api.server.moesif.publisher.v1/src/gen/java/org/wso2/carbon/identity/api/server/moesif/publisher/v1/model/MoesifPublisherReq.java
+++ b/components/org.wso2.carbon.identity.api.server.moesif.publisher/org.wso2.carbon.identity.api.server.moesif.publisher.v1/src/gen/java/org/wso2/carbon/identity/api/server/moesif/publisher/v1/model/MoesifPublisherReq.java
@@ -37,6 +37,7 @@ public class MoesifPublisherReq  {
   
     private String apiKeyValue;
     private Map<String, Boolean> eventPublisherEnablement = null;
+    private Boolean enableAllPublishers;
 
 
     /**
@@ -89,6 +90,26 @@ public class MoesifPublisherReq  {
     }
 
     
+
+    /**
+    * When true, all supported publishers are enabled regardless of eventPublisherEnablement.
+    **/
+    public MoesifPublisherReq enableAllPublishers(Boolean enableAllPublishers) {
+
+        this.enableAllPublishers = enableAllPublishers;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "false", value = "When true, all supported publishers are enabled regardless of eventPublisherEnablement.")
+    @JsonProperty("enableAllPublishers")
+    @Valid
+    public Boolean getEnableAllPublishers() {
+        return enableAllPublishers;
+    }
+    public void setEnableAllPublishers(Boolean enableAllPublishers) {
+        this.enableAllPublishers = enableAllPublishers;
+    }
+
 
     @Override
     public boolean equals(java.lang.Object o) {

--- a/components/org.wso2.carbon.identity.api.server.moesif.publisher/org.wso2.carbon.identity.api.server.moesif.publisher.v1/src/main/java/org/wso2/carbon/identity/api/server/moesif/publisher/v1/core/MoesifPublisherManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.moesif.publisher/org.wso2.carbon.identity.api.server.moesif.publisher.v1/src/main/java/org/wso2/carbon/identity/api/server/moesif/publisher/v1/core/MoesifPublisherManagementService.java
@@ -52,7 +52,8 @@ public class MoesifPublisherManagementService {
 
         try {
             MoesifPublisherDTO result = moesifConfigurationManagementService.addMoesifPublisher(
-                    moesifPublisherReq.getApiKeyValue(), moesifPublisherReq.getEventPublisherEnablement());
+                    moesifPublisherReq.getApiKeyValue(), moesifPublisherReq.getEventPublisherEnablement(),
+                    Boolean.TRUE.equals(moesifPublisherReq.getEnableAllPublishers()));
             return buildResponse(result);
         } catch (MoesifConfigurationManagementException e) {
             throw handleException(e);
@@ -69,12 +70,14 @@ public class MoesifPublisherManagementService {
         }
     }
 
-    public MoesifPublisher updateMoesifPublisher(String apiKeyValue, Map<String, Boolean> eventPublisherEnablement) {
+    public MoesifPublisher updateMoesifPublisher(String apiKeyValue, Map<String, Boolean> eventPublisherEnablement,
+                                                 Boolean enableAllPublishers) {
 
         try {
             MoesifPublisherDTO result = moesifConfigurationManagementService
                     .updateMoesifPublisher(apiKeyValue,
-                            eventPublisherEnablement != null ? eventPublisherEnablement : Collections.emptyMap());
+                            eventPublisherEnablement != null ? eventPublisherEnablement : Collections.emptyMap(),
+                            Boolean.TRUE.equals(enableAllPublishers));
             return buildResponse(result);
         } catch (MoesifConfigurationManagementException e) {
             throw handleException(e);
@@ -97,6 +100,7 @@ public class MoesifPublisherManagementService {
         if (dto.getPublisherTypes() != null) {
             publisher.setEventPublisherEnablement(dto.getPublisherTypes());
         }
+        publisher.setEnableAllPublishers(dto.isEnableAllPublishers());
         return publisher;
     }
 

--- a/components/org.wso2.carbon.identity.api.server.moesif.publisher/org.wso2.carbon.identity.api.server.moesif.publisher.v1/src/main/java/org/wso2/carbon/identity/api/server/moesif/publisher/v1/impl/MoesifPublishersApiServiceImpl.java
+++ b/components/org.wso2.carbon.identity.api.server.moesif.publisher/org.wso2.carbon.identity.api.server.moesif.publisher.v1/src/main/java/org/wso2/carbon/identity/api/server/moesif/publisher/v1/impl/MoesifPublishersApiServiceImpl.java
@@ -73,7 +73,8 @@ public class MoesifPublishersApiServiceImpl implements MoesifPublishersApiServic
 
         MoesifPublisher updated = moesifPublisherManagementService.updateMoesifPublisher(
                 moesifPublisherPatchReq.getApiKeyValue(),
-                moesifPublisherPatchReq.getEventPublisherEnablement());
+                moesifPublisherPatchReq.getEventPublisherEnablement(),
+                moesifPublisherPatchReq.getEnableAllPublishers());
         return Response.ok().entity(updated).build();
     }
 

--- a/components/org.wso2.carbon.identity.api.server.moesif.publisher/org.wso2.carbon.identity.api.server.moesif.publisher.v1/src/main/resources/moesif-publisher.yaml
+++ b/components/org.wso2.carbon.identity.api.server.moesif.publisher/org.wso2.carbon.identity.api.server.moesif.publisher.v1/src/main/resources/moesif-publisher.yaml
@@ -117,6 +117,12 @@ components:
             moesif-registration-publisher: false
             moesif-flow-publisher: true
             moesif-oauth2-token-publisher: true
+        enableAllPublishers:
+          type: boolean
+          description: >
+            When true, all supported publishers are enabled for the organization regardless of
+            eventPublisherEnablement, and the individual governance toggles are not consulted.
+          example: false
     MoesifPublisherPatchReq:
       type: object
       required:
@@ -142,6 +148,13 @@ components:
             moesif-registration-publisher: false
             moesif-flow-publisher: true
             moesif-oauth2-token-publisher: true
+        enableAllPublishers:
+          type: boolean
+          nullable: true
+          description: >
+            When true, all supported publishers are enabled regardless of eventPublisherEnablement.
+            If omitted/null, the existing setting is retained.
+          example: false
     MoesifPublisher:
       type: object
       properties:
@@ -158,6 +171,10 @@ components:
             registration: false
             flow: true
             oauthToken: true
+        enableAllPublishers:
+          type: boolean
+          description: Whether all supported publishers are currently enabled for the organization.
+          example: false
 
     Error:
       type: object

--- a/pom.xml
+++ b/pom.xml
@@ -1148,7 +1148,7 @@
         <org.wso2.carbon.identity.organization.management.core.version.range>[1.0.0, 2.0.0)
         </org.wso2.carbon.identity.organization.management.core.version.range>
 
-        <org.wso2.carbon.identity.moesif.version>1.0.0</org.wso2.carbon.identity.moesif.version>
+        <org.wso2.carbon.identity.moesif.version>1.0.7</org.wso2.carbon.identity.moesif.version>
 
         <!-- Organization management service Version -->
         <org.wso2.carbon.identity.organization.management.version>2.5.10


### PR DESCRIPTION
## Purpose

Adds an `enableAllPublishers` flag to the Moesif publisher API so an organization's analytics can enable **all** supported publishers at once, in addition to the existing per-type `eventPublisherEnablement` map. When `true`, all supported publishers are enabled regardless of the individual toggles.

This is the api-server side of the Moesif analytics-enable feature: the tenant-management "enable advanced analytics" flow PATCHes this endpoint with `enableAllPublishers` (set for higher subscription tiers) while limited tiers continue to use the per-type map.

## What changed

- **OpenAPI spec** (`moesif-publisher.yaml`): add `enableAllPublishers` to `MoesifPublisherReq`, `MoesifPublisherPatchReq` (nullable — omitting it retains the existing setting), and the `MoesifPublisher` read model.
- **Generated models**: add the `enableAllPublishers` field/getter/setter to the three models.
- **Core/impl wiring**: `MoesifPublisherManagementService` add/update now pass the flag to the backend `addMoesifPublisher`/`updateMoesifPublisher`, and the read response surfaces `dto.isEnableAllPublishers()`. `MoesifPublishersApiServiceImpl` forwards the patch value.
- **Dependency**: bump `org.wso2.carbon.identity.moesif.version` to `1.0.7` (provides the backend methods that accept the flag).

## Related

Pairs with the tenant-management change that sends `enableAllPublishers` when enabling analytics. Follows up PR #1129 (PUT→PATCH for the Moesif publisher update endpoint).