### PR TITLE
Return the resolved organization and application from the branding preference API

### DIFF
--- a/components/org.wso2.carbon.identity.api.server.branding.preference.management/org.wso2.carbon.identity.api.server.branding.preference.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/branding/preference/management/v1/model/ResolvedBrandingPreferenceModelResolvedFrom.java
+++ b/components/org.wso2.carbon.identity.api.server.branding.preference.management/org.wso2.carbon.identity.api.server.branding.preference.management.v1/src/gen/java/org/wso2/carbon/identity/api/server/branding/preference/management/v1/model/ResolvedBrandingPreferenceModelResolvedFrom.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2025-2026, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -67,6 +67,8 @@ public enum TypeEnum {
 
     private TypeEnum type;
     private String name;
+    private String organization;
+    private String application;
 
     /**
     **/
@@ -89,6 +91,7 @@ public enum TypeEnum {
     }
 
     /**
+    * Deprecated. Use `organization` and `application` instead.
     **/
     public ResolvedBrandingPreferenceModelResolvedFrom name(String name) {
 
@@ -96,7 +99,7 @@ public enum TypeEnum {
         return this;
     }
     
-    @ApiModelProperty(example = "WSO2", required = true, value = "")
+    @ApiModelProperty(example = "WSO2", required = true, value = "Deprecated. Use `organization` and `application` instead.")
     @JsonProperty("name")
     @Valid
     @NotNull(message = "Property name cannot be null.")
@@ -106,6 +109,44 @@ public enum TypeEnum {
     }
     public void setName(String name) {
         this.name = name;
+    }
+
+    /**
+    * The organization the preference belongs to. This can be an ancestor organization, when the organization inherits its preference.
+    **/
+    public ResolvedBrandingPreferenceModelResolvedFrom organization(String organization) {
+
+        this.organization = organization;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "WSO2", value = "The organization the preference belongs to. This can be an ancestor organization, when the organization inherits its preference.")
+    @JsonProperty("organization")
+    @Valid
+    public String getOrganization() {
+        return organization;
+    }
+    public void setOrganization(String organization) {
+        this.organization = organization;
+    }
+
+    /**
+    * The application the preference belongs to. Returned only when the type is APP.
+    **/
+    public ResolvedBrandingPreferenceModelResolvedFrom application(String application) {
+
+        this.application = application;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "fa9b9ac5-a429-49e2-9c51-4259c7ebe45e", value = "The application the preference belongs to. Returned only when the type is APP.")
+    @JsonProperty("application")
+    @Valid
+    public String getApplication() {
+        return application;
+    }
+    public void setApplication(String application) {
+        this.application = application;
     }
 
 
@@ -121,12 +162,14 @@ public enum TypeEnum {
         }
         ResolvedBrandingPreferenceModelResolvedFrom resolvedBrandingPreferenceModelResolvedFrom = (ResolvedBrandingPreferenceModelResolvedFrom) o;
         return Objects.equals(this.type, resolvedBrandingPreferenceModelResolvedFrom.type) &&
-            Objects.equals(this.name, resolvedBrandingPreferenceModelResolvedFrom.name);
+            Objects.equals(this.name, resolvedBrandingPreferenceModelResolvedFrom.name) &&
+            Objects.equals(this.organization, resolvedBrandingPreferenceModelResolvedFrom.organization) &&
+            Objects.equals(this.application, resolvedBrandingPreferenceModelResolvedFrom.application);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(type, name);
+        return Objects.hash(type, name, organization, application);
     }
 
     @Override
@@ -137,6 +180,8 @@ public enum TypeEnum {
         
         sb.append("    type: ").append(toIndentedString(type)).append("\n");
         sb.append("    name: ").append(toIndentedString(name)).append("\n");
+        sb.append("    organization: ").append(toIndentedString(organization)).append("\n");
+        sb.append("    application: ").append(toIndentedString(application)).append("\n");
         sb.append("}");
         return sb.toString();
     }

--- a/components/org.wso2.carbon.identity.api.server.branding.preference.management/org.wso2.carbon.identity.api.server.branding.preference.management.v1/src/main/java/org/wso2/carbon/identity/api/server/branding/preference/management/v1/core/BrandingPreferenceManagementService.java
+++ b/components/org.wso2.carbon.identity.api.server.branding.preference.management/org.wso2.carbon.identity.api.server.branding.preference.management.v1/src/main/java/org/wso2/carbon/identity/api/server/branding/preference/management/v1/core/BrandingPreferenceManagementService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2024, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2021-2026, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -595,6 +595,8 @@ public class BrandingPreferenceManagementService {
         resolvedFrom.setType(ResolvedBrandingPreferenceModelResolvedFrom.TypeEnum.valueOf(
                 responseDTO.getResolvedFrom().getType()));
         resolvedFrom.setName(responseDTO.getResolvedFrom().getName());
+        resolvedFrom.setOrganization(responseDTO.getResolvedFrom().getOrganization());
+        resolvedFrom.setApplication(responseDTO.getResolvedFrom().getApplication());
         ResolvedBrandingPreferenceModel brandingPreferenceResponse = new ResolvedBrandingPreferenceModel();
         brandingPreferenceResponse.setType(ResolvedBrandingPreferenceModel.TypeEnum.valueOf(responseDTO.getType()));
         brandingPreferenceResponse.setName(responseDTO.getName());
@@ -634,6 +636,8 @@ public class BrandingPreferenceManagementService {
         resolvedFrom.setType(ResolvedBrandingPreferenceModelResolvedFrom.TypeEnum.valueOf(
                 responseDTO.getResolvedFrom().getType()));
         resolvedFrom.setName(responseDTO.getResolvedFrom().getName());
+        resolvedFrom.setOrganization(responseDTO.getResolvedFrom().getOrganization());
+        resolvedFrom.setApplication(responseDTO.getResolvedFrom().getApplication());
         ResolvedCustomTextModal customTextModel = new ResolvedCustomTextModal();
         customTextModel.setType(ResolvedCustomTextModal.TypeEnum.valueOf(responseDTO.getType()));
         customTextModel.setName(responseDTO.getName());

--- a/components/org.wso2.carbon.identity.api.server.branding.preference.management/org.wso2.carbon.identity.api.server.branding.preference.management.v1/src/main/resources/branding-preference.yaml
+++ b/components/org.wso2.carbon.identity.api.server.branding.preference.management/org.wso2.carbon.identity.api.server.branding.preference.management.v1/src/main/resources/branding-preference.yaml
@@ -625,7 +625,17 @@ components:
               example: "ORG"
             name:
               type: string
+              deprecated: true
+              description: "Deprecated. Use `organization` and `application` instead."
               example: "WSO2"
+            organization:
+              type: string
+              description: "The organization the preference belongs to. This can be an ancestor organization, when the organization inherits its preference."
+              example: "WSO2"
+            application:
+              type: string
+              description: "The application the preference belongs to. Returned only when the type is APP."
+              example: "fa9b9ac5-a429-49e2-9c51-4259c7ebe45e"
         preference:
           type: object
           description: "This is the JSON structured branding preference"
@@ -788,7 +798,17 @@ components:
               example: "ORG"
             name:
               type: string
+              deprecated: true
+              description: "Deprecated. Use `organization` and `application` instead."
               example: "WSO2"
+            organization:
+              type: string
+              description: "The organization the preference belongs to. This can be an ancestor organization, when the organization inherits its preference."
+              example: "WSO2"
+            application:
+              type: string
+              description: "The application the preference belongs to. Returned only when the type is APP."
+              example: "fa9b9ac5-a429-49e2-9c51-4259c7ebe45e"
         preference:
           type: object
           description: "This is the JSON structured branding preference"

--- a/pom.xml
+++ b/pom.xml
@@ -1135,7 +1135,7 @@
         <org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.version>2.5.18</org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.version>
         <org.wso2.carbon.logging.service.version>4.11.0</org.wso2.carbon.logging.service.version>
         <org.wso2.carbon.event.publisher.version>5.2.61</org.wso2.carbon.event.publisher.version>
-        <identity.branding.preference.management.version>1.1.22</identity.branding.preference.management.version>
+        <identity.branding.preference.management.version>1.4.4-SNAPSHOT</identity.branding.preference.management.version>
         <apache.felix.scr.ds.annotations.version>1.2.4</apache.felix.scr.ds.annotations.version>
         <workflow.imple.bps.version>5.5.21</workflow.imple.bps.version>
         <carbon.workflow.engine.version>1.0.18</carbon.workflow.engine.version>

--- a/pom.xml
+++ b/pom.xml
@@ -1135,7 +1135,7 @@
         <org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.version>2.5.18</org.wso2.carbon.identity.oauth2.token.handler.clientauth.jwt.version>
         <org.wso2.carbon.logging.service.version>4.11.0</org.wso2.carbon.logging.service.version>
         <org.wso2.carbon.event.publisher.version>5.2.61</org.wso2.carbon.event.publisher.version>
-        <identity.branding.preference.management.version>1.4.4-SNAPSHOT</identity.branding.preference.management.version>
+        <identity.branding.preference.management.version>1.4.4</identity.branding.preference.management.version>
         <apache.felix.scr.ds.annotations.version>1.2.4</apache.felix.scr.ds.annotations.version>
         <workflow.imple.bps.version>5.5.21</workflow.imple.bps.version>
         <carbon.workflow.engine.version>1.0.18</carbon.workflow.engine.version>


### PR DESCRIPTION
Returns the two new `resolvedFrom` fields, `organization` and `application`, from the branding preference and the custom text resolve endpoints. `name` is still returned and is now marked as deprecated in the API definition.

Depends on https://github.com/wso2-extensions/identity-branding-preference-management/pull/74. `identity.branding.preference.management.version` currently points to `1.4.4-SNAPSHOT` and needs to be updated to the released version before this is merged.

Related to https://github.com/wso2/product-is/issues/28242
