### PR TITLE
Introduce Device Policy API

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.device.policy/org.wso2.carbon.identity.api.server.device.policy.common/pom.xml
+++ b/components/org.wso2.carbon.identity.api.server.device.policy/org.wso2.carbon.identity.api.server.device.policy.common/pom.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+  ~
+  ~ WSO2 LLC. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.wso2.carbon.identity.server.api</groupId>
+        <artifactId>org.wso2.carbon.identity.api.server.device.policy</artifactId>
+        <version>1.6.36-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>org.wso2.carbon.identity.api.server.device.policy.common</artifactId>
+    <packaging>jar</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.rule.metadata</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.device.policy</artifactId>
+            <version>${carbon.identity.framework.version}</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/components/org.wso2.carbon.identity.api.server.device.policy/org.wso2.carbon.identity.api.server.device.policy.common/src/main/java/org/wso2/carbon/identity/api/server/device/policy/common/Constants.java
+++ b/components/org.wso2.carbon.identity.api.server.device.policy/org.wso2.carbon.identity.api.server.device.policy.common/src/main/java/org/wso2/carbon/identity/api/server/device/policy/common/Constants.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.device.policy.common;
+
+/**
+ * Constants for the Device Policy API.
+ */
+public class Constants {
+
+    private Constants() {
+    }
+
+    public static final String DEVICE_POLICY_ERROR_PREFIX = "DPM-";
+
+    public static final String V1_API_PATH_COMPONENT = "/v1";
+
+    public static final String DEVICE_POLICY_PATH_COMPONENT = "/device-policies";
+
+    /**
+     * Error messages for the Device Policy API.
+     */
+    public enum ErrorMessage {
+
+        ERROR_CODE_INVALID_PLATFORM("60001",
+                "Invalid platform.",
+                "Supported platforms: android, ios, macos, windows."),
+        ERROR_CODE_ERROR_RETRIEVING_METADATA("65001",
+                "Unable to retrieve device policy metadata.",
+                "Server encountered an error while retrieving device policy field metadata.");
+
+        private final String code;
+        private final String message;
+        private final String description;
+
+        ErrorMessage(String code, String message, String description) {
+
+            this.code = code;
+            this.message = message;
+            this.description = description;
+        }
+
+        /**
+         * Returns the error code with prefix.
+         *
+         * @return Error code.
+         */
+        public String code() {
+
+            return DEVICE_POLICY_ERROR_PREFIX + code;
+        }
+
+        /**
+         * Returns the error message.
+         *
+         * @return Error message.
+         */
+        public String message() {
+
+            return message;
+        }
+
+        /**
+         * Returns the error description.
+         *
+         * @return Error description.
+         */
+        public String description() {
+
+            return description;
+        }
+    }
+}

--- a/components/org.wso2.carbon.identity.api.server.device.policy/org.wso2.carbon.identity.api.server.device.policy.common/src/main/java/org/wso2/carbon/identity/api/server/device/policy/common/DevicePolicyMetadataServiceHolder.java
+++ b/components/org.wso2.carbon.identity.api.server.device.policy/org.wso2.carbon.identity.api.server.device.policy.common/src/main/java/org/wso2/carbon/identity/api/server/device/policy/common/DevicePolicyMetadataServiceHolder.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.device.policy.common;
+
+import org.wso2.carbon.context.PrivilegedCarbonContext;
+import org.wso2.carbon.identity.device.policy.api.service.DeviceFieldMetadataService;
+import org.wso2.carbon.identity.rule.metadata.api.service.RuleMetadataService;
+
+/**
+ * Service holder for the device policy API — retrieves OSGi services from the Carbon context.
+ */
+public class DevicePolicyMetadataServiceHolder {
+
+    private DevicePolicyMetadataServiceHolder() {}
+
+    private static class RuleMetadataServiceHolder {
+
+        static final RuleMetadataService SERVICE = (RuleMetadataService) PrivilegedCarbonContext
+                .getThreadLocalCarbonContext().getOSGiService(RuleMetadataService.class, null);
+    }
+
+    private static class DeviceFieldMetadataServiceHolder {
+
+        static final DeviceFieldMetadataService SERVICE = (DeviceFieldMetadataService) PrivilegedCarbonContext
+                .getThreadLocalCarbonContext().getOSGiService(DeviceFieldMetadataService.class, null);
+    }
+
+    /**
+     * Returns the RuleMetadataService OSGi service.
+     */
+    public static RuleMetadataService getRuleMetadataService() {
+
+        return RuleMetadataServiceHolder.SERVICE;
+    }
+
+    /**
+     * Returns the DeviceFieldMetadataService OSGi service.
+     */
+    public static DeviceFieldMetadataService getDeviceFieldMetadataService() {
+
+        return DeviceFieldMetadataServiceHolder.SERVICE;
+    }
+}

