### PR TITLE
Add device registration flow support to flow management API

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.flow.management/org.wso2.carbon.identity.api.server.flow.management.v1/src/main/java/org/wso2/carbon/identity/api/server/flow/management/v1/constants/FlowEndpointConstants.java
+++ b/components/org.wso2.carbon.identity.api.server.flow.management/org.wso2.carbon.identity.api.server.flow.management.v1/src/main/java/org/wso2/carbon/identity/api/server/flow/management/v1/constants/FlowEndpointConstants.java
@@ -172,6 +172,7 @@ public class FlowEndpointConstants {
         public static final String CONFIRMATION_CODE_VALIDATION_EXECUTOR = "ConfirmationCodeValidationExecutor";
         public static final String USER_PROVISIONING_EXECUTOR = "UserProvisioningExecutor";
         public static final String FLOW_EXTENSION_EXECUTOR = "FlowExtensionExecutor";
+        public static final String DEVICE_REGISTRATION_EXECUTOR = "DeviceRegistrationExecutor";
     }
 
     /**

--- a/components/org.wso2.carbon.identity.api.server.flow.management/org.wso2.carbon.identity.api.server.flow.management.v1/src/main/java/org/wso2/carbon/identity/api/server/flow/management/v1/core/ServerFlowMgtService.java
+++ b/components/org.wso2.carbon.identity.api.server.flow.management/org.wso2.carbon.identity.api.server.flow.management.v1/src/main/java/org/wso2/carbon/identity/api/server/flow/management/v1/core/ServerFlowMgtService.java
@@ -36,6 +36,7 @@ import org.wso2.carbon.identity.api.server.flow.management.v1.FlowResponse;
 import org.wso2.carbon.identity.api.server.flow.management.v1.Step;
 import org.wso2.carbon.identity.api.server.flow.management.v1.response.handlers.AbstractMetaResponseHandler;
 import org.wso2.carbon.identity.api.server.flow.management.v1.response.handlers.AskPasswordFlowMetaHandler;
+import org.wso2.carbon.identity.api.server.flow.management.v1.response.handlers.DeviceRegistrationFlowMetaHandler;
 import org.wso2.carbon.identity.api.server.flow.management.v1.response.handlers.PasswordRecoveryFlowMetaHandler;
 import org.wso2.carbon.identity.api.server.flow.management.v1.response.handlers.RegistrationFlowMetaHandler;
 import org.wso2.carbon.identity.api.server.flow.management.v1.utils.FlowExtensionContextMapper;
@@ -397,6 +398,8 @@ public class ServerFlowMgtService {
                 return new PasswordRecoveryFlowMetaHandler();
             case INVITED_USER_REGISTRATION:
                 return new AskPasswordFlowMetaHandler();
+            case DEVICE_REGISTRATION:
+                return new DeviceRegistrationFlowMetaHandler();
             default:
                 throw new IllegalStateException("Unhandled flow type: " + flowType);
         }

--- a/components/org.wso2.carbon.identity.api.server.flow.management/org.wso2.carbon.identity.api.server.flow.management.v1/src/main/java/org/wso2/carbon/identity/api/server/flow/management/v1/response/handlers/AskPasswordFlowMetaHandler.java
+++ b/components/org.wso2.carbon.identity.api.server.flow.management/org.wso2.carbon.identity.api.server.flow.management.v1/src/main/java/org/wso2/carbon/identity/api/server/flow/management/v1/response/handlers/AskPasswordFlowMetaHandler.java
@@ -25,6 +25,7 @@ import java.util.List;
 
 import static org.wso2.carbon.identity.api.server.flow.management.v1.constants.FlowEndpointConstants.Executors.APPLE_EXECUTOR;
 import static org.wso2.carbon.identity.api.server.flow.management.v1.constants.FlowEndpointConstants.Executors.CONFIRMATION_CODE_VALIDATION_EXECUTOR;
+import static org.wso2.carbon.identity.api.server.flow.management.v1.constants.FlowEndpointConstants.Executors.DEVICE_REGISTRATION_EXECUTOR;
 import static org.wso2.carbon.identity.api.server.flow.management.v1.constants.FlowEndpointConstants.Executors.FACEBOOK_EXECUTOR;
 import static org.wso2.carbon.identity.api.server.flow.management.v1.constants.FlowEndpointConstants.Executors.FIDO2_EXECUTOR;
 import static org.wso2.carbon.identity.api.server.flow.management.v1.constants.FlowEndpointConstants.Executors.GITHUB_EXECUTOR;
@@ -73,6 +74,7 @@ public class AskPasswordFlowMetaHandler extends AbstractMetaResponseHandler {
         supportedExecutors.add(APPLE_EXECUTOR);
         supportedExecutors.add(GITHUB_EXECUTOR);
         supportedExecutors.add(FIDO2_EXECUTOR);
+        supportedExecutors.add(DEVICE_REGISTRATION_EXECUTOR);
         return supportedExecutors;
     }
 

--- a/components/org.wso2.carbon.identity.api.server.flow.management/org.wso2.carbon.identity.api.server.flow.management.v1/src/main/java/org/wso2/carbon/identity/api/server/flow/management/v1/response/handlers/DeviceRegistrationFlowMetaHandler.java
+++ b/components/org.wso2.carbon.identity.api.server.flow.management/org.wso2.carbon.identity.api.server.flow.management.v1/src/main/java/org/wso2/carbon/identity/api/server/flow/management/v1/response/handlers/DeviceRegistrationFlowMetaHandler.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.flow.management.v1.response.handlers;
+
+import org.wso2.carbon.identity.api.server.flow.management.v1.constants.FlowEndpointConstants;
+import org.wso2.carbon.identity.flow.mgt.Constants;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.wso2.carbon.identity.api.server.flow.management.v1.constants.FlowEndpointConstants.Executors.DEVICE_REGISTRATION_EXECUTOR;
+import static org.wso2.carbon.identity.api.server.flow.management.v1.constants.FlowEndpointConstants.Executors.EMAIL_OTP_EXECUTOR;
+import static org.wso2.carbon.identity.api.server.flow.management.v1.constants.FlowEndpointConstants.Executors.SMS_OTP_EXECUTOR;
+import static org.wso2.carbon.identity.api.server.flow.management.v1.constants.FlowEndpointConstants.Executors.USER_RESOLVE_EXECUTOR;
+
+/**
+ * Handler for managing the device registration flow meta information.
+ */
+public class DeviceRegistrationFlowMetaHandler extends AbstractMetaResponseHandler {
+
+    @Override
+    public String getFlowType() {
+
+        return Constants.FlowTypes.DEVICE_REGISTRATION.getType();
+    }
+
+    @Override
+    public String getAttributeProfile() {
+
+        return FlowEndpointConstants.END_USER_ATTRIBUTE_PROFILE;
+    }
+
+    @Override
+    public List<String> getRequiredInputFields() {
+
+        List<String> fields = new ArrayList<>();
+        fields.add(FlowEndpointConstants.USERNAME_IDENTIFIER);
+        return fields;
+    }
+
+    @Override
+    public List<String> getSupportedExecutors() {
+
+        List<String> executors = new ArrayList<>();
+        executors.add(DEVICE_REGISTRATION_EXECUTOR);
+        executors.add(EMAIL_OTP_EXECUTOR);
+        executors.add(SMS_OTP_EXECUTOR);
+        executors.add(USER_RESOLVE_EXECUTOR);
+        return executors;
+    }
+}

