### PR TITLE
Handle null request body in Organization management POST endpoints

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.v1/src/main/java/org/wso2/carbon/identity/api/server/organization/management/v1/service/OrganizationManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.organization.management/org.wso2.carbon.identity.api.server.organization.management.v1/src/main/java/org/wso2/carbon/identity/api/server/organization/management/v1/service/OrganizationManagementService.java
@@ -273,6 +273,10 @@ public class OrganizationManagementService {
     public Response addOrganization(OrganizationPOSTRequest organizationPOSTRequest) {
 
         try {
+            if (organizationPOSTRequest == null) {
+                throw new OrganizationManagementClientException("Empty request body.", 
+                        "The request body cannot be empty or null.", "ORG-60025");
+            }
             Organization organization = organizationManager.addOrganization(getOrganizationFromPostRequest
                     (organizationPOSTRequest));
             String organizationId = organization.getId();
@@ -415,6 +419,10 @@ public class OrganizationManagementService {
                                                                organizationDiscoveryPostRequest) {
 
         try {
+            if (organizationDiscoveryPostRequest == null) {
+                throw new OrganizationManagementClientException("Empty request body.", 
+                        "The request body cannot be empty or null.", "ORG-60025");
+            }
             List<OrgDiscoveryAttribute> orgDiscoveryAttributeList = organizationDiscoveryManager
                     .addOrganizationDiscoveryAttributes(organizationDiscoveryPostRequest.getOrganizationId(),
                             getOrgDiscoveryAttributesFromPostRequest(organizationDiscoveryPostRequest), true);
@@ -549,6 +557,10 @@ public class OrganizationManagementService {
                                                           organizationDiscoveryCheckPOSTRequest) {
 
         try {
+            if (organizationDiscoveryCheckPOSTRequest == null) {
+                throw new OrganizationManagementClientException("Empty request body.", 
+                        "The request body cannot be empty or null.", "ORG-60025");
+            }
             boolean discoveryAttributeValueAvailable = organizationDiscoveryManager
                     .isDiscoveryAttributeValueAvailable(organizationDiscoveryCheckPOSTRequest.getType(),
                             organizationDiscoveryCheckPOSTRequest.getValue());


### PR DESCRIPTION
## Purpose
Fixes https://github.com/wso2/product-is/issues/24011

## Goals
Prevent a `NullPointerException` (500 Server Error) when a POST request is sent with an empty or null body to the organization management endpoints. Instead, the server should reject the request with a proper `400 Bad Request` (client error).

## Approach
Added null-checks in `addOrganization`, `addOrganizationDiscoveryAttributes`, and `isDiscoveryAttributeAvailable` methods inside `OrganizationManagementService.java` before reading values from the incoming request objects. 

If the request object is null, we throw a new `OrganizationManagementClientException` with a descriptive message and error code (`ORG-60025`), which gets cleanly mapped to `400 Bad Request` by `OrganizationManagementEndpointUtil.handleClientErrorResponse`.

## User stories
N/A

## Developer Checklist (Mandatory)
- [ ] Complete the **Developer Checklist** in the related `product-is` issue to track any behavioral change or migration impact.

## Release note
Fix 500 server error when posting empty body to organization management endpoints.

## Documentation
N/A

## Training
N/A

## Certification
N/A

## Marketing
N/A

## Automation tests
 - Unit tests 
   N/A
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
N/A

## Migrations (if applicable)
N/A

## Test environment
Verified locally.
 
## Learning
N/A