### PR TITLE
Add API validation for negative values

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.consent.management/org.wso2.carbon.identity.api.server.consent.management.v2/src/gen/java/org/wso2/carbon/identity/api/server/consent/management/v2/model/ConsentUpdateRequest.java
+++ b/components/org.wso2.carbon.identity.api.server.consent.management/org.wso2.carbon.identity.api.server.consent.management.v2/src/gen/java/org/wso2/carbon/identity/api/server/consent/management/v2/model/ConsentUpdateRequest.java
@@ -55,9 +55,10 @@ public class ConsentUpdateRequest  {
         return this;
     }
     
-    @ApiModelProperty(example = "1766383796000", value = "When present, sets or extends the consent's expiry time to the given milliseconds-since-epoch timestamp. Omit to leave the existing expiry unchanged. Pass any negative value (e.g. `-1`) to remove the expiry entirely (the consent no longer expires). ")
+    @ApiModelProperty(example = "1766383796000", value = "When present, sets or extends the consent's expiry time to the given milliseconds-since-epoch timestamp. Omit to leave the existing expiry unchanged. ")
     @JsonProperty("expiryTime")
     @Valid
+    @Min(0)
     public Long getExpiryTime() {
         return expiryTime;
     }


### PR DESCRIPTION
Related issue https://github.com/wso2/product-is/issues/26859

This pull request makes a small but important change to the `ConsentUpdateRequest` model by updating the API documentation and adding input validation for the `expiryTime` field.

Validation and documentation update:

* Added a `@Min(0)` annotation to the `expiryTime` field in `ConsentUpdateRequest.java` to enforce that only non-negative expiry times are accepted, and updated the API documentation to remove instructions about using negative values to remove expiry.