--- a/components/org.wso2.carbon.identity.api.server.flow.management/org.wso2.carbon.identity.api.server.flow.management.v1/src/main/java/org/wso2/carbon/identity/api/server/flow/management/v1/response/handlers/RegistrationFlowMetaHandler.java
+++ b/components/org.wso2.carbon.identity.api.server.flow.management/org.wso2.carbon.identity.api.server.flow.management.v1/src/main/java/org/wso2/carbon/identity/api/server/flow/management/v1/response/handlers/RegistrationFlowMetaHandler.java
@@ -28,6 +28,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static org.wso2.carbon.identity.api.server.flow.management.v1.constants.FlowEndpointConstants.Executors.APPLE_EXECUTOR;
+import static org.wso2.carbon.identity.api.server.flow.management.v1.constants.FlowEndpointConstants.Executors.DEVICE_REGISTRATION_EXECUTOR;
 import static org.wso2.carbon.identity.api.server.flow.management.v1.constants.FlowEndpointConstants.Executors.FACEBOOK_EXECUTOR;
 import static org.wso2.carbon.identity.api.server.flow.management.v1.constants.FlowEndpointConstants.Executors.FIDO2_EXECUTOR;
 import static org.wso2.carbon.identity.api.server.flow.management.v1.constants.FlowEndpointConstants.Executors.GITHUB_EXECUTOR;
