### PR TITLE
Add REST APIs for multiple client secrets and secret expiry

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/application/management/v1/ApplicationsApi.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/application/management/v1/ApplicationsApi.java
@@ -196,7 +196,7 @@ public class ApplicationsApi  {
     @Path("/{applicationId}/inbound-protocols/oidc/secrets")
     @Consumes({ "application/json" })
     @Produces({ "application/json" })
-    @ApiOperation(value = "Create a new OAuth2/OIDC client secret.", notes = "This API creates a new client secret for the application. Existing secrets, access tokens, refresh tokens, and authorization codes remain valid.  <b>Scope(Permission) required:</b> `internal_application_mgt_client_secret_create`  Responds with 404 when the multiple client secrets feature is disabled on the server.", response = ClientSecretResponse.class, authorizations = {
+    @ApiOperation(value = "Create a new OAuth2/OIDC client secret.", notes = "This API creates a new client secret for the application. Existing secrets, access tokens, refresh tokens, and authorization codes remain valid.  <b>Scope(Permission) required:</b> `internal_application_mgt_client_secret_create` ", response = ClientSecretResponse.class, authorizations = {
         @Authorization(value = "BasicAuth"),
         @Authorization(value = "OAuth2", scopes = {
             
@@ -363,7 +363,7 @@ public class ApplicationsApi  {
     @Path("/{applicationId}/inbound-protocols/oidc/secrets/{secretId}")
     
     @Produces({ "application/json" })
-    @ApiOperation(value = "Delete a specific OAuth2/OIDC client secret.", notes = "This API deletes the client secret identified by `secretId`. The application's most recently added active secret cannot be deleted — at least one active secret must remain per application.  <b>Scope(Permission) required:</b> `internal_application_mgt_client_secret_delete`  Responds with 404 when the multiple client secrets feature is disabled on the server.", response = Void.class, authorizations = {
+    @ApiOperation(value = "Delete a specific OAuth2/OIDC client secret.", notes = "This API deletes the client secret identified by `secretId`. The application's most recently added active secret cannot be deleted — at least one active secret must remain per application.  <b>Scope(Permission) required:</b> `internal_application_mgt_client_secret_delete` ", response = Void.class, authorizations = {
         @Authorization(value = "BasicAuth"),
         @Authorization(value = "OAuth2", scopes = {
             
@@ -891,7 +891,7 @@ public class ApplicationsApi  {
     @Path("/{applicationId}/inbound-protocols/oidc/secrets/{secretId}")
     
     @Produces({ "application/json" })
-    @ApiOperation(value = "Get a specific client secret's metadata.", notes = "This API returns the metadata of the client secret identified by `secretId`.  <b>Scope(Permission) required:</b> `internal_application_mgt_client_secret_view`  Responds with 404 when the multiple client secrets feature is disabled on the server.", response = ClientSecretResponse.class, authorizations = {
+    @ApiOperation(value = "Get a specific client secret's metadata.", notes = "This API returns the metadata of the client secret identified by `secretId`.  <b>Scope(Permission) required:</b> `internal_application_mgt_client_secret_view` ", response = ClientSecretResponse.class, authorizations = {
         @Authorization(value = "BasicAuth"),
         @Authorization(value = "OAuth2", scopes = {
             
@@ -915,7 +915,7 @@ public class ApplicationsApi  {
     @Path("/{applicationId}/inbound-protocols/oidc/secrets")
     
     @Produces({ "application/json" })
-    @ApiOperation(value = "List client secrets of the application.", notes = "This API returns metadata of all client secrets attached to the application.  <b>Scope(Permission) required:</b> `internal_application_mgt_client_secret_view`  Responds with 404 when the multiple client secrets feature is disabled on the server.", response = ClientSecretList.class, authorizations = {
+    @ApiOperation(value = "List client secrets of the application.", notes = "This API returns metadata of all client secrets attached to the application.  <b>Scope(Permission) required:</b> `internal_application_mgt_client_secret_view` ", response = ClientSecretList.class, authorizations = {
         @Authorization(value = "BasicAuth"),
         @Authorization(value = "OAuth2", scopes = {
             

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/application/management/v1/ApplicationsApi.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/application/management/v1/ApplicationsApi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2025, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2023-2026, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -42,6 +42,9 @@ import org.wso2.carbon.identity.api.server.application.management.v1.AuthProtoco
 import org.wso2.carbon.identity.api.server.application.management.v1.AuthorizedAPICreationModel;
 import org.wso2.carbon.identity.api.server.application.management.v1.AuthorizedAPIPatchModel;
 import org.wso2.carbon.identity.api.server.application.management.v1.AuthorizedAPIResponse;
+import org.wso2.carbon.identity.api.server.application.management.v1.ClientSecretCreationRequest;
+import org.wso2.carbon.identity.api.server.application.management.v1.ClientSecretList;
+import org.wso2.carbon.identity.api.server.application.management.v1.ClientSecretResponse;
 import org.wso2.carbon.identity.api.server.application.management.v1.ConfiguredAuthenticatorsModal;
 import org.wso2.carbon.identity.api.server.application.management.v1.CustomInboundProtocolConfiguration;
 import org.wso2.carbon.identity.api.server.application.management.v1.CustomInboundProtocolMetaData;
@@ -189,6 +192,31 @@ public class ApplicationsApi  {
     }
 
     @Valid
+    @POST
+    @Path("/{applicationId}/inbound-protocols/oidc/secrets")
+    @Consumes({ "application/json" })
+    @Produces({ "application/json" })
+    @ApiOperation(value = "Create a new OAuth2/OIDC client secret.", notes = "This API creates a new client secret for the application. Existing secrets, access tokens, refresh tokens, and authorization codes remain valid.  <b>Scope(Permission) required:</b> `internal_application_mgt_client_secret_create` ", response = ClientSecretResponse.class, authorizations = {
+        @Authorization(value = "BasicAuth"),
+        @Authorization(value = "OAuth2", scopes = {
+            
+        })
+    }, tags={ "Inbound Protocols - OAuth / OIDC", })
+    @ApiResponses(value = { 
+        @ApiResponse(code = 201, message = "Client secret created.", response = ClientSecretResponse.class),
+        @ApiResponse(code = 400, message = "Bad Request", response = Error.class),
+        @ApiResponse(code = 401, message = "Unauthorized", response = Void.class),
+        @ApiResponse(code = 403, message = "Forbidden", response = Void.class),
+        @ApiResponse(code = 404, message = "Not Found", response = Error.class),
+        @ApiResponse(code = 409, message = "Conflict — client secret limit reached for the application.", response = Error.class),
+        @ApiResponse(code = 500, message = "Server Error", response = Error.class)
+    })
+    public Response createOAuthClientSecret(@ApiParam(value = "ID of the application.",required=true) @PathParam("applicationId") String applicationId, @ApiParam(value = "" ) @Valid ClientSecretCreationRequest clientSecretCreationRequest) {
+
+        return delegate.createOAuthClientSecret(applicationId,  clientSecretCreationRequest );
+    }
+
+    @Valid
     @DELETE
     @Path("/{applicationId}")
     
@@ -328,6 +356,31 @@ public class ApplicationsApi  {
     public Response deleteInboundSAMLConfiguration(@ApiParam(value = "ID of the application.",required=true) @PathParam("applicationId") String applicationId) {
 
         return delegate.deleteInboundSAMLConfiguration(applicationId );
+    }
+
+    @Valid
+    @DELETE
+    @Path("/{applicationId}/inbound-protocols/oidc/secrets/{secretId}")
+    
+    @Produces({ "application/json" })
+    @ApiOperation(value = "Delete a specific OAuth2/OIDC client secret.", notes = "This API deletes the client secret identified by `secretId`. The application's most recently added active secret cannot be deleted — at least one active secret must remain per application.  <b>Scope(Permission) required:</b> `internal_application_mgt_client_secret_create` ", response = Void.class, authorizations = {
+        @Authorization(value = "BasicAuth"),
+        @Authorization(value = "OAuth2", scopes = {
+            
+        })
+    }, tags={ "Inbound Protocols - OAuth / OIDC", })
+    @ApiResponses(value = { 
+        @ApiResponse(code = 204, message = "Client secret deleted.", response = Void.class),
+        @ApiResponse(code = 400, message = "Bad Request", response = Error.class),
+        @ApiResponse(code = 401, message = "Unauthorized", response = Void.class),
+        @ApiResponse(code = 403, message = "Forbidden", response = Void.class),
+        @ApiResponse(code = 404, message = "Not Found", response = Error.class),
+        @ApiResponse(code = 409, message = "Conflict — cannot delete the last active client secret.", response = Error.class),
+        @ApiResponse(code = 500, message = "Server Error", response = Error.class)
+    })
+    public Response deleteOAuthClientSecret(@ApiParam(value = "ID of the application.",required=true) @PathParam("applicationId") String applicationId, @ApiParam(value = "ID of the client secret to delete.",required=true) @PathParam("secretId") String secretId) {
+
+        return delegate.deleteOAuthClientSecret(applicationId,  secretId );
     }
 
     @Valid
@@ -521,7 +574,7 @@ public class ApplicationsApi  {
         @ApiResponse(code = 500, message = "Server Error", response = Error.class),
         @ApiResponse(code = 501, message = "Not Implemented", response = Error.class)
     })
-    public Response getAllApplications(    @Valid @Min(1)@ApiParam(value = "Maximum number of records to return. ", defaultValue="30") @DefaultValue("30")  @QueryParam("limit") Integer limit,     @Valid@ApiParam(value = "Number of records to skip for pagination. ", defaultValue="0") @DefaultValue("0")  @QueryParam("offset") Integer offset,     @Valid@ApiParam(value = "Condition to filter the retrieval of records. Supports 'sw', 'co', 'ew', and 'eq' operations with 'and', 'or' logical operators. Note that 'and' and 'or' operators in filters follow the general precedence of logical operators. For example, A and B or C and D = (A and B) or (C and D)). Currently supports only filtering based on the 'name', the 'clientId', and the 'issuer' attributes.  /applications?filter=name+eq+user_portal <br> /applications?filter=name+co+prod+or+clientId+co+123 ")  @QueryParam("filter") String filter,     @Valid@ApiParam(value = "Define the order in which the retrieved records should be sorted. _This parameter is not supported yet._ ", allowableValues="ASC, DESC")  @QueryParam("sortOrder") String sortOrder,     @Valid@ApiParam(value = "Attribute by which the retrieved records should be sorted. _This parameter is not supported yet._ ")  @QueryParam("sortBy") String sortBy,     @Valid@ApiParam(value = "Specifies the required parameters in the response. Only 'advancedConfigurations', 'templateId', 'templateVersion', 'clientId', 'issuer',  and 'associatedRoles.allowedAudience' attributes are currently supported.  /applications?attributes=advancedConfigurations,templateId,templateVersion,clientId,issuer, associatedRoles.allowedAudience ")  @QueryParam("attributes") String attributes,     @Valid@ApiParam(value = "Specifies whether to include or exclude system portals in the response.  Default will be treated as false if parameter is not preset in the request.  /applications?excludeSystemPortals=true ")  @QueryParam("excludeSystemPortals") Boolean excludeSystemPortals) {
+    public Response getAllApplications(    @Valid @Min(1)@ApiParam(value = "Maximum number of records to return. ", defaultValue="30") @DefaultValue("30")  @QueryParam("limit") Integer limit,     @Valid@ApiParam(value = "Number of records to skip for pagination. ", defaultValue="0") @DefaultValue("0")  @QueryParam("offset") Integer offset,     @Valid@ApiParam(value = "Condition to filter the retrieval of records. Supports 'sw', 'co', 'ew', and 'eq' operations with 'and', 'or' logical operators. Note that 'and' and 'or' operators in filters follow the general precedence of logical operators. For example, A and B or C and D = (A and B) or (C and D)). Currently supports only filtering based on the 'name', the 'clientId', and the 'issuer' attributes.  /applications?filter=name+eq+user_portal <br> /applications?filter=name+co+prod+or+clientId+co+123 ")  @QueryParam("filter") String filter,     @Valid@ApiParam(value = "Define the order in which the retrieved records should be sorted. _This parameter is not supported yet._ ", allowableValues="ASC, DESC")  @QueryParam("sortOrder") String sortOrder,     @Valid@ApiParam(value = "Attribute by which the retrieved records should be sorted. _This parameter is not supported yet._ ")  @QueryParam("sortBy") String sortBy,     @Valid@ApiParam(value = "Specifies the required parameters in the response. Only 'advancedConfigurations', 'templateId', 'templateVersion', 'clientId', 'issuer', and 'associatedRoles.allowedAudience' attributes are currently supported.  /applications?attributes=advancedConfigurations,templateId,templateVersion,clientId,issuer, associatedRoles.allowedAudience ")  @QueryParam("attributes") String attributes,     @Valid@ApiParam(value = "Specifies whether to include or exclude system portals in the response.  Default will be treated as false if parameter is not preset in the request.  /applications?excludeSystemPortals=true ")  @QueryParam("excludeSystemPortals") Boolean excludeSystemPortals) {
 
         return delegate.getAllApplications(limit,  offset,  filter,  sortOrder,  sortBy,  attributes,  excludeSystemPortals );
     }
@@ -835,6 +888,54 @@ public class ApplicationsApi  {
 
     @Valid
     @GET
+    @Path("/{applicationId}/inbound-protocols/oidc/secrets/{secretId}")
+    
+    @Produces({ "application/json" })
+    @ApiOperation(value = "Get a specific client secret's metadata.", notes = "This API returns the metadata of the client secret identified by `secretId`.  <b>Scope(Permission) required:</b> `internal_application_mgt_client_secret_view` ", response = ClientSecretResponse.class, authorizations = {
+        @Authorization(value = "BasicAuth"),
+        @Authorization(value = "OAuth2", scopes = {
+            
+        })
+    }, tags={ "Inbound Protocols - OAuth / OIDC", })
+    @ApiResponses(value = { 
+        @ApiResponse(code = 200, message = "OK", response = ClientSecretResponse.class),
+        @ApiResponse(code = 400, message = "Bad Request", response = Error.class),
+        @ApiResponse(code = 401, message = "Unauthorized", response = Void.class),
+        @ApiResponse(code = 403, message = "Forbidden", response = Void.class),
+        @ApiResponse(code = 404, message = "Not Found", response = Error.class),
+        @ApiResponse(code = 500, message = "Server Error", response = Error.class)
+    })
+    public Response getOAuthClientSecret(@ApiParam(value = "ID of the application.",required=true) @PathParam("applicationId") String applicationId, @ApiParam(value = "ID of the client secret.",required=true) @PathParam("secretId") String secretId) {
+
+        return delegate.getOAuthClientSecret(applicationId,  secretId );
+    }
+
+    @Valid
+    @GET
+    @Path("/{applicationId}/inbound-protocols/oidc/secrets")
+    
+    @Produces({ "application/json" })
+    @ApiOperation(value = "List client secrets of the application.", notes = "This API returns metadata of all client secrets attached to the application.  <b>Scope(Permission) required:</b> `internal_application_mgt_client_secret_view` ", response = ClientSecretList.class, authorizations = {
+        @Authorization(value = "BasicAuth"),
+        @Authorization(value = "OAuth2", scopes = {
+            
+        })
+    }, tags={ "Inbound Protocols - OAuth / OIDC", })
+    @ApiResponses(value = { 
+        @ApiResponse(code = 200, message = "OK", response = ClientSecretList.class),
+        @ApiResponse(code = 400, message = "Bad Request", response = Error.class),
+        @ApiResponse(code = 401, message = "Unauthorized", response = Void.class),
+        @ApiResponse(code = 403, message = "Forbidden", response = Void.class),
+        @ApiResponse(code = 404, message = "Not Found", response = Error.class),
+        @ApiResponse(code = 500, message = "Server Error", response = Error.class)
+    })
+    public Response getOAuthClientSecrets(@ApiParam(value = "ID of the application.",required=true) @PathParam("applicationId") String applicationId) {
+
+        return delegate.getOAuthClientSecrets(applicationId );
+    }
+
+    @Valid
+    @GET
     @Path("/meta/inbound-protocols/oidc")
     
     @Produces({ "application/json" })
@@ -1093,9 +1194,8 @@ public class ApplicationsApi  {
     @Valid
     @POST
     @Path("/{applicationId}/inbound-protocols/oidc/regenerate-secret")
-    
     @Produces({ "application/json" })
-    @ApiOperation(value = "Regenerate the OAuth2/OIDC client secret. ", notes = "This API regenerates the OAuth2/OIDC client secret. <br>   <b>Scope(Permission) required:</b> `internal_application_mgt_create` ", response = OpenIDConnectConfiguration.class, authorizations = {
+    @ApiOperation(value = "Regenerate the OAuth2/OIDC client secret. ", notes = "This API regenerates a new client secret. Existing secrets, access tokens, refresh tokens, and authorization codes are revoked.  <b>Scope(Permission) required:</b> `internal_application_mgt_client_secret_create` ", response = OpenIDConnectConfiguration.class, authorizations = {
         @Authorization(value = "BasicAuth"),
         @Authorization(value = "OAuth2", scopes = {
             
@@ -1109,7 +1209,7 @@ public class ApplicationsApi  {
         @ApiResponse(code = 404, message = "Not Found", response = Error.class),
         @ApiResponse(code = 500, message = "Server Error", response = Error.class)
     })
-    public Response regenerateOAuthClientSecret(@ApiParam(value = "ID of the application",required=true) @PathParam("applicationId") String applicationId) {
+    public Response regenerateOAuthClientSecret(@ApiParam(value = "ID of the application.",required=true) @PathParam("applicationId") String applicationId) {
 
         return delegate.regenerateOAuthClientSecret(applicationId );
     }
@@ -1119,7 +1219,7 @@ public class ApplicationsApi  {
     @Path("/{applicationId}/inbound-protocols/oidc/revoke")
     
     @Produces({ "application/json" })
-    @ApiOperation(value = "Revoke the OAuth2/OIDC client of application. ", notes = "This API revokes the OAuth2/OIDC client secret. To re-activate the client, the client secret needs to be regenerated. <br>   <b>Scope(Permission) required:</b> `internal_application_mgt_create` ", response = Void.class, authorizations = {
+    @ApiOperation(value = "Revoke the OAuth2/OIDC client of application. ", notes = "This API revokes the OAuth2/OIDC client of application and all the client secrets. To re-activate the client, a client secret needs to be regenerated. <br>   <b>Scope(Permission) required:</b> `internal_application_mgt_create` ", response = Void.class, authorizations = {
         @Authorization(value = "BasicAuth"),
         @Authorization(value = "OAuth2", scopes = {
             

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/application/management/v1/ApplicationsApi.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/application/management/v1/ApplicationsApi.java
@@ -363,7 +363,7 @@ public class ApplicationsApi  {
     @Path("/{applicationId}/inbound-protocols/oidc/secrets/{secretId}")
     
     @Produces({ "application/json" })
-    @ApiOperation(value = "Delete a specific OAuth2/OIDC client secret.", notes = "This API deletes the client secret identified by `secretId`. The application's most recently added active secret cannot be deleted — at least one active secret must remain per application.  <b>Scope(Permission) required:</b> `internal_application_mgt_client_secret_create` ", response = Void.class, authorizations = {
+    @ApiOperation(value = "Delete a specific OAuth2/OIDC client secret.", notes = "This API deletes the client secret identified by `secretId`. The application's most recently added active secret cannot be deleted — at least one active secret must remain per application.  <b>Scope(Permission) required:</b> `internal_application_mgt_client_secret_delete` ", response = Void.class, authorizations = {
         @Authorization(value = "BasicAuth"),
         @Authorization(value = "OAuth2", scopes = {
             
@@ -1195,7 +1195,7 @@ public class ApplicationsApi  {
     @POST
     @Path("/{applicationId}/inbound-protocols/oidc/regenerate-secret")
     @Produces({ "application/json" })
-    @ApiOperation(value = "Regenerate the OAuth2/OIDC client secret. ", notes = "This API regenerates a new client secret. Existing secrets, access tokens, refresh tokens, and authorization codes are revoked.  <b>Scope(Permission) required:</b> `internal_application_mgt_client_secret_create` ", response = OpenIDConnectConfiguration.class, authorizations = {
+    @ApiOperation(value = "Regenerate the OAuth2/OIDC client secret. ", notes = "This API regenerates a new client secret. Existing secrets, access tokens, refresh tokens, and authorization codes are revoked.  <b>Scope(Permission) required:</b> `internal_application_mgt_client_secret_regenerate`  When the multiple client secrets feature is disabled, this endpoint falls back to the `internal_application_mgt_client_secret_create` scope. ", response = OpenIDConnectConfiguration.class, authorizations = {
         @Authorization(value = "BasicAuth"),
         @Authorization(value = "OAuth2", scopes = {
             

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/application/management/v1/ApplicationsApi.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/application/management/v1/ApplicationsApi.java
@@ -196,7 +196,7 @@ public class ApplicationsApi  {
     @Path("/{applicationId}/inbound-protocols/oidc/secrets")
     @Consumes({ "application/json" })
     @Produces({ "application/json" })
-    @ApiOperation(value = "Create a new OAuth2/OIDC client secret.", notes = "This API creates a new client secret for the application. Existing secrets, access tokens, refresh tokens, and authorization codes remain valid.  <b>Scope(Permission) required:</b> `internal_application_mgt_client_secret_create` ", response = ClientSecretResponse.class, authorizations = {
+    @ApiOperation(value = "Create a new OAuth2/OIDC client secret.", notes = "This API creates a new client secret for the application. Existing secrets, access tokens, refresh tokens, and authorization codes remain valid.  <b>Scope(Permission) required:</b> `internal_application_mgt_client_secret_create`  Responds with 404 when the multiple client secrets feature is disabled on the server.", response = ClientSecretResponse.class, authorizations = {
         @Authorization(value = "BasicAuth"),
         @Authorization(value = "OAuth2", scopes = {
             
@@ -363,7 +363,7 @@ public class ApplicationsApi  {
     @Path("/{applicationId}/inbound-protocols/oidc/secrets/{secretId}")
     
     @Produces({ "application/json" })
-    @ApiOperation(value = "Delete a specific OAuth2/OIDC client secret.", notes = "This API deletes the client secret identified by `secretId`. The application's most recently added active secret cannot be deleted — at least one active secret must remain per application.  <b>Scope(Permission) required:</b> `internal_application_mgt_client_secret_delete` ", response = Void.class, authorizations = {
+    @ApiOperation(value = "Delete a specific OAuth2/OIDC client secret.", notes = "This API deletes the client secret identified by `secretId`. The application's most recently added active secret cannot be deleted — at least one active secret must remain per application.  <b>Scope(Permission) required:</b> `internal_application_mgt_client_secret_delete`  Responds with 404 when the multiple client secrets feature is disabled on the server.", response = Void.class, authorizations = {
         @Authorization(value = "BasicAuth"),
         @Authorization(value = "OAuth2", scopes = {
             
@@ -891,7 +891,7 @@ public class ApplicationsApi  {
     @Path("/{applicationId}/inbound-protocols/oidc/secrets/{secretId}")
     
     @Produces({ "application/json" })
-    @ApiOperation(value = "Get a specific client secret's metadata.", notes = "This API returns the metadata of the client secret identified by `secretId`.  <b>Scope(Permission) required:</b> `internal_application_mgt_client_secret_view` ", response = ClientSecretResponse.class, authorizations = {
+    @ApiOperation(value = "Get a specific client secret's metadata.", notes = "This API returns the metadata of the client secret identified by `secretId`.  <b>Scope(Permission) required:</b> `internal_application_mgt_client_secret_view`  Responds with 404 when the multiple client secrets feature is disabled on the server.", response = ClientSecretResponse.class, authorizations = {
         @Authorization(value = "BasicAuth"),
         @Authorization(value = "OAuth2", scopes = {
             
@@ -915,7 +915,7 @@ public class ApplicationsApi  {
     @Path("/{applicationId}/inbound-protocols/oidc/secrets")
     
     @Produces({ "application/json" })
-    @ApiOperation(value = "List client secrets of the application.", notes = "This API returns metadata of all client secrets attached to the application.  <b>Scope(Permission) required:</b> `internal_application_mgt_client_secret_view` ", response = ClientSecretList.class, authorizations = {
+    @ApiOperation(value = "List client secrets of the application.", notes = "This API returns metadata of all client secrets attached to the application.  <b>Scope(Permission) required:</b> `internal_application_mgt_client_secret_view`  Responds with 404 when the multiple client secrets feature is disabled on the server.", response = ClientSecretList.class, authorizations = {
         @Authorization(value = "BasicAuth"),
         @Authorization(value = "OAuth2", scopes = {
             
@@ -1195,7 +1195,7 @@ public class ApplicationsApi  {
     @POST
     @Path("/{applicationId}/inbound-protocols/oidc/regenerate-secret")
     @Produces({ "application/json" })
-    @ApiOperation(value = "Regenerate the OAuth2/OIDC client secret. ", notes = "This API regenerates a new client secret. Existing secrets, access tokens, refresh tokens, and authorization codes are revoked.  <b>Scope(Permission) required:</b> `internal_application_mgt_client_secret_regenerate`  When the multiple client secrets feature is disabled, this endpoint falls back to the `internal_application_mgt_client_secret_create` scope. ", response = OpenIDConnectConfiguration.class, authorizations = {
+    @ApiOperation(value = "Regenerate the OAuth2/OIDC client secret. ", notes = "This API regenerates a new client secret. Existing secrets, access tokens, refresh tokens, and authorization codes are revoked.  <b>Scope(Permission) required:</b> `internal_application_mgt_client_secret_create` ", response = OpenIDConnectConfiguration.class, authorizations = {
         @Authorization(value = "BasicAuth"),
         @Authorization(value = "OAuth2", scopes = {
             

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/application/management/v1/ApplicationsApiService.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/application/management/v1/ApplicationsApiService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2024-2026, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -44,6 +44,9 @@ import org.wso2.carbon.identity.api.server.application.management.v1.AuthProtoco
 import org.wso2.carbon.identity.api.server.application.management.v1.AuthorizedAPICreationModel;
 import org.wso2.carbon.identity.api.server.application.management.v1.AuthorizedAPIPatchModel;
 import org.wso2.carbon.identity.api.server.application.management.v1.AuthorizedAPIResponse;
+import org.wso2.carbon.identity.api.server.application.management.v1.ClientSecretCreationRequest;
+import org.wso2.carbon.identity.api.server.application.management.v1.ClientSecretList;
+import org.wso2.carbon.identity.api.server.application.management.v1.ClientSecretResponse;
 import org.wso2.carbon.identity.api.server.application.management.v1.ConfiguredAuthenticatorsModal;
 import org.wso2.carbon.identity.api.server.application.management.v1.CustomInboundProtocolConfiguration;
 import org.wso2.carbon.identity.api.server.application.management.v1.CustomInboundProtocolMetaData;
@@ -82,6 +85,8 @@ public interface ApplicationsApiService {
 
       public Response createApplicationTemplate(ApplicationTemplateModel applicationTemplateModel);
 
+      public Response createOAuthClientSecret(String applicationId, ClientSecretCreationRequest clientSecretCreationRequest);
+
       public Response deleteApplication(String applicationId);
 
       public Response deleteApplicationTemplate(String templateId);
@@ -93,6 +98,8 @@ public interface ApplicationsApiService {
       public Response deleteInboundOAuthConfiguration(String applicationId);
 
       public Response deleteInboundSAMLConfiguration(String applicationId);
+
+      public Response deleteOAuthClientSecret(String applicationId, String secretId);
 
       public Response deletePassiveStsConfiguration(String applicationId);
 
@@ -137,6 +144,10 @@ public interface ApplicationsApiService {
       public Response getLoginFlowGenerationResult(String operationId);
 
       public Response getLoginFlowGenerationStatus(String operationId);
+
+      public Response getOAuthClientSecret(String applicationId, String secretId);
+
+      public Response getOAuthClientSecrets(String applicationId);
 
       public Response getOIDCMetadata();
 

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/application/management/v1/ClientSecretCreationRequest.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/application/management/v1/ClientSecretCreationRequest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.application.management.v1;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import javax.validation.constraints.*;
+
+/**
+ * Request payload for creating a new client secret.
+ **/
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+import javax.validation.Valid;
+import javax.xml.bind.annotation.*;
+@ApiModel(description = "Request payload for creating a new client secret.")
+public class ClientSecretCreationRequest  {
+  
+    private Long expiresAt;
+
+    /**
+    * Expiry time as Unix epoch seconds; must be a future time. 0 or omitted for a non-expiring secret.
+    **/
+    public ClientSecretCreationRequest expiresAt(Long expiresAt) {
+
+        this.expiresAt = expiresAt;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "1761568483", value = "Expiry time as Unix epoch seconds; must be a future time. 0 or omitted for a non-expiring secret.")
+    @JsonProperty("expiresAt")
+    @Valid
+    public Long getExpiresAt() {
+        return expiresAt;
+    }
+    public void setExpiresAt(Long expiresAt) {
+        this.expiresAt = expiresAt;
+    }
+
+
+
+    @Override
+    public boolean equals(java.lang.Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ClientSecretCreationRequest clientSecretCreationRequest = (ClientSecretCreationRequest) o;
+        return Objects.equals(this.expiresAt, clientSecretCreationRequest.expiresAt);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(expiresAt);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class ClientSecretCreationRequest {\n");
+        
+        sb.append("    expiresAt: ").append(toIndentedString(expiresAt)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+    * Convert the given object to string with each line indented by 4 spaces
+    * (except the first line).
+    */
+    private String toIndentedString(java.lang.Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}
+

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/application/management/v1/ClientSecretList.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/application/management/v1/ClientSecretList.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.application.management.v1;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import java.util.ArrayList;
+import java.util.List;
+import org.wso2.carbon.identity.api.server.application.management.v1.ClientSecretResponse;
+import javax.validation.constraints.*;
+
+/**
+ * List of client secrets attached to an application.
+ **/
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+import javax.validation.Valid;
+import javax.xml.bind.annotation.*;
+@ApiModel(description = "List of client secrets attached to an application.")
+public class ClientSecretList  {
+  
+    private Integer count;
+    private List<ClientSecretResponse> list = null;
+
+
+    /**
+    * Number of client secrets returned.
+    **/
+    public ClientSecretList count(Integer count) {
+
+        this.count = count;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "2", value = "Number of client secrets returned.")
+    @JsonProperty("count")
+    @Valid
+    public Integer getCount() {
+        return count;
+    }
+    public void setCount(Integer count) {
+        this.count = count;
+    }
+
+    /**
+    **/
+    public ClientSecretList list(List<ClientSecretResponse> list) {
+
+        this.list = list;
+        return this;
+    }
+    
+    @ApiModelProperty(value = "")
+    @JsonProperty("list")
+    @Valid
+    public List<ClientSecretResponse> getList() {
+        return list;
+    }
+    public void setList(List<ClientSecretResponse> list) {
+        this.list = list;
+    }
+
+    public ClientSecretList addListItem(ClientSecretResponse listItem) {
+        if (this.list == null) {
+            this.list = new ArrayList<>();
+        }
+        this.list.add(listItem);
+        return this;
+    }
+
+    
+
+    @Override
+    public boolean equals(java.lang.Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ClientSecretList clientSecretList = (ClientSecretList) o;
+        return Objects.equals(this.count, clientSecretList.count) &&
+            Objects.equals(this.list, clientSecretList.list);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(count, list);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class ClientSecretList {\n");
+        
+        sb.append("    count: ").append(toIndentedString(count)).append("\n");
+        sb.append("    list: ").append(toIndentedString(list)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+    * Convert the given object to string with each line indented by 4 spaces
+    * (except the first line).
+    */
+    private String toIndentedString(java.lang.Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}
+

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/application/management/v1/ClientSecretResponse.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/application/management/v1/ClientSecretResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -38,6 +38,7 @@ public class ClientSecretResponse  {
     private String secretId;
     private String secretValue;
     private Long expiresAt;
+    private Long createdAt;
 
 @XmlType(name="StatusEnum")
 @XmlEnum(String.class)
@@ -136,6 +137,25 @@ public enum StatusEnum {
     }
 
     /**
+    * Creation time as Unix epoch seconds.
+    **/
+    public ClientSecretResponse createdAt(Long createdAt) {
+
+        this.createdAt = createdAt;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "1761568483", value = "Creation time as Unix epoch seconds.")
+    @JsonProperty("createdAt")
+    @Valid
+    public Long getCreatedAt() {
+        return createdAt;
+    }
+    public void setCreatedAt(Long createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    /**
     * Status of the secret.
     **/
     public ClientSecretResponse status(StatusEnum status) {
@@ -192,13 +212,14 @@ public enum StatusEnum {
         return Objects.equals(this.secretId, clientSecretResponse.secretId) &&
             Objects.equals(this.secretValue, clientSecretResponse.secretValue) &&
             Objects.equals(this.expiresAt, clientSecretResponse.expiresAt) &&
+            Objects.equals(this.createdAt, clientSecretResponse.createdAt) &&
             Objects.equals(this.status, clientSecretResponse.status) &&
             Objects.equals(this.latest, clientSecretResponse.latest);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(secretId, secretValue, expiresAt, status, latest);
+        return Objects.hash(secretId, secretValue, expiresAt, createdAt, status, latest);
     }
 
     @Override
@@ -210,6 +231,7 @@ public enum StatusEnum {
         sb.append("    secretId: ").append(toIndentedString(secretId)).append("\n");
         sb.append("    secretValue: ").append(toIndentedString(secretValue)).append("\n");
         sb.append("    expiresAt: ").append(toIndentedString(expiresAt)).append("\n");
+        sb.append("    createdAt: ").append(toIndentedString(createdAt)).append("\n");
         sb.append("    status: ").append(toIndentedString(status)).append("\n");
         sb.append("    latest: ").append(toIndentedString(latest)).append("\n");
         sb.append("}");

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/application/management/v1/ClientSecretResponse.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/application/management/v1/ClientSecretResponse.java
@@ -1,0 +1,231 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.server.application.management.v1;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import javax.validation.constraints.*;
+
+/**
+ * Client secret details.
+ **/
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+import javax.validation.Valid;
+import javax.xml.bind.annotation.*;
+@ApiModel(description = "Client secret details.")
+public class ClientSecretResponse  {
+  
+    private String secretId;
+    private String secretValue;
+    private Long expiresAt;
+
+@XmlType(name="StatusEnum")
+@XmlEnum(String.class)
+public enum StatusEnum {
+
+    @XmlEnumValue("ACTIVE") ACTIVE(String.valueOf("ACTIVE")), @XmlEnumValue("EXPIRED") EXPIRED(String.valueOf("EXPIRED"));
+
+
+    private String value;
+
+    StatusEnum(String v) {
+        value = v;
+    }
+
+    public String value() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    public static StatusEnum fromValue(String value) {
+        for (StatusEnum b : StatusEnum.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
+}
+
+    private StatusEnum status;
+    private Boolean latest;
+
+    /**
+    * Identifier of the secret.
+    **/
+    public ClientSecretResponse secretId(String secretId) {
+
+        this.secretId = secretId;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "4a7f9b23-c1e0-4d86-b5fa-28c93a71b4ef", required = true, value = "Identifier of the secret.")
+    @JsonProperty("secretId")
+    @Valid
+    @NotNull(message = "Property secretId cannot be null.")
+
+    public String getSecretId() {
+        return secretId;
+    }
+    public void setSecretId(String secretId) {
+        this.secretId = secretId;
+    }
+
+    /**
+    * The client secret value, as maintained in the configured client secret persistence mode.
+    **/
+    public ClientSecretResponse secretValue(String secretValue) {
+
+        this.secretValue = secretValue;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "AbCd1234EfGh5678IjKlMnOp", value = "The client secret value, as maintained in the configured client secret persistence mode.")
+    @JsonProperty("secretValue")
+    @Valid
+    public String getSecretValue() {
+        return secretValue;
+    }
+    public void setSecretValue(String secretValue) {
+        this.secretValue = secretValue;
+    }
+
+    /**
+    * Expiry time as Unix epoch seconds; 0 if the secret never expires.
+    **/
+    public ClientSecretResponse expiresAt(Long expiresAt) {
+
+        this.expiresAt = expiresAt;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "1761568483", required = true, value = "Expiry time as Unix epoch seconds; 0 if the secret never expires.")
+    @JsonProperty("expiresAt")
+    @Valid
+    @NotNull(message = "Property expiresAt cannot be null.")
+
+    public Long getExpiresAt() {
+        return expiresAt;
+    }
+    public void setExpiresAt(Long expiresAt) {
+        this.expiresAt = expiresAt;
+    }
+
+    /**
+    * Status of the secret.
+    **/
+    public ClientSecretResponse status(StatusEnum status) {
+
+        this.status = status;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "ACTIVE", required = true, value = "Status of the secret.")
+    @JsonProperty("status")
+    @Valid
+    @NotNull(message = "Property status cannot be null.")
+
+    public StatusEnum getStatus() {
+        return status;
+    }
+    public void setStatus(StatusEnum status) {
+        this.status = status;
+    }
+
+    /**
+    * Whether this is the latest (active) secret of the application. The latest secret cannot be deleted.
+    **/
+    public ClientSecretResponse latest(Boolean latest) {
+
+        this.latest = latest;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "true", required = true, value = "Whether this is the latest (active) secret of the application. The latest secret cannot be deleted.")
+    @JsonProperty("latest")
+    @Valid
+    @NotNull(message = "Property latest cannot be null.")
+
+    public Boolean getLatest() {
+        return latest;
+    }
+    public void setLatest(Boolean latest) {
+        this.latest = latest;
+    }
+
+
+
+    @Override
+    public boolean equals(java.lang.Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ClientSecretResponse clientSecretResponse = (ClientSecretResponse) o;
+        return Objects.equals(this.secretId, clientSecretResponse.secretId) &&
+            Objects.equals(this.secretValue, clientSecretResponse.secretValue) &&
+            Objects.equals(this.expiresAt, clientSecretResponse.expiresAt) &&
+            Objects.equals(this.status, clientSecretResponse.status) &&
+            Objects.equals(this.latest, clientSecretResponse.latest);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(secretId, secretValue, expiresAt, status, latest);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class ClientSecretResponse {\n");
+        
+        sb.append("    secretId: ").append(toIndentedString(secretId)).append("\n");
+        sb.append("    secretValue: ").append(toIndentedString(secretValue)).append("\n");
+        sb.append("    expiresAt: ").append(toIndentedString(expiresAt)).append("\n");
+        sb.append("    status: ").append(toIndentedString(status)).append("\n");
+        sb.append("    latest: ").append(toIndentedString(latest)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+    * Convert the given object to string with each line indented by 4 spaces
+    * (except the first line).
+    */
+    private String toIndentedString(java.lang.Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}
+

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/application/management/v1/OpenIDConnectConfiguration.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/application/management/v1/OpenIDConnectConfiguration.java
@@ -148,7 +148,7 @@ public enum StateEnum {
     }
 
     /**
-    * Expiry time of the client secret as Unix epoch seconds; 0 if it never expires. On creation, sets the initial secret&#39;s expiry. Present in responses and effective in requests only when multiple client secrets are enabled.
+    * The expiration time of the latest client secret, expressed in Unix epoch seconds. A value of 0 indicates that the secret never expires.
     **/
     public OpenIDConnectConfiguration clientSecretExpiresAt(Long clientSecretExpiresAt) {
 
@@ -156,7 +156,7 @@ public enum StateEnum {
         return this;
     }
     
-    @ApiModelProperty(example = "1761568483", value = "Expiry time of the client secret as Unix epoch seconds; 0 if it never expires. On creation, sets the initial secret's expiry. Present in responses and effective in requests only when multiple client secrets are enabled.")
+    @ApiModelProperty(example = "1761568483", value = "The expiration time of the latest client secret, expressed in Unix epoch seconds. A value of 0 indicates that the secret never expires.")
     @JsonProperty("clientSecretExpiresAt")
     @Valid
     public Long getClientSecretExpiresAt() {
@@ -167,7 +167,7 @@ public enum StateEnum {
     }
 
     /**
-    * Whether the application has more than one client secret configured. When true, the full set can be retrieved via the client secrets sub-resource. Present only when multiple client secrets are enabled.
+    * Indicates if the application has more than one client secret.
     **/
     public OpenIDConnectConfiguration multipleClientSecretsConfigured(Boolean multipleClientSecretsConfigured) {
 
@@ -175,7 +175,7 @@ public enum StateEnum {
         return this;
     }
     
-    @ApiModelProperty(example = "true", value = "Whether the application has more than one client secret configured. When true, the full set can be retrieved via the client secrets sub-resource. Present only when multiple client secrets are enabled.")
+    @ApiModelProperty(example = "true", value = "Indicates if the application has more than one client secret.")
     @JsonProperty("multipleClientSecretsConfigured")
     @Valid
     public Boolean getMultipleClientSecretsConfigured() {

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/application/management/v1/OpenIDConnectConfiguration.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/application/management/v1/OpenIDConnectConfiguration.java
@@ -20,6 +20,7 @@ package org.wso2.carbon.identity.api.server.application.management.v1;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
+
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import java.util.ArrayList;
@@ -48,6 +49,8 @@ public class OpenIDConnectConfiguration  {
   
     private String clientId;
     private String clientSecret;
+    private Long clientSecretExpiresAt;
+    private Boolean multipleClientSecretsConfigured;
 
 @XmlType(name="StateEnum")
 @XmlEnum(String.class)
@@ -142,6 +145,44 @@ public enum StateEnum {
     }
     public void setClientSecret(String clientSecret) {
         this.clientSecret = clientSecret;
+    }
+
+    /**
+    * Expiry time of the client secret as Unix epoch seconds; 0 if it never expires. On creation, sets the initial secret&#39;s expiry. Present in responses and effective in requests only when multiple client secrets are enabled.
+    **/
+    public OpenIDConnectConfiguration clientSecretExpiresAt(Long clientSecretExpiresAt) {
+
+        this.clientSecretExpiresAt = clientSecretExpiresAt;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "1761568483", value = "Expiry time of the client secret as Unix epoch seconds; 0 if it never expires. On creation, sets the initial secret's expiry. Present in responses and effective in requests only when multiple client secrets are enabled.")
+    @JsonProperty("clientSecretExpiresAt")
+    @Valid
+    public Long getClientSecretExpiresAt() {
+        return clientSecretExpiresAt;
+    }
+    public void setClientSecretExpiresAt(Long clientSecretExpiresAt) {
+        this.clientSecretExpiresAt = clientSecretExpiresAt;
+    }
+
+    /**
+    * Whether the application has more than one client secret configured. When true, the full set can be retrieved via the client secrets sub-resource. Present only when multiple client secrets are enabled.
+    **/
+    public OpenIDConnectConfiguration multipleClientSecretsConfigured(Boolean multipleClientSecretsConfigured) {
+
+        this.multipleClientSecretsConfigured = multipleClientSecretsConfigured;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "true", value = "Whether the application has more than one client secret configured. When true, the full set can be retrieved via the client secrets sub-resource. Present only when multiple client secrets are enabled.")
+    @JsonProperty("multipleClientSecretsConfigured")
+    @Valid
+    public Boolean getMultipleClientSecretsConfigured() {
+        return multipleClientSecretsConfigured;
+    }
+    public void setMultipleClientSecretsConfigured(Boolean multipleClientSecretsConfigured) {
+        this.multipleClientSecretsConfigured = multipleClientSecretsConfigured;
     }
 
     /**
@@ -608,6 +649,8 @@ public enum StateEnum {
         OpenIDConnectConfiguration openIDConnectConfiguration = (OpenIDConnectConfiguration) o;
         return Objects.equals(this.clientId, openIDConnectConfiguration.clientId) &&
             Objects.equals(this.clientSecret, openIDConnectConfiguration.clientSecret) &&
+            Objects.equals(this.clientSecretExpiresAt, openIDConnectConfiguration.clientSecretExpiresAt) &&
+            Objects.equals(this.multipleClientSecretsConfigured, openIDConnectConfiguration.multipleClientSecretsConfigured) &&
             Objects.equals(this.state, openIDConnectConfiguration.state) &&
             Objects.equals(this.grantTypes, openIDConnectConfiguration.grantTypes) &&
             Objects.equals(this.callbackURLs, openIDConnectConfiguration.callbackURLs) &&
@@ -636,7 +679,7 @@ public enum StateEnum {
     @Override
     public int hashCode() {
 
-        return Objects.hash(clientId, clientSecret, state, grantTypes, callbackURLs, allowedOrigins, publicClient, pkce, accessToken, hybridFlow, refreshToken, subjectToken, idToken, logout, validateRequestObjectSignature, scopeValidators, clientAuthentication, requestObject, pushAuthorizationRequest, subject, isFAPIApplication, fapiMetadata, cibaAuthenticationRequest, issuer);
+        return Objects.hash(clientId, clientSecret, clientSecretExpiresAt, multipleClientSecretsConfigured, state, grantTypes, callbackURLs, allowedOrigins, publicClient, pkce, accessToken, hybridFlow, refreshToken, subjectToken, idToken, logout, validateRequestObjectSignature, scopeValidators, clientAuthentication, requestObject, pushAuthorizationRequest, subject, isFAPIApplication, fapiMetadata, cibaAuthenticationRequest, issuer);
     }
 
     @Override
@@ -647,6 +690,8 @@ public enum StateEnum {
         
         sb.append("    clientId: ").append(toIndentedString(clientId)).append("\n");
         sb.append("    clientSecret: ").append(toIndentedString(clientSecret)).append("\n");
+        sb.append("    clientSecretExpiresAt: ").append(toIndentedString(clientSecretExpiresAt)).append("\n");
+        sb.append("    multipleClientSecretsConfigured: ").append(toIndentedString(multipleClientSecretsConfigured)).append("\n");
         sb.append("    state: ").append(toIndentedString(state)).append("\n");
         sb.append("    grantTypes: ").append(toIndentedString(grantTypes)).append("\n");
         sb.append("    callbackURLs: ").append(toIndentedString(callbackURLs)).append("\n");

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/ServerApplicationManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/ServerApplicationManagementService.java
@@ -52,6 +52,9 @@ import org.wso2.carbon.identity.api.server.application.management.v1.AuthorizedA
 import org.wso2.carbon.identity.api.server.application.management.v1.AuthorizedAPIResponse;
 import org.wso2.carbon.identity.api.server.application.management.v1.AuthorizedAuthorizationDetailsTypes;
 import org.wso2.carbon.identity.api.server.application.management.v1.AuthorizedScope;
+import org.wso2.carbon.identity.api.server.application.management.v1.ClientSecretCreationRequest;
+import org.wso2.carbon.identity.api.server.application.management.v1.ClientSecretList;
+import org.wso2.carbon.identity.api.server.application.management.v1.ClientSecretResponse;
 import org.wso2.carbon.identity.api.server.application.management.v1.ConfiguredAuthenticator;
 import org.wso2.carbon.identity.api.server.application.management.v1.ConfiguredAuthenticatorsModal;
 import org.wso2.carbon.identity.api.server.application.management.v1.CustomInboundProtocolConfiguration;
@@ -1875,6 +1878,35 @@ public class ServerApplicationManagementService {
         InboundAuthenticationRequestConfig oauthInbound = getInboundAuthRequestConfig(applicationId, OAUTH2);
         String clientId = oauthInbound.getInboundAuthKey();
         return OAuthInboundFunctions.regenerateClientSecret(clientId);
+    }
+
+    public ClientSecretResponse createOAuthClientSecret(String applicationId,
+                                                          ClientSecretCreationRequest request) {
+
+        InboundAuthenticationRequestConfig oauthInbound = getInboundAuthRequestConfig(applicationId, OAUTH2);
+        String clientId = oauthInbound.getInboundAuthKey();
+        return OAuthInboundFunctions.createClientSecret(clientId, request);
+    }
+
+    public ClientSecretList getOAuthClientSecrets(String applicationId) {
+
+        InboundAuthenticationRequestConfig oauthInbound = getInboundAuthRequestConfig(applicationId, OAUTH2);
+        String clientId = oauthInbound.getInboundAuthKey();
+        return OAuthInboundFunctions.getClientSecrets(clientId);
+    }
+
+    public ClientSecretResponse getOAuthClientSecret(String applicationId, String secretId) {
+
+        InboundAuthenticationRequestConfig oauthInbound = getInboundAuthRequestConfig(applicationId, OAUTH2);
+        String clientId = oauthInbound.getInboundAuthKey();
+        return OAuthInboundFunctions.getClientSecret(clientId, secretId);
+    }
+
+    public void deleteOAuthClientSecret(String applicationId, String secretId) {
+
+        InboundAuthenticationRequestConfig oauthInbound = getInboundAuthRequestConfig(applicationId, OAUTH2);
+        String clientId = oauthInbound.getInboundAuthKey();
+        OAuthInboundFunctions.deleteClientSecret(clientId, secretId);
     }
 
     public void revokeOAuthClient(String applicationId) {

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/ServerApplicationManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/ServerApplicationManagementService.java
@@ -1885,28 +1885,32 @@ public class ServerApplicationManagementService {
 
         InboundAuthenticationRequestConfig oauthInbound = getInboundAuthRequestConfig(applicationId, OAUTH2);
         String clientId = oauthInbound.getInboundAuthKey();
-        return OAuthInboundFunctions.createClientSecret(clientId, request);
+        String tenantDomain = PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantDomain();
+        return OAuthInboundFunctions.createClientSecret(clientId, tenantDomain, request);
     }
 
     public ClientSecretList getOAuthClientSecrets(String applicationId) {
 
         InboundAuthenticationRequestConfig oauthInbound = getInboundAuthRequestConfig(applicationId, OAUTH2);
         String clientId = oauthInbound.getInboundAuthKey();
-        return OAuthInboundFunctions.getClientSecrets(clientId);
+        String tenantDomain = PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantDomain();
+        return OAuthInboundFunctions.getClientSecrets(clientId, tenantDomain);
     }
 
     public ClientSecretResponse getOAuthClientSecret(String applicationId, String secretId) {
 
         InboundAuthenticationRequestConfig oauthInbound = getInboundAuthRequestConfig(applicationId, OAUTH2);
         String clientId = oauthInbound.getInboundAuthKey();
-        return OAuthInboundFunctions.getClientSecret(clientId, secretId);
+        String tenantDomain = PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantDomain();
+        return OAuthInboundFunctions.getClientSecret(clientId, tenantDomain, secretId);
     }
 
     public void deleteOAuthClientSecret(String applicationId, String secretId) {
 
         InboundAuthenticationRequestConfig oauthInbound = getInboundAuthRequestConfig(applicationId, OAUTH2);
         String clientId = oauthInbound.getInboundAuthKey();
-        OAuthInboundFunctions.deleteClientSecret(clientId, secretId);
+        String tenantDomain = PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantDomain();
+        OAuthInboundFunctions.deleteClientSecret(clientId, tenantDomain, secretId);
     }
 
     public void revokeOAuthClient(String applicationId) {

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/functions/application/inbound/oauth2/ApiModelToOAuthConsumerApp.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/functions/application/inbound/oauth2/ApiModelToOAuthConsumerApp.java
@@ -68,6 +68,7 @@ public class ApiModelToOAuthConsumerApp implements ApiModelToOAuthConsumerAppFun
         consumerAppDTO.setApplicationName(appName);
         consumerAppDTO.setOauthConsumerKey(oidcModel.getClientId());
         consumerAppDTO.setOauthConsumerSecret(oidcModel.getClientSecret());
+        consumerAppDTO.setOauthConsumerSecretExpiryTime(oidcModel.getClientSecretExpiresAt());
 
         consumerAppDTO.setCallbackUrl(getCallbackUrl(oidcModel.getCallbackURLs()));
 

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/functions/application/inbound/oauth2/OAuthConsumerAppToApiModel.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/functions/application/inbound/oauth2/OAuthConsumerAppToApiModel.java
@@ -59,6 +59,8 @@ public class OAuthConsumerAppToApiModel implements Function<OAuthConsumerAppDTO,
         return new OpenIDConnectConfiguration()
                 .clientId(oauthAppDTO.getOauthConsumerKey())
                 .clientSecret(oauthAppDTO.getOauthConsumerSecret())
+                .clientSecretExpiresAt(oauthAppDTO.getOauthConsumerSecretExpiryTime())
+                .multipleClientSecretsConfigured(oauthAppDTO.getMultipleConsumerSecretsConfigured())
                 .state(OpenIDConnectConfiguration.StateEnum.valueOf(oauthAppDTO.getState()))
                 .grantTypes(buildGrantTypeList(oauthAppDTO))
                 .publicClient(oauthAppDTO.isBypassClientCredentials())

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/functions/application/inbound/oauth2/OAuthInboundFunctions.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/functions/application/inbound/oauth2/OAuthInboundFunctions.java
@@ -43,7 +43,6 @@ import org.wso2.carbon.identity.oauth.Error;
 import org.wso2.carbon.identity.oauth.IdentityOAuthAdminException;
 import org.wso2.carbon.identity.oauth.IdentityOAuthClientException;
 import org.wso2.carbon.identity.oauth.common.OAuthConstants;
-import org.wso2.carbon.identity.oauth.dto.OAuthClientSecretRequestDTO;
 import org.wso2.carbon.identity.oauth.dto.OAuthClientSecretResponseDTO;
 import org.wso2.carbon.identity.oauth.dto.OAuthConsumerAppDTO;
 
@@ -176,8 +175,7 @@ public class OAuthInboundFunctions {
         if (e instanceof IdentityOAuthClientException) {
             String errorCode = ((IdentityOAuthClientException) e).getErrorCode();
             if (Error.INVALID_SECRET_ID.getErrorCode().equals(errorCode)
-                    || Error.INVALID_OAUTH_CLIENT.getErrorCode().equals(errorCode)
-                    || Error.FEATURE_NOT_ENABLED.getErrorCode().equals(errorCode)) {
+                    || Error.INVALID_OAUTH_CLIENT.getErrorCode().equals(errorCode)) {
                 return buildNotFoundError(errorCode, contextMessage, e.getMessage());
             }
             if (Error.CLIENT_SECRET_LIMIT_REACHED.getErrorCode().equals(errorCode)
@@ -305,13 +303,10 @@ public class OAuthInboundFunctions {
     public static ClientSecretResponse createClientSecret(String clientId, String tenantDomain,
                                                             ClientSecretCreationRequest request) {
 
-        OAuthClientSecretRequestDTO secretRequest = new OAuthClientSecretRequestDTO();
-        if (request != null) {
-            secretRequest.setExpiryTime(request.getExpiresAt());
-        }
         try {
             OAuthClientSecretResponseDTO created = ApplicationManagementServiceHolder.getOAuthAdminService()
-                    .createOAuthClientSecret(clientId, tenantDomain, secretRequest);
+                    .createOAuthClientSecret(clientId, tenantDomain,
+                            request == null ? null : request.getExpiresAt());
             return toClientSecretResponse(created);
         } catch (IdentityOAuthAdminException e) {
             throw handleClientSecretException(e, "Unable to create the client secret.");
@@ -360,6 +355,7 @@ public class OAuthInboundFunctions {
         response.setSecretId(dto.getSecretId());
         response.setSecretValue(dto.getSecretValue());
         response.setExpiresAt(dto.getExpiryTime());
+        response.setCreatedAt(dto.getCreatedTime());
         response.setStatus(ClientSecretResponse.StatusEnum.valueOf(dto.getStatus().name()));
         response.setLatest(dto.isLatest());
         return response;

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/functions/application/inbound/oauth2/OAuthInboundFunctions.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/functions/application/inbound/oauth2/OAuthInboundFunctions.java
@@ -175,7 +175,9 @@ public class OAuthInboundFunctions {
 
         if (e instanceof IdentityOAuthClientException) {
             String errorCode = ((IdentityOAuthClientException) e).getErrorCode();
-            if (Error.INVALID_SECRET_ID.getErrorCode().equals(errorCode)) {
+            if (Error.INVALID_SECRET_ID.getErrorCode().equals(errorCode)
+                    || Error.INVALID_OAUTH_CLIENT.getErrorCode().equals(errorCode)
+                    || Error.FEATURE_NOT_ENABLED.getErrorCode().equals(errorCode)) {
                 return buildNotFoundError(errorCode, contextMessage, e.getMessage());
             }
             if (Error.CLIENT_SECRET_LIMIT_REACHED.getErrorCode().equals(errorCode)
@@ -312,7 +314,7 @@ public class OAuthInboundFunctions {
                     .createOAuthClientSecret(clientId, tenantDomain, secretRequest);
             return toClientSecretResponse(created);
         } catch (IdentityOAuthAdminException e) {
-            throw handleClientSecretException(e, "Error while creating the client secret.");
+            throw handleClientSecretException(e, "Unable to create the client secret.");
         }
     }
 
@@ -327,7 +329,7 @@ public class OAuthInboundFunctions {
                     .collect(Collectors.toList()));
             return list;
         } catch (IdentityOAuthAdminException e) {
-            throw handleClientSecretException(e, "Error while listing the client secrets.");
+            throw handleClientSecretException(e, "Unable to list the client secrets.");
         }
     }
 
@@ -338,7 +340,7 @@ public class OAuthInboundFunctions {
                     .getOAuthClientSecret(clientId, tenantDomain, secretId);
             return toClientSecretResponse(secret);
         } catch (IdentityOAuthAdminException e) {
-            throw handleClientSecretException(e, "Error while retrieving the client secret.");
+            throw handleClientSecretException(e, "Unable to retrieve the client secret.");
         }
     }
 
@@ -348,7 +350,7 @@ public class OAuthInboundFunctions {
             ApplicationManagementServiceHolder.getOAuthAdminService()
                     .removeOAuthClientSecret(clientId, tenantDomain, secretId);
         } catch (IdentityOAuthAdminException e) {
-            throw handleClientSecretException(e, "Error while deleting the client secret.");
+            throw handleClientSecretException(e, "Unable to delete the client secret.");
         }
     }
 

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/functions/application/inbound/oauth2/OAuthInboundFunctions.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/functions/application/inbound/oauth2/OAuthInboundFunctions.java
@@ -300,7 +300,7 @@ public class OAuthInboundFunctions {
         }
     }
 
-    public static ClientSecretResponse createClientSecret(String clientId,
+    public static ClientSecretResponse createClientSecret(String clientId, String tenantDomain,
                                                             ClientSecretCreationRequest request) {
 
         OAuthClientSecretRequestDTO secretRequest = new OAuthClientSecretRequestDTO();
@@ -309,18 +309,18 @@ public class OAuthInboundFunctions {
         }
         try {
             OAuthClientSecretResponseDTO created = ApplicationManagementServiceHolder.getOAuthAdminService()
-                    .createOAuthClientSecret(clientId, secretRequest);
+                    .createOAuthClientSecret(clientId, tenantDomain, secretRequest);
             return toClientSecretResponse(created);
         } catch (IdentityOAuthAdminException e) {
             throw handleClientSecretException(e, "Error while creating the client secret.");
         }
     }
 
-    public static ClientSecretList getClientSecrets(String clientId) {
+    public static ClientSecretList getClientSecrets(String clientId, String tenantDomain) {
 
         try {
-            List<OAuthClientSecretResponseDTO> secrets =
-                    ApplicationManagementServiceHolder.getOAuthAdminService().getOAuthClientSecrets(clientId);
+            List<OAuthClientSecretResponseDTO> secrets = ApplicationManagementServiceHolder.getOAuthAdminService()
+                    .getOAuthClientSecrets(clientId, tenantDomain);
             ClientSecretList list = new ClientSecretList();
             list.setCount(secrets.size());
             list.setList(secrets.stream().map(OAuthInboundFunctions::toClientSecretResponse)
@@ -331,21 +331,22 @@ public class OAuthInboundFunctions {
         }
     }
 
-    public static ClientSecretResponse getClientSecret(String clientId, String secretId) {
+    public static ClientSecretResponse getClientSecret(String clientId, String tenantDomain, String secretId) {
 
         try {
             OAuthClientSecretResponseDTO secret = ApplicationManagementServiceHolder.getOAuthAdminService()
-                    .getOAuthClientSecret(clientId, secretId);
+                    .getOAuthClientSecret(clientId, tenantDomain, secretId);
             return toClientSecretResponse(secret);
         } catch (IdentityOAuthAdminException e) {
             throw handleClientSecretException(e, "Error while retrieving the client secret.");
         }
     }
 
-    public static void deleteClientSecret(String clientId, String secretId) {
+    public static void deleteClientSecret(String clientId, String tenantDomain, String secretId) {
 
         try {
-            ApplicationManagementServiceHolder.getOAuthAdminService().removeOAuthClientSecret(clientId, secretId);
+            ApplicationManagementServiceHolder.getOAuthAdminService()
+                    .removeOAuthClientSecret(clientId, tenantDomain, secretId);
         } catch (IdentityOAuthAdminException e) {
             throw handleClientSecretException(e, "Error while deleting the client secret.");
         }

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/functions/application/inbound/oauth2/OAuthInboundFunctions.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/core/functions/application/inbound/oauth2/OAuthInboundFunctions.java
@@ -21,6 +21,9 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.identity.api.server.application.management.common.ApplicationManagementConstants;
 import org.wso2.carbon.identity.api.server.application.management.common.ApplicationManagementServiceHolder;
+import org.wso2.carbon.identity.api.server.application.management.v1.ClientSecretCreationRequest;
+import org.wso2.carbon.identity.api.server.application.management.v1.ClientSecretList;
+import org.wso2.carbon.identity.api.server.application.management.v1.ClientSecretResponse;
 import org.wso2.carbon.identity.api.server.application.management.v1.OpenIDConnectConfiguration;
 import org.wso2.carbon.identity.api.server.common.ContextLoader;
 import org.wso2.carbon.identity.api.server.common.error.APIError;
@@ -36,9 +39,12 @@ import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.cors.mgt.core.exception.CORSManagementServiceClientException;
 import org.wso2.carbon.identity.cors.mgt.core.exception.CORSManagementServiceException;
 import org.wso2.carbon.identity.cors.mgt.core.model.CORSOrigin;
+import org.wso2.carbon.identity.oauth.Error;
 import org.wso2.carbon.identity.oauth.IdentityOAuthAdminException;
 import org.wso2.carbon.identity.oauth.IdentityOAuthClientException;
 import org.wso2.carbon.identity.oauth.common.OAuthConstants;
+import org.wso2.carbon.identity.oauth.dto.OAuthClientSecretRequestDTO;
+import org.wso2.carbon.identity.oauth.dto.OAuthClientSecretResponseDTO;
 import org.wso2.carbon.identity.oauth.dto.OAuthConsumerAppDTO;
 
 import java.util.List;
@@ -48,6 +54,9 @@ import java.util.stream.Collectors;
 
 import static org.wso2.carbon.identity.api.server.application.management.common.ApplicationManagementConstants.VIEW_APPLICATION_CLIENT_SECRET_OPERATION;
 import static org.wso2.carbon.identity.api.server.application.management.v1.core.functions.Utils.buildBadRequestError;
+import static org.wso2.carbon.identity.api.server.application.management.v1.core.functions.Utils.buildClientError;
+import static org.wso2.carbon.identity.api.server.application.management.v1.core.functions.Utils.buildConflictError;
+import static org.wso2.carbon.identity.api.server.application.management.v1.core.functions.Utils.buildNotFoundError;
 import static org.wso2.carbon.identity.api.server.application.management.v1.core.functions.Utils.buildServerError;
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.StandardInboundProtocols.OAUTH2;
 
@@ -159,6 +168,26 @@ public class OAuthInboundFunctions {
     }
 
     /**
+     * Build an APIError for a failed client secret operation, propagating the backend error code and mapping it
+     * to the appropriate HTTP status.
+     */
+    private static APIError handleClientSecretException(Exception e, String contextMessage) {
+
+        if (e instanceof IdentityOAuthClientException) {
+            String errorCode = ((IdentityOAuthClientException) e).getErrorCode();
+            if (Error.INVALID_SECRET_ID.getErrorCode().equals(errorCode)) {
+                return buildNotFoundError(errorCode, contextMessage, e.getMessage());
+            }
+            if (Error.CLIENT_SECRET_LIMIT_REACHED.getErrorCode().equals(errorCode)
+                    || Error.INVALID_DELETE.getErrorCode().equals(errorCode)) {
+                return buildConflictError(errorCode, contextMessage, e.getMessage());
+            }
+            return buildClientError(errorCode, contextMessage, e.getMessage());
+        }
+        return buildServerError(contextMessage, e);
+    }
+
+    /**
      * @deprecated This method will be removed in the upcoming major release.
      * Because, service provider name should be passed to create oauth app name.
      * Use {@link #createOAuthInbound(String, OpenIDConnectConfiguration)} instead.
@@ -210,8 +239,6 @@ public class OAuthInboundFunctions {
 
             OpenIDConnectConfiguration openIDConnectConfiguration = new OAuthConsumerAppToApiModel().apply(oauthApp);
 
-            removeClientSecretIfUnauthorized(openIDConnectConfiguration);
-
             // Set CORS origins as allowed domains.
             String tenantDomain = ContextLoader.getTenantDomainFromContext();
             String applicationResourceId = ApplicationManagementServiceHolder.getApplicationManagementService()
@@ -221,6 +248,9 @@ public class OAuthInboundFunctions {
             openIDConnectConfiguration.setAllowedOrigins(corsOriginList.stream().map(CORSOrigin::getOrigin)
                     .collect(Collectors.toList()));
 
+            // Strip the secret-related properties for a caller without the dedicated view scope.
+            removeClientSecretPropertiesIfUnauthorized(openIDConnectConfiguration);
+
             return openIDConnectConfiguration;
 
         } catch (IdentityOAuthAdminException | IdentityApplicationManagementException
@@ -229,7 +259,8 @@ public class OAuthInboundFunctions {
         }
     }
 
-    private static void removeClientSecretIfUnauthorized(OpenIDConnectConfiguration openIDConnectConfiguration) {
+    private static void removeClientSecretPropertiesIfUnauthorized(
+            OpenIDConnectConfiguration openIDConnectConfiguration) {
 
         if (Boolean.parseBoolean(IdentityUtil.getProperty(
                 ApplicationManagementConstants.SKIP_ENFORCE_CLIENT_SECRET_UPDATE_PERMISSION))) {
@@ -239,8 +270,11 @@ public class OAuthInboundFunctions {
         try {
             AuthorizationUtil.validateOperationScopes(VIEW_APPLICATION_CLIENT_SECRET_OPERATION);
         } catch (ForbiddenException e) {
-            // Removing the client secret if operation scope is not present.
+            /* Remove the client secret and its related properties when the operation scope is not present, so the
+               response carries no client secret information for callers without the dedicated view scope. */
             openIDConnectConfiguration.setClientSecret(null);
+            openIDConnectConfiguration.setClientSecretExpiresAt(null);
+            openIDConnectConfiguration.setMultipleClientSecretsConfigured(null);
         }
     }
 
@@ -262,8 +296,70 @@ public class OAuthInboundFunctions {
                     .getOAuthAdminService().updateAndRetrieveOauthSecretKey(clientId);
             return new OAuthConsumerAppToApiModel().apply(oAuthConsumerAppDTO);
         } catch (IdentityOAuthAdminException e) {
-            throw buildServerError("Error while regenerating client secret of oauth application.", e);
+            throw handleException(e);
         }
+    }
+
+    public static ClientSecretResponse createClientSecret(String clientId,
+                                                            ClientSecretCreationRequest request) {
+
+        OAuthClientSecretRequestDTO secretRequest = new OAuthClientSecretRequestDTO();
+        if (request != null) {
+            secretRequest.setExpiryTime(request.getExpiresAt());
+        }
+        try {
+            OAuthClientSecretResponseDTO created = ApplicationManagementServiceHolder.getOAuthAdminService()
+                    .createOAuthClientSecret(clientId, secretRequest);
+            return toClientSecretResponse(created);
+        } catch (IdentityOAuthAdminException e) {
+            throw handleClientSecretException(e, "Error while creating the client secret.");
+        }
+    }
+
+    public static ClientSecretList getClientSecrets(String clientId) {
+
+        try {
+            List<OAuthClientSecretResponseDTO> secrets =
+                    ApplicationManagementServiceHolder.getOAuthAdminService().getOAuthClientSecrets(clientId);
+            ClientSecretList list = new ClientSecretList();
+            list.setCount(secrets.size());
+            list.setList(secrets.stream().map(OAuthInboundFunctions::toClientSecretResponse)
+                    .collect(Collectors.toList()));
+            return list;
+        } catch (IdentityOAuthAdminException e) {
+            throw handleClientSecretException(e, "Error while listing the client secrets.");
+        }
+    }
+
+    public static ClientSecretResponse getClientSecret(String clientId, String secretId) {
+
+        try {
+            OAuthClientSecretResponseDTO secret = ApplicationManagementServiceHolder.getOAuthAdminService()
+                    .getOAuthClientSecret(clientId, secretId);
+            return toClientSecretResponse(secret);
+        } catch (IdentityOAuthAdminException e) {
+            throw handleClientSecretException(e, "Error while retrieving the client secret.");
+        }
+    }
+
+    public static void deleteClientSecret(String clientId, String secretId) {
+
+        try {
+            ApplicationManagementServiceHolder.getOAuthAdminService().removeOAuthClientSecret(clientId, secretId);
+        } catch (IdentityOAuthAdminException e) {
+            throw handleClientSecretException(e, "Error while deleting the client secret.");
+        }
+    }
+
+    private static ClientSecretResponse toClientSecretResponse(OAuthClientSecretResponseDTO dto) {
+
+        ClientSecretResponse response = new ClientSecretResponse();
+        response.setSecretId(dto.getSecretId());
+        response.setSecretValue(dto.getSecretValue());
+        response.setExpiresAt(dto.getExpiryTime());
+        response.setStatus(ClientSecretResponse.StatusEnum.valueOf(dto.getStatus().name()));
+        response.setLatest(dto.isLatest());
+        return response;
     }
 
     public static void revokeOAuthClient(String clientId) {

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/impl/ApplicationsApiServiceImpl.java
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/java/org/wso2/carbon/identity/api/server/application/management/v1/impl/ApplicationsApiServiceImpl.java
@@ -35,6 +35,9 @@ import org.wso2.carbon.identity.api.server.application.management.v1.Application
 import org.wso2.carbon.identity.api.server.application.management.v1.ApplicationsApiService;
 import org.wso2.carbon.identity.api.server.application.management.v1.AuthorizedAPICreationModel;
 import org.wso2.carbon.identity.api.server.application.management.v1.AuthorizedAPIPatchModel;
+import org.wso2.carbon.identity.api.server.application.management.v1.ClientSecretCreationRequest;
+import org.wso2.carbon.identity.api.server.application.management.v1.ClientSecretList;
+import org.wso2.carbon.identity.api.server.application.management.v1.ClientSecretResponse;
 import org.wso2.carbon.identity.api.server.application.management.v1.CustomInboundProtocolConfiguration;
 import org.wso2.carbon.identity.api.server.application.management.v1.InboundProtocolListItem;
 import org.wso2.carbon.identity.api.server.application.management.v1.LoginFlowGenerateRequest;
@@ -365,6 +368,38 @@ public class ApplicationsApiServiceImpl implements ApplicationsApiService {
         OpenIDConnectConfiguration openIDConnectConfiguration =
                 applicationManagementService.regenerateOAuthApplicationSecret(applicationId);
         return Response.ok(openIDConnectConfiguration).build();
+    }
+
+    @Override
+    public Response createOAuthClientSecret(String applicationId,
+                                              ClientSecretCreationRequest clientSecretCreationRequest) {
+
+        ClientSecretResponse response =
+                applicationManagementService.createOAuthClientSecret(applicationId,
+                        clientSecretCreationRequest);
+        return Response.status(Response.Status.CREATED).entity(response).build();
+    }
+
+    @Override
+    public Response getOAuthClientSecrets(String applicationId) {
+
+        ClientSecretList list = applicationManagementService.getOAuthClientSecrets(applicationId);
+        return Response.ok(list).build();
+    }
+
+    @Override
+    public Response getOAuthClientSecret(String applicationId, String secretId) {
+
+        ClientSecretResponse response =
+                applicationManagementService.getOAuthClientSecret(applicationId, secretId);
+        return Response.ok(response).build();
+    }
+
+    @Override
+    public Response deleteOAuthClientSecret(String applicationId, String secretId) {
+
+        applicationManagementService.deleteOAuthClientSecret(applicationId, secretId);
+        return Response.noContent().build();
     }
 
     @Override

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/resources/applications.yaml
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/resources/applications.yaml
@@ -1234,13 +1234,15 @@ paths:
       summary: |
         Regenerate the OAuth2/OIDC client secret.
       description: |
-        This API regenerates the OAuth2/OIDC client secret. <br>
-          <b>Scope(Permission) required:</b> `internal_application_mgt_create`
+        This API regenerates a new client secret. Existing secrets, access tokens, refresh
+        tokens, and authorization codes are revoked.
+
+        <b>Scope(Permission) required:</b> `internal_application_mgt_client_secret_create`
       operationId: regenerateOAuthClientSecret
       parameters:
         - name: applicationId
           in: path
-          description: ID of the application
+          description: ID of the application.
           required: true
           schema:
             type: string
@@ -1273,6 +1275,217 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
+  /applications/{applicationId}/inbound-protocols/oidc/secrets:
+    post:
+      tags:
+        - Inbound Protocols - OAuth / OIDC
+      summary: Create a new OAuth2/OIDC client secret.
+      description: |
+        This API creates a new client secret for the application. Existing secrets, access tokens,
+        refresh tokens, and authorization codes remain valid.
+
+        <b>Scope(Permission) required:</b> `internal_application_mgt_client_secret_create`
+      operationId: createOAuthClientSecret
+      parameters:
+        - name: applicationId
+          in: path
+          description: ID of the application.
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ClientSecretCreationRequest'
+      responses:
+        '201':
+          description: Client secret created.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ClientSecretResponse'
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '409':
+          description: Conflict — client secret limit reached for the application.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '500':
+          description: Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+    get:
+      tags:
+        - Inbound Protocols - OAuth / OIDC
+      summary: List client secrets of the application.
+      description: |
+        This API returns metadata of all client secrets attached to the application.
+
+        <b>Scope(Permission) required:</b> `internal_application_mgt_client_secret_view`
+      operationId: getOAuthClientSecrets
+      parameters:
+        - name: applicationId
+          in: path
+          description: ID of the application.
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ClientSecretList'
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '500':
+          description: Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+  /applications/{applicationId}/inbound-protocols/oidc/secrets/{secretId}:
+    get:
+      tags:
+        - Inbound Protocols - OAuth / OIDC
+      summary: Get a specific client secret's metadata.
+      description: |
+        This API returns the metadata of the client secret identified by `secretId`.
+
+        <b>Scope(Permission) required:</b> `internal_application_mgt_client_secret_view`
+      operationId: getOAuthClientSecret
+      parameters:
+        - name: applicationId
+          in: path
+          description: ID of the application.
+          required: true
+          schema:
+            type: string
+        - name: secretId
+          in: path
+          description: ID of the client secret.
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ClientSecretResponse'
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '500':
+          description: Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+    delete:
+      tags:
+        - Inbound Protocols - OAuth / OIDC
+      summary: Delete a specific OAuth2/OIDC client secret.
+      description: |
+        This API deletes the client secret identified by `secretId`. The application's most recently
+        added active secret cannot be deleted — at least one active secret must remain per
+        application.
+
+        <b>Scope(Permission) required:</b> `internal_application_mgt_client_secret_create`
+      operationId: deleteOAuthClientSecret
+      parameters:
+        - name: applicationId
+          in: path
+          description: ID of the application.
+          required: true
+          schema:
+            type: string
+        - name: secretId
+          in: path
+          description: ID of the client secret to delete.
+          required: true
+          schema:
+            type: string
+      responses:
+        '204':
+          description: Client secret deleted.
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '409':
+          description: Conflict — cannot delete the last active client secret.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '500':
+          description: Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
   /applications/{applicationId}/inbound-protocols/oidc/revoke:
     post:
       tags:
@@ -1280,8 +1493,8 @@ paths:
       summary: |
         Revoke the OAuth2/OIDC client of application.
       description: |
-        This API revokes the OAuth2/OIDC client secret.
-        To re-activate the client, the client secret needs to be regenerated. <br>
+        This API revokes the OAuth2/OIDC client of application and all the client secrets.
+        To re-activate the client, a client secret needs to be regenerated. <br>
           <b>Scope(Permission) required:</b> `internal_application_mgt_create`
       operationId: revokeOAuthClient
       parameters:
@@ -3903,6 +4116,16 @@ components:
           type: string
         clientSecret:
           type: string
+        clientSecretExpiresAt:
+          type: integer
+          format: int64
+          description: Expiry time of the client secret as Unix epoch seconds; 0 if it never expires. On creation, sets the initial secret's expiry. Present in responses and effective in requests only when multiple client secrets are enabled.
+          example: 1761568483
+        multipleClientSecretsConfigured:
+          type: boolean
+          readOnly: true
+          description: Whether the application has more than one client secret configured. When true, the full set can be retrieved via the client secrets sub-resource. Present only when multiple client secrets are enabled.
+          example: true
         state:
           type: string
           enum:
@@ -4118,6 +4341,60 @@ components:
         method:
           type: string
           example: A128CBC+HS256
+    ClientSecretCreationRequest:
+      type: object
+      description: Request payload for creating a new client secret.
+      properties:
+        expiresAt:
+          type: integer
+          format: int64
+          description: Expiry time as Unix epoch seconds; must be a future time. 0 or omitted for a non-expiring secret.
+          example: 1761568483
+    ClientSecretResponse:
+      type: object
+      description: Client secret details.
+      required:
+        - secretId
+        - expiresAt
+        - status
+        - latest
+      properties:
+        secretId:
+          type: string
+          description: Identifier of the secret.
+          example: "4a7f9b23-c1e0-4d86-b5fa-28c93a71b4ef"
+        secretValue:
+          type: string
+          description: The client secret value, as maintained in the configured client secret persistence mode.
+          example: "AbCd1234EfGh5678IjKlMnOp"
+        expiresAt:
+          type: integer
+          format: int64
+          description: Expiry time as Unix epoch seconds; 0 if the secret never expires.
+          example: 1761568483
+        status:
+          type: string
+          enum:
+            - ACTIVE
+            - EXPIRED
+          description: Status of the secret.
+          example: ACTIVE
+        latest:
+          type: boolean
+          description: Whether this is the latest (active) secret of the application. The latest secret cannot be deleted.
+          example: true
+    ClientSecretList:
+      type: object
+      description: List of client secrets attached to an application.
+      properties:
+        count:
+          type: integer
+          description: Number of client secrets returned.
+          example: 2
+        list:
+          type: array
+          items:
+            $ref: '#/components/schemas/ClientSecretResponse'
     ClientAuthenticationConfiguration:
       type: object
       properties:

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/resources/applications.yaml
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/resources/applications.yaml
@@ -1237,7 +1237,10 @@ paths:
         This API regenerates a new client secret. Existing secrets, access tokens, refresh
         tokens, and authorization codes are revoked.
 
-        <b>Scope(Permission) required:</b> `internal_application_mgt_client_secret_create`
+        <b>Scope(Permission) required:</b> `internal_application_mgt_client_secret_regenerate`
+
+        When the multiple client secrets feature is disabled, this endpoint falls back to the
+        `internal_application_mgt_client_secret_create` scope.
       operationId: regenerateOAuthClientSecret
       parameters:
         - name: applicationId
@@ -1440,7 +1443,7 @@ paths:
         added active secret cannot be deleted — at least one active secret must remain per
         application.
 
-        <b>Scope(Permission) required:</b> `internal_application_mgt_client_secret_create`
+        <b>Scope(Permission) required:</b> `internal_application_mgt_client_secret_delete`
       operationId: deleteOAuthClientSecret
       parameters:
         - name: applicationId

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/resources/applications.yaml
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/resources/applications.yaml
@@ -1285,8 +1285,6 @@ paths:
         refresh tokens, and authorization codes remain valid.
 
         <b>Scope(Permission) required:</b> `internal_application_mgt_client_secret_create`
-
-        Responds with 404 when the multiple client secrets feature is disabled on the server.
       operationId: createOAuthClientSecret
       parameters:
         - name: applicationId
@@ -1344,8 +1342,6 @@ paths:
         This API returns metadata of all client secrets attached to the application.
 
         <b>Scope(Permission) required:</b> `internal_application_mgt_client_secret_view`
-
-        Responds with 404 when the multiple client secrets feature is disabled on the server.
       operationId: getOAuthClientSecrets
       parameters:
         - name: applicationId
@@ -1392,8 +1388,6 @@ paths:
         This API returns the metadata of the client secret identified by `secretId`.
 
         <b>Scope(Permission) required:</b> `internal_application_mgt_client_secret_view`
-
-        Responds with 404 when the multiple client secrets feature is disabled on the server.
       operationId: getOAuthClientSecret
       parameters:
         - name: applicationId
@@ -1447,8 +1441,6 @@ paths:
         application.
 
         <b>Scope(Permission) required:</b> `internal_application_mgt_client_secret_delete`
-
-        Responds with 404 when the multiple client secrets feature is disabled on the server.
       operationId: deleteOAuthClientSecret
       parameters:
         - name: applicationId
@@ -4127,12 +4119,12 @@ components:
         clientSecretExpiresAt:
           type: integer
           format: int64
-          description: Expiry time of the client secret as Unix epoch seconds; 0 if it never expires. On creation, sets the initial secret's expiry. Present in responses and effective in requests only when multiple client secrets are enabled.
+          description: The expiration time of the latest client secret, expressed in Unix epoch seconds. A value of 0 indicates that the secret never expires.
           example: 1761568483
         multipleClientSecretsConfigured:
           type: boolean
           readOnly: true
-          description: Whether the application has more than one client secret configured. When true, the full set can be retrieved via the client secrets sub-resource. Present only when multiple client secrets are enabled.
+          description: Indicates if the application has more than one client secret.
           example: true
         state:
           type: string
@@ -4379,6 +4371,11 @@ components:
           type: integer
           format: int64
           description: Expiry time as Unix epoch seconds; 0 if the secret never expires.
+          example: 1761568483
+        createdAt:
+          type: integer
+          format: int64
+          description: Creation time as Unix epoch seconds.
           example: 1761568483
         status:
           type: string

--- a/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/resources/applications.yaml
+++ b/components/org.wso2.carbon.identity.api.server.application.management/org.wso2.carbon.identity.api.server.application.management.v1/src/main/resources/applications.yaml
@@ -1237,10 +1237,7 @@ paths:
         This API regenerates a new client secret. Existing secrets, access tokens, refresh
         tokens, and authorization codes are revoked.
 
-        <b>Scope(Permission) required:</b> `internal_application_mgt_client_secret_regenerate`
-
-        When the multiple client secrets feature is disabled, this endpoint falls back to the
-        `internal_application_mgt_client_secret_create` scope.
+        <b>Scope(Permission) required:</b> `internal_application_mgt_client_secret_create`
       operationId: regenerateOAuthClientSecret
       parameters:
         - name: applicationId
@@ -1288,6 +1285,8 @@ paths:
         refresh tokens, and authorization codes remain valid.
 
         <b>Scope(Permission) required:</b> `internal_application_mgt_client_secret_create`
+
+        Responds with 404 when the multiple client secrets feature is disabled on the server.
       operationId: createOAuthClientSecret
       parameters:
         - name: applicationId
@@ -1345,6 +1344,8 @@ paths:
         This API returns metadata of all client secrets attached to the application.
 
         <b>Scope(Permission) required:</b> `internal_application_mgt_client_secret_view`
+
+        Responds with 404 when the multiple client secrets feature is disabled on the server.
       operationId: getOAuthClientSecrets
       parameters:
         - name: applicationId
@@ -1391,6 +1392,8 @@ paths:
         This API returns the metadata of the client secret identified by `secretId`.
 
         <b>Scope(Permission) required:</b> `internal_application_mgt_client_secret_view`
+
+        Responds with 404 when the multiple client secrets feature is disabled on the server.
       operationId: getOAuthClientSecret
       parameters:
         - name: applicationId
@@ -1444,6 +1447,8 @@ paths:
         application.
 
         <b>Scope(Permission) required:</b> `internal_application_mgt_client_secret_delete`
+
+        Responds with 404 when the multiple client secrets feature is disabled on the server.
       operationId: deleteOAuthClientSecret
       parameters:
         - name: applicationId

--- a/pom.xml
+++ b/pom.xml
@@ -1118,7 +1118,7 @@
         <maven.checkstyleplugin.excludes>**/gen/**/*</maven.checkstyleplugin.excludes>
         <identity.event.handler.version>1.12.4</identity.event.handler.version>
         <identity.data.publisher.authentication.version>5.10.1</identity.data.publisher.authentication.version>
-        <identity.inbound.oauth2.version>7.5.59</identity.inbound.oauth2.version>
+        <identity.inbound.oauth2.version>7.5.76</identity.inbound.oauth2.version>
         <identity.inbound.saml2.version>5.11.51</identity.inbound.saml2.version>
         <identity.x509Certificate.validation.version>1.1.19</identity.x509Certificate.validation.version>
         <commons.beanutils.version>1.9.4</commons.beanutils.version>


### PR DESCRIPTION
### Purpose

Expose the multiple client secrets lifecycle and client‑secret expiry through the Application Management REST API (v1). Adds dedicated endpoints to create, list, retrieve, and delete an application's OAuth2/OIDC client secrets, and surfaces the latest secret's expiry on the OIDC inbound configuration.

#### New endpoints (`/applications/{applicationId}/inbound-protocols/oidc/secrets`)

Method | Path | Description | Required scope
-- | -- | -- | --
POST | /secrets | Create a new client secret. Existing secrets, access/refresh tokens, and authorization codes remain valid. 409 when the per‑app secret limit is reached. | internal_application_mgt_client_secret_create
GET | /secrets | List metadata of all client secrets of the application. | internal_application_mgt_client_secret_view
GET | /secrets/{secretId} | Get a single client secret's metadata. | internal_application_mgt_client_secret_view
DELETE | /secrets/{secretId} | Delete a client secret. The latest (active) secret cannot be deleted — at least one active secret must remain (409). | internal_application_mgt_client_secret_delete

- The existing `POST …/oidc/regenerate-secret` will require the same previously defined `internal_application_mgt_client_secret_create`. 
- Organization‑level callers use the `internal_org_application_mgt_client_secret_*` variants.

#### New API models

  - `ClientSecretCreationRequest` — `expiresAt` (Unix epoch seconds; must be a future time; 0 or omitted = non‑expiring).
  - `ClientSecretResponse` — `secretId`, `secretValue`, `expiresAt`, `createdAt`, `status` (`ACTIVE`/`EXPIRED`), `latest`.
  - `ClientSecretList` — `count`, `list[]`.

- `OpenIDConnectConfiguration` additions
   - `clientSecretExpiresAt` — expiry of the client secret as Unix epoch seconds (0 = never). On create, sets the initial secret's expiry.
   - `multipleClientSecretsConfigured` — flag indicating the app holds more than one secret.

    Both fields are stripped from the response when the caller lacks the client‑secret view scope.

#### Notes on Error Responses

  - [Secrets CRUD API] Reaching the configured maximum secret count on create, or deleting the latest (active) secret, returns `409 Conflict`.
  - [Secrets CRUD API / Application Mgt / DCR] Setting a client‑secret expiry to a past time returns `400 Bad Request`.

### Related PRs

  - https://github.com/wso2-extensions/identity-inbound-auth-oauth/pull/3284
  - https://github.com/wso2/carbon-identity-framework/pull/8226
  - https://github.com/wso2/carbon-identity-framework/pull/8259
  - https://github.com/wso2/identity-apps/pull/10587

### Related Issue
  - https://github.com/wso2/product-is/issues/28127
  
### To be merged after 
 https://github.com/wso2-extensions/identity-inbound-auth-oauth/pull/3284
https://github.com/wso2/carbon-identity-framework/pull/8259