--- a/components/org.wso2.carbon.identity.api.server.device.policy/org.wso2.carbon.identity.api.server.device.policy.v1/.openapi-generator-ignore
+++ b/components/org.wso2.carbon.identity.api.server.device.policy/org.wso2.carbon.identity.api.server.device.policy.v1/.openapi-generator-ignore
@@ -1,0 +1,4 @@
+# OpenAPI Generator Ignore
+# Prevents the generator from overwriting hand-written impl classes.
+
+**/impl/*

--- a/components/org.wso2.carbon.identity.api.server.device.policy/org.wso2.carbon.identity.api.server.device.policy.v1/pom.xml
+++ b/components/org.wso2.carbon.identity.api.server.device.policy/org.wso2.carbon.identity.api.server.device.policy.v1/pom.xml
@@ -1,0 +1,170 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+  ~
+  ~ WSO2 LLC. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.wso2.carbon.identity.server.api</groupId>
+        <artifactId>org.wso2.carbon.identity.api.server.device.policy</artifactId>
+        <version>1.6.36-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>org.wso2.carbon.identity.api.server.device.policy.v1</artifactId>
+    <packaging>jar</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.cxf</groupId>
+            <artifactId>cxf-rt-frontend-jaxrs</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.cxf</groupId>
+            <artifactId>cxf-rt-rs-service-description</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>javax.ws.rs</groupId>
+            <artifactId>javax.ws.rs-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.swagger</groupId>
+            <artifactId>swagger-jaxrs</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-databind</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-annotations</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.dataformat</groupId>
+                    <artifactId>jackson-dataformat-yaml</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>javax.ws.rs</groupId>
+                    <artifactId>jsr311-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.google.guava</groupId>
+                    <artifactId>guava</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.jaxrs</groupId>
+            <artifactId>jackson-jaxrs-json-provider</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.server.api</groupId>
+            <artifactId>org.wso2.carbon.identity.api.server.common</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.server.api</groupId>
+            <artifactId>org.wso2.carbon.identity.api.server.device.policy.common</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.rule.metadata</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.device.policy</artifactId>
+            <version>${carbon.identity.framework.version}</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.openapitools</groupId>
+                <artifactId>openapi-generator-maven-plugin</artifactId>
+                <version>4.1.2</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>generate</goal>
+                        </goals>
+                        <configuration>
+                            <inputSpec>${project.basedir}/src/main/resources/device-policy.yaml</inputSpec>
+                            <generatorName>org.wso2.carbon.codegen.CxfWso2Generator</generatorName>
+                            <configOptions>
+                                <sourceFolder>src/gen/java</sourceFolder>
+                                <apiPackage>org.wso2.carbon.identity.api.server.device.policy.v1</apiPackage>
+                                <modelPackage>org.wso2.carbon.identity.api.server.device.policy.v1.model</modelPackage>
+                                <packageName>org.wso2.carbon.identity.api.server.device.policy.v1</packageName>
+                                <dateLibrary>java8</dateLibrary>
+                                <hideGenerationTimestamp>true</hideGenerationTimestamp>
+                            </configOptions>
+                            <output>.</output>
+                            <skipOverwrite>false</skipOverwrite>
+                        </configuration>
+                    </execution>
+                </executions>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.openapitools</groupId>
+                        <artifactId>cxf-wso2-openapi-generator</artifactId>
+                        <version>1.0.0</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <version>1.8</version>
+                <executions>
+                    <execution>
+                        <id>add-source</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>add-source</goal>
+                        </goals>
+                        <configuration>
+                            <sources>
+                                <source>src/gen/java</source>
+                            </sources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>${maven.compiler.plugin.version}</version>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/components/org.wso2.carbon.identity.api.server.device.policy/org.wso2.carbon.identity.api.server.device.policy.v1/src/gen/java/org/wso2/carbon/identity/api/server/device/policy/v1/DevicePoliciesApi.java
+++ b/components/org.wso2.carbon.identity.api.server.device.policy/org.wso2.carbon.identity.api.server.device.policy.v1/src/gen/java/org/wso2/carbon/identity/api/server/device/policy/v1/DevicePoliciesApi.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.device.policy.v1;
+
+import org.apache.cxf.jaxrs.ext.multipart.Attachment;
+import org.apache.cxf.jaxrs.ext.multipart.Multipart;
+import java.io.InputStream;
+import java.util.List;
+
+import org.wso2.carbon.identity.api.server.device.policy.v1.model.DevicePolicyFieldDefinition;
+import org.wso2.carbon.identity.api.server.device.policy.v1.model.Error;
+import org.wso2.carbon.identity.api.server.device.policy.v1.DevicePoliciesApiService;
+import org.wso2.carbon.identity.api.server.device.policy.v1.factories.DevicePoliciesApiServiceFactory;
+
+import javax.validation.Valid;
+import javax.ws.rs.*;
+import javax.ws.rs.core.Response;
+import io.swagger.annotations.*;
+
+import javax.validation.constraints.*;
+
+@Path("/device-policies")
+@Api(description = "The device-policies API")
+
+public class DevicePoliciesApi  {
+
+    private final DevicePoliciesApiService delegate;
+
+    public DevicePoliciesApi() {
+
+        this.delegate = DevicePoliciesApiServiceFactory.getDevicePoliciesApi();
+    }
+
+    @Valid
+    @GET
+    @Path("/metadata")
+    
+    @Produces({ "application/json" })
+    @ApiOperation(value = "Get device policy field metadata filtered by platform.", notes = "Returns the list of rule fields applicable for the devicePolicy flow, optionally filtered to a specific platform. Used by the UI to populate the rule builder with platform-relevant fields only. ", response = DevicePolicyFieldDefinition.class, responseContainer = "List", authorizations = {
+        @Authorization(value = "BasicAuth"),
+        @Authorization(value = "OAuth2", scopes = {
+            
+        })
+    }, tags={ "Device Policy Management" })
+    @ApiResponses(value = { 
+        @ApiResponse(code = 200, message = "Applicable fields for the given platform.", response = DevicePolicyFieldDefinition.class, responseContainer = "List"),
+        @ApiResponse(code = 400, message = "Bad Request", response = Error.class),
+        @ApiResponse(code = 401, message = "Unauthorized", response = Void.class),
+        @ApiResponse(code = 403, message = "Forbidden", response = Void.class),
+        @ApiResponse(code = 500, message = "Server Error", response = Error.class)
+    })
+    public Response getDevicePolicyMetadata(    @Valid@ApiParam(value = "Filter fields to those applicable for this platform. If omitted all fields are returned.", allowableValues="android, ios, macos, windows")  @QueryParam("platform") String platform) {
+
+        return delegate.getDevicePolicyMetadata(platform );
+    }
+
+}

--- a/components/org.wso2.carbon.identity.api.server.device.policy/org.wso2.carbon.identity.api.server.device.policy.v1/src/gen/java/org/wso2/carbon/identity/api/server/device/policy/v1/DevicePoliciesApiService.java
+++ b/components/org.wso2.carbon.identity.api.server.device.policy/org.wso2.carbon.identity.api.server.device.policy.v1/src/gen/java/org/wso2/carbon/identity/api/server/device/policy/v1/DevicePoliciesApiService.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.device.policy.v1;
+
+import org.wso2.carbon.identity.api.server.device.policy.v1.*;
+import org.wso2.carbon.identity.api.server.device.policy.v1.model.*;
+import org.apache.cxf.jaxrs.ext.multipart.Attachment;
+import org.apache.cxf.jaxrs.ext.multipart.Multipart;
+import java.io.InputStream;
+import java.util.List;
+import org.wso2.carbon.identity.api.server.device.policy.v1.model.DevicePolicyFieldDefinition;
+import org.wso2.carbon.identity.api.server.device.policy.v1.model.Error;
+import javax.ws.rs.core.Response;
+
+
+public interface DevicePoliciesApiService {
+
+      public Response getDevicePolicyMetadata(String platform);
+}

--- a/components/org.wso2.carbon.identity.api.server.device.policy/org.wso2.carbon.identity.api.server.device.policy.v1/src/gen/java/org/wso2/carbon/identity/api/server/device/policy/v1/factories/DevicePoliciesApiServiceFactory.java
+++ b/components/org.wso2.carbon.identity.api.server.device.policy/org.wso2.carbon.identity.api.server.device.policy.v1/src/gen/java/org/wso2/carbon/identity/api/server/device/policy/v1/factories/DevicePoliciesApiServiceFactory.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.device.policy.v1.factories;
+
+import org.wso2.carbon.identity.api.server.device.policy.v1.DevicePoliciesApiService;
+import org.wso2.carbon.identity.api.server.device.policy.v1.impl.DevicePoliciesApiServiceImpl;
+
+public class DevicePoliciesApiServiceFactory {
+
+   private final static DevicePoliciesApiService SERVICE = new DevicePoliciesApiServiceImpl();
+
+   public static DevicePoliciesApiService getDevicePoliciesApi() {
+
+      return SERVICE;
+   }
+}

--- a/components/org.wso2.carbon.identity.api.server.device.policy/org.wso2.carbon.identity.api.server.device.policy.v1/src/gen/java/org/wso2/carbon/identity/api/server/device/policy/v1/model/DevicePolicyField.java
+++ b/components/org.wso2.carbon.identity.api.server.device.policy/org.wso2.carbon.identity.api.server.device.policy.v1/src/gen/java/org/wso2/carbon/identity/api/server/device/policy/v1/model/DevicePolicyField.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.device.policy.v1.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import javax.validation.constraints.*;
+
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+import javax.validation.Valid;
+import javax.xml.bind.annotation.*;
+
+public class DevicePolicyField  {
+  
+    private String name;
+    private String displayName;
+
+    /**
+    **/
+    public DevicePolicyField name(String name) {
+
+        this.name = name;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "platform", value = "")
+    @JsonProperty("name")
+    @Valid
+    public String getName() {
+        return name;
+    }
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    /**
+    **/
+    public DevicePolicyField displayName(String displayName) {
+
+        this.displayName = displayName;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "platform", value = "")
+    @JsonProperty("displayName")
+    @Valid
+    public String getDisplayName() {
+        return displayName;
+    }
+    public void setDisplayName(String displayName) {
+        this.displayName = displayName;
+    }
+
+
+
+    @Override
+    public boolean equals(java.lang.Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        DevicePolicyField devicePolicyField = (DevicePolicyField) o;
+        return Objects.equals(this.name, devicePolicyField.name) &&
+            Objects.equals(this.displayName, devicePolicyField.displayName);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, displayName);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class DevicePolicyField {\n");
+        
+        sb.append("    name: ").append(toIndentedString(name)).append("\n");
+        sb.append("    displayName: ").append(toIndentedString(displayName)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+    * Convert the given object to string with each line indented by 4 spaces
+    * (except the first line).
+    */
+    private String toIndentedString(java.lang.Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}
+

--- a/components/org.wso2.carbon.identity.api.server.device.policy/org.wso2.carbon.identity.api.server.device.policy.v1/src/gen/java/org/wso2/carbon/identity/api/server/device/policy/v1/model/DevicePolicyFieldDefinition.java
+++ b/components/org.wso2.carbon.identity.api.server.device.policy/org.wso2.carbon.identity.api.server.device.policy.v1/src/gen/java/org/wso2/carbon/identity/api/server/device/policy/v1/model/DevicePolicyFieldDefinition.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.device.policy.v1.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import java.util.ArrayList;
+import java.util.List;
+import org.wso2.carbon.identity.api.server.device.policy.v1.model.DevicePolicyField;
+import org.wso2.carbon.identity.api.server.device.policy.v1.model.DevicePolicyOperator;
+import org.wso2.carbon.identity.api.server.device.policy.v1.model.DevicePolicyValue;
+import javax.validation.constraints.*;
+
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+import javax.validation.Valid;
+import javax.xml.bind.annotation.*;
+
+public class DevicePolicyFieldDefinition  {
+  
+    private DevicePolicyField field;
+    private List<DevicePolicyOperator> operators = null;
+
+    private DevicePolicyValue value;
+
+    /**
+    **/
+    public DevicePolicyFieldDefinition field(DevicePolicyField field) {
+
+        this.field = field;
+        return this;
+    }
+    
+    @ApiModelProperty(value = "")
+    @JsonProperty("field")
+    @Valid
+    public DevicePolicyField getField() {
+        return field;
+    }
+    public void setField(DevicePolicyField field) {
+        this.field = field;
+    }
+
+    /**
+    **/
+    public DevicePolicyFieldDefinition operators(List<DevicePolicyOperator> operators) {
+
+        this.operators = operators;
+        return this;
+    }
+    
+    @ApiModelProperty(value = "")
+    @JsonProperty("operators")
+    @Valid
+    public List<DevicePolicyOperator> getOperators() {
+        return operators;
+    }
+    public void setOperators(List<DevicePolicyOperator> operators) {
+        this.operators = operators;
+    }
+
+    public DevicePolicyFieldDefinition addOperatorsItem(DevicePolicyOperator operatorsItem) {
+        if (this.operators == null) {
+            this.operators = new ArrayList<>();
+        }
+        this.operators.add(operatorsItem);
+        return this;
+    }
+
+        /**
+    **/
+    public DevicePolicyFieldDefinition value(DevicePolicyValue value) {
+
+        this.value = value;
+        return this;
+    }
+    
+    @ApiModelProperty(value = "")
+    @JsonProperty("value")
+    @Valid
+    public DevicePolicyValue getValue() {
+        return value;
+    }
+    public void setValue(DevicePolicyValue value) {
+        this.value = value;
+    }
+
+
+
+    @Override
+    public boolean equals(java.lang.Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        DevicePolicyFieldDefinition devicePolicyFieldDefinition = (DevicePolicyFieldDefinition) o;
+        return Objects.equals(this.field, devicePolicyFieldDefinition.field) &&
+            Objects.equals(this.operators, devicePolicyFieldDefinition.operators) &&
+            Objects.equals(this.value, devicePolicyFieldDefinition.value);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(field, operators, value);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class DevicePolicyFieldDefinition {\n");
+        
+        sb.append("    field: ").append(toIndentedString(field)).append("\n");
+        sb.append("    operators: ").append(toIndentedString(operators)).append("\n");
+        sb.append("    value: ").append(toIndentedString(value)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+    * Convert the given object to string with each line indented by 4 spaces
+    * (except the first line).
+    */
+    private String toIndentedString(java.lang.Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}
+

--- a/components/org.wso2.carbon.identity.api.server.device.policy/org.wso2.carbon.identity.api.server.device.policy.v1/src/gen/java/org/wso2/carbon/identity/api/server/device/policy/v1/model/DevicePolicyLink.java
+++ b/components/org.wso2.carbon.identity.api.server.device.policy/org.wso2.carbon.identity.api.server.device.policy.v1/src/gen/java/org/wso2/carbon/identity/api/server/device/policy/v1/model/DevicePolicyLink.java
@@ -1,0 +1,206 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.device.policy.v1.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import javax.validation.constraints.*;
+
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+import javax.validation.Valid;
+import javax.xml.bind.annotation.*;
+
+public class DevicePolicyLink  {
+  
+    private String href;
+
+@XmlType(name="MethodEnum")
+@XmlEnum(String.class)
+public enum MethodEnum {
+
+    @XmlEnumValue("GET") GET(String.valueOf("GET"));
+
+
+    private String value;
+
+    MethodEnum(String v) {
+        value = v;
+    }
+
+    public String value() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    public static MethodEnum fromValue(String value) {
+        for (MethodEnum b : MethodEnum.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
+}
+
+    private MethodEnum method;
+
+@XmlType(name="RelEnum")
+@XmlEnum(String.class)
+public enum RelEnum {
+
+    @XmlEnumValue("values") VALUES(String.valueOf("values")), @XmlEnumValue("filter") FILTER(String.valueOf("filter"));
+
+
+    private String value;
+
+    RelEnum(String v) {
+        value = v;
+    }
+
+    public String value() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    public static RelEnum fromValue(String value) {
+        for (RelEnum b : RelEnum.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
+}
+
+    private RelEnum rel;
+
+    /**
+    **/
+    public DevicePolicyLink href(String href) {
+
+        this.href = href;
+        return this;
+    }
+    
+    @ApiModelProperty(value = "")
+    @JsonProperty("href")
+    @Valid
+    public String getHref() {
+        return href;
+    }
+    public void setHref(String href) {
+        this.href = href;
+    }
+
+    /**
+    **/
+    public DevicePolicyLink method(MethodEnum method) {
+
+        this.method = method;
+        return this;
+    }
+    
+    @ApiModelProperty(value = "")
+    @JsonProperty("method")
+    @Valid
+    public MethodEnum getMethod() {
+        return method;
+    }
+    public void setMethod(MethodEnum method) {
+        this.method = method;
+    }
+
+    /**
+    **/
+    public DevicePolicyLink rel(RelEnum rel) {
+
+        this.rel = rel;
+        return this;
+    }
+    
+    @ApiModelProperty(value = "")
+    @JsonProperty("rel")
+    @Valid
+    public RelEnum getRel() {
+        return rel;
+    }
+    public void setRel(RelEnum rel) {
+        this.rel = rel;
+    }
+
+
+
+    @Override
+    public boolean equals(java.lang.Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        DevicePolicyLink devicePolicyLink = (DevicePolicyLink) o;
+        return Objects.equals(this.href, devicePolicyLink.href) &&
+            Objects.equals(this.method, devicePolicyLink.method) &&
+            Objects.equals(this.rel, devicePolicyLink.rel);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(href, method, rel);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class DevicePolicyLink {\n");
+        
+        sb.append("    href: ").append(toIndentedString(href)).append("\n");
+        sb.append("    method: ").append(toIndentedString(method)).append("\n");
+        sb.append("    rel: ").append(toIndentedString(rel)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+    * Convert the given object to string with each line indented by 4 spaces
+    * (except the first line).
+    */
+    private String toIndentedString(java.lang.Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}
+

--- a/components/org.wso2.carbon.identity.api.server.device.policy/org.wso2.carbon.identity.api.server.device.policy.v1/src/gen/java/org/wso2/carbon/identity/api/server/device/policy/v1/model/DevicePolicyOperator.java
+++ b/components/org.wso2.carbon.identity.api.server.device.policy/org.wso2.carbon.identity.api.server.device.policy.v1/src/gen/java/org/wso2/carbon/identity/api/server/device/policy/v1/model/DevicePolicyOperator.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.device.policy.v1.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import javax.validation.constraints.*;
+
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+import javax.validation.Valid;
+import javax.xml.bind.annotation.*;
+
+public class DevicePolicyOperator  {
+  
+    private String name;
+    private String displayName;
+
+    /**
+    **/
+    public DevicePolicyOperator name(String name) {
+
+        this.name = name;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "equals", value = "")
+    @JsonProperty("name")
+    @Valid
+    public String getName() {
+        return name;
+    }
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    /**
+    **/
+    public DevicePolicyOperator displayName(String displayName) {
+
+        this.displayName = displayName;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "equals", value = "")
+    @JsonProperty("displayName")
+    @Valid
+    public String getDisplayName() {
+        return displayName;
+    }
+    public void setDisplayName(String displayName) {
+        this.displayName = displayName;
+    }
+
+
+
+    @Override
+    public boolean equals(java.lang.Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        DevicePolicyOperator devicePolicyOperator = (DevicePolicyOperator) o;
+        return Objects.equals(this.name, devicePolicyOperator.name) &&
+            Objects.equals(this.displayName, devicePolicyOperator.displayName);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, displayName);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class DevicePolicyOperator {\n");
+        
+        sb.append("    name: ").append(toIndentedString(name)).append("\n");
+        sb.append("    displayName: ").append(toIndentedString(displayName)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+    * Convert the given object to string with each line indented by 4 spaces
+    * (except the first line).
+    */
+    private String toIndentedString(java.lang.Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}
+

--- a/components/org.wso2.carbon.identity.api.server.device.policy/org.wso2.carbon.identity.api.server.device.policy.v1/src/gen/java/org/wso2/carbon/identity/api/server/device/policy/v1/model/DevicePolicyValue.java
+++ b/components/org.wso2.carbon.identity.api.server.device.policy/org.wso2.carbon.identity.api.server.device.policy.v1/src/gen/java/org/wso2/carbon/identity/api/server/device/policy/v1/model/DevicePolicyValue.java
@@ -1,0 +1,249 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.device.policy.v1.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import java.util.ArrayList;
+import java.util.List;
+import org.wso2.carbon.identity.api.server.device.policy.v1.model.DevicePolicyLink;
+import org.wso2.carbon.identity.api.server.device.policy.v1.model.DevicePolicyValueObject;
+import javax.validation.constraints.*;
+
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+import javax.validation.Valid;
+import javax.xml.bind.annotation.*;
+
+public class DevicePolicyValue  {
+  
+
+@XmlType(name="InputTypeEnum")
+@XmlEnum(String.class)
+public enum InputTypeEnum {
+
+    @XmlEnumValue("input") INPUT(String.valueOf("input")), @XmlEnumValue("options") OPTIONS(String.valueOf("options"));
+
+
+    private String value;
+
+    InputTypeEnum(String v) {
+        value = v;
+    }
+
+    public String value() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    public static InputTypeEnum fromValue(String value) {
+        for (InputTypeEnum b : InputTypeEnum.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
+}
+
+    private InputTypeEnum inputType;
+
+@XmlType(name="ValueTypeEnum")
+@XmlEnum(String.class)
+public enum ValueTypeEnum {
+
+    @XmlEnumValue("string") STRING(String.valueOf("string")), @XmlEnumValue("number") NUMBER(String.valueOf("number")), @XmlEnumValue("boolean") BOOLEAN(String.valueOf("boolean")), @XmlEnumValue("date") DATE(String.valueOf("date")), @XmlEnumValue("reference") REFERENCE(String.valueOf("reference")), @XmlEnumValue("symbolic") SYMBOLIC(String.valueOf("symbolic"));
+
+
+    private String value;
+
+    ValueTypeEnum(String v) {
+        value = v;
+    }
+
+    public String value() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    public static ValueTypeEnum fromValue(String value) {
+        for (ValueTypeEnum b : ValueTypeEnum.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
+}
+
+    private ValueTypeEnum valueType;
+    private List<DevicePolicyValueObject> values = null;
+
+    private List<DevicePolicyLink> links = null;
+
+
+    /**
+    **/
+    public DevicePolicyValue inputType(InputTypeEnum inputType) {
+
+        this.inputType = inputType;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "options", value = "")
+    @JsonProperty("inputType")
+    @Valid
+    public InputTypeEnum getInputType() {
+        return inputType;
+    }
+    public void setInputType(InputTypeEnum inputType) {
+        this.inputType = inputType;
+    }
+
+    /**
+    **/
+    public DevicePolicyValue valueType(ValueTypeEnum valueType) {
+
+        this.valueType = valueType;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "string", value = "")
+    @JsonProperty("valueType")
+    @Valid
+    public ValueTypeEnum getValueType() {
+        return valueType;
+    }
+    public void setValueType(ValueTypeEnum valueType) {
+        this.valueType = valueType;
+    }
+
+    /**
+    **/
+    public DevicePolicyValue values(List<DevicePolicyValueObject> values) {
+
+        this.values = values;
+        return this;
+    }
+    
+    @ApiModelProperty(value = "")
+    @JsonProperty("values")
+    @Valid
+    public List<DevicePolicyValueObject> getValues() {
+        return values;
+    }
+    public void setValues(List<DevicePolicyValueObject> values) {
+        this.values = values;
+    }
+
+    public DevicePolicyValue addValuesItem(DevicePolicyValueObject valuesItem) {
+        if (this.values == null) {
+            this.values = new ArrayList<>();
+        }
+        this.values.add(valuesItem);
+        return this;
+    }
+
+        /**
+    **/
+    public DevicePolicyValue links(List<DevicePolicyLink> links) {
+
+        this.links = links;
+        return this;
+    }
+    
+    @ApiModelProperty(value = "")
+    @JsonProperty("links")
+    @Valid
+    public List<DevicePolicyLink> getLinks() {
+        return links;
+    }
+    public void setLinks(List<DevicePolicyLink> links) {
+        this.links = links;
+    }
+
+    public DevicePolicyValue addLinksItem(DevicePolicyLink linksItem) {
+        if (this.links == null) {
+            this.links = new ArrayList<>();
+        }
+        this.links.add(linksItem);
+        return this;
+    }
+
+    
+
+    @Override
+    public boolean equals(java.lang.Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        DevicePolicyValue devicePolicyValue = (DevicePolicyValue) o;
+        return Objects.equals(this.inputType, devicePolicyValue.inputType) &&
+            Objects.equals(this.valueType, devicePolicyValue.valueType) &&
+            Objects.equals(this.values, devicePolicyValue.values) &&
+            Objects.equals(this.links, devicePolicyValue.links);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(inputType, valueType, values, links);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class DevicePolicyValue {\n");
+        
+        sb.append("    inputType: ").append(toIndentedString(inputType)).append("\n");
+        sb.append("    valueType: ").append(toIndentedString(valueType)).append("\n");
+        sb.append("    values: ").append(toIndentedString(values)).append("\n");
+        sb.append("    links: ").append(toIndentedString(links)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+    * Convert the given object to string with each line indented by 4 spaces
+    * (except the first line).
+    */
+    private String toIndentedString(java.lang.Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}
+

--- a/components/org.wso2.carbon.identity.api.server.device.policy/org.wso2.carbon.identity.api.server.device.policy.v1/src/gen/java/org/wso2/carbon/identity/api/server/device/policy/v1/model/DevicePolicyValueObject.java
+++ b/components/org.wso2.carbon.identity.api.server.device.policy/org.wso2.carbon.identity.api.server.device.policy.v1/src/gen/java/org/wso2/carbon/identity/api/server/device/policy/v1/model/DevicePolicyValueObject.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.device.policy.v1.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import javax.validation.constraints.*;
+
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+import javax.validation.Valid;
+import javax.xml.bind.annotation.*;
+
+public class DevicePolicyValueObject  {
+  
+    private String name;
+    private String displayName;
+
+    /**
+    **/
+    public DevicePolicyValueObject name(String name) {
+
+        this.name = name;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "android", value = "")
+    @JsonProperty("name")
+    @Valid
+    public String getName() {
+        return name;
+    }
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    /**
+    **/
+    public DevicePolicyValueObject displayName(String displayName) {
+
+        this.displayName = displayName;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "Android", value = "")
+    @JsonProperty("displayName")
+    @Valid
+    public String getDisplayName() {
+        return displayName;
+    }
+    public void setDisplayName(String displayName) {
+        this.displayName = displayName;
+    }
+
+
+
+    @Override
+    public boolean equals(java.lang.Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        DevicePolicyValueObject devicePolicyValueObject = (DevicePolicyValueObject) o;
+        return Objects.equals(this.name, devicePolicyValueObject.name) &&
+            Objects.equals(this.displayName, devicePolicyValueObject.displayName);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, displayName);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class DevicePolicyValueObject {\n");
+        
+        sb.append("    name: ").append(toIndentedString(name)).append("\n");
+        sb.append("    displayName: ").append(toIndentedString(displayName)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+    * Convert the given object to string with each line indented by 4 spaces
+    * (except the first line).
+    */
+    private String toIndentedString(java.lang.Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}
+

--- a/components/org.wso2.carbon.identity.api.server.device.policy/org.wso2.carbon.identity.api.server.device.policy.v1/src/gen/java/org/wso2/carbon/identity/api/server/device/policy/v1/model/Error.java
+++ b/components/org.wso2.carbon.identity.api.server.device.policy/org.wso2.carbon.identity.api.server.device.policy.v1/src/gen/java/org/wso2/carbon/identity/api/server/device/policy/v1/model/Error.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.device.policy.v1.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import javax.validation.constraints.*;
+
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+import javax.validation.Valid;
+import javax.xml.bind.annotation.*;
+
+public class Error  {
+  
+    private String code;
+    private String message;
+    private String description;
+    private String traceId;
+
+    /**
+    **/
+    public Error code(String code) {
+
+        this.code = code;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "DPM-65001", value = "")
+    @JsonProperty("code")
+    @Valid
+    public String getCode() {
+        return code;
+    }
+    public void setCode(String code) {
+        this.code = code;
+    }
+
+    /**
+    **/
+    public Error message(String message) {
+
+        this.message = message;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "Some Error Message.", value = "")
+    @JsonProperty("message")
+    @Valid
+    public String getMessage() {
+        return message;
+    }
+    public void setMessage(String message) {
+        this.message = message;
+    }
+
+    /**
+    **/
+    public Error description(String description) {
+
+        this.description = description;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "Some Error Description.", value = "")
+    @JsonProperty("description")
+    @Valid
+    public String getDescription() {
+        return description;
+    }
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    /**
+    **/
+    public Error traceId(String traceId) {
+
+        this.traceId = traceId;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "e0fbcfeb-3617-43c4-8dd0-7b7d38e13047", value = "")
+    @JsonProperty("traceId")
+    @Valid
+    public String getTraceId() {
+        return traceId;
+    }
+    public void setTraceId(String traceId) {
+        this.traceId = traceId;
+    }
+
+
+
+    @Override
+    public boolean equals(java.lang.Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Error error = (Error) o;
+        return Objects.equals(this.code, error.code) &&
+            Objects.equals(this.message, error.message) &&
+            Objects.equals(this.description, error.description) &&
+            Objects.equals(this.traceId, error.traceId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(code, message, description, traceId);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class Error {\n");
+        
+        sb.append("    code: ").append(toIndentedString(code)).append("\n");
+        sb.append("    message: ").append(toIndentedString(message)).append("\n");
+        sb.append("    description: ").append(toIndentedString(description)).append("\n");
+        sb.append("    traceId: ").append(toIndentedString(traceId)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+    * Convert the given object to string with each line indented by 4 spaces
+    * (except the first line).
+    */
+    private String toIndentedString(java.lang.Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}
+

--- a/components/org.wso2.carbon.identity.api.server.device.policy/org.wso2.carbon.identity.api.server.device.policy.v1/src/main/java/org/wso2/carbon/identity/api/server/device/policy/v1/core/DevicePolicyMetadataService.java
+++ b/components/org.wso2.carbon.identity.api.server.device.policy/org.wso2.carbon.identity.api.server.device.policy.v1/src/main/java/org/wso2/carbon/identity/api/server/device/policy/v1/core/DevicePolicyMetadataService.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.device.policy.v1.core;
+
+import org.wso2.carbon.identity.api.server.common.ContextLoader;
+import org.wso2.carbon.identity.api.server.device.policy.common.Constants;
+import org.wso2.carbon.identity.api.server.device.policy.v1.model.DevicePolicyField;
+import org.wso2.carbon.identity.api.server.device.policy.v1.model.DevicePolicyFieldDefinition;
+import org.wso2.carbon.identity.api.server.device.policy.v1.model.DevicePolicyLink;
+import org.wso2.carbon.identity.api.server.device.policy.v1.model.DevicePolicyOperator;
+import org.wso2.carbon.identity.api.server.device.policy.v1.model.DevicePolicyValue;
+import org.wso2.carbon.identity.api.server.device.policy.v1.model.DevicePolicyValueObject;
+import org.wso2.carbon.identity.api.server.device.policy.v1.util.DevicePolicyAPIErrorBuilder;
+import org.wso2.carbon.identity.device.policy.api.service.DeviceFieldMetadataService;
+import org.wso2.carbon.identity.rule.metadata.api.exception.RuleMetadataException;
+import org.wso2.carbon.identity.rule.metadata.api.model.FieldDefinition;
+import org.wso2.carbon.identity.rule.metadata.api.model.FlowType;
+import org.wso2.carbon.identity.rule.metadata.api.model.Link;
+import org.wso2.carbon.identity.rule.metadata.api.model.Operator;
+import org.wso2.carbon.identity.rule.metadata.api.model.OptionsInputValue;
+import org.wso2.carbon.identity.rule.metadata.api.model.OptionsReferenceValue;
+import org.wso2.carbon.identity.rule.metadata.api.model.OptionsValue;
+import org.wso2.carbon.identity.rule.metadata.api.model.Value;
+import org.wso2.carbon.identity.rule.metadata.api.service.RuleMetadataService;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import javax.ws.rs.core.Response;
+
+/**
+ * Core service for the Device Policy API — serves device policy field metadata,
+ * optionally filtered by platform.
+ */
+public class DevicePolicyMetadataService {
+
+    private static final Set<String> SUPPORTED_PLATFORMS = Collections.unmodifiableSet(
+            new HashSet<>(Arrays.asList("android", "ios", "macos", "windows")));
+
+    private final RuleMetadataService ruleMetadataService;
+    private final DeviceFieldMetadataService deviceFieldMetadataService;
+
+    public DevicePolicyMetadataService(RuleMetadataService ruleMetadataService,
+                                       DeviceFieldMetadataService deviceFieldMetadataService) {
+
+        this.ruleMetadataService = ruleMetadataService;
+        this.deviceFieldMetadataService = deviceFieldMetadataService;
+    }
+
+    /**
+     * Returns device policy field metadata, optionally filtered to a specific platform.
+     * Retrieves field definitions from the rule metadata service and applies the platform
+     * filter based on the device field applicable-platforms mapping.
+     *
+     * @param platform Platform to filter by (android/ios/macos/windows); null returns all fields.
+     * @return List of device policy field definitions.
+     */
+    public List<DevicePolicyFieldDefinition> getMetadata(String platform) {
+
+        if (platform != null && !SUPPORTED_PLATFORMS.contains(platform)) {
+            throw DevicePolicyAPIErrorBuilder.handleException(Response.Status.BAD_REQUEST,
+                    Constants.ErrorMessage.ERROR_CODE_INVALID_PLATFORM);
+        }
+
+        try {
+            String tenantDomain = ContextLoader.getTenantDomainFromContext();
+            List<FieldDefinition> allFields =
+                    ruleMetadataService.getExpressionMeta(FlowType.DEVICE_POLICY, tenantDomain);
+
+            Map<String, List<String>> applicablePlatforms =
+                    deviceFieldMetadataService.getFieldApplicablePlatforms();
+
+            return allFields.stream()
+                    .filter(fd -> isApplicable(fd.getField().getName(), platform, applicablePlatforms))
+                    .map(this::toApiModel)
+                    .collect(Collectors.toList());
+        } catch (RuleMetadataException e) {
+            throw DevicePolicyAPIErrorBuilder.handleException(Response.Status.INTERNAL_SERVER_ERROR,
+                    Constants.ErrorMessage.ERROR_CODE_ERROR_RETRIEVING_METADATA, e);
+        }
+    }
+
+    private boolean isApplicable(String fieldName, String platform,
+                                 Map<String, List<String>> applicablePlatformsMap) {
+
+        if (platform == null) {
+            return true;
+        }
+        List<String> platforms = applicablePlatformsMap.get(fieldName);
+        return platforms == null || platforms.contains(platform);
+    }
+
+    private DevicePolicyFieldDefinition toApiModel(FieldDefinition fd) {
+
+        DevicePolicyField field = new DevicePolicyField();
+        field.setName(fd.getField().getName());
+        field.setDisplayName(fd.getField().getDisplayName());
+
+        List<DevicePolicyOperator> operators = new ArrayList<>();
+        for (Operator op : fd.getOperators()) {
+            DevicePolicyOperator apiOp = new DevicePolicyOperator();
+            apiOp.setName(op.getName());
+            apiOp.setDisplayName(op.getDisplayName());
+            operators.add(apiOp);
+        }
+
+        DevicePolicyValue value = new DevicePolicyValue();
+        Value coreValue = fd.getValue();
+        value.setInputType(DevicePolicyValue.InputTypeEnum.fromValue(
+                coreValue.getInputType().name().toLowerCase()));
+        value.setValueType(DevicePolicyValue.ValueTypeEnum.fromValue(
+                mapValueType(coreValue.getValueType())));
+
+        if (coreValue instanceof OptionsInputValue) {
+            List<DevicePolicyValueObject> values = new ArrayList<>();
+            for (OptionsValue ov : ((OptionsInputValue) coreValue).getValues()) {
+                DevicePolicyValueObject vo = new DevicePolicyValueObject();
+                vo.setName(ov.getName());
+                vo.setDisplayName(ov.getDisplayName());
+                values.add(vo);
+            }
+            value.setValues(values);
+        } else if (coreValue instanceof OptionsReferenceValue) {
+            List<DevicePolicyLink> links = new ArrayList<>();
+            for (Link l : ((OptionsReferenceValue) coreValue).getLinks()) {
+                DevicePolicyLink link = new DevicePolicyLink();
+                link.setHref(l.getHref());
+                link.setMethod(DevicePolicyLink.MethodEnum.fromValue(l.getMethod()));
+                link.setRel(DevicePolicyLink.RelEnum.fromValue(l.getRel()));
+                links.add(link);
+            }
+            value.setLinks(links);
+        }
+
+        DevicePolicyFieldDefinition result = new DevicePolicyFieldDefinition();
+        result.setField(field);
+        result.setOperators(operators);
+        result.setValue(value);
+        return result;
+    }
+
+    private String mapValueType(Value.ValueType valueType) {
+
+        if (valueType == Value.ValueType.DATE_TIME) {
+            return "date";
+        }
+        return valueType.name().toLowerCase();
+    }
+}

--- a/components/org.wso2.carbon.identity.api.server.device.policy/org.wso2.carbon.identity.api.server.device.policy.v1/src/main/java/org/wso2/carbon/identity/api/server/device/policy/v1/factories/DevicePolicyMetadataServiceFactory.java
+++ b/components/org.wso2.carbon.identity.api.server.device.policy/org.wso2.carbon.identity.api.server.device.policy.v1/src/main/java/org/wso2/carbon/identity/api/server/device/policy/v1/factories/DevicePolicyMetadataServiceFactory.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.device.policy.v1.factories;
+
+import org.wso2.carbon.identity.api.server.device.policy.common.DevicePolicyMetadataServiceHolder;
+import org.wso2.carbon.identity.api.server.device.policy.v1.core.DevicePolicyMetadataService;
+import org.wso2.carbon.identity.device.policy.api.service.DeviceFieldMetadataService;
+import org.wso2.carbon.identity.rule.metadata.api.service.RuleMetadataService;
+
+/**
+ * Factory class for DevicePolicyMetadataService.
+ * Gets the OSGi services from the ServiceHolder and injects them into DevicePolicyMetadataService.
+ * Created once at startup — singleton pattern using static initializer.
+ */
+public class DevicePolicyMetadataServiceFactory {
+
+    private static final DevicePolicyMetadataService SERVICE;
+
+    static {
+        RuleMetadataService ruleMetadataService = DevicePolicyMetadataServiceHolder.getRuleMetadataService();
+        DeviceFieldMetadataService deviceFieldMetadataService =
+                DevicePolicyMetadataServiceHolder.getDeviceFieldMetadataService();
+
+        if (ruleMetadataService == null) {
+            throw new IllegalStateException("RuleMetadataService is not available from OSGi context.");
+        }
+        if (deviceFieldMetadataService == null) {
+            throw new IllegalStateException("DeviceFieldMetadataService is not available from OSGi context.");
+        }
+
+        SERVICE = new DevicePolicyMetadataService(ruleMetadataService, deviceFieldMetadataService);
+    }
+
+    public static DevicePolicyMetadataService getDevicePolicyMetadataService() {
+
+        return SERVICE;
+    }
+}

--- a/components/org.wso2.carbon.identity.api.server.device.policy/org.wso2.carbon.identity.api.server.device.policy.v1/src/main/java/org/wso2/carbon/identity/api/server/device/policy/v1/impl/DevicePoliciesApiServiceImpl.java
+++ b/components/org.wso2.carbon.identity.api.server.device.policy/org.wso2.carbon.identity.api.server.device.policy.v1/src/main/java/org/wso2/carbon/identity/api/server/device/policy/v1/impl/DevicePoliciesApiServiceImpl.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.device.policy.v1.impl;
+
+import org.wso2.carbon.identity.api.server.device.policy.v1.DevicePoliciesApiService;
+import org.wso2.carbon.identity.api.server.device.policy.v1.core.DevicePolicyMetadataService;
+import org.wso2.carbon.identity.api.server.device.policy.v1.factories.DevicePolicyMetadataServiceFactory;
+
+import javax.ws.rs.core.Response;
+
+/**
+ * JAX-RS delegate implementation — bridges generated DevicePoliciesApiService to the core service.
+ */
+public class DevicePoliciesApiServiceImpl implements DevicePoliciesApiService {
+
+    private final DevicePolicyMetadataService devicePolicyMetadataService;
+
+    public DevicePoliciesApiServiceImpl() {
+
+        this.devicePolicyMetadataService = DevicePolicyMetadataServiceFactory.getDevicePolicyMetadataService();
+    }
+
+    @Override
+    public Response getDevicePolicyMetadata(String platform) {
+
+        return Response.ok().entity(devicePolicyMetadataService.getMetadata(platform)).build();
+    }
+}

--- a/components/org.wso2.carbon.identity.api.server.device.policy/org.wso2.carbon.identity.api.server.device.policy.v1/src/main/java/org/wso2/carbon/identity/api/server/device/policy/v1/util/DevicePolicyAPIErrorBuilder.java
+++ b/components/org.wso2.carbon.identity.api.server.device.policy/org.wso2.carbon.identity.api.server.device.policy.v1/src/main/java/org/wso2/carbon/identity/api/server/device/policy/v1/util/DevicePolicyAPIErrorBuilder.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.device.policy.v1.util;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.identity.api.server.common.error.APIError;
+import org.wso2.carbon.identity.api.server.common.error.ErrorResponse;
+import org.wso2.carbon.identity.api.server.device.policy.common.Constants;
+
+import javax.ws.rs.core.Response;
+
+/**
+ * Builds {@link APIError} instances for the Device Policy API.
+ */
+public class DevicePolicyAPIErrorBuilder {
+
+    private static final Log LOG = LogFactory.getLog(DevicePolicyAPIErrorBuilder.class);
+
+    private DevicePolicyAPIErrorBuilder() {
+
+    }
+
+    /**
+     * Build an APIError for an error detected at the API layer, with no backend cause to log
+     * (e.g. request validation failures).
+     *
+     * @param status    HTTP status to return.
+     * @param errorEnum API-layer error message.
+     * @return APIError to be thrown back to the JAX-RS layer.
+     */
+    public static APIError handleException(Response.Status status, Constants.ErrorMessage errorEnum) {
+
+        ErrorResponse errorResponse = new ErrorResponse.Builder()
+                .withCode(errorEnum.code())
+                .withMessage(errorEnum.message())
+                .withDescription(errorEnum.description())
+                .build();
+        return new APIError(status, errorResponse);
+    }
+
+    /**
+     * Build an APIError that wraps a backend cause (e.g. a failure while retrieving rule metadata).
+     * The cause is logged.
+     *
+     * @param status    HTTP status to return.
+     * @param errorEnum API-layer error message.
+     * @param cause     The underlying exception to log.
+     * @return APIError to be thrown back to the JAX-RS layer.
+     */
+    public static APIError handleException(Response.Status status, Constants.ErrorMessage errorEnum, Exception cause) {
+
+        ErrorResponse errorResponse = new ErrorResponse.Builder()
+                .withCode(errorEnum.code())
+                .withMessage(errorEnum.message())
+                .withDescription(errorEnum.description())
+                .build(LOG, cause, errorEnum.description());
+        return new APIError(status, errorResponse);
+    }
+}

--- a/components/org.wso2.carbon.identity.api.server.device.policy/org.wso2.carbon.identity.api.server.device.policy.v1/src/main/resources/device-policy.yaml
+++ b/components/org.wso2.carbon.identity.api.server.device.policy/org.wso2.carbon.identity.api.server.device.policy.v1/src/main/resources/device-policy.yaml
@@ -1,0 +1,165 @@
+openapi: 3.0.0
+info:
+  version: v1
+  title: 'WSO2 Identity Server - Device Policy API'
+  description: 'This document specifies a RESTful API for WSO2 Identity Server Device Policy Management'
+  contact:
+    name: WSO2
+    url: 'http://wso2.com/products/identity-server/'
+    email: architecture@wso2.org
+  license:
+    name: Apache 2.0
+    url: 'http://www.apache.org/licenses/LICENSE-2.0.html'
+security:
+  - OAuth2: []
+  - BasicAuth: []
+paths:
+  /device-policies/metadata:
+    get:
+      tags:
+        - Device Policy Management
+      summary: Get device policy field metadata filtered by platform.
+      operationId: getDevicePolicyMetadata
+      description: |
+        Returns the list of rule fields applicable for the devicePolicy flow,
+        optionally filtered to a specific platform. Used by the UI to populate
+        the rule builder with platform-relevant fields only.
+      parameters:
+        - name: platform
+          in: query
+          description: Filter fields to those applicable for this platform. If omitted all fields are returned.
+          required: false
+          schema:
+            type: string
+            enum:
+              - android
+              - ios
+              - macos
+              - windows
+      responses:
+        '200':
+          description: Applicable fields for the given platform.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/DevicePolicyFieldDefinition'
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '500':
+          description: Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+servers:
+  - url: 'https://localhost:9443/t/{tenant-domain}/api/server/v1'
+    variables:
+      tenant-domain:
+        default: carbon.super
+components:
+  securitySchemes:
+    BasicAuth:
+      type: http
+      scheme: basic
+    OAuth2:
+      type: oauth2
+      flows:
+        authorizationCode:
+          authorizationUrl: 'https://localhost:9443/oauth2/authorize'
+          tokenUrl: 'https://localhost:9443/oauth2/token'
+          scopes:
+            read: internal_device_policy_view
+  schemas:
+    DevicePolicyFieldDefinition:
+      type: object
+      properties:
+        field:
+          $ref: '#/components/schemas/DevicePolicyField'
+        operators:
+          type: array
+          items:
+            $ref: '#/components/schemas/DevicePolicyOperator'
+        value:
+          $ref: '#/components/schemas/DevicePolicyValue'
+    DevicePolicyField:
+      type: object
+      properties:
+        name:
+          type: string
+          example: platform
+        displayName:
+          type: string
+          example: platform
+    DevicePolicyOperator:
+      type: object
+      properties:
+        name:
+          type: string
+          example: equals
+        displayName:
+          type: string
+          example: equals
+    DevicePolicyValue:
+      type: object
+      properties:
+        inputType:
+          type: string
+          enum: [input, options]
+          example: options
+        valueType:
+          type: string
+          enum: [string, number, boolean, date, reference, symbolic]
+          example: string
+        values:
+          type: array
+          items:
+            $ref: '#/components/schemas/DevicePolicyValueObject'
+        links:
+          type: array
+          items:
+            $ref: '#/components/schemas/DevicePolicyLink'
+    DevicePolicyValueObject:
+      type: object
+      properties:
+        name:
+          type: string
+          example: android
+        displayName:
+          type: string
+          example: Android
+    DevicePolicyLink:
+      type: object
+      properties:
+        href:
+          type: string
+        method:
+          type: string
+          enum: [GET]
+        rel:
+          type: string
+          enum: [values, filter]
+    Error:
+      type: object
+      properties:
+        code:
+          type: string
+          example: DPM-65001
+        message:
+          type: string
+          example: Some Error Message.
+        description:
+          type: string
+          example: Some Error Description.
+        traceId:
+          type: string
+          example: "e0fbcfeb-3617-43c4-8dd0-7b7d38e13047"

--- a/components/org.wso2.carbon.identity.api.server.device.policy/pom.xml
+++ b/components/org.wso2.carbon.identity.api.server.device.policy/pom.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+  ~
+  ~ WSO2 LLC. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>identity-api-server</artifactId>
+        <groupId>org.wso2.carbon.identity.server.api</groupId>
+        <version>1.6.36-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>org.wso2.carbon.identity.api.server.device.policy</artifactId>
+    <packaging>pom</packaging>
+    <modules>
+        <module>org.wso2.carbon.identity.api.server.device.policy.common</module>
+        <module>org.wso2.carbon.identity.api.server.device.policy.v1</module>
+    </modules>
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -478,6 +478,12 @@
                 <scope>provided</scope>
             </dependency>
             <dependency>
+                <groupId>org.wso2.carbon.identity.server.api</groupId>
+                <artifactId>org.wso2.carbon.identity.api.server.device.policy.common</artifactId>
+                <version>${project.version}</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
                 <groupId>org.apache.cxf</groupId>
                 <artifactId>cxf-rt-rs-extension-search</artifactId>
                 <version>${cxf.extensions.search.version}</version>
@@ -1216,6 +1222,7 @@
         <module>components/org.wso2.carbon.identity.api.server.vc.template.management</module>
         <module>components/org.wso2.carbon.identity.api.server.credential.management</module>
         <module>components/org.wso2.carbon.identity.api.server.moesif.publisher</module>
+        <module>components/org.wso2.carbon.identity.api.server.device.policy</module>
     </modules>
 
 </project>


### PR DESCRIPTION
## Purpose
This PR introduces a new **Device Policy REST API** (`/api/server/v1/device-policies`) to the Identity Server API Server layer. It exposes device policy rule field metadata over HTTP so that the console rule builder can be populated with the fields applicable to a given device platform. Rule field metadata for the `devicePolicy` flow is served by the flow-agnostic `RuleMetadataService`, while platform applicability is device domain knowledge owned by `carbon-identity-framework`; this component composes the two so that `rule-mgt` never has to learn about device platforms.

## Goals
Expose platform-aware device policy field metadata through a versioned (`v1`) REST API:
- Return the rule fields applicable to the `devicePolicy` flow.
- Filter those fields to a single platform (`android`, `ios`, `macos`, `windows`) so that platform-irrelevant fields are not offered to the user.
- Treat fields with no declared platform restriction as universal, applicable to every platform.
- Reject unsupported platform values with `400` rather than silently returning a partial list.

## Approach
A new Maven component `org.wso2.carbon.identity.api.server.device.policy` is added with two modules, following the established API-server conventions:

- **`.common`** – shared `Constants` (error codes with the `DPM-` prefix) and `DevicePolicyMetadataServiceHolder`, which resolves the `RuleMetadataService` and `DeviceFieldMetadataService` OSGi services from the Carbon context.
- **`.v1`** – the versioned API:
  - `device-policy.yaml` – the OpenAPI 3.0 contract; the `src/gen` interfaces and models are generated from it.
  - `DevicePoliciesApiServiceImpl` – JAX-RS delegate; maps the core service result to a `200` response.
  - `DevicePolicyMetadataService` (core) – resolves the tenant domain from context, retrieves the `DEVICE_POLICY` field definitions from `RuleMetadataService`, applies the platform filter, and translates the framework models into the API models.
  - `DevicePolicyMetadataServiceFactory` – constructor-injects both OSGi services into the core service once at startup, failing fast if either is unavailable.
  - `DevicePolicyAPIErrorBuilder` – centralizes error construction, mapping request validation failures to 400 and metadata retrieval failures to 500.

The component is registered in the reactor and in `dependencyManagement` in the root `pom.xml`; no existing module is modified. The endpoint is guarded by the `internal_device_policy_view` scope.

## User stories
- As a tenant admin configuring a device policy for Android, I want to see only the rule fields that are meaningful on Android so that I do not build a rule that can never be satisfied.
- As a tenant admin, I want fields that apply to every platform to always be offered, regardless of which platform I am configuring.
- As an API client, I want an unsupported platform value to be rejected explicitly so that a typo does not silently produce an incomplete field list.

## Developer Checklist (Mandatory)

- [ ] Complete the **Developer Checklist** in the related `product-is` issue to track any behavioral change or migration impact.

## Release note
N/A

## Documentation
N/A

## Training
N/A

## Certification
N/A

## Marketing
N/A

## Automation tests
N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? <!-- yes/no -->
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
<!-- carbon-identity-framework PR introducing org.wso2.carbon.identity.device.policy -->

This PR depends on the new `org.wso2.carbon.identity.device.policy` component in `carbon-identity-framework`, which is not yet published to the WSO2 Maven repository.

## Migrations (if applicable)
N/A – new API, no migration required.

## Test environment
N/A

## Learning
N/A