@@ -86,6 +87,7 @@ public class RegistrationFlowMetaHandler extends AbstractMetaResponseHandler {
         supportedExecutors.add(APPLE_EXECUTOR);
         supportedExecutors.add(GITHUB_EXECUTOR);
         supportedExecutors.add(FIDO2_EXECUTOR);
+        supportedExecutors.add(DEVICE_REGISTRATION_EXECUTOR);
         return supportedExecutors;
     }
 }

--- a/components/org.wso2.carbon.identity.api.server.flow.management/org.wso2.carbon.identity.api.server.flow.management.v1/src/main/java/org/wso2/carbon/identity/api/server/flow/management/v1/utils/Utils.java
+++ b/components/org.wso2.carbon.identity.api.server.flow.management/org.wso2.carbon.identity.api.server.flow.management.v1/src/main/java/org/wso2/carbon/identity/api/server/flow/management/v1/utils/Utils.java
@@ -44,6 +44,7 @@ import org.wso2.carbon.identity.api.server.flow.management.v1.Size;
 import org.wso2.carbon.identity.api.server.flow.management.v1.Step;
 import org.wso2.carbon.identity.api.server.flow.management.v1.constants.FlowEndpointConstants;
 import org.wso2.carbon.identity.api.server.flow.management.v1.response.handlers.AbstractMetaResponseHandler;
+import org.wso2.carbon.identity.api.server.flow.management.v1.response.handlers.DeviceRegistrationFlowMetaHandler;
 import org.wso2.carbon.identity.api.server.flow.management.v1.response.handlers.PasswordRecoveryFlowMetaHandler;
 import org.wso2.carbon.identity.application.common.model.Property;
 import org.wso2.carbon.identity.core.util.LambdaExceptionUtils;
