### PR TITLE
[identity-api-server] Bump Jackson to 2.22.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1104,11 +1104,11 @@
         <!--Maven Plugin Version-->
         <maven.compiler.plugin.version>3.10.1</maven.compiler.plugin.version>
         <maven.bundle.plugin.version>2.4.0</maven.bundle.plugin.version>
-        <jackson-jaxrs-json-provider.version>2.21.2</jackson-jaxrs-json-provider.version>
-        <jackson-databind.version>2.21.2</jackson-databind.version>
+        <jackson-jaxrs-json-provider.version>2.22.2</jackson-jaxrs-json-provider.version>
+        <jackson-databind.version>2.22.2</jackson-databind.version>
         <cxf-bundle.version>3.5.9</cxf-bundle.version>
         <cxf.extensions.search.version>3.5.9</cxf.extensions.search.version>
-        <jackson.version>2.21.2</jackson.version>
+        <jackson.version>2.22.2</jackson.version>
         <swagger-jaxrs.version>1.6.2</swagger-jaxrs.version>
         <javax.ws.rs-api.version>2.1.1</javax.ws.rs-api.version>
         <version.org.wso2.orbit.javax.xml.bind>2.3.1.wso2v1</version.org.wso2.orbit.javax.xml.bind>


### PR DESCRIPTION
## Purpose

Upgrade the Jackson artifacts to the latest stable 2.x release, `2.22.2`.

`2.21.2` is still within the affected range of GHSA-r7wm-3cxj-wff9 (`[2.19.0, 2.21.4)`), which is
the follow-up to CVE-2026-18401 and is described upstream as an incomplete fix for it. `2.22.2` is
the current latest on the 2.x line and is clear of both.

## Approach

Version property bumps only — no code or logic changes.

`pom.xml`:

- `jackson.version`: `2.21.2` → `2.22.2`
- `jackson-databind.version`: `2.21.2` → `2.22.2`
- `jackson-jaxrs-json-provider.version`: `2.21.2` → `2.22.2`
