### PR TITLE
Add API-level filtering to exclude AGENT userstore from GET /userstores endpoint

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.userstore/org.wso2.carbon.identity.api.server.userstore.v1/src/gen/java/org/wso2/carbon/identity/api/server/userstore/v1/UserstoresApi.java
+++ b/components/org.wso2.carbon.identity.api.server.userstore/org.wso2.carbon.identity.api.server.userstore.v1/src/gen/java/org/wso2/carbon/identity/api/server/userstore/v1/UserstoresApi.java
@@ -190,9 +190,9 @@ public class UserstoresApi  {
         @ApiResponse(code = 500, message = "Internal Server Error.", response = Error.class),
         @ApiResponse(code = 501, message = "Not Implemented.", response = Error.class)
     })
-    public Response getSecondaryUserStores(    @Valid@ApiParam(value = "maximum number of records to return")  @QueryParam("limit") Integer limit,     @Valid@ApiParam(value = "number of records to skip for pagination")  @QueryParam("offset") Integer offset,     @Valid@ApiParam(value = "Condition to filter the retrieval of records.")  @QueryParam("filter") String filter,     @Valid@ApiParam(value = "Define the order of how the retrieved records should be sorted.")  @QueryParam("sort") String sort,     @Valid@ApiParam(value = "Define set of user store attributes (as comma separated) to be returned.")  @QueryParam("requiredAttributes") String requiredAttributes) {
+    public Response getSecondaryUserStores(    @Valid@ApiParam(value = "maximum number of records to return")  @QueryParam("limit") Integer limit,     @Valid@ApiParam(value = "number of records to skip for pagination")  @QueryParam("offset") Integer offset,     @Valid@ApiParam(value = "Condition to filter the retrieval of records.")  @QueryParam("filter") String filter,     @Valid@ApiParam(value = "Define the order of how the retrieved records should be sorted.")  @QueryParam("sort") String sort,     @Valid@ApiParam(value = "Define set of user store attributes (as comma separated) to be returned.")  @QueryParam("requiredAttributes") String requiredAttributes,     @Valid@ApiParam(value = "Whether to exclude AGENT userstore.")  @QueryParam("excludeAgentUserstore") Boolean excludeAgentUserstore) {
 
-        return delegate.getSecondaryUserStores(limit,  offset,  filter,  sort,  requiredAttributes );
+        return delegate.getSecondaryUserStores(limit,  offset,  filter,  sort,  requiredAttributes,  excludeAgentUserstore );
     }
 
     @Valid

--- a/components/org.wso2.carbon.identity.api.server.userstore/org.wso2.carbon.identity.api.server.userstore.v1/src/gen/java/org/wso2/carbon/identity/api/server/userstore/v1/UserstoresApiService.java
+++ b/components/org.wso2.carbon.identity.api.server.userstore/org.wso2.carbon.identity.api.server.userstore.v1/src/gen/java/org/wso2/carbon/identity/api/server/userstore/v1/UserstoresApiService.java
@@ -51,8 +51,7 @@ public interface UserstoresApiService {
 
       public Response getPrimaryUserStore();
 
-      public Response getSecondaryUserStores(Integer limit, Integer offset, String filter, String sort, String requiredAttributes);
-
+      public Response getSecondaryUserStores(Integer limit, Integer offset, String filter, String sort, String requiredAttributes, Boolean excludeAgentUserstore);
       public Response getUserStoreAttributeMappings(String typeId, Boolean includeIdentityClaimMappings);
 
       public Response getUserStoreByDomainId(String userstoreDomainId);

--- a/components/org.wso2.carbon.identity.api.server.userstore/org.wso2.carbon.identity.api.server.userstore.v1/src/main/java/org/wso2/carbon/identity/api/server/userstore/v1/impl/UserstoresApiServiceImpl.java
+++ b/components/org.wso2.carbon.identity.api.server.userstore/org.wso2.carbon.identity.api.server.userstore.v1/src/main/java/org/wso2/carbon/identity/api/server/userstore/v1/impl/UserstoresApiServiceImpl.java
@@ -35,8 +35,8 @@ import org.wso2.carbon.identity.api.server.userstore.v1.model.UserStoreResponse;
 import java.io.InputStream;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
-import java.util.ArrayList; 
 import java.util.List;
+import java.util.stream.Collectors;
 import javax.ws.rs.core.Response;
 
 import static org.wso2.carbon.identity.api.server.common.Constants.V1_API_PATH_COMPONENT;
@@ -101,7 +101,7 @@ public class UserstoresApiServiceImpl implements UserstoresApiService {
         return Response.ok().entity(serverUserStoreService.getPrimaryUserStore()).build();
     }
 
-    @Override
+   @Override
     public Response getSecondaryUserStores(Integer limit, Integer offset, String filter, String sort,
                                            String requiredAttributes, Boolean excludeAgentUserstore) {
 
@@ -109,18 +109,14 @@ public class UserstoresApiServiceImpl implements UserstoresApiService {
                 limit, offset, filter, sort, requiredAttributes);
 
         if (Boolean.TRUE.equals(excludeAgentUserstore) && userStoreList != null) {
-            List<UserStoreListResponse> filteredUserStores = new ArrayList<>();
-            for (UserStoreListResponse userStore : userStoreList) {
-                if (!"AGENT".equalsIgnoreCase(userStore.getName())) {
-                    filteredUserStores.add(userStore);
-                }
-            }
+            List<UserStoreListResponse> filteredUserStores = userStoreList.stream()
+                    .filter(userStore -> !"AGENT".equalsIgnoreCase(userStore.getName()))
+                    .collect(Collectors.toList());
             return Response.ok().entity(filteredUserStores).build();
         }
 
         return Response.ok().entity(userStoreList).build();
     }
-
     @Override
     public Response getUserStoreAttributeMappings(String typeId, Boolean includeIdentityClaimMappings) {
 

--- a/components/org.wso2.carbon.identity.api.server.userstore/org.wso2.carbon.identity.api.server.userstore.v1/src/main/java/org/wso2/carbon/identity/api/server/userstore/v1/impl/UserstoresApiServiceImpl.java
+++ b/components/org.wso2.carbon.identity.api.server.userstore/org.wso2.carbon.identity.api.server.userstore.v1/src/main/java/org/wso2/carbon/identity/api/server/userstore/v1/impl/UserstoresApiServiceImpl.java
@@ -28,12 +28,14 @@ import org.wso2.carbon.identity.api.server.userstore.v1.factories.ServerUserStor
 import org.wso2.carbon.identity.api.server.userstore.v1.model.ClaimAttributeMapping;
 import org.wso2.carbon.identity.api.server.userstore.v1.model.PatchDocument;
 import org.wso2.carbon.identity.api.server.userstore.v1.model.RDBMSConnectionReq;
+import org.wso2.carbon.identity.api.server.userstore.v1.model.UserStoreListResponse;
 import org.wso2.carbon.identity.api.server.userstore.v1.model.UserStoreReq;
 import org.wso2.carbon.identity.api.server.userstore.v1.model.UserStoreResponse;
 
 import java.io.InputStream;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList; 
 import java.util.List;
 import javax.ws.rs.core.Response;
 
@@ -42,7 +44,7 @@ import static org.wso2.carbon.identity.api.server.common.ContextLoader.buildURIF
 import static org.wso2.carbon.identity.api.server.userstore.common.UserStoreConstants.USER_STORE_PATH_COMPONENT;
 
 /**
- * User Store API Service Implementation
+ * User Store API Service Implementation.
  */
 public class UserstoresApiServiceImpl implements UserstoresApiService {
 
@@ -101,11 +103,22 @@ public class UserstoresApiServiceImpl implements UserstoresApiService {
 
     @Override
     public Response getSecondaryUserStores(Integer limit, Integer offset, String filter, String sort,
-                                           String requiredAttributes) {
+                                           String requiredAttributes, Boolean excludeAgentUserstore) {
 
-        return Response.ok()
-                .entity(serverUserStoreService.getUserStoreList(limit, offset, filter, sort, requiredAttributes))
-                .build();
+        List<UserStoreListResponse> userStoreList = serverUserStoreService.getUserStoreList(
+                limit, offset, filter, sort, requiredAttributes);
+
+        if (Boolean.TRUE.equals(excludeAgentUserstore) && userStoreList != null) {
+            List<UserStoreListResponse> filteredUserStores = new ArrayList<>();
+            for (UserStoreListResponse userStore : userStoreList) {
+                if (!"AGENT".equalsIgnoreCase(userStore.getName())) {
+                    filteredUserStores.add(userStore);
+                }
+            }
+            return Response.ok().entity(filteredUserStores).build();
+        }
+
+        return Response.ok().entity(userStoreList).build();
     }
 
     @Override

--- a/components/org.wso2.carbon.identity.api.server.userstore/org.wso2.carbon.identity.api.server.userstore.v1/src/main/resources/userstore.yaml
+++ b/components/org.wso2.carbon.identity.api.server.userstore/org.wso2.carbon.identity.api.server.userstore.v1/src/main/resources/userstore.yaml
@@ -82,6 +82,8 @@ paths:
         - $ref: '#/components/parameters/filterQueryParam'
         - $ref: '#/components/parameters/sortQueryParam'
         - $ref: '#/components/parameters/requiredAttributesQueryParam'
+        - $ref: '#/components/parameters/excludeAgentUserstoreQueryParam'
+
       responses:
         '200':
           description: Successful response.
@@ -641,6 +643,14 @@ components:
       description: Define set of user store attributes (as comma separated) to be returned.
       schema:
         type: string
+    excludeAgentUserstoreQueryParam:
+      in: query
+      name: excludeAgentUserstore
+      required: false
+      description: Whether to exclude AGENT userstore.
+      schema:
+        type: boolean
+        default: false
     fileTypeHeaderParam:
       in: header
       name: Accept


### PR DESCRIPTION
## Purpose
Currently, the `AGENT` userstore appears in UI selection dropdowns across various features (such as JIT provisioning, user attribute mappings, etc.) where it should not be selectable. UI components are implementing ad-hoc hardcoded filtering logic to exclude it, which is not scalable. 

This PR introduces an optional query parameter `excludeAgentUserstore` to the `GET /api/server/v1/userstores` endpoint to exclude the `AGENT` userstore at the API level.

Resolves: wso2/product-is#27435

## Goals
Exclude the `AGENT` userstore at the API level from the `/userstores` GET endpoint response when requested.

## Approach
1. Updated the OpenAPI specification (`userstore.yaml`) to introduce a new boolean query parameter `excludeAgentUserstore` (default: `false` for backward compatibility).
2. Manually updated the generated interfaces `UserstoresApi.java` and `UserstoresApiService.java` to support the new parameter.
3. Updated the implementation in `UserstoresApiServiceImpl.java` to filter out any userstores with the name `"AGENT"` (case-insensitive) from the returned list when `excludeAgentUserstore` is set to `true`.

## User stories
N/A

## Developer Checklist (Mandatory)

- [x] Complete the **Developer Checklist** in the related `product-is` issue to track any behavioral change or migration impact.

## Release note
Added a new query parameter `excludeAgentUserstore` to the `/userstores` API to exclude the `AGENT` userstore at the API level.

## Documentation
N/A - This is a self-documented API query parameter in the OpenAPI spec.

## Training
N/A

## Certification
N/A

## Marketing
N/A

## Automation tests
 - Unit tests 
   > N/A - Local build and compilation completed successfully.
 - Integration tests
   > N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? Yes
 - Ran FindSecurityBugs plugin and verified report? Yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? Yes

## Samples
N/A

## Related PRs
N/A

## Migrations (if applicable)
N/A

## Test environment
- JDK Version: Java 21 (Temurin JDK 21.0.10)
- Operating System: Windows 11
 
## Learning
Standard JAX-RS REST API development patterns and Swagger/OpenAPI code-generation workflows within the WSO2 identity-api-server repository.