@@ -540,6 +541,16 @@ public class Utils {
             if (!executors.contains(FlowEndpointConstants.Executors.EMAIL_OTP_EXECUTOR) &&
                     !executors.contains(FlowEndpointConstants.Executors.SMS_OTP_EXECUTOR) &&
                     !executors.contains(FlowEndpointConstants.Executors.MAGIC_LINK_EXECUTOR)) {
+                throw handleFlowMgtException(new FlowMgtClientException(
+                        FlowEndpointConstants.ErrorMessages.ERROR_CODE_REQUIRED_EXECUTOR_MISSING.getCode(),
+                        FlowEndpointConstants.ErrorMessages.ERROR_CODE_REQUIRED_EXECUTOR_MISSING.getMessage(),
+                        FlowEndpointConstants.ErrorMessages.ERROR_CODE_REQUIRED_EXECUTOR_MISSING.getDescription()));
+            }
+        }
+
+        // For device registration flow, ensure DeviceRegistrationExecutor is present.
+        if (metaResponseHandler instanceof DeviceRegistrationFlowMetaHandler) {
+            if (!executors.contains(FlowEndpointConstants.Executors.DEVICE_REGISTRATION_EXECUTOR)) {
                 throw handleFlowMgtException(new FlowMgtClientException(
                         FlowEndpointConstants.ErrorMessages.ERROR_CODE_REQUIRED_EXECUTOR_MISSING.getCode(),
                         FlowEndpointConstants.ErrorMessages.ERROR_CODE_REQUIRED_EXECUTOR_MISSING.getMessage(),

--- a/components/org.wso2.carbon.identity.api.server.flow.management/org.wso2.carbon.identity.api.server.flow.management.v1/src/main/resources/flow.yaml
+++ b/components/org.wso2.carbon.identity.api.server.flow.management/org.wso2.carbon.identity.api.server.flow.management.v1/src/main/resources/flow.yaml
@@ -86,7 +86,7 @@ paths:
           required: true
           schema:
             type: string
-            enum: [REGISTRATION, PASSWORD_RECOVERY, ASK_PASSWORD]
+            enum: [REGISTRATION, PASSWORD_RECOVERY, ASK_PASSWORD, DEVICE_REGISTRATION]
           description: Type of the flow to retrieve
       responses:
         '200':
@@ -131,7 +131,7 @@ paths:
           required: true
           schema:
             type: string
-            enum: [REGISTRATION, PASSWORD_RECOVERY, ASK_PASSWORD]
+            enum: [REGISTRATION, PASSWORD_RECOVERY, ASK_PASSWORD, DEVICE_REGISTRATION]
           description: Type of the flow to delete
       responses:
         '204':
@@ -173,7 +173,7 @@ paths:
           required: true
           schema:
             type: string
-            enum: [REGISTRATION, PASSWORD_RECOVERY, ASK_PASSWORD]
+            enum: [REGISTRATION, PASSWORD_RECOVERY, ASK_PASSWORD, DEVICE_REGISTRATION]
           description: Type of the flow to get metadata for
       responses:
         '200':
@@ -369,7 +369,7 @@ paths:
           required: false
           schema:
             type: string
-            enum: [REGISTRATION, PASSWORD_RECOVERY, INVITED_USER_REGISTRATION, ASK_PASSWORD]
+            enum: [REGISTRATION, PASSWORD_RECOVERY, INVITED_USER_REGISTRATION, ASK_PASSWORD, DEVICE_REGISTRATION]
           description: Optional flow type. When omitted, the default tree is returned.
       responses:
         '200':
@@ -437,7 +437,7 @@ paths:
           required: true
           schema:
             type: string
-            enum: [REGISTRATION, PASSWORD_RECOVERY, ASK_PASSWORD]
+            enum: [REGISTRATION, PASSWORD_RECOVERY, ASK_PASSWORD, DEVICE_REGISTRATION]
           description: Type of the flow to get configurations for
       responses:
         '200':


### PR DESCRIPTION

## Purpose
This PR adds `DEVICE_REGISTRATION` as a supported flow type in the Flow Management API (`/api/server/v1/flow`). It allows tenant administrators to design, retrieve, and manage a device registration flow through the same endpoints already used for registration, password recovery, and ask password flows.

## Goals
The flow type is supported across the existing Flow Management operations:
- Retrieve meta information for the device registration flow (`GET /flow/meta`).
- Retrieve, update, and delete a device registration flow (`GET /flow`, `PUT /flow`, `DELETE /flow`).
- Retrieve the flow configuration for the device registration flow (`GET /flow/config`).
- Allow the `DeviceRegistrationExecutor` to be used as a step within the registration and ask password flows.

## Implementation
The change follows the existing meta response handler pattern in `org.wso2.carbon.identity.api.server.flow.management.v1`, so no new Maven component is introduced.

### Changes

**`response/handlers`**
- `DeviceRegistrationFlowMetaHandler` is a new handler extending `AbstractMetaResponseHandler`, supplying the meta information for the device registration flow.
- The handler declares the `endUser` attribute profile, the username claim as the required input field, and the `DeviceRegistrationExecutor`, `EmailOTPExecutor`, `SMSOTPExecutor` and `UserResolveExecutor` executors.
- `RegistrationFlowMetaHandler` and `AskPasswordFlowMetaHandler` now include `DeviceRegistrationExecutor` in their supported executors, so device registration can be composed into those flows as a step.

**`core` and `constants`**
- `ServerFlowMgtService.resolveHandler` maps the `DEVICE_REGISTRATION` flow type to the new handler.
- `FlowEndpointConstants` defines the `DEVICE_REGISTRATION_EXECUTOR` constant.

**`utils`**
- `Utils.validateExecutors` rejects a device registration flow that does not contain the `DeviceRegistrationExecutor`, mirroring the existing validation for the password recovery flow.

**`flow.yaml`**
- `DEVICE_REGISTRATION` is added to the `flowType` enum on all endpoints that accept it.

The `endUser` attribute profile is used because the device registration flow operates on an existing user who is resolved by username and verified before the device is registered, which matches how the password recovery flow resolves its attribute set. Flow type validation and flow completion configuration resolution are already driven by the `Constants.FlowTypes` enum, so no changes were required there.

No changes are required in the Flow Execution API. It validates the flow type against the same enum and gates execution on the flow configuration, without any per-flow-type handling.

## User stories
- As a tenant administrator, I can design a device registration flow in the console using the device registration, OTP, and user resolve executors.
- As a tenant administrator, I can add a device registration step to an existing registration or ask password flow.
- As a tenant administrator, I am prevented from saving a device registration flow that does not include the device registration executor.

## Developer Checklist (Mandatory)

- [ ] Complete the Developer Checklist in the related `product-is` issue to capture any behavioral changes or migration impacts.

## Release note
N/A

## Documentation
N/A

## Training
N/A

## Certification
N/A

## Marketing
N/A

## Automation tests
N/A

## Security checks
- Followed the WSO2 Secure Engineering Guidelines: Yes
- Ran the FindSecurityBugs plugin and verified the report:
- Confirmed that no keys, passwords, tokens, or other secrets are included: Yes

## Samples
N/A

## Related PRs
<!-- Add the carbon-identity-framework PR once it is available. -->
This PR depends on a `carbon-identity-framework` release that includes `Constants.FlowTypes.DEVICE_REGISTRATION`. 
## Migrations
N/A – This adds a new flow type to an existing API and does not require any migration.

## Test environment
N/A

## Learning
N/A
