### PR TITLE
Fix GET /consent/{consent-id} not returning pending authorizations

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.consent.management/org.wso2.carbon.identity.api.server.consent.management.v2/src/gen/java/org/wso2/carbon/identity/api/server/consent/management/v2/model/AuthorizationDTO.java
+++ b/components/org.wso2.carbon.identity.api.server.consent.management/org.wso2.carbon.identity.api.server.consent.management.v2/src/gen/java/org/wso2/carbon/identity/api/server/consent/management/v2/model/AuthorizationDTO.java
@@ -38,7 +38,7 @@ public class AuthorizationDTO  {
 @XmlEnum(String.class)
 public enum StateEnum {
 
-    @XmlEnumValue("APPROVED") APPROVED(String.valueOf("APPROVED")), @XmlEnumValue("REJECTED") REJECTED(String.valueOf("REJECTED")), @XmlEnumValue("REVOKED") REVOKED(String.valueOf("REVOKED")), @XmlEnumValue("EXPIRED") EXPIRED(String.valueOf("EXPIRED"));
+    @XmlEnumValue("PENDING") PENDING(String.valueOf("PENDING")), @XmlEnumValue("APPROVED") APPROVED(String.valueOf("APPROVED")), @XmlEnumValue("REJECTED") REJECTED(String.valueOf("REJECTED")), @XmlEnumValue("REVOKED") REVOKED(String.valueOf("REVOKED")), @XmlEnumValue("EXPIRED") EXPIRED(String.valueOf("EXPIRED"));
 
 
     private String value;

--- a/components/org.wso2.carbon.identity.api.server.consent.management/org.wso2.carbon.identity.api.server.consent.management.v2/src/main/java/org/wso2/carbon/identity/api/server/consent/management/v2/core/ConsentManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.consent.management/org.wso2.carbon.identity.api.server.consent.management.v2/src/main/java/org/wso2/carbon/identity/api/server/consent/management/v2/core/ConsentManagementService.java
@@ -71,7 +71,6 @@ import static org.wso2.carbon.consent.mgt.core.constant.ConsentConstants.ErrorMe
 import static org.wso2.carbon.consent.mgt.core.constant.ConsentConstants.ErrorMessages.ERROR_CODE_INVALID_FILTER_EXPRESSION;
 import static org.wso2.carbon.consent.mgt.core.constant.ConsentConstants.ErrorMessages.ERROR_CODE_INVALID_QUERY_PARAM;
 import static org.wso2.carbon.consent.mgt.core.constant.ConsentConstants.FilterConstants;
-import static org.wso2.carbon.consent.mgt.core.constant.ConsentConstants.PENDING_STATE;
 import static org.wso2.carbon.consent.mgt.core.constant.ConsentConstants.REVOKE_STATE;
 import static org.wso2.carbon.consent.mgt.core.util.ConsentUtils.handleClientException;
 
@@ -398,10 +397,6 @@ public class ConsentManagementService {
         List<AuthorizationDTO> authDTOs = new ArrayList<>();
         if (auths != null) {
             for (ConsentAuthorization auth : auths) {
-                // Skip PENDING authorizations — they are not exposed in the API response DTO
-                if (PENDING_STATE.equals(auth.getStatus().name())) {
-                    continue;
-                }
                 try {
                     AuthorizationDTO.StateEnum stateEnum =
                             AuthorizationDTO.StateEnum.fromValue(auth.getStatus().name());

--- a/components/org.wso2.carbon.identity.api.server.consent.management/org.wso2.carbon.identity.api.server.consent.management.v2/src/main/resources/consent-management-v2.yaml
+++ b/components/org.wso2.carbon.identity.api.server.consent.management/org.wso2.carbon.identity.api.server.consent.management.v2/src/main/resources/consent-management-v2.yaml
@@ -1682,7 +1682,7 @@ components:
           example: "alice@wso2.com"
         state:
           type: string
-          enum: [APPROVED, REJECTED, REVOKED, EXPIRED]
+          enum: [PENDING, APPROVED, REJECTED, REVOKED, EXPIRED]
           description: Current state of this authorization
           example: "APPROVED"
         updatedTime:


### PR DESCRIPTION
## Purpose
Fixes https://github.com/wso2/product-is/issues/28224

`GET /consent/{consent-id}` returns an empty `authorizations` array even when the consent has authorizers configured in the database.

## Root cause
Every authorizer is created with status `PENDING` and only transitions to `APPROVED`/`REJECTED`/`REVOKED` once acted upon. `AuthorizationDTO.state` only supports the terminal states (`APPROVED, REJECTED, REVOKED, EXPIRED`), so `ConsentManagementService.toConsentDTO` silently skipped any `PENDING` authorization when building the response — leaving `authorizations` empty for any consent whose authorizers hadn't yet responded.

## Fix
- Added `PENDING` to the `AuthorizationDTO.state` enum in `consent-management-v2.yaml` and the generated model.
- Removed the code path in `ConsentManagementService.toConsentDTO` that skipped `PENDING` authorizations.

## Test environment
Verified manually against a locally built `wso2is-7.4.0-SNAPSHOT` pack with the patched jar:
1. Created a consent as admin with an authorizer (`alice`, initial state `PENDING`).
2. `GET /consent/{id}` — confirmed `authorizations` now returns `[{"userId":"alice","state":"PENDING",...}]` (previously empty).
3. Alice approved via `POST /me/consents/{id}/authorize` (`identity-api-user`).
4. `GET /consent/{id}` again — confirmed `authorizations` now shows `[{"userId":"alice","state":"APPROVED",...}]` and consent `state` is `ACTIVE